### PR TITLE
chore(docs): gate feature-map coverage of every code area

### DIFF
--- a/.docs/feature-map.md
+++ b/.docs/feature-map.md
@@ -46,61 +46,70 @@ cli-args.ts → main.ts → container/ → app/bootstrap → app/session (Sessio
 
 ## Search and catalog
 
-| Feature                               | Owned by                                                                | Docs                                                                                        |
-| ------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Search routing and backends           | `apps/cli/src/services/search/*`, `apps/cli/src/app/search/*`           | [.plans/search-service.md](../.plans/search-service.md)                                     |
-| TMDB season/episode metadata          | `apps/cli/src/tmdb.ts`, `apps/cli/src/services/catalog/*`               | [architecture.md](./architecture.md)                                                        |
-| Anime identity / title reconciliation | `apps/cli/src/domain/catalog/*`, `packages/storage` `catalog-crosswalk` | [.plans/catalog-identity-parity.md](../.plans/catalog-identity-parity.md)                   |
-| `/discover`, `/trending`, `/random`   | `apps/cli/src/app/discover/*`, `services/recommendations/*`             | [recommendations-and-discover.md](./recommendations-and-discover.md)                        |
-| `/calendar`, release schedules        | `apps/cli/src/domain/calendar/*`, `services/release-reconciliation/*`   | [.plans/catalog-release-schedule-service.md](../.plans/catalog-release-schedule-service.md) |
-| AniList / TMDB account sync           | `apps/cli/src/services/sync/*`                                          | `docs/users/reliability-and-privacy.mdx`                                                    |
+| Feature                               | Owned by                                                                                                        | Docs                                                                                        |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Search routing and backends           | `apps/cli/src/services/search/*`, `apps/cli/src/app/search/*`                                                   | [.plans/search-service.md](../.plans/search-service.md)                                     |
+| Search intent parsing                 | `apps/cli/src/domain/search/*` — `SearchIntentParser` / `SearchIntentEngine` turn raw input into a typed intent | [.plans/search-service.md](../.plans/search-service.md)                                     |
+| TMDB season/episode metadata          | `apps/cli/src/tmdb.ts`, `apps/cli/src/services/catalog/*`                                                       | [architecture.md](./architecture.md)                                                        |
+| Anime identity / title reconciliation | `apps/cli/src/domain/catalog/*`, `packages/storage` `catalog-crosswalk`                                         | [.plans/catalog-identity-parity.md](../.plans/catalog-identity-parity.md)                   |
+| `/discover`, `/trending`, `/random`   | `apps/cli/src/app/discover/*`, `services/recommendations/*`                                                     | [recommendations-and-discover.md](./recommendations-and-discover.md)                        |
+| `/calendar`, release schedules        | `apps/cli/src/domain/calendar/*`, `services/release-reconciliation/*`                                           | [.plans/catalog-release-schedule-service.md](../.plans/catalog-release-schedule-service.md) |
+| AniList / TMDB account sync           | `apps/cli/src/services/sync/*`                                                                                  | `docs/users/reliability-and-privacy.mdx`                                                    |
 
 ## Providers and resolution
 
-| Feature                                      | Owned by                                                                                  | Docs                                                                                                   |
-| -------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| Production registry                          | `apps/cli/src/container/bootstrap-providers.ts` — `loadProductionProviderModules()`       | [providers.md](./providers.md)                                                                         |
-| Resolve engine, fallback, hedging            | `packages/core/src/provider-engine.ts`                                                    | [providers.md](./providers.md)                                                                         |
-| Provider modules                             | `packages/providers/src/*/direct.ts`                                                      | [provider-examples.md](./provider-examples.md)                                                         |
-| Adding a provider                            | —                                                                                         | [provider-intake.md](./provider-intake.md), [provider-agent-workflow.md](./provider-agent-workflow.md) |
-| Source inventory (source/quality/audio/subs) | `apps/cli/src/services/playback/*`, `packages/storage` `source-inventory`                 | [playback-source-inventory-contract.md](./playback-source-inventory-contract.md)                       |
-| Provider health + `/reset-provider-health`   | `packages/storage` `provider-health`, `title-provider-health`, `provider-endpoint-health` | [title-provider-health-and-cache-reset.md](./title-provider-health-and-cache-reset.md)                 |
-| Geo relay (user-owned)                       | `packages/relay/*`, `apps/relay-server`                                                   | [runtime-boundary-map.md](./runtime-boundary-map.md#provider-relay-ownership)                          |
-| Provider research                            | `apps/experiments/*`, `.docs/provider-dossiers/*`                                         | [provider-intake.md](./provider-intake.md)                                                             |
+| Feature                                      | Owned by                                                                                                                                   | Docs                                                                                                   |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| Production registry                          | `apps/cli/src/container/bootstrap-providers.ts` — `loadProductionProviderModules()`                                                        | [providers.md](./providers.md)                                                                         |
+| CLI-side provider adapters                   | `apps/cli/src/services/providers/*` — `ProviderRegistry` (engine compat wrapper), priority, lanes, relay settings, request/result adapters | [providers.md](./providers.md)                                                                         |
+| Attempt timeline, failure classification     | `apps/cli/src/domain/provider/*` — pure classification of what a failed attempt means                                                      | [debugging-map.md](./debugging-map.md)                                                                 |
+| Resolve engine, fallback, hedging            | `packages/core/src/provider-engine.ts`                                                                                                     | [providers.md](./providers.md)                                                                         |
+| Provider modules                             | `packages/providers/src/*/direct.ts`                                                                                                       | [provider-examples.md](./provider-examples.md)                                                         |
+| Adding a provider                            | —                                                                                                                                          | [provider-intake.md](./provider-intake.md), [provider-agent-workflow.md](./provider-agent-workflow.md) |
+| Source inventory (source/quality/audio/subs) | `apps/cli/src/services/playback/*`, `packages/storage` `source-inventory`                                                                  | [playback-source-inventory-contract.md](./playback-source-inventory-contract.md)                       |
+| Provider health + `/reset-provider-health`   | `packages/storage` `provider-health`, `title-provider-health`, `provider-endpoint-health`                                                  | [title-provider-health-and-cache-reset.md](./title-provider-health-and-cache-reset.md)                 |
+| Geo relay (user-owned)                       | `packages/relay/*`, `apps/relay-server`                                                                                                    | [runtime-boundary-map.md](./runtime-boundary-map.md#provider-relay-ownership)                          |
+| Provider research                            | `apps/experiments/*`, `.docs/provider-dossiers/*`                                                                                          | [provider-intake.md](./provider-intake.md)                                                             |
 
 ## Playback
 
-| Feature                                    | Owned by                                             | Docs                                                                             |
-| ------------------------------------------ | ---------------------------------------------------- | -------------------------------------------------------------------------------- |
-| Playback state machine                     | `apps/cli/src/app/playback/PlaybackPhase.ts`         | [architecture.md](./architecture.md)                                             |
-| mpv launch + IPC (socket / named pipe)     | `apps/cli/src/infra/player/*`, `apps/cli/src/mpv.ts` | [quickstart.md](./quickstart.md)                                                 |
-| Persistent session + autoplay              | `apps/cli/src/infra/player/PersistentMpvSession.ts`  | [mpv-in-process-reconnect.md](./mpv-in-process-reconnect.md)                     |
-| Intro/credits auto-skip (IntroDB, AniSkip) | `apps/cli/src/aniskip.ts`, `apps/cli/src/introdb.ts` | [playback-timing-and-aniskip.md](./playback-timing-and-aniskip.md)               |
-| Subtitles                                  | `apps/cli/src/subtitle.ts`                           | [playback-source-inventory-contract.md](./playback-source-inventory-contract.md) |
-| Recovery / fallback / `/recover`           | `apps/cli/src/domain/recovery/*`                     | [debugging-map.md](./debugging-map.md)                                           |
-| Post-playback actions                      | `apps/cli/src/app/post-play/*`                       | [ux-architecture.md](./ux-architecture.md)                                       |
+| Feature                                    | Owned by                                                                                                            | Docs                                                                             |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Playback state machine                     | `apps/cli/src/app/playback/PlaybackPhase.ts`                                                                        | [architecture.md](./architecture.md)                                             |
+| mpv launch + IPC (socket / named pipe)     | `apps/cli/src/infra/player/*`, `apps/cli/src/mpv.ts`                                                                | [quickstart.md](./quickstart.md)                                                 |
+| Persistent session + autoplay              | `apps/cli/src/infra/player/PersistentMpvSession.ts`                                                                 | [mpv-in-process-reconnect.md](./mpv-in-process-reconnect.md)                     |
+| Intro/credits auto-skip (IntroDB, AniSkip) | `apps/cli/src/aniskip.ts`, `apps/cli/src/introdb.ts`                                                                | [playback-timing-and-aniskip.md](./playback-timing-and-aniskip.md)               |
+| Timing sources and merge                   | `apps/cli/src/infra/timing/*` — `PlaybackTimingAggregator` merges IntroDB, AniSkip, and provider-native timings     | [playback-timing-and-aniskip.md](./playback-timing-and-aniskip.md)               |
+| Subtitles                                  | `apps/cli/src/subtitle.ts`                                                                                          | [playback-source-inventory-contract.md](./playback-source-inventory-contract.md) |
+| Recovery / fallback / `/recover`           | `apps/cli/src/domain/recovery/*`                                                                                    | [debugging-map.md](./debugging-map.md)                                           |
+| Post-playback actions                      | `apps/cli/src/app/post-play/*`                                                                                      | [ux-architecture.md](./ux-architecture.md)                                       |
+| Playback rules (pure, no I/O)              | `apps/cli/src/domain/playback/*` — playable refs, progress/completion policy, problem classification, local streams | [architecture.md](./architecture.md)                                             |
+| Source selection (pure)                    | `apps/cli/src/domain/playback-source/*` — `SourceSelectionEngine`, offline availability                             | [playback-source-inventory-contract.md](./playback-source-inventory-contract.md) |
 
 ## Library and personal state
 
 Vocabulary is locked — see [adr/0001-personal-media-vocabulary.md](./adr/0001-personal-media-vocabulary.md).
 Do not reuse these nouns for anything else.
 
-| Feature                        | Owned by                                                             | Docs                                                                   |
-| ------------------------------ | -------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| History + continue             | `packages/storage` `history`, `apps/cli/src/services/continuation/*` | [features/new-episode-tracking.md](./features/new-episode-tracking.md) |
-| Watchlist / playlists          | `packages/storage` `lists`, `playlists`; `services/playlists/*`      | [features/playlists.md](./features/playlists.md)                       |
-| Up Next queue                  | `packages/storage` `queue`, `apps/cli/src/domain/queue/*`            | [features/queue.md](./features/queue.md)                               |
-| Follow / new-episode attention | `packages/storage` `followed-titles`; `services/attention/*`         | [features/new-episode-tracking.md](./features/new-episode-tracking.md) |
-| Notifications inbox            | `packages/storage` `notifications`; `services/notifications/*`       | [features/notifications.md](./features/notifications.md)               |
-| Watch stats                    | `packages/storage` `watch-stats`                                     | [features/privacy-and-storage.md](./features/privacy-and-storage.md)   |
+| Feature                        | Owned by                                                                                                                                             | Docs                                                                                   |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| History + continue             | `packages/storage` `history`, `apps/cli/src/services/continuation/*`, `domain/continuation/*` (`ContinuationEngine`, watch-progress, catalog bounds) | [features/new-episode-tracking.md](./features/new-episode-tracking.md)                 |
+| History identity repair        | `apps/cli/src/services/history-metadata/*` — consolidator, healer, ledger backfill for rows whose title identity drifted                             | [title-provider-health-and-cache-reset.md](./title-provider-health-and-cache-reset.md) |
+| Row-scoped media actions       | `apps/cli/src/services/media-actions/MediaActionRouter.ts` — routes an action at a specific media item rather than session state                     | [runtime-boundary-map.md](./runtime-boundary-map.md)                                   |
+| Watchlist / playlists          | `packages/storage` `lists`, `playlists`; `services/playlists/*`                                                                                      | [features/playlists.md](./features/playlists.md)                                       |
+| Up Next queue                  | `packages/storage` `queue`, `apps/cli/src/domain/queue/*`                                                                                            | [features/queue.md](./features/queue.md)                                               |
+| Follow / new-episode attention | `packages/storage` `followed-titles`; `services/attention/*`                                                                                         | [features/new-episode-tracking.md](./features/new-episode-tracking.md)                 |
+| Notifications inbox            | `packages/storage` `notifications`; `services/notifications/*`                                                                                       | [features/notifications.md](./features/notifications.md)                               |
+| Watch stats                    | `packages/storage` `watch-stats`                                                                                                                     | [features/privacy-and-storage.md](./features/privacy-and-storage.md)                   |
+| Lists and stats domain         | `apps/cli/src/domain/lists/*` — `ListService`, `StatsService`, genre stats, formatting                                                               | [features/playlists.md](./features/playlists.md)                                       |
 
 ## Offline and downloads
 
-| Feature                       | Owned by                                                                                | Docs                                                               |
-| ----------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| Download jobs                 | `apps/cli/src/services/download/*`, `services/ytdlp/*`                                  | [download-offline-onboarding.md](./download-offline-onboarding.md) |
-| Offline library + assets      | `apps/cli/src/services/offline/*`, `app/offline/*`, `packages/storage` `offline-assets` | [download-offline-onboarding.md](./download-offline-onboarding.md) |
-| Network status / offline mode | `apps/cli/src/services/network/*`                                                       | [download-offline-onboarding.md](./download-offline-onboarding.md) |
+| Feature                       | Owned by                                                                                                                          | Docs                                                               |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Download jobs                 | `apps/cli/src/services/download/*`, `services/ytdlp/*`                                                                            | [download-offline-onboarding.md](./download-offline-onboarding.md) |
+| Offline library + assets      | `apps/cli/src/services/offline/*`, `app/offline/*`, `domain/offline/OfflineLibraryEngine.ts`, `packages/storage` `offline-assets` | [download-offline-onboarding.md](./download-offline-onboarding.md) |
+| Network status / offline mode | `apps/cli/src/services/network/*`                                                                                                 | [download-offline-onboarding.md](./download-offline-onboarding.md) |
 
 ## Diagnostics, privacy, distribution
 
@@ -112,6 +121,49 @@ Do not reuse these nouns for anything else.
 | Discord Rich Presence                 | `apps/cli/src/services/presence/*`                                                          | [presence-integrations.md](./presence-integrations.md)                                              |
 | Update check                          | `apps/cli/src/services/update/*`                                                            | [release-reliability-gate.md](./release-reliability-gate.md)                                        |
 | Installers, binaries, npm packages    | `install.sh`, `install.ps1`, `apps/cli/scripts/build*.ts`, `scripts/publish-npm-release.ts` | [repo-infrastructure.md](./repo-infrastructure.md), [../plans/README.md](../plans/README.md) wave 6 |
+
+## Cross-cutting plumbing
+
+Not features. Listed because they own a mechanism that several features depend
+on, and because guessing wrong here produces a layering violation.
+
+| Mechanism                     | Owned by                                                                                                                            | Note                                                                                                  |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Config and stores             | `apps/cli/src/services/persistence/*` — `ConfigService`, `ConfigStore`, `CacheStore`, `SyncTokenStore`, `StorageMaintenanceService` | The only writer of `config.json`; startup maintenance prunes cache-class rows                         |
+| Media vocabulary and identity | `apps/cli/src/domain/media/*` — content kind, episode cursor, media-item identity and adapters, track model, preferences            | Locked nouns live in [adr/0001-personal-media-vocabulary.md](./adr/0001-personal-media-vocabulary.md) |
+| Background work lanes         | `apps/cli/src/infra/work/*` (`WorkControlService`), `services/background/BackgroundWorkScheduler.ts`                                | Scheduling and cancellation for background jobs; not a place for policy                               |
+| Atomic file writes            | `apps/cli/src/infra/fs/atomic-write.ts` (`writeAtomicJson`)                                                                         | Use this for whole-file JSON rather than hand-rolling temp-file + rename                              |
+| OS integration                | `apps/cli/src/infra/os/*` — external open, protocol handler, reveal in file manager                                                 | Backs `--install-protocol-handler` and `kunai://`                                                     |
+| Build-time shims              | `apps/cli/src/infra/build/*` — compiled entrypoint, react-devtools stub                                                             | Only touched by the binary build; not runtime behavior                                                |
+| Cancellation and deadlines    | `apps/cli/src/infra/abort/timeout-signal.ts`                                                                                        | One helper. Do not hand-roll another `AbortSignal` timeout                                            |
+| Structured logging            | `apps/cli/src/infra/logger/*`, `apps/cli/src/logger.ts`                                                                             | `logger.ts` is the legacy flat entry; new work uses `infra/logger`                                    |
+| File and path mechanics       | `apps/cli/src/infra/storage/*` (`FileStorage`, `kunai-paths.ts`)                                                                    | Wraps `packages/storage` paths for the CLI                                                            |
+| Terminal shell-outs           | `apps/cli/src/infra/shell/*` (`open-external-url.ts`)                                                                               | The only place that launches an external program other than mpv and yt-dlp                            |
+| Stream resolve cache          | `apps/cli/src/services/cache/stream-resolve-cache.ts`                                                                               | Distinct from `packages/storage` `stream-cache` — see the doc column below                            |
+| Storage read models           | `apps/cli/src/services/storage/storage-read-models.ts`                                                                              | Shapes repository rows for the app layer so UI never reads repositories                               |
+| Feature flags                 | `apps/cli/src/domain/features/feature-flags.ts`                                                                                     | Experimental gates                                                                                    |
+| YouTube lane                  | `apps/cli/src/services/youtube/*`                                                                                                   | Invidious health, diagnostics probes, history metadata, recommendations                               |
+| Share link copy               | `apps/cli/src/infra/share/copy-share-link.ts`                                                                                       | Mechanism; `domain/share` owns the model — see [share-links.md](./share-links.md)                     |
+
+The two caches are intentionally separate layers, not duplication:
+`services/cache/stream-resolve-cache.ts` is the resolve-time memo, and
+`packages/storage` `stream-cache` is the durable one.
+
+## Shared packages
+
+Dependency direction between these is enforced — see
+[runtime-boundary-map.md](./runtime-boundary-map.md#package-dependency-direction).
+
+| Package            | Owns                                                                                           |
+| ------------------ | ---------------------------------------------------------------------------------------------- |
+| `@kunai/types`     | Serializable contracts crossing package, storage, and provider boundaries. Depends on nothing. |
+| `@kunai/design`    | Design tokens and color resolution. Depends on nothing.                                        |
+| `@kunai/schemas`   | Runtime validation for untrusted or persisted data                                             |
+| `@kunai/core`      | Provider engine, cycle engine, failure classifier, cache-key and manifest policy               |
+| `@kunai/config`    | Config schema, defaults, and parsing — the shape `ConfigService` persists                      |
+| `@kunai/providers` | Provider-specific extraction, decryption, source evidence                                      |
+| `@kunai/relay`     | Relay validation, host allowlists, fetch-port adapter                                          |
+| `@kunai/storage`   | SQLite paths, migrations, repositories, TTL helpers                                            |
 
 ## Not in the active runtime
 

--- a/.docs/repo-infrastructure.md
+++ b/.docs/repo-infrastructure.md
@@ -100,16 +100,23 @@ The invariant is enforced two ways:
 
 **Parallel jobs** (`.github/workflows/ci.yml`):
 
-| Job              | PR                                                                                    | Main         |
-| ---------------- | ------------------------------------------------------------------------------------- | ------------ |
-| `fmt`            | `turbo run fmt:check --affected`                                                      | full         |
-| `lint`           | `turbo run lint --affected`                                                           | full         |
-| `typecheck`      | `turbo run typecheck --affected`                                                      | full         |
-| `test`           | `turbo run test --affected` (CLI splits into cached `test:unit` + `test:integration`) | full         |
-| `windows-cli`    | root typecheck + CLI tests when CLI paths change                                      | same on main |
-| `build-cli`      | `bun run build` + `bun run pkg:check` when CLI paths change                           | same on main |
-| `build-binaries` | 2 Linux targets via Turbo when CLI/installer paths change                             | same         |
-| `checks-docs`    | docs gate when docs paths change                                                      | same         |
+| Job                   | PR                                                                                    | Main         |
+| --------------------- | ------------------------------------------------------------------------------------- | ------------ |
+| `fmt`                 | `turbo run fmt:check --affected`                                                      | full         |
+| `lint`                | `turbo run lint --affected`                                                           | full         |
+| `typecheck`           | `turbo run typecheck --affected`                                                      | full         |
+| `test`                | `turbo run test --affected` (CLI splits into cached `test:unit` + `test:integration`) | full         |
+| `windows-cli`         | root typecheck + CLI tests when CLI paths change                                      | same on main |
+| `build-cli`           | `bun run build` + `bun run pkg:check` when CLI paths change                           | same on main |
+| `build-binaries`      | 2 Linux targets via Turbo when CLI/installer paths change                             | same         |
+| `checks-docs`         | docs gate when docs paths change                                                      | same         |
+| `checks-doc-coverage` | `verify:doc-coverage` when a scanned code root or the feature map changes             | same         |
+
+`checks-doc-coverage` is separate from `checks-docs` on purpose. Its trigger is
+every directory the gate scans (`apps/cli/src/{services,domain,infra,app}`,
+`packages/**`), because a new unrouted directory arrives as new _code_ files and
+would otherwise skip the check meant to catch it. It runs `setup-bun` without
+`bun install` — the script imports only `node:fs` and `node:path`.
 
 Install cache key: `${{ runner.os }}-bun-store-${{ hashFiles('bun.lock') }}` covering
 `~/.bun/install/cache` only (Bun reconstructs `node_modules` from the store).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       cli: ${{ steps.filter.outputs.cli }}
       docs: ${{ steps.filter.outputs.docs }}
+      doc-coverage: ${{ steps.filter.outputs.doc-coverage }}
       installer: ${{ steps.filter.outputs.installer }}
       installer-matrix: ${{ steps.installer-matrix.outputs.cells }}
     steps:
@@ -71,6 +72,19 @@ jobs:
               - 'turbo.json'
               - 'package.json'
               - 'bun.lock'
+            # verify:doc-coverage fails when a code area has no route in the
+            # feature map. A new directory arrives as new files, so the trigger
+            # has to be the scanned roots themselves — not just doc paths, or a
+            # pure-code PR would add an unrouted directory and skip the gate
+            # that exists to catch exactly that.
+            doc-coverage:
+              - 'apps/cli/src/services/**'
+              - 'apps/cli/src/domain/**'
+              - 'apps/cli/src/infra/**'
+              - 'apps/cli/src/app/**'
+              - 'packages/**'
+              - '.docs/feature-map.md'
+              - 'scripts/verify-doc-coverage.ts'
             installer:
               - 'apps/cli/scripts/build*.ts'
               - 'apps/cli/src/services/update/**'
@@ -409,6 +423,29 @@ jobs:
           bun run --cwd apps/docs lint
           bun run --cwd apps/docs test
           bun run --cwd apps/docs build:app
+
+  # Deliberately its own job rather than a step in Docs build: the coverage gate
+  # has a much broader trigger (any code directory) than the docs site build, and
+  # folding it in would either run the site build on every service edit or leave
+  # the gate skipped on the PRs most likely to trip it.
+  checks-doc-coverage:
+    name: Docs coverage
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.doc-coverage == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # No `bun install`: verify-doc-coverage.ts imports only node:fs and
+      # node:path, so the workspace install would be pure latency here.
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Verify every code area is routed in the feature map
+        run: bun run verify:doc-coverage
 
   build-binaries:
     name: Build linux binaries

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "verify:build-pipeline:all-targets": "bun run scripts/verify-build-pipeline.ts --all-targets",
     "verify:readme:commands": "bun run scripts/verify-readme-commands.ts",
     "verify:doc-paths": "bun run scripts/verify-doc-paths.ts",
+    "verify:doc-coverage": "bun run scripts/verify-doc-coverage.ts",
     "release:dry-run": "bun run --cwd apps/cli release:dry-run",
     "changeset": "bunx changeset",
     "version:packages": "bunx changeset version && bun run scripts/sync-npm-platform-versions.ts && bun run scripts/sync-root-changelog.ts && bun run release:notes",

--- a/scripts/verify-doc-coverage.ts
+++ b/scripts/verify-doc-coverage.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env bun
+// =============================================================================
+// verify-doc-coverage.ts — fail when a code area has no route in the feature map.
+//
+// verify-doc-paths.ts catches docs pointing at code that moved. This catches the
+// opposite: code that exists with nothing pointing at it. A directory nobody
+// documented is a directory the next agent will either miss or reimplement.
+//
+// Every second-level directory under apps/cli/src/{services,domain,infra,app}
+// and every packages/* must appear somewhere in .docs/feature-map.md.
+//
+// Usage:
+//   bun run verify:doc-coverage
+// =============================================================================
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dir, "..");
+const FEATURE_MAP = join(ROOT, ".docs/feature-map.md");
+
+/** Roots whose immediate subdirectories each need a route. */
+const COVERED_ROOTS = [
+  "apps/cli/src/services",
+  "apps/cli/src/domain",
+  "apps/cli/src/infra",
+  "apps/cli/src/app",
+  "packages",
+];
+
+/**
+ * Directories deliberately absent from the feature map. Each needs a reason —
+ * "it is small" is not one. Prefer adding a row over adding an entry here.
+ */
+const EXEMPT = new Map<string, string>([
+  ["apps/cli/src/app/compiled-smoke", "test fixture provider, not a runtime feature"],
+]);
+
+function subdirectories(relativeRoot: string): string[] {
+  const absolute = join(ROOT, relativeRoot);
+  if (!existsSync(absolute)) return [];
+  return readdirSync(absolute, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => `${relativeRoot}/${entry.name}`);
+}
+
+const featureMap = readFileSync(FEATURE_MAP, "utf8");
+
+/**
+ * A directory counts as routed if the map names its path, or names it as a
+ * bare segment under a shorthand parent (the map writes `services/youtube/*`
+ * as often as the full path).
+ */
+function isRouted(directory: string): boolean {
+  if (featureMap.includes(directory)) return true;
+  const shorthand = directory.replace(/^apps\/cli\/src\//, "");
+  if (featureMap.includes(shorthand)) return true;
+  const packageName = directory.replace(/^packages\//, "@kunai/");
+  return featureMap.includes(packageName);
+}
+
+const missing = COVERED_ROOTS.flatMap(subdirectories)
+  .filter((directory) => !EXEMPT.has(directory))
+  .filter((directory) => !isRouted(directory));
+
+if (missing.length > 0) {
+  console.error(`\nCode areas with no route in .docs/feature-map.md (${missing.length}):\n`);
+  for (const directory of missing) {
+    const fileCount = readdirSync(join(ROOT, directory)).length;
+    console.error(`  ${directory}  (${fileCount} entries)`);
+  }
+  console.error(
+    `\nAdd a row to .docs/feature-map.md saying what owns this area, or add it to
+EXEMPT with a reason. A directory nobody routed is one the next agent misses.\n`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `verify:doc-coverage — every code area under ${COVERED_ROOTS.length} roots is routed in the feature map.`,
+);


### PR DESCRIPTION
## What

`verify:doc-paths` catches docs pointing at code that moved. This catches the opposite: **code that exists with nothing routing to it** — a directory nobody documented is one the next agent either misses or reimplements.

Every second-level directory under `apps/cli/src/{services,domain,infra,app}` and every `packages/*` must appear in `.docs/feature-map.md`, or be listed in `EXEMPT` with a reason.

## Where this came from

Salvaged from **#23**, which is superseded — that same work landed on `main` via merge `6d9098bf` (branch `docs/agent-context-surface`), and #23 is a parallel branch that now conflicts across 261 files. The doc-coverage gate is the one thing in it that never made it over.

## Why it's two files, not one

The script cannot land on its own. Run against `main` as-is, it fails with **30 unrouted directories** — `services/providers`, `services/persistence`, `domain/playback`, `infra/timing`, `packages/schemas` and 25 more. It only passes alongside the feature-map rows that route them, which is why `.docs/feature-map.md` comes with it (+92/-40).

Those rows are a **strict superset** of what `main`'s feature map already had — I diffed every backticked path across both versions and `main` has zero rows that this version lacks, so nothing existing is lost.

## Test plan

- [x] `bun run verify:doc-coverage` — passes; every code area under all 5 roots is routed
- [x] `bun run verify:doc-paths` — 45 docs scanned, all paths resolve (so the new rows point at real directories)
- [x] Spot-checked that newly routed paths exist on disk
- [x] `bun run fmt`

## CI wiring

Now wired, as its own `Docs coverage` job rather than a step in `Docs build`.
The two need different triggers: the docs site build keys off doc paths, while
the coverage gate has to fire on the code roots it scans. A new unrouted
directory arrives as new *code* files, so folding it into the docs job would
have skipped the check on exactly the PRs that introduce the problem.

Trigger (`doc-coverage` path filter): `apps/cli/src/{services,domain,infra,app}/**`,
`packages/**`, `.docs/feature-map.md`, `scripts/verify-doc-coverage.ts`. Not
always-on, so unrelated PRs don't pay for it.

The job runs `setup-bun` without `bun install` — the script imports only
`node:fs` and `node:path`, so the workspace install would be pure latency.
`.docs/repo-infrastructure.md` gains the job row and the rationale.

https://claude.ai/code/session_01GvsvjGP1oMYdA4aHK5xZNb
