### PR TITLE
fix(browse): download the highlighted row, not the first result

### DIFF
--- a/apps/cli/src/app-shell/browse-shell.tsx
+++ b/apps/cli/src/app-shell/browse-shell.tsx
@@ -1200,7 +1200,7 @@ export function BrowseShell<T>({
           return;
         }
         if (input.toLowerCase() === "d" && selectedOption && searchState === "ready") {
-          onResolve("download");
+          onResolve("download", selectedOption.value);
           return;
         }
       }
@@ -1384,7 +1384,9 @@ export function BrowseShell<T>({
       (listFocused && input.toLowerCase() === "d")
     ) {
       if (selectedOption && displayOptions.length > 0 && !queryDirty && searchState === "ready") {
-        onResolve("download");
+        // Carry the highlighted row: the download target is read out of session
+        // state, which only tracks the cursor for actions that report it.
+        onResolve("download", selectedOption.value);
       }
       return;
     }

--- a/apps/cli/src/app/search/SearchPhase.ts
+++ b/apps/cli/src/app/search/SearchPhase.ts
@@ -53,6 +53,7 @@ import {
 } from "@/domain/media/media-item-adapters";
 import { createSearchIntentEngine } from "@/domain/search/SearchIntentEngine";
 import { ensureSessionProviderMatchesLane } from "@/domain/session/session-display";
+import type { SessionStateManager } from "@/domain/session/SessionStateManager";
 import type { SearchResult, ShellMode, TitleInfo } from "@/domain/types";
 import { openExternalUrl } from "@/infra/shell/open-external-url";
 import {
@@ -742,6 +743,9 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
           }
 
           if (outcome.action === "download") {
+            if (outcome.value) {
+              syncSelectedResultIndex(stateManager, outcome.value);
+            }
             const { downloadSelectedResult } = await import("../../app-shell/workflows");
             await downloadSelectedResult(container);
             continue;
@@ -764,12 +768,7 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
                     providerRegistry,
                     signal: context.signal,
                   });
-              const selectedIndex = stateManager
-                .getState()
-                .searchResults.findIndex((result) => result.id === originalSelected.id);
-              if (selectedIndex >= 0) {
-                stateManager.dispatch({ type: "SELECT_RESULT", index: selectedIndex });
-              }
+              syncSelectedResultIndex(stateManager, originalSelected);
               const title = await enrichSelectedTitleIdentity(
                 container.catalogIdentityService,
                 titleInfoFromSearchResult(
@@ -948,12 +947,7 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
               providerRegistry,
               signal: context.signal,
             });
-        const selectedIndex = stateManager
-          .getState()
-          .searchResults.findIndex((result) => result.id === originalSelected.id);
-        if (selectedIndex >= 0) {
-          stateManager.dispatch({ type: "SELECT_RESULT", index: selectedIndex });
-        }
+        syncSelectedResultIndex(stateManager, originalSelected);
 
         // Convert SearchResult to TitleInfo
         const title = await enrichSelectedTitleIdentity(
@@ -999,6 +993,27 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
         }),
       };
     }
+  }
+}
+
+/**
+ * Point `selectedResultIndex` at the row the shell says is highlighted.
+ *
+ * Browse keeps its cursor in local Ink state and only reports it back with the
+ * action that carries a value. Every action that reads the selection out of
+ * session state must call this first: results loads reset the index to 0, so an
+ * unsynced action silently targets the first row rather than the highlighted
+ * one.
+ */
+function syncSelectedResultIndex(
+  stateManager: SessionStateManager,
+  selected: { readonly id: string },
+): void {
+  const selectedIndex = stateManager
+    .getState()
+    .searchResults.findIndex((result) => result.id === selected.id);
+  if (selectedIndex >= 0) {
+    stateManager.dispatch({ type: "SELECT_RESULT", index: selectedIndex });
   }
 }
 

--- a/apps/cli/test/unit/app-shell/browse-download-selection.useinput.test.tsx
+++ b/apps/cli/test/unit/app-shell/browse-download-selection.useinput.test.tsx
@@ -1,0 +1,106 @@
+import { expect, test } from "bun:test";
+
+import { BrowseShell } from "@/app-shell/browse-shell";
+import type { BrowseShellOption, ShellAction } from "@/app-shell/types";
+import type { SearchResult } from "@/domain/types";
+import React from "react";
+
+import { render } from "../../harness/render-capture";
+
+const DOWN = `${String.fromCharCode(27)}[B`;
+const CTRL_D = String.fromCharCode(4);
+
+function trendingOption(label: string): BrowseShellOption<SearchResult> {
+  return {
+    label,
+    value: {
+      id: label,
+      type: "series",
+      title: label,
+      year: "2026",
+      overview: "",
+      posterPath: null,
+    },
+  };
+}
+
+type Resolved = Array<{ action: ShellAction; value?: SearchResult }>;
+
+/**
+ * The download target is read out of session state, whose selected index is
+ * reset to 0 on every results load. Browse tracks its cursor in local state, so
+ * unless the download action carries the highlighted row, every Ctrl+D on a
+ * trending list downloads the first item regardless of where the cursor is.
+ */
+function renderTrendingBrowse(resolved: Resolved) {
+  return render(
+    <BrowseShell
+      mode="series"
+      provider="vidking"
+      initialResults={[
+        trendingOption("First trending"),
+        trendingOption("Second trending"),
+        trendingOption("Third trending"),
+      ]}
+      initialResultSubtitle="3 trending"
+      placeholder="Search"
+      commands={[]}
+      onSearch={async () => ({ options: [], subtitle: "", emptyMessage: "" })}
+      onResolve={(action, value) => resolved.push({ action, value })}
+      onSubmit={() => {}}
+      onCancel={() => {}}
+    />,
+    { columns: 120, rows: 30 },
+  );
+}
+
+// Keys go in one at a time: the harness delivers an array as a single read,
+// which the shell sees as one keypress rather than a burst of arrows.
+function press(handle: ReturnType<typeof renderTrendingBrowse>, keys: readonly string[]): void {
+  for (const key of keys) handle.stdin.enqueue([key]);
+}
+
+test("Ctrl+D carries the highlighted trending row, not the first one", () => {
+  const resolved: Resolved = [];
+  const handle = renderTrendingBrowse(resolved);
+
+  try {
+    press(handle, [DOWN, DOWN, CTRL_D]);
+
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]?.action).toBe("download");
+    expect(resolved[0]?.value?.title).toBe("Third trending");
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("bare d in the results zone carries the highlighted row too", () => {
+  const resolved: Resolved = [];
+  const handle = renderTrendingBrowse(resolved);
+
+  try {
+    press(handle, [DOWN, "d"]);
+
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]?.action).toBe("download");
+    expect(resolved[0]?.value?.title).toBe("Second trending");
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("download without moving the cursor still names the first row explicitly", () => {
+  const resolved: Resolved = [];
+  const handle = renderTrendingBrowse(resolved);
+
+  try {
+    press(handle, [CTRL_D]);
+
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]?.action).toBe("download");
+    expect(resolved[0]?.value?.title).toBe("First trending");
+  } finally {
+    handle.unmount();
+  }
+});


### PR DESCRIPTION
## The bug

Ctrl+D on a trending list downloads the **first** title no matter which row is highlighted.

## Root cause

`browse-shell.tsx` fired the action without the selected row:

```ts
onResolve("download");   // no value
```

while the target is read out of session state in `shell-workflows.ts`:

```ts
const selected = state.searchResults[state.selectedResultIndex];
```

Browse keeps its cursor in local Ink state and only reports it back on actions that carry a value — the `menu` path one line below already passed `selectedOption?.value`. Since `SearchPhase` resets `SELECT_RESULT` to `0` on every results load, the index was always 0 on a freshly loaded trending list, so every download hit the first title.

## Fix

- Carry the highlighted row on the action, at both download call sites (Ctrl+D and bare `d`).
- Sync `selectedResultIndex` from that value before downloading, following the convention the `menu` path already used.
- The index-sync block was **byte-identical** at two existing sites, so it is now `syncSelectedResultIndex()` and all three call it rather than adding a third copy.

Matching by result **id** rather than position is what keeps this correct under a local filter, where the visible row and the session index disagree — the original positional read is exactly why this broke.

## Test plan

- [x] New `browse-download-selection.useinput.test.tsx`: Ctrl+D after moving, bare `d` after moving, and download without moving
- [x] Verified red before / green after — all 3 fail without the fix
- [x] `bun run test` (14/14 tasks), `typecheck`, `lint`, `fmt`