### PR TITLE
fix(anidb): default AniDB and release-provider truth

### DIFF
--- a/.changeset/default-anidb-release-truth.md
+++ b/.changeset/default-anidb-release-truth.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Repair the default AniDB anime route across current browse parsing, provider-native identity, season and absolute-episode routing, and production-derived release signoff.

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -292,7 +292,8 @@ silently harvests browser tokens.
 - Implement provider module in `packages/providers/src/<provider>/direct.ts` implementing `CoreProviderModule`
 - Define manifest in `packages/providers/src/<provider>/manifest.ts` using `defineProviderManifest`
 - Export from `packages/providers/src/index.ts`
-- Register the module in `apps/cli/src/container.ts` — the `createProviderEngine()` call
+- Register the module in `apps/cli/src/container/bootstrap-providers.ts` —
+  `loadProductionProviderModules()` is the single production provider list
 - The `ProviderRegistry` (engine compat wrapper) is built automatically from engine modules
 
 No separate CLI adapter file is needed. The `createProviderFromModule()` factory in `apps/cli/src/services/providers/Provider.ts` creates the CLI `Provider` wrapper with `resolveStream` (calls module), `metadata`, `canHandle`, and optional `search`/`listEpisodes`.
@@ -450,7 +451,13 @@ Recommended workflow:
 
 ## Active Beta Providers
 
-Active providers are registered in `apps/cli/src/container.ts` via `createProviderEngine({ modules: [...] })`.
+Active providers are registered in `apps/cli/src/container/bootstrap-providers.ts` via
+`loadProductionProviderModules()`. A module existing under `packages/providers/src/` does not make
+it live, and release signoff derives its cases from that list plus the configured lane defaults.
+
+`anidb` is the **default** provider-native anime catalog (`animeProvider: "anidb"`); `allanime` is
+the **fallback** (`animeProviderPriority: ["anidb", "allanime"]`); `miruro` stays manually
+selectable.
 
 | ID           | Content Types | Runtime     | Module Location                               |
 | ------------ | ------------- | ----------- | --------------------------------------------- |
@@ -465,8 +472,60 @@ Active providers are registered in `apps/cli/src/container.ts` via `createProvid
 
 Provider manifests expose `catalogIdentity` (`provider-native` | `anilist` | `tmdb`) via `resolveProviderCatalogIdentity()` in `@kunai/core`.
 
-- **AllAnime (`allanime`)** — `provider-native`. AniList-backed discovery results are remapped to opaque AllAnime show ids before resolve; `externalIds.anilistId` is preserved on merge.
+- **AniDB (`anidb`)** — `provider-native`, and the default anime route. Native ids must satisfy
+  `slug-positiveNumericSuffix`; numeric AniList ids and opaque AllAnime ids are not AniDB ids. The
+  AllManga Tier-1 lookup never runs for AniDB, and only a validated AniDB slug may be written to
+  `providerNativeIds.anidb` — otherwise the result keeps its catalog identity.
+- **AllAnime (`allanime`)** — `provider-native`, fallback anime route. AniList-backed discovery
+  results are remapped to opaque AllAnime show ids before resolve; `externalIds.anilistId` is
+  preserved on merge. An AllAnime lookup may populate only `providerNativeIds.allanime`.
 - **Miruro** — `anilist`. Discovery ids stay numeric AniList ids; no AllManga Tier-1 remapping runs.
+
+A catalog's own id space is numeric, so a non-numeric id is never accepted into the `anilistId` or
+`tmdbId` slot even when the active provider declares that catalog identity.
+
+### AniDB catalog search compatibility
+
+Advanced AniDB discovery uses the explicitly declared compatible AniList catalog
+(`compatibleProviders` in `apps/cli/src/services/search/definitions/`), retaining AniList identity
+until a validated AniDB slug is found. It **never** falls through to the default TMDB catalog: when
+no compatible catalog exists, `SearchRoutingService` returns either a diagnosed provider-native
+fallback or an `unsupported` result carrying filter evidence, each with
+`attemptedDefaultFallback: false`.
+
+### AniDB browse parsing
+
+`packages/providers/src/anidb/browse-parser.ts` is the single parser for both markup generations,
+used by search and resolve so they cannot drift apart:
+
+- It captures the complete anchor opening tag first and only then parses and validates `href`;
+  href matching never delimits the attributes used for title extraction.
+- Attribute matching is anchored on a start-or-whitespace boundary, so `data-href`, `xlink:href`
+  and `data-original-title` cannot shadow the real attribute.
+- Title precedence is anchor `title` / `aria-label` → image `alt` → nested text, so a `title`
+  placed after `href` still wins.
+- Legacy relative `/anime/<slug-id>` cards and current absolute `https://anidb.app/anime/<slug-id>`
+  cards both parse; entities decode in a single pass; rows without a positive numeric suffix are
+  rejected; results dedupe by validated slug.
+- Only anchors carrying result-card evidence (a `title`/`aria-label` attribute or nested card
+  markup) become results, so nav, breadcrumb, related-rail and footer links cannot become
+  `results[0]` and pin the wrong show.
+
+### AniDB season routing and episode numbering
+
+AniDB models each season as its own title, so `routeAnidbSeason()` in
+`packages/providers/src/anidb/season-routing.ts` decides identity and numbering from evidence:
+
+- Season 1 retains the base title.
+- Season 2+ searches `<normalized base> Season N` and requires both a matching parsed season and
+  exact/prefix normalized base-title evidence. An ambiguous best score fails closed with a
+  structured `not-found` rather than resolving the wrong title.
+- `absoluteEpisode` survives CLI adaptation but is consumed **only** when the routed title's own
+  resolved AniDB episode catalog contains that exact episode number. A missing season label is not
+  evidence. A season-specific title, an unconfirmed base, and every routed season sibling use the
+  one-based cour episode.
+- The resolve trace records requested season, base id, routed id, route evidence, numbering
+  evidence and reason, episode number, and whether the absolute episode was used.
 
 ### Title identity persistence contract
 

--- a/.docs/research/anidb-provider-dossier.md
+++ b/.docs/research/anidb-provider-dossier.md
@@ -22,7 +22,19 @@
 
 ## Known
 
-- Search: `GET /browse?q=%s` HTML; parse `anime/{slug}-{id}` + `alt="title"`
+- Search: `GET /browse?q=%s` HTML
+- Browse parser captures the complete anchor opening tag before separately parsing
+  and validating `href`; it accepts legacy relative `/anime/<slug-id>` cards with
+  image `alt` titles and current absolute `https://anidb.app/anime/<slug-id>` cards
+  where anchor `title`/`aria-label` precedes image `alt` and nested text.
+- Search results require a positive numeric AniDB suffix and carry parsed season
+  evidence.
+- Season 1 retains the base AniDB id. Season 2+ requires a unique normalized-title
+  and explicit-season match; ambiguity fails closed.
+- A missing season label is not absolute-numbering evidence. `absoluteEpisode` is
+  used only when the retained base title's resolved AniDB episode catalog contains
+  that exact episode; otherwise the retained base and every routed season sibling
+  use the one-based cour episode.
 - Episodes: `GET /api/frontend/anime/{numericId}/episodes` → `{episodes:[{id,number,filler}]}`
 - Languages: `GET /api/frontend/episode/{epId}/languages` → `embed_url` per `jpn` / `eng`
 - Embed HTML: `file: 'https://hls.anidb.app/.../master.m3u8'`
@@ -33,7 +45,6 @@
 ## Suspected
 
 - Some regions may need curl-impersonate (ani-cli dies on "Just a moment")
-- Season picker on anime pages exists but is optional for v1
 
 ## Unknown
 

--- a/apps/cli/src/app/discover/anime-provider-mapping.ts
+++ b/apps/cli/src/app/discover/anime-provider-mapping.ts
@@ -1,7 +1,7 @@
 import type { SearchResult, ShellMode, TitleAlias } from "@/domain/types";
 import type { ProviderRegistry } from "@/services/providers/ProviderRegistry";
 import { mergeProviderNativeId } from "@kunai/core";
-import { searchAllManga, type AllMangaSearchResult } from "@kunai/providers";
+import { looksLikeAnidbShowId, searchAllManga, type AllMangaSearchResult } from "@kunai/providers";
 import type { ProviderId } from "@kunai/types";
 
 export type AnimeProviderMappingContext = {
@@ -48,8 +48,10 @@ export async function mapAnimeDiscoveryResultToProviderNative(
   const discoveryAniListId = parseInt(result.id, 10);
   const searchProviderNative = context.searchProviderNative ?? searchAllManga;
 
-  // Tier 1: Direct AniList ID match via API (fast, accurate) — AllAnime opaque id only
-  if (!isNaN(discoveryAniListId)) {
+  // Tier 1: Direct AniList ID match via the AllManga API. This returns AllAnime
+  // opaque ids, so it may only ever populate the allanime id slot — writing one
+  // into another provider's slot pins an id that provider cannot resolve.
+  if (context.providerId === "allanime" && !Number.isNaN(discoveryAniListId)) {
     const animeLang =
       context.animeLanguageProfile.audio === "ja" ||
       context.animeLanguageProfile.audio === "original"
@@ -65,27 +67,19 @@ export async function mapAnimeDiscoveryResultToProviderNative(
         animeLang,
         context.signal,
       ).catch(() => []);
-      const idMatch = matches.find((r) => r.aniListId === discoveryAniListId);
-      if (idMatch)
-        return mergeAniListDiscoveryWithProviderResult(
-          result,
-          idMatch,
-          context.providerId,
-          context,
-        );
-      const titleMatch = chooseProviderSearchMatch(result, matches);
-      if (titleMatch)
-        return mergeAniListDiscoveryWithProviderResult(
-          result,
-          titleMatch,
-          context.providerId,
-          context,
-        );
+      const match =
+        matches.find((candidate) => candidate.aniListId === discoveryAniListId) ??
+        chooseProviderSearchMatch(result, matches);
+      if (match) {
+        return mergeAniListDiscoveryWithProviderResult(result, match, "allanime", context);
+      }
     }
   }
 
-  // Tier 2: Title-based match via provider search (testable via mock)
-  if (!provider?.search) return result;
+  // Tier 2: Title-based match via the active provider's own search. Every match
+  // must be an id the active provider actually owns, otherwise we fail closed to
+  // catalog identity rather than pinning a foreign id.
+  if (!provider?.search) return ensureAniListDiscoveryExternalIds(result);
 
   for (const query of providerSearchQueries(result)) {
     const providerResults = await provider
@@ -101,9 +95,14 @@ export async function mapAnimeDiscoveryResultToProviderNative(
 
     if (!providerResults?.length) continue;
 
+    const owned = providerResults.filter((candidate) =>
+      isValidProviderNativeId(context.providerId, candidate.id),
+    );
+    if (owned.length === 0) continue;
+
     // Try numeric ID match on provider results
     if (!isNaN(discoveryAniListId)) {
-      const idMatch = providerResults.find((r) => r.id === discoveryAniListId.toString());
+      const idMatch = owned.find((r) => r.id === discoveryAniListId.toString());
       if (idMatch) {
         return mergeAniListDiscoveryWithProviderResult(
           result,
@@ -114,12 +113,24 @@ export async function mapAnimeDiscoveryResultToProviderNative(
       }
     }
 
-    const match = chooseProviderSearchMatch(result, providerResults.map(toAllMangaResult));
+    const match = chooseProviderSearchMatch(result, owned.map(toAllMangaResult));
     if (match)
       return mergeAniListDiscoveryWithProviderResult(result, match, context.providerId, context);
   }
 
-  return result;
+  return ensureAniListDiscoveryExternalIds(result);
+}
+
+/**
+ * Does `id` belong to `providerId`'s own id space? Fail closed: a provider-native
+ * id slot must never receive another catalog's id, because resolve trusts it.
+ */
+function isValidProviderNativeId(providerId: string, id: string): boolean {
+  const trimmed = id.trim();
+  if (!trimmed) return false;
+  if (providerId === "anidb") return looksLikeAnidbShowId(trimmed);
+  if (providerId === "allanime") return !/^\d+$/.test(trimmed);
+  return true;
 }
 
 function shouldRemapDiscoveryToProviderNative(result: SearchResult): boolean {
@@ -256,9 +267,11 @@ function mergeAniListDiscoveryWithProviderResult(
     posterSource: discovery.posterPath
       ? discovery.posterSource
       : providerResult.posterUrl
-        ? "AllManga"
+        ? providerId
         : undefined,
-    metadataSource: `${discovery.metadataSource} + allanime search`,
+    // Name the provider that actually supplied the identity; this string is
+    // surfaced to the user as "Metadata source".
+    metadataSource: `${discovery.metadataSource} + ${providerId} search`,
     episodeCount: providerResult.epCount ?? discovery.episodeCount,
   };
 }

--- a/apps/cli/src/app/search/SearchPhase.ts
+++ b/apps/cli/src/app/search/SearchPhase.ts
@@ -565,6 +565,7 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
               strategy: search.strategy,
               source: search.sourceId,
               filters: search.evidence,
+              diagnosis: search.diagnosis?.code,
             });
             diagnosticsService.record(
               buildSearchDiagnosticEvent({
@@ -579,6 +580,7 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
                   strategy: search.strategy,
                   source: search.sourceId,
                   filters: search.evidence,
+                  diagnosis: search.diagnosis?.code,
                 },
               }),
             );

--- a/apps/cli/src/cli-args.ts
+++ b/apps/cli/src/cli-args.ts
@@ -48,7 +48,7 @@ LAUNCH
   -S, --search <query>       Search for a title on launch
   -i, --id <id>              Open a specific title id
   -t, --type <movie|tv>      Content type for --id (tv = series)
-  -a, --anime                Anime mode (AllAnime providers)
+  -a, --anime                Anime mode (AniDB default with provider fallback)
   -y, --youtube              YouTube mode (YouTube provider)
       --continue, --resume   Jump into Continue Watching
       --history              Open watch history

--- a/apps/cli/src/container/bootstrap-providers.ts
+++ b/apps/cli/src/container/bootstrap-providers.ts
@@ -4,6 +4,7 @@ import {
   orderProviderModulesByPriority,
   type CoreProviderModule,
   type ProviderEngine,
+  type ProviderPriorityInput,
 } from "@kunai/core";
 import { buildProviderRelayRegistry, createRelayFetchPort } from "@kunai/relay";
 
@@ -27,8 +28,13 @@ export type ProviderBootstrap = {
   readonly playbackResolveWork: PlaybackResolveWorkService;
 };
 
-async function loadProductionProviderModules(
-  providerPriority: ReturnType<typeof createProviderPrioritySnapshot>,
+/**
+ * The single production provider list. Exported so contract tests can prove the
+ * configured lane defaults are actually registered without building a second
+ * registry that could drift from this one.
+ */
+export async function loadProductionProviderModules(
+  providerPriority: ProviderPriorityInput,
 ): Promise<readonly CoreProviderModule[]> {
   const [
     { videasyProviderModule },

--- a/apps/cli/src/services/providers/stream-request-adapter.ts
+++ b/apps/cli/src/services/providers/stream-request-adapter.ts
@@ -181,6 +181,7 @@ export function episodeToCoreIdentity(
   return {
     season: episode.season,
     episode: episode.episode,
+    absoluteEpisode: episode.absoluteEpisode,
     title: episode.name,
     airDate: episode.airDate,
     release: episode.release,

--- a/apps/cli/src/services/search/SearchRoutingService.ts
+++ b/apps/cli/src/services/search/SearchRoutingService.ts
@@ -23,13 +23,31 @@ export type SearchRoutingContext = {
   enrichAnimeMetadata?: boolean;
 };
 
+/**
+ * Why an advanced search could not use a declared compatible catalog. Advanced
+ * search must never silently fall through to the default TMDB catalog, because
+ * that changes the catalog identity of the returned titles without saying so.
+ */
+export type SearchRoutingDiagnosis =
+  | {
+      readonly code: "provider-native-fallback";
+      readonly providerId: string;
+      readonly attemptedDefaultFallback: false;
+    }
+  | {
+      readonly code: "compatible-catalog-unavailable";
+      readonly providerId: string;
+      readonly attemptedDefaultFallback: false;
+    };
+
 export type SearchRoutingResult = {
   readonly results: SearchResult[];
   readonly resolvedLane: ProviderLane;
   readonly sourceId: string;
   readonly sourceName: string;
-  readonly strategy: "provider-native" | "registry";
+  readonly strategy: "provider-native" | "registry" | "unsupported";
   readonly evidence: SearchFilterEvidence;
+  readonly diagnosis?: SearchRoutingDiagnosis;
 };
 
 export type SearchFilterEvidence = {
@@ -82,23 +100,78 @@ export async function searchTitles(
   }
 
   if (advanced) {
-    const searchService =
-      context.searchRegistry.getForProvider(routing.providerId) ??
-      context.searchRegistry.getDefault();
-    const evidence = classifySearchEvidence(intent, searchService.metadata.id, context.mode);
-    const results = applyLocalSearchFilters(
-      await searchService.search(query, context.signal, intent),
-      intent,
-      evidence,
-    );
+    const compatibleSearch = context.searchRegistry.getForProvider(routing.providerId);
+    if (compatibleSearch) {
+      const evidence = classifySearchEvidence(intent, compatibleSearch.metadata.id, context.mode);
+      const results = applyLocalSearchFilters(
+        await compatibleSearch.search(query, context.signal, intent),
+        intent,
+        evidence,
+      );
+      return {
+        results: withResolvedSearchLane(results, resolvedLane),
+        resolvedLane,
+        sourceId: compatibleSearch.metadata.id,
+        sourceName: compatibleSearch.metadata.name,
+        strategy: "registry",
+        evidence,
+      };
+    }
 
+    // No declared compatible catalog. A provider-native search keeps the
+    // provider's own catalog identity, so it is safe; the default TMDB catalog
+    // is not, and is never consulted here.
+    if (provider?.search && query.trim().length > 0) {
+      const evidence = classifySearchEvidence(intent, provider.metadata.id, context.mode);
+      const results =
+        (await provider.search(
+          query,
+          {
+            audioPreference: context.animeLanguageProfile.audio,
+            subtitlePreference: context.animeLanguageProfile.subtitle,
+          },
+          context.signal,
+        )) ?? [];
+      return {
+        results: withResolvedSearchLane(
+          applyLocalSearchFilters(results.map(normalizeProviderSearchResult), intent, evidence),
+          resolvedLane,
+        ),
+        resolvedLane,
+        sourceId: provider.metadata.id,
+        sourceName: provider.metadata.name,
+        strategy: "provider-native",
+        evidence,
+        diagnosis: {
+          code: "provider-native-fallback",
+          providerId: routing.providerId,
+          attemptedDefaultFallback: false,
+        },
+      };
+    }
+
+    // The ambient session mode is not a filter that failed to apply, so it is
+    // only reported when the search deliberately crossed modes — matching how
+    // classifySearchEvidence() treats the mode key on every other path.
+    const unsupported = [
+      ...describeSearchIntentFilters({
+        mode: intent.mode === "all" || intent.mode === context.mode ? undefined : intent.mode,
+        filters: intent.filters,
+        sort: intent.sort,
+      }),
+    ];
     return {
-      results: withResolvedSearchLane(results, resolvedLane),
+      results: [],
       resolvedLane,
-      sourceId: searchService.metadata.id,
-      sourceName: searchService.metadata.name,
-      strategy: "registry",
-      evidence,
+      sourceId: routing.providerId,
+      sourceName: provider?.metadata.name ?? routing.providerId,
+      strategy: "unsupported",
+      evidence: { upstream: [], local: [], unsupported },
+      diagnosis: {
+        code: "compatible-catalog-unavailable",
+        providerId: routing.providerId,
+        attemptedDefaultFallback: false,
+      },
     };
   }
 

--- a/apps/cli/src/services/search/definitions/anilist.ts
+++ b/apps/cli/src/services/search/definitions/anilist.ts
@@ -32,7 +32,7 @@ export class AniListSearchService implements SearchService {
     description: "AniList GraphQL search and advanced anime discovery",
   };
 
-  readonly compatibleProviders = ["allanime", "allmanga", "miruro", "hianime"];
+  readonly compatibleProviders = ["anidb", "allanime", "allmanga", "miruro", "hianime"];
 
   constructor(private deps: SearchDeps) {}
 

--- a/apps/cli/src/services/search/definitions/index.ts
+++ b/apps/cli/src/services/search/definitions/index.ts
@@ -16,7 +16,7 @@ export const SEARCH_SERVICE_DEFINITIONS: SearchServiceDefinition[] = [
       name: "AniList",
       description: "AniList GraphQL search and advanced anime discovery",
     },
-    compatibleProviders: ["allanime", "allmanga", "miruro", "hianime"],
+    compatibleProviders: ["anidb", "allanime", "allmanga", "miruro", "hianime"],
     factory: createAniListSearchService,
   },
   {

--- a/apps/cli/test/integration/anime-discovery-resolve-handoff.test.ts
+++ b/apps/cli/test/integration/anime-discovery-resolve-handoff.test.ts
@@ -163,6 +163,53 @@ describe("anime discovery → resolve handoff (CLI-shaped)", () => {
     { timeout: 60_000 },
   );
 
+  test("anidb handoff uses only AniDB-native search and preserves absolute identity", async () => {
+    const { container, dispose } = await createIsolatedContainer("anidb-handoff");
+    disposers.push(dispose);
+
+    let allMangaCalls = 0;
+    const originalWhich = Bun.which;
+    const originalFetch = globalThis.fetch;
+
+    try {
+      // Keep the deterministic suite off anidb.app: force the fetch path and
+      // answer the browse request from a fixture-shaped response.
+      Bun.which = ((_cmd: string) => null) as typeof Bun.which;
+      globalThis.fetch = (async (input: unknown) => {
+        const url = String(
+          typeof input === "string" ? input : ((input as { url?: string })?.url ?? input),
+        );
+        if (url.includes("anidb.app/browse")) {
+          return new Response(
+            '<a href="https://anidb.app/anime/solo-leveling-19413" title="Solo Leveling"><article></article></a>',
+            { status: 200 },
+          );
+        }
+        throw new Error(`unexpected network call: ${url}`);
+      }) as unknown as typeof fetch;
+
+      const { mapped, resolveInput } = await handoffAniListSearchPick(container, {
+        discovery: SOLO_LEVELING,
+        providerId: "anidb",
+        episode: { season: 2, episode: 1, absoluteEpisode: 13 },
+        searchProviderNative: async () => {
+          allMangaCalls += 1;
+          return [];
+        },
+      });
+
+      const nativeAnidbId = mapped.externalIds?.providerNativeIds?.anidb;
+      expect(allMangaCalls).toBe(0);
+      expect(nativeAnidbId).toMatch(/-\d+$/);
+      expect(mapped.externalIds?.providerNativeIds?.allanime).toBeUndefined();
+      expect(resolveInput.title.id).toBe(nativeAnidbId as string);
+      expect(resolveInput.episode).toEqual({ season: 2, episode: 1, absoluteEpisode: 13 });
+    } finally {
+      globalThis.fetch = originalFetch;
+      Bun.which = originalWhich;
+    }
+  });
+
   liveProviderTest(
     "miruro resolves a playable stream after AniList search handoff (Farming Life S2)",
     async () => {
@@ -172,7 +219,7 @@ describe("anime discovery → resolve handoff (CLI-shaped)", () => {
       const { request, resolveInput, title } = await handoffAniListSearchPick(container, {
         discovery: FARMING_LIFE_S2,
         providerId: "miruro",
-        episode: 1,
+        episode: { season: 1, episode: 1 },
       });
 
       expect(title.id).toBe("197824");

--- a/apps/cli/test/integration/helpers/anime-search-handoff.ts
+++ b/apps/cli/test/integration/helpers/anime-search-handoff.ts
@@ -5,6 +5,7 @@ import type { Container } from "@/container";
 import type { SearchResult, TitleInfo } from "@/domain/types";
 import type { StreamRequest } from "@/services/providers/Provider";
 import { streamRequestToResolveInput } from "@/services/providers/stream-request-adapter";
+import { resolveProviderCatalogIdentity } from "@kunai/core";
 import type { searchAllManga } from "@kunai/providers";
 import type { ProviderResolveInput } from "@kunai/types";
 
@@ -14,7 +15,11 @@ export async function handoffAniListSearchPick(
   options: {
     readonly discovery: SearchResult;
     readonly providerId: string;
-    readonly episode?: number;
+    readonly episode?: {
+      readonly season: number;
+      readonly episode: number;
+      readonly absoluteEpisode?: number;
+    };
     readonly searchProviderNative?: typeof searchAllManga;
     readonly signal?: AbortSignal;
   },
@@ -40,15 +45,28 @@ export async function handoffAniListSearchPick(
 
   const request: StreamRequest = {
     title,
-    episode: { season: 1, episode: options.episode ?? 1 },
+    episode: options.episode ?? { season: 1, episode: 1 },
     audioPreference: container.config.animeLanguageProfile.audio,
     subtitlePreference: container.config.animeLanguageProfile.subtitle,
   };
+
+  // Mirror production: resolve input carries the selected provider's manifest
+  // catalog identity and provider id, not an untyped default.
+  const manifest = container.providerRegistry.getManifest(options.providerId);
+  if (!manifest) {
+    throw new Error(`Missing provider manifest: ${options.providerId}`);
+  }
 
   return {
     mapped,
     title,
     request,
-    resolveInput: streamRequestToResolveInput(request, "anime"),
+    resolveInput: streamRequestToResolveInput(
+      request,
+      "anime",
+      "play",
+      resolveProviderCatalogIdentity(manifest),
+      options.providerId,
+    ),
   };
 }

--- a/apps/cli/test/live/anidb-onigiri.smoke.ts
+++ b/apps/cli/test/live/anidb-onigiri.smoke.ts
@@ -1,4 +1,4 @@
-import type { TitleInfo } from "@/domain/types";
+import { titleInfoFromSearchResult } from "@/app/bootstrap/title-info";
 
 import {
   buildProviderSmokePayload,
@@ -10,12 +10,11 @@ import {
 import { directSmokeArgs } from "./smoke-argv";
 
 const profile = createProviderSmokeProfile("anidb");
-// bun path/to/smoke.ts [episode] [showId] [title...]
+// bun path/to/smoke.ts [episode] [search query...]
 const args = directSmokeArgs();
 
 const episode = Number(args[0] ?? "1");
-const showId = args[1] ?? "onigiri-3942";
-const titleName = args.slice(2).join(" ") || "Onigiri";
+const searchQuery = args.slice(1).join(" ") || "Onigiri";
 const clearCache = process.env.KITSUNE_CLEAR_CACHE === "1";
 
 const { createContainer } = await import("@/container");
@@ -31,13 +30,42 @@ if (clearCache) {
   await container.cacheStore.clear();
 }
 
-const title: TitleInfo = {
-  id: showId,
-  type: "series",
-  name: titleName,
-  isAnime: true,
-  externalIds: { providerNativeIds: { anidb: showId } },
-};
+// Search through the default provider itself. A hard-coded native id would let
+// this smoke pass while AniDB search — the route users actually take — is dead.
+if (!provider.search) {
+  console.error(JSON.stringify({ ok: false, stage: "search", reason: "anidb_has_no_search" }));
+  process.exit(1);
+}
+
+const searchResults =
+  (await provider.search(searchQuery, {
+    audioPreference: container.config.animeLanguageProfile.audio,
+    subtitlePreference: container.config.animeLanguageProfile.subtitle,
+  })) ?? [];
+
+const normalizeTitle = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+const selected =
+  searchResults.find((result) => normalizeTitle(result.title) === normalizeTitle(searchQuery)) ??
+  searchResults[0];
+
+if (!selected) {
+  console.error(
+    JSON.stringify({
+      ok: false,
+      stage: "search",
+      searchedProvider: "anidb",
+      searchResults: 0,
+      reason: `anidb search returned zero results for "${searchQuery}"`,
+    }),
+  );
+  process.exit(1);
+}
+
+const title = titleInfoFromSearchResult(selected, selected.title);
 
 let resolveError: unknown = null;
 let failureCodes: readonly string[] = [];
@@ -75,6 +103,8 @@ const payload = {
     resolveDurationMs,
   }),
   ...(resolveError ? providerSmokeError(resolveError) : {}),
+  searchedProvider: "anidb",
+  searchResults: searchResults.length,
   failureCodes,
   failureMessages,
   streamCandidates,

--- a/apps/cli/test/live/provider-smoke.ts
+++ b/apps/cli/test/live/provider-smoke.ts
@@ -8,7 +8,9 @@ import { providerResolveResultToStreamInfo } from "@/services/providers/provider
 import { streamRequestToResolveInput } from "@/services/providers/stream-request-adapter";
 import {
   ProviderResolveFailureError,
+  resolveProviderCatalogIdentity,
   summarizeProviderTraceEvents,
+  type CoreProviderManifest,
   type ProviderTraceEventSummary,
 } from "@kunai/core";
 import { getKunaiPaths, type StoragePlatform } from "@kunai/storage";
@@ -144,6 +146,7 @@ export async function resolveProviderSmokeStream({
   readonly container: {
     readonly engine: {
       get(providerId: string): unknown;
+      getManifest(providerId: string): CoreProviderManifest | undefined;
       resolve(
         input: ReturnType<typeof streamRequestToResolveInput>,
         providerId: string,
@@ -162,9 +165,22 @@ export async function resolveProviderSmokeStream({
     throw new Error(`Missing provider module: ${providerId}`);
   }
 
+  // Select title identity exactly the way production does, so a smoke pass
+  // cannot come from an identity shortcut the real app never takes.
+  const manifest = container.engine.getManifest(providerId);
+  if (!manifest) {
+    throw new Error(`Missing provider manifest: ${providerId}`);
+  }
+
   const startedAt = Date.now();
   const result = await container.engine.resolve(
-    streamRequestToResolveInput(request, mode),
+    streamRequestToResolveInput(
+      request,
+      mode,
+      "play",
+      resolveProviderCatalogIdentity(manifest),
+      providerId,
+    ),
     providerId,
   );
   return {

--- a/apps/cli/test/live/release-provider-routes.ts
+++ b/apps/cli/test/live/release-provider-routes.ts
@@ -1,0 +1,117 @@
+/**
+ * Derivation of release-signoff cases from runtime configuration and the
+ * registered production provider modules.
+ *
+ * Release signoff previously hard-coded which providers it exercised, so it
+ * could report a green release while proving a provider the product does not
+ * actually default to. Cases are now derived from config, and a configured
+ * default that is not a registered production module fails before any network
+ * work happens.
+ */
+
+import { titleInfoFromSearchResult } from "@/app/bootstrap/title-info";
+import type { TitleInfo } from "@/domain/types";
+import type { Provider } from "@/services/providers/Provider";
+
+export type ReleaseProviderRouteCase =
+  | {
+      readonly lane: "movie" | "series";
+      readonly configuredProvider: string;
+      readonly mode: "series";
+      readonly title: TitleInfo;
+      readonly season?: number;
+      readonly episode?: number;
+    }
+  | {
+      readonly lane: "anime";
+      readonly configuredProvider: string;
+      readonly mode: "anime";
+      readonly searchQuery: "Onigiri";
+      readonly expectedTitle: "Onigiri";
+      readonly season: 1;
+      readonly episode: 1;
+    };
+
+export function buildReleaseProviderRouteCases(
+  config: { readonly provider: string; readonly animeProvider: string },
+  productionProviderIds: readonly string[],
+): readonly ReleaseProviderRouteCase[] {
+  const registered = new Set(productionProviderIds);
+  if (!registered.has(config.provider)) {
+    throw new Error(`Configured series release provider is not registered: ${config.provider}`);
+  }
+  if (!registered.has(config.animeProvider)) {
+    throw new Error(`Configured anime release provider is not registered: ${config.animeProvider}`);
+  }
+  return [
+    {
+      lane: "movie",
+      configuredProvider: config.provider,
+      mode: "series",
+      title: { id: "438631", type: "movie", name: "Dune", year: "2021" },
+    },
+    {
+      lane: "series",
+      configuredProvider: config.provider,
+      mode: "series",
+      title: { id: "299167", type: "series", name: "Dutton Ranch", year: "2026" },
+      season: 1,
+      episode: 1,
+    },
+    {
+      lane: "anime",
+      configuredProvider: config.animeProvider,
+      mode: "anime",
+      searchQuery: "Onigiri",
+      expectedTitle: "Onigiri",
+      season: 1,
+      episode: 1,
+    },
+  ];
+}
+
+/**
+ * Search the configured anime default and turn its own result into the resolve
+ * title. A zero-result search is provider drift, not a reason to fall back to a
+ * hard-coded native id — that is exactly how a broken default route used to pass
+ * signoff.
+ */
+export async function resolveReleaseAnimeSearchTitle(
+  route: Extract<ReleaseProviderRouteCase, { readonly lane: "anime" }>,
+  provider: Pick<Provider, "search">,
+  language: { readonly audio: string; readonly subtitle: string },
+  signal?: AbortSignal,
+): Promise<TitleInfo> {
+  if (!provider.search) {
+    throw new Error(
+      `Default anime provider "${route.configuredProvider}" has no search capability`,
+    );
+  }
+  const results =
+    (await provider.search(
+      route.searchQuery,
+      { audioPreference: language.audio, subtitlePreference: language.subtitle },
+      signal,
+    )) ?? [];
+  if (results.length === 0) {
+    throw new Error(
+      `Default anime provider "${route.configuredProvider}" search returned zero results for "${route.searchQuery}"`,
+    );
+  }
+  const normalizedExpected = normalizeTitle(route.expectedTitle);
+  const selected =
+    results.find((result) => normalizeTitle(result.title) === normalizedExpected) ?? results[0];
+  if (!selected) {
+    throw new Error(
+      `Default anime provider "${route.configuredProvider}" returned no selectable result`,
+    );
+  }
+  return titleInfoFromSearchResult(selected, selected.title);
+}
+
+function normalizeTitle(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}

--- a/apps/cli/test/live/release-provider-signoff.smoke.ts
+++ b/apps/cli/test/live/release-provider-signoff.smoke.ts
@@ -17,7 +17,6 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import type { TitleInfo } from "@/domain/types";
 import { isStreamReachableForResolve, probeStreamReachability } from "@kunai/providers";
 
 import {
@@ -26,54 +25,19 @@ import {
   resolveProviderSmokeStream,
 } from "./provider-smoke";
 import {
+  buildReleaseProviderRouteCases,
+  resolveReleaseAnimeSearchTitle,
+  type ReleaseProviderRouteCase,
+} from "./release-provider-routes";
+import {
   buildReleaseProviderSignoff,
   classifyReleaseSignoffFailure,
   redactVolatileSignoffText,
   type ReleaseProviderSignoffRoute,
-  type ReleaseSignoffLane,
 } from "./release-provider-signoff";
 
 const CLI_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
-
-type DefaultRouteFixture = {
-  readonly lane: ReleaseSignoffLane;
-  readonly configuredProvider: string;
-  readonly mode: "series" | "anime";
-  readonly title: TitleInfo;
-  readonly season?: number;
-  readonly episode?: number;
-};
-
-const DEFAULT_ROUTES: readonly DefaultRouteFixture[] = [
-  {
-    lane: "movie",
-    configuredProvider: "videasy",
-    mode: "series",
-    title: { id: "438631", type: "movie", name: "Dune", year: "2021" },
-  },
-  {
-    lane: "series",
-    configuredProvider: "videasy",
-    mode: "series",
-    title: { id: "299167", type: "series", name: "Dutton Ranch", year: "2026" },
-    season: 1,
-    episode: 1,
-  },
-  {
-    lane: "anime",
-    configuredProvider: "allanime",
-    mode: "anime",
-    title: {
-      id: "SJms742bSTrcyJZay",
-      type: "series",
-      name: "Kimetsu no Yaiba",
-      isAnime: true,
-    },
-    season: 1,
-    episode: 1,
-  },
-];
 
 function printJson(value: unknown): void {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
@@ -102,15 +66,26 @@ async function writeArtifact(path: string, payload: unknown): Promise<void> {
   await writeFile(absolute, `${JSON.stringify(payload, null, 2)}\n`);
 }
 
+function requireProvider(
+  container: Awaited<ReturnType<typeof import("@/container").createContainer>>,
+  providerId: string,
+) {
+  const provider = container.providerRegistry.get(providerId);
+  if (!provider) {
+    throw new Error(`Configured release provider is not registered: ${providerId}`);
+  }
+  return provider;
+}
+
 async function resolveRoute(
-  fixture: DefaultRouteFixture,
+  routeCase: ReleaseProviderRouteCase,
   container: Awaited<ReturnType<typeof import("@/container").createContainer>>,
 ): Promise<ReleaseProviderSignoffRoute> {
   const startedAt = Date.now();
   const language =
-    fixture.lane === "anime"
+    routeCase.lane === "anime"
       ? container.config.animeLanguageProfile
-      : fixture.lane === "movie"
+      : routeCase.lane === "movie"
         ? container.config.movieLanguageProfile
         : container.config.seriesLanguageProfile;
 
@@ -122,14 +97,26 @@ async function resolveRoute(
   let streamHeaders: Record<string, string> | undefined;
 
   try {
+    // The anime lane must prove the configured default can FIND the title
+    // itself. A zero-result search throws here and is classified as drift,
+    // without any engine resolve happening.
+    const title =
+      routeCase.lane === "anime"
+        ? await resolveReleaseAnimeSearchTitle(
+            routeCase,
+            requireProvider(container, routeCase.configuredProvider),
+            language,
+          )
+        : routeCase.title;
+
     const resolved = await resolveProviderSmokeStream({
       container,
-      providerId: fixture.configuredProvider,
-      mode: fixture.mode,
+      providerId: routeCase.configuredProvider,
+      mode: routeCase.mode,
       request: {
-        title: fixture.title,
-        ...(fixture.season !== undefined && fixture.episode !== undefined
-          ? { episode: { season: fixture.season, episode: fixture.episode } }
+        title,
+        ...(routeCase.season !== undefined && routeCase.episode !== undefined
+          ? { episode: { season: routeCase.season, episode: routeCase.episode } }
           : {}),
         audioPreference: language.audio,
         subtitlePreference: language.subtitle,
@@ -144,7 +131,7 @@ async function resolveRoute(
       resolved.stream?.url !== undefined && resolved.stream.url !== null
         ? (resolved.result.providerId ??
           resolved.result.trace.selectedProviderId ??
-          fixture.configuredProvider)
+          routeCase.configuredProvider)
         : null;
   } catch (error) {
     resolveError = error;
@@ -174,8 +161,8 @@ async function resolveRoute(
         : null;
 
   return {
-    lane: fixture.lane,
-    configuredProvider: fixture.configuredProvider,
+    lane: routeCase.lane,
+    configuredProvider: routeCase.configuredProvider,
     successfulProvider,
     resolved,
     streamCandidates,
@@ -202,9 +189,19 @@ if (process.env.KUNAI_LIVE_RELEASE_SIGNOFF !== "1") {
   const { createContainer } = await import("@/container");
   const container = await createContainer({ debug: true });
 
+  // Derive the cases from what the product actually defaults to, and prove each
+  // configured default is a registered production module before any network work.
+  const cases = buildReleaseProviderRouteCases(
+    {
+      provider: container.config.provider,
+      animeProvider: container.config.animeProvider,
+    },
+    container.engine.getProviderIds(),
+  );
+
   const routes: ReleaseProviderSignoffRoute[] = [];
-  for (const fixture of DEFAULT_ROUTES) {
-    routes.push(await resolveRoute(fixture, container));
+  for (const routeCase of cases) {
+    routes.push(await resolveRoute(routeCase, container));
   }
 
   const signoff = buildReleaseProviderSignoff({
@@ -215,7 +212,11 @@ if (process.env.KUNAI_LIVE_RELEASE_SIGNOFF !== "1") {
   });
 
   const ok = signoff.routes.every(
-    (route) => route.resolved && route.streamReachable === true && route.failureClass === null,
+    (route) =>
+      route.resolved &&
+      route.streamReachable === true &&
+      route.failureClass === null &&
+      route.successfulProvider === route.configuredProvider,
   );
 
   const report = {

--- a/apps/cli/test/live/release-provider-signoff.ts
+++ b/apps/cli/test/live/release-provider-signoff.ts
@@ -125,8 +125,15 @@ export function isReleaseProviderSignoffAcceptable(
   assertReleaseProviderSignoffComplete(signoff);
   assertReleaseProviderSignoffRedacted(signoff);
   if (!isReleaseProviderSignoffFresh(signoff.generatedAt, nowMs)) return false;
+  // A different provider succeeding is still a failed release for the
+  // CONFIGURED default, even though some stream played. Substitution is exactly
+  // how signoff went green while the product's real default route was broken.
   return signoff.routes.every(
-    (route) => route.resolved && route.streamReachable === true && route.failureClass === null,
+    (route) =>
+      route.resolved &&
+      route.streamReachable === true &&
+      route.failureClass === null &&
+      route.successfulProvider === route.configuredProvider,
   );
 }
 

--- a/apps/cli/test/unit/app/anime-provider-mapping.test.ts
+++ b/apps/cli/test/unit/app/anime-provider-mapping.test.ts
@@ -52,6 +52,35 @@ const allanimeProviderRegistry = {
   getCompatible: () => [],
 } as never;
 
+const anidbProviderRegistry = {
+  get: () => ({
+    metadata: {
+      id: "anidb",
+      name: "AniDB",
+      description: "",
+      domain: "anidb.app",
+      recommended: true,
+      isAnimeProvider: true,
+      catalogIdentity: "provider-native" as const,
+    },
+    capabilities: {} as never,
+    canHandle: () => true,
+    resolveStream: async () => null,
+    search: async () => [
+      {
+        id: "solo-leveling-19413",
+        type: "series",
+        title: "Solo Leveling",
+        year: "2024",
+        overview: "",
+        posterPath: null,
+      },
+    ],
+  }),
+  getAll: () => [],
+  getCompatible: () => [],
+} as never;
+
 const miruroProviderRegistry = {
   get: () => ({
     metadata: {
@@ -206,4 +235,65 @@ test("leaves ordinary provider-native anime search results unchanged", async () 
     } as never,
   });
   expect(mapped).toBe(providerNative);
+});
+
+test("AniDB mapping never stores an AllAnime opaque id under providerNativeIds.anidb", async () => {
+  let allMangaCalls = 0;
+  const mapped = await mapAnimeDiscoveryResultToProviderNative(discovery, {
+    mode: "anime",
+    providerId: "anidb",
+    animeLanguageProfile: { audio: "original", subtitle: "en" },
+    providerRegistry: anidbProviderRegistry,
+    searchProviderNative: async () => {
+      allMangaCalls += 1;
+      return [
+        {
+          id: "LrLqaxWbfzjShWbXW",
+          title: "Solo Leveling",
+          type: "series",
+          aniListId: 151807,
+        },
+      ];
+    },
+  });
+
+  expect(allMangaCalls).toBe(0);
+  expect(mapped.id).toBe("solo-leveling-19413");
+  expect(mapped.externalIds?.providerNativeIds?.anidb).toBe("solo-leveling-19413");
+  expect(mapped.externalIds?.providerNativeIds?.allanime).toBeUndefined();
+  expect(mapped.externalIds?.anilistId).toBe("151807");
+});
+
+test("AniDB mapping rejects a non-AniDB native result and retains catalog identity", async () => {
+  const mapped = await mapAnimeDiscoveryResultToProviderNative(discovery, {
+    mode: "anime",
+    providerId: "anidb",
+    animeLanguageProfile: { audio: "original", subtitle: "en" },
+    providerRegistry: {
+      get: () => ({
+        metadata: {
+          id: "anidb",
+          name: "AniDB",
+          description: "",
+          domain: "anidb.app",
+          recommended: true,
+          isAnimeProvider: true,
+          catalogIdentity: "provider-native" as const,
+        },
+        capabilities: {} as never,
+        canHandle: () => true,
+        resolveStream: async () => null,
+        search: async () => [{ id: "LrLqaxWbfzjShWbXW", type: "series", title: "Solo Leveling" }],
+      }),
+      getAll: () => [],
+      getCompatible: () => [],
+    } as never,
+    searchProviderNative: async () => {
+      throw new Error("AllManga search must not run for AniDB");
+    },
+  });
+
+  expect(mapped.id).toBe("151807");
+  expect(mapped.externalIds?.anilistId).toBe("151807");
+  expect(mapped.externalIds?.providerNativeIds?.anidb).toBeUndefined();
 });

--- a/apps/cli/test/unit/container/bootstrap-providers.test.ts
+++ b/apps/cli/test/unit/container/bootstrap-providers.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import { loadProductionProviderModules } from "@/container/bootstrap-providers";
+import { createProviderPrioritySnapshot } from "@/services/providers/provider-priority";
+import { DEFAULT_CONFIG } from "@kunai/config";
+
+describe("production provider defaults", () => {
+  test("every configured lane default is a registered production module", async () => {
+    const modules = await loadProductionProviderModules(
+      createProviderPrioritySnapshot(DEFAULT_CONFIG),
+    );
+    const ids = modules.map((module) => module.providerId);
+
+    expect(DEFAULT_CONFIG.provider).toBe("videasy");
+    expect(DEFAULT_CONFIG.animeProvider).toBe("anidb");
+    expect(ids).toContain(DEFAULT_CONFIG.provider);
+    expect(ids).toContain(DEFAULT_CONFIG.animeProvider);
+    expect(ids).toContain(DEFAULT_CONFIG.youtubeProvider);
+  });
+});

--- a/apps/cli/test/unit/live/release-provider-signoff.test.ts
+++ b/apps/cli/test/unit/live/release-provider-signoff.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
+import { DEFAULT_CONFIG } from "@kunai/config";
+
+import {
+  buildReleaseProviderRouteCases,
+  resolveReleaseAnimeSearchTitle,
+} from "../../live/release-provider-routes";
 import {
   assertReleaseProviderSignoffComplete,
   assertReleaseProviderSignoffRedacted,
@@ -41,8 +47,8 @@ function baseRoutes(
   };
   const anime: ReleaseProviderSignoffRoute = {
     lane: "anime",
-    configuredProvider: "allanime",
-    successfulProvider: "allanime",
+    configuredProvider: "anidb",
+    successfulProvider: "anidb",
     resolved: true,
     streamCandidates: 1,
     streamReachable: true,
@@ -206,5 +212,92 @@ describe("release provider signoff", () => {
         harness: true,
       }),
     ).toBe("harness-failure");
+  });
+});
+
+describe("release provider route derivation", () => {
+  test("derives signoff providers from production defaults", () => {
+    const cases = buildReleaseProviderRouteCases(DEFAULT_CONFIG, ["videasy", "anidb", "youtube"]);
+    expect(cases.map((route) => [route.lane, route.configuredProvider])).toEqual([
+      ["movie", "videasy"],
+      ["series", "videasy"],
+      ["anime", "anidb"],
+    ]);
+  });
+
+  test("rejects a configured default missing from production registration", () => {
+    expect(() =>
+      buildReleaseProviderRouteCases({ provider: "videasy", animeProvider: "anidb" }, ["videasy"]),
+    ).toThrow("Configured anime release provider is not registered: anidb");
+  });
+
+  test("rejects a configured series default missing from production registration", () => {
+    expect(() =>
+      buildReleaseProviderRouteCases({ provider: "videasy", animeProvider: "anidb" }, ["anidb"]),
+    ).toThrow("Configured series release provider is not registered: videasy");
+  });
+
+  test("default anime search returning zero is provider drift", async () => {
+    await expect(
+      resolveReleaseAnimeSearchTitle(
+        {
+          lane: "anime",
+          configuredProvider: "anidb",
+          mode: "anime",
+          searchQuery: "Onigiri",
+          expectedTitle: "Onigiri",
+          season: 1,
+          episode: 1,
+        },
+        { search: async () => [] } as never,
+        { audio: "original", subtitle: "en" },
+      ),
+    ).rejects.toThrow('Default anime provider "anidb" search returned zero results for "Onigiri"');
+  });
+
+  test("default anime search selects the provider's own native result", async () => {
+    const title = await resolveReleaseAnimeSearchTitle(
+      {
+        lane: "anime",
+        configuredProvider: "anidb",
+        mode: "anime",
+        searchQuery: "Onigiri",
+        expectedTitle: "Onigiri",
+        season: 1,
+        episode: 1,
+      },
+      {
+        search: async () => [
+          { id: "other-1", type: "series", title: "Onigiri Tabetai" },
+          {
+            id: "onigiri-3942",
+            type: "series",
+            title: "Onigiri",
+            externalIds: { providerNativeIds: { anidb: "onigiri-3942" } },
+          },
+        ],
+      } as never,
+      { audio: "original", subtitle: "en" },
+    );
+
+    expect(title.id).toBe("onigiri-3942");
+    expect(title.externalIds?.providerNativeIds?.anidb).toBe("onigiri-3942");
+  });
+
+  test("release evidence is unacceptable when a different provider succeeds", () => {
+    const signoff = buildReleaseProviderSignoff({
+      generatedAt: "2026-08-11T12:00:00.000Z",
+      commitSha: "abc123",
+      version: "0.3.0",
+      routes: baseRoutes({
+        anime: {
+          configuredProvider: "anidb",
+          successfulProvider: "allanime",
+        },
+      }),
+    });
+    expect(
+      isReleaseProviderSignoffAcceptable(signoff, Date.parse("2026-08-11T13:00:00.000Z")),
+    ).toBe(false);
   });
 });

--- a/apps/cli/test/unit/services/playback/playback-resolve-service.test.ts
+++ b/apps/cli/test/unit/services/playback/playback-resolve-service.test.ts
@@ -121,7 +121,11 @@ function createResolvedEngineOutput(
   };
 }
 
-function createManifest(providerId: ProviderId, mediaKinds: readonly string[]) {
+function createManifest(
+  providerId: ProviderId,
+  mediaKinds: readonly string[],
+  catalogIdentity?: string,
+) {
   return {
     id: providerId,
     displayName: providerId,
@@ -136,6 +140,7 @@ function createManifest(providerId: ProviderId, mediaKinds: readonly string[]) {
     browserSafe: true,
     relaySafe: true,
     status: "production",
+    catalogIdentity,
   };
 }
 
@@ -1963,4 +1968,41 @@ test("PlaybackResolveService stops a stalling provider fan-out at its total dead
   expect(outcome).not.toBe("hung");
   expect(observedSignal).not.toBe(controller.signal);
   if (outcome !== "hung") expect(outcome.stream).toBeNull();
+});
+
+test("PlaybackResolveService routes AniDB identity and absolute episode into the production engine", async () => {
+  let observed: ProviderResolveInput | null = null;
+  const engine = createMockEngine(createResolvedEngineOutput("anidb" as ProviderId), {
+    modules: [
+      {
+        providerId: "anidb" as ProviderId,
+        manifest: createManifest("anidb" as ProviderId, ["anime"], "provider-native"),
+      },
+    ],
+    onResolveInput: (input) => {
+      observed = input;
+    },
+  });
+  const service = new PlaybackResolveService({ engine, cacheStore: createMemoryCache(null) });
+
+  await service.resolve({
+    title: {
+      id: "151807",
+      type: "series",
+      name: "Solo Leveling",
+      isAnime: true,
+      externalIds: { anilistId: "151807" },
+    },
+    episode: { season: 2, episode: 1, absoluteEpisode: 13 },
+    mode: "anime",
+    providerId: "anidb",
+    audioPreference: "original",
+    subtitlePreference: "en",
+    signal: new AbortController().signal,
+  });
+
+  const input = observed as ProviderResolveInput | null;
+  expect(input?.title.id).toBe("151807");
+  expect(input?.title.anilistId).toBe("151807");
+  expect(input?.episode).toEqual({ season: 2, episode: 1, absoluteEpisode: 13 });
 });

--- a/apps/cli/test/unit/services/providers/stream-request-adapter.test.ts
+++ b/apps/cli/test/unit/services/providers/stream-request-adapter.test.ts
@@ -294,3 +294,28 @@ test("western series stays untouched by dual-lane adaptation", () => {
   expect(input.mediaKind).toBe("series");
   expect(input.title.id).toBe("1396");
 });
+
+test("preserves absoluteEpisode for anime provider resolution", () => {
+  const input = streamRequestToResolveInput(
+    {
+      title: {
+        id: "151807",
+        type: "series",
+        name: "Solo Leveling",
+        isAnime: true,
+        externalIds: { anilistId: "151807" },
+      },
+      episode: { season: 2, episode: 1, absoluteEpisode: 13 },
+      audioPreference: "original",
+      subtitlePreference: "en",
+    },
+    "anime",
+    "play",
+    "provider-native",
+    "anidb",
+  );
+
+  expect(input.episode).toEqual({ season: 2, episode: 1, absoluteEpisode: 13 });
+  expect(input.title.id).toBe("151807");
+  expect(input.title.anilistId).toBe("151807");
+});

--- a/apps/cli/test/unit/services/search/search-routing.test.ts
+++ b/apps/cli/test/unit/services/search/search-routing.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test } from "bun:test";
 import { normalizeSearchIntent } from "@/domain/search/SearchIntent";
 import { createSearchIntentEngine } from "@/domain/search/SearchIntentEngine";
 import type { SearchResult, ProviderMetadata } from "@/domain/types";
+import { AniListSearchService } from "@/services/search/definitions/anilist";
+import { SEARCH_SERVICE_DEFINITIONS } from "@/services/search/definitions/index";
 import { searchTitles } from "@/services/search/SearchRoutingService";
 
 describe("searchTitles", () => {
@@ -837,6 +839,158 @@ describe("searchTitles", () => {
       filters: { year: 2024, minRating: 7 },
     });
   });
+
+  test("declares AniDB/AniList catalog compatibility in both authorities", () => {
+    const anilistDefinition = SEARCH_SERVICE_DEFINITIONS.find((def) => def.id === "anilist");
+    const anilistService = new AniListSearchService({} as never);
+    const expected = ["anidb", "allanime", "allmanga", "miruro", "hianime"];
+
+    expect(anilistDefinition?.compatibleProviders).toEqual(expected);
+    expect(anilistService.compatibleProviders).toEqual(expected);
+  });
+
+  test("uses explicitly compatible AniList search for advanced AniDB filters", async () => {
+    let defaultCalls = 0;
+    const provider = {
+      metadata: {
+        id: "anidb",
+        name: "AniDB",
+        description: "",
+        recommended: true,
+        isAnimeProvider: true,
+        providerLane: "anime",
+        catalogIdentity: "provider-native",
+        domain: "anidb.app",
+      },
+      search: async () => {
+        throw new Error("advanced AniDB search should use declared AniList compatibility");
+      },
+    } as never;
+    const registry = createSearchRegistry({
+      animeResults: [
+        {
+          id: "151807",
+          type: "series",
+          title: "Solo Leveling",
+          year: "2024",
+          overview: "",
+          posterPath: null,
+          externalIds: { anilistId: "151807" },
+        },
+      ],
+      onDefault: () => {
+        defaultCalls += 1;
+      },
+    });
+
+    const result = await searchTitles(
+      normalizeSearchIntent({
+        query: "solo leveling",
+        mode: "anime",
+        filters: { genres: ["action"], minRating: 7 },
+        sort: "rating",
+      }),
+      {
+        mode: "anime",
+        providerId: "anidb",
+        animeLanguageProfile: { audio: "original", subtitle: "en" },
+        searchRegistry: registry as never,
+        providerRegistry: { get: () => provider } as never,
+      },
+    );
+
+    expect(defaultCalls).toBe(0);
+    expect(result.strategy).toBe("registry");
+    expect(result.sourceId).toBe("anilist");
+    expect(result.diagnosis).toBeUndefined();
+    expect(result.results[0]?.externalIds?.anilistId).toBe("151807");
+  });
+
+  test("diagnoses unsupported advanced search instead of falling through to default TMDB", async () => {
+    let defaultCalls = 0;
+    const result = await searchTitles(
+      normalizeSearchIntent({
+        query: "",
+        mode: "anime",
+        filters: { genres: ["action"] },
+        sort: "popular",
+      }),
+      {
+        mode: "anime",
+        providerId: "native-without-catalog",
+        animeLanguageProfile: { audio: "original", subtitle: "en" },
+        searchRegistry: {
+          getForProvider: () => undefined,
+          getDefault: () => {
+            defaultCalls += 1;
+            throw new Error("default TMDB fallback must not run");
+          },
+        } as never,
+        providerRegistry: {
+          get: () => ({
+            metadata: {
+              id: "native-without-catalog",
+              name: "Native only",
+              isAnimeProvider: true,
+              providerLane: "anime",
+            },
+          }),
+        } as never,
+      },
+    );
+
+    expect(defaultCalls).toBe(0);
+    expect(result.strategy).toBe("unsupported");
+    expect(result.results).toEqual([]);
+    expect(result.evidence.unsupported).toEqual(["genre action", "sort popular"]);
+    expect(result.diagnosis).toEqual({
+      code: "compatible-catalog-unavailable",
+      providerId: "native-without-catalog",
+      attemptedDefaultFallback: false,
+    });
+  });
+
+  test("diagnoses a provider-native fallback when a text query can still be searched safely", async () => {
+    let defaultCalls = 0;
+    const result = await searchTitles(
+      normalizeSearchIntent({
+        query: "mob",
+        mode: "anime",
+        filters: { year: 2019 },
+        sort: "relevance",
+      }),
+      {
+        mode: "anime",
+        providerId: "native-with-search",
+        animeLanguageProfile: { audio: "original", subtitle: "en" },
+        searchRegistry: {
+          getForProvider: () => undefined,
+          getDefault: () => {
+            defaultCalls += 1;
+            throw new Error("default TMDB fallback must not run");
+          },
+        } as never,
+        providerRegistry: {
+          get: () => ({
+            metadata: { id: "native-with-search", name: "Native search", isAnimeProvider: true },
+            search: async () => [
+              { id: "mob-1", type: "series", title: "Mob Psycho 100", year: "2019" },
+            ],
+          }),
+        } as never,
+        enrichAnimeMetadata: false,
+      },
+    );
+
+    expect(defaultCalls).toBe(0);
+    expect(result.strategy).toBe("provider-native");
+    expect(result.results.map((item) => item.id)).toEqual(["mob-1"]);
+    expect(result.diagnosis).toEqual({
+      code: "provider-native-fallback",
+      providerId: "native-with-search",
+      attemptedDefaultFallback: false,
+    });
+  });
 });
 
 function createSearchRegistry({
@@ -845,12 +999,14 @@ function createSearchRegistry({
   animeResults = [],
   onSearch,
   onProviderResolution,
+  onDefault,
 }: {
   providerResults?: SearchResult[];
   defaultResults?: SearchResult[];
   animeResults?: SearchResult[];
   onSearch?: (query: string, signal?: AbortSignal, intent?: any) => void;
   onProviderResolution?: (providerId: string) => void;
+  onDefault?: () => void;
 }) {
   const providerService = {
     metadata: { id: "tmdb", name: "TMDB", description: "" },
@@ -864,7 +1020,7 @@ function createSearchRegistry({
 
   const animeService = {
     metadata: { id: "anilist", name: "AniList", description: "" },
-    compatibleProviders: ["allanime"],
+    compatibleProviders: ["anidb", "allanime"],
     search: async () => animeResults,
     getTitleDetails: async () => null,
   };
@@ -879,10 +1035,11 @@ function createSearchRegistry({
   return {
     getForProvider(providerId: string) {
       onProviderResolution?.(providerId);
-      if (providerId === "allanime") return animeService;
+      if (providerId === "anidb" || providerId === "allanime") return animeService;
       return providerId === "vidking" ? providerService : undefined;
     },
     getDefault() {
+      onDefault?.();
       return defaultService;
     },
   };

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,10 +1,10 @@
 {
-  "syncedAt": "2026-08-02T11:40:50.081Z",
+  "syncedAt": "2026-08-12T15:12:15.476Z",
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceRevision": "bd7df8cc",
-  "cliSourceFingerprint": "5fa66c7f325b72e1715e0d8c400d826d0e4a68860ddb1d6e3e5834234a0a4ac9",
-  "docsContentFingerprint": "0cf763af5f9a6173fbcfa1ff6f3a20a78d533590fc62c3d915c40b8d1aa12d69",
+  "cliSourceRevision": "878f26b6",
+  "cliSourceFingerprint": "654d028b6540e5e28c450106192ff8697fc12431ccabcdc91b9ae53a8954c5ff",
+  "docsContentFingerprint": "cc5e3c276b34bdb4b5e12264c7f88d6efd6a1d69c3fc148dc3f96703315e39f0",
   "featureStatusRevision": "cfb217102303c9ee08bc57588f58ac7e278e7c1bf9ca607ebac1c712c5eb129b",
   "commandCount": 81,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],
@@ -643,7 +643,7 @@
     {
       "short": "-a",
       "long": "--anime",
-      "description": "Anime mode (AllAnime providers)"
+      "description": "Anime mode (AniDB default with provider fallback)"
     },
     {
       "short": "-y",

--- a/docs/users/feature-tour.mdx
+++ b/docs/users/feature-tour.mdx
@@ -64,7 +64,8 @@ Live registry — same table as [Providers](/docs/users/providers#active-provide
 
 - Search by title with TMDB-backed metadata
 - Movie and series playback through Videasy, VidLink, and Rivestream (candidate)
-- Anime playback through AllManga-compatible client (`allanime` id) and Miruro (candidate)
+- Anime playback through AniDB by default, with the AllManga-compatible `allanime`
+  provider as fallback and Miruro manually selectable
 - YouTube mode via Invidious search and yt-dlp playback
 - Watch history with resume support
 - Continue Watching with unfinished/new episode detection

--- a/docs/users/providers.mdx
+++ b/docs/users/providers.mdx
@@ -19,7 +19,7 @@ Live registry synced from the CLI when docs are generated. Click a provider name
 Mode defaults at a glance:
 
 - **Movies / series** — Videasy, VidLink, Rivestream (candidate)
-- **Anime** — AllManga-compatible client (`allanime` id), Miruro (candidate)
+- **Anime** — AniDB (`anidb` id, default), AllManga-compatible client (`allanime` id, fallback), Miruro (manually selectable)
 - **YouTube** — dedicated video mode via Invidious search + yt-dlp playback
 
 Legacy id `vidking` maps to Videasy in config and cache. Cineby is research-only — not registered for production resolve.
@@ -54,16 +54,37 @@ Legacy id `vidking` maps to Videasy in config and cache. Cineby is research-only
 
 </ProviderDocSection>
 
+<ProviderDocSection id="anidb" title="AniDB">
+
+**When to use:** the default anime route (sub and dub). Kunai searches AniDB directly, routes each
+season to its own AniDB title, and resolves streams from that title.
+
+**Config id:** `anidb` for `animeProvider` / `animeProviderPriority`.
+
+```json
+{
+  "animeProvider": "anidb",
+  "animeProviderPriority": ["anidb", "allanime"]
+}
+```
+
+**Caveats:** anime mode must be active (`-a` or anime mode in the shell). Some networks need `curl`
+installed for AniDB requests to get past Cloudflare. If a season cannot be matched unambiguously,
+Kunai reports that rather than playing a different season.
+
+</ProviderDocSection>
+
 <ProviderDocSection id="allanime" title="AllManga">
 
-**When to use:** primary anime source (sub and dub). Display name is AllManga; the runtime id is `allanime`.
+**When to use:** fallback anime source (sub and dub) when the AniDB route does not resolve. Display name is AllManga; the runtime id is `allanime`.
 
-**Config id:** `allanime` for `animeProvider` / `animeProviderPriority`.
+**Config id:** `allanime` for `animeProvider` / `animeProviderPriority`. To make it the primary anime
+source instead of the fallback:
 
 ```json
 {
   "animeProvider": "allanime",
-  "animeProviderPriority": ["allanime", "miruro"]
+  "animeProviderPriority": ["allanime", "anidb"]
 }
 ```
 
@@ -119,6 +140,10 @@ Kunai builds a resolve request from your mode, language profiles, and any per-ti
 ### Kunai tries the default provider first
 
 Your `provider` or `animeProvider` config key sets the session default. Startup priority policy may influence first pick.
+
+Falling back to another provider can change the available source inventory (quality ladder, sub/dub
+mix). Title and catalog identity never silently cross to another catalog: an advanced search with no
+compatible catalog is reported as unsupported rather than quietly answered by TMDB.
 </Step>
 <Step>
 ### Provider-local cycling
@@ -147,8 +172,8 @@ Configure order in `/settings` or `~/.config/kunai/config.json`:
 {
   "provider": "videasy",
   "providerPriority": ["videasy", "vidlink", "rivestream"],
-  "animeProvider": "allanime",
-  "animeProviderPriority": ["allanime", "miruro"]
+  "animeProvider": "anidb",
+  "animeProviderPriority": ["anidb", "allanime"]
 }
 ```
 

--- a/docs/users/supported-and-unsupported.mdx
+++ b/docs/users/supported-and-unsupported.mdx
@@ -30,9 +30,10 @@ Production providers are registered in the CLI container. The live table and per
 | --- | --- | --- |
 | Videasy (`videasy`, legacy `vidking` alias) | Movies and series | Active |
 | VidLink | Movies and series | Active |
-| AllManga-compatible (`allanime` id) | Anime | Active |
+| AniDB (`anidb`) | Anime | Active default |
+| AllManga-compatible (`allanime`) | Anime | Active fallback |
 | Rivestream | Movies and series | Candidate — quality varies |
-| Miruro | Anime | Candidate — quality varies |
+| Miruro (`miruro`) | Anime | Active, manually selectable |
 | YouTube | Video mode (Invidious + yt-dlp) | Production |
 | Cineby | — | Not in production engine (research module) |
 | Playwright / browser providers | — | Not supported in active runtime |

--- a/packages/core/src/title-identity.ts
+++ b/packages/core/src/title-identity.ts
@@ -180,8 +180,14 @@ export function resolveProviderTitleIdentity(
       break;
   }
 
-  const resolvedAnilistId = anilistId ?? (catalogIdentity === "anilist" ? resolvedId : undefined);
-  const resolvedTmdbId = tmdbId ?? (catalogIdentity === "tmdb" ? resolvedId : undefined);
+  // A catalog's own id space is numeric. Without this guard an opaque provider
+  // id (e.g. an AllAnime show id) carried on a title with no external ids would
+  // be laundered into the anilistId/tmdbId slot purely because the active
+  // provider declares that catalog identity.
+  const resolvedAnilistId =
+    anilistId ?? (catalogIdentity === "anilist" ? asCatalogId(resolvedId) : undefined);
+  const resolvedTmdbId =
+    tmdbId ?? (catalogIdentity === "tmdb" ? asCatalogId(resolvedId) : undefined);
   const resolvedExternalIds = compactExternalIds({
     anilistId: resolvedAnilistId,
     tmdbId: resolvedTmdbId,
@@ -204,6 +210,12 @@ export function resolveProviderTitleIdentity(
     malId,
     externalIds: resolvedExternalIds,
   };
+}
+
+/** AniList and TMDB ids are numeric; anything else is a foreign id space. */
+function asCatalogId(value: string): string | undefined {
+  const trimmed = value.trim();
+  return /^\d+$/.test(trimmed) ? trimmed : undefined;
 }
 
 function compactExternalIds(externalIds: ProviderExternalIds): ProviderExternalIds | undefined {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -21,7 +21,8 @@
     "lint": "oxlint .",
     "fmt": "oxfmt --write .",
     "fmt:check": "oxfmt --check .",
-    "test": "bun test test"
+    "test": "bun test test",
+    "test:file": "bun test"
   },
   "dependencies": {
     "@assemblyscript/loader": "catalog:providers",

--- a/packages/providers/src/anidb/browse-parser.ts
+++ b/packages/providers/src/anidb/browse-parser.ts
@@ -150,7 +150,7 @@ function parseAnidbShowIdFromHref(href: string | undefined): string | null {
 function extractAnidbTitle(attrs: string, body: string): string {
   const anchorTitle = extractAttribute(attrs, "title") ?? extractAttribute(attrs, "aria-label");
   const imageAlt = IMAGE_ALT_PATTERN.exec(body)?.[1];
-  const nestedText = body.replace(SCRIPT_BLOCK_PATTERN, " ").replace(/<[^>]+>/g, " ");
+  const nestedText = stripScriptBlocks(body).replace(/<[^>]+>/g, " ");
   const decoded = decodeHtmlEntities(anchorTitle ?? imageAlt ?? nestedText);
   // A raw ESC/BEL byte in the response body is the other half of the entity
   // vector closed in decodeCodePoint(); `\s` matches neither, so without this
@@ -191,13 +191,49 @@ const ATTRIBUTE_PATTERNS = {
 const IMAGE_ALT_PATTERN = /<img\b[^>]*\salt\s*=\s*["']([^"']*)["']/i;
 
 /**
- * An HTML end tag's name ends at whitespace, `/`, or `>`, and anything up to the
- * `>` is then ignored — so `</script>`, `</script >`, `</script\t\n bar>` and
- * `</script/>` all close a script, while `</scriptfoo>` does not. Matching only
- * `</script>` (or only `</script\s*>`) leaves script source in the anchor body,
- * where it becomes the title.
+ * Removes `<script>…</script>` spans by scanning, not by regex.
+ *
+ * `/<script\b[\s\S]*?<\/script(?:[\s/][^>]*)?>/` is polynomial: the lazy body
+ * advances one character at a time and each position re-scans `[^>]*` to the end,
+ * so input repeating `</script\t` with no `>` degrades quadratically. This runs on
+ * fetched provider markup, so that is a denial-of-service vector, not a nicety.
+ *
+ * Tag-name boundaries follow HTML: a name ends at whitespace, `/`, or `>`, and the
+ * rest of an end tag is ignored — `</script>`, `</script >`, `</script\t\n bar>`
+ * and `</script/>` all close, `</scriptfoo>` does not. An unterminated `<script`
+ * drops the remainder: leaving it would put raw script source in a title.
  */
-const SCRIPT_BLOCK_PATTERN = /<script\b[\s\S]*?<\/script(?:[\s/][^>]*)?>/gi;
+function stripScriptBlocks(body: string): string {
+  const lowered = body.toLowerCase();
+  let out = "";
+  let cursor = 0;
+  for (;;) {
+    const open = indexOfTag(lowered, "<script", cursor);
+    if (open === -1) return out + body.slice(cursor);
+    const openEnd = body.indexOf(">", open);
+    if (openEnd === -1) return `${out + body.slice(cursor, open)} `;
+    const close = indexOfTag(lowered, "</script", openEnd + 1);
+    if (close === -1) return `${out + body.slice(cursor, open)} `;
+    const closeEnd = body.indexOf(">", close);
+    if (closeEnd === -1) return `${out + body.slice(cursor, open)} `;
+    out += `${body.slice(cursor, open)} `;
+    cursor = closeEnd + 1;
+  }
+}
+
+/** `indexOf` for a tag whose name ends at the match — not `<scriptfoo>`. */
+function indexOfTag(lowered: string, tag: string, from: number): number {
+  for (
+    let index = lowered.indexOf(tag, from);
+    index !== -1;
+    index = lowered.indexOf(tag, index + 1)
+  ) {
+    const next = lowered.charCodeAt(index + tag.length);
+    // whitespace, `/`, `>`, or end of input all terminate the tag name.
+    if (Number.isNaN(next) || next === 0x2f || next === 0x3e || next <= 0x20) return index;
+  }
+  return -1;
+}
 
 function extractAttribute(
   attrs: string,

--- a/packages/providers/src/anidb/browse-parser.ts
+++ b/packages/providers/src/anidb/browse-parser.ts
@@ -1,0 +1,195 @@
+/**
+ * Pure AniDB browse-markup parsing.
+ *
+ * anidb.app has shipped two card generations: legacy relative `/anime/<slug-id>`
+ * anchors whose title only exists in the nested image `alt`, and current absolute
+ * `https://anidb.app/anime/<slug-id>` anchors that carry the title on the anchor
+ * itself. Both must survive one parser so search and resolve cannot drift apart.
+ *
+ * The parser captures the complete anchor opening tag first and only then parses
+ * `href` out of those attributes. Making href matching also delimit the attribute
+ * text is what previously let a `title` placed after `href` be lost.
+ */
+
+export interface AnidbSeasonEvidence {
+  readonly seasonNumber: number | null;
+  readonly label: string | null;
+  readonly normalizedBaseTitle: string;
+}
+
+export interface AnidbSearchResult {
+  readonly id: string;
+  readonly title: string;
+  readonly numericId: number;
+  readonly seasonEvidence: AnidbSeasonEvidence;
+}
+
+/** `slug-1234` show ids used by anidb.app / ani-cli. The suffix must be positive. */
+export function looksLikeAnidbShowId(value: string | undefined): value is string {
+  if (!value?.trim()) return false;
+  return /^[a-z0-9]+(?:-[a-z0-9]+)*-\d+$/i.test(value.trim()) && anidbNumericId(value) !== null;
+}
+
+export function anidbNumericId(showId: string): number | null {
+  const match = /-(\d+)$/.exec(showId.trim());
+  if (!match?.[1]) return null;
+  const numeric = Number(match[1]);
+  return Number.isInteger(numeric) && numeric > 0 ? numeric : null;
+}
+
+export function parseAnidbSeasonEvidence(title: string): AnidbSeasonEvidence {
+  const normalizedTitle = decodeHtmlEntities(title).replace(/\s+/g, " ").trim();
+  const match =
+    /\bseason\s+(\d+)\b/i.exec(normalizedTitle) ??
+    /\b(\d+)(?:st|nd|rd|th)\s+season\b/i.exec(normalizedTitle) ??
+    /\bs(\d+)\b/i.exec(normalizedTitle);
+  const seasonNumber = Number(match?.[1]);
+  const validSeason = Number.isInteger(seasonNumber) && seasonNumber > 0 ? seasonNumber : null;
+  const label = validSeason === null ? null : (match?.[0] ?? null);
+  const baseTitle =
+    match && validSeason !== null
+      ? `${normalizedTitle.slice(0, match.index)} ${normalizedTitle.slice(match.index + match[0].length)}`
+      : normalizedTitle;
+  return {
+    seasonNumber: validSeason,
+    label,
+    normalizedBaseTitle: normalizeTitle(baseTitle),
+  };
+}
+
+export function parseAnidbBrowseHtml(html: string): readonly AnidbSearchResult[] {
+  // Instantiated per call: a shared /g/ regex would carry `lastIndex` between calls.
+  const anchorPattern = /<a\b([^>]*)>([\s\S]*?)<\/a>/gi;
+  const results: AnidbSearchResult[] = [];
+  const seen = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = anchorPattern.exec(html)) !== null) {
+    const attrs = match[1] ?? "";
+    const body = match[2] ?? "";
+    const id = parseAnidbShowIdFromHref(extractAttribute(attrs, "href"));
+    if (!id || seen.has(id) || !hasResultCardEvidence(attrs, body)) continue;
+    const title = extractAnidbTitle(attrs, body);
+    const numericId = anidbNumericId(id);
+    if (!title || numericId === null) continue;
+    seen.add(id);
+    results.push({ id, title, numericId, seasonEvidence: parseAnidbSeasonEvidence(title) });
+  }
+  return results;
+}
+
+/**
+ * Pick the result a query actually asked for instead of trusting document order.
+ *
+ * `parseAnidbBrowseHtml` already drops page chrome, but a "related"/"you may also
+ * like" card is structurally identical to a result card, so document order alone
+ * is not safe to resolve against.
+ */
+export function chooseAnidbSearchMatch(
+  query: string,
+  results: readonly AnidbSearchResult[],
+): AnidbSearchResult | null {
+  const first = results[0] ?? null;
+  const normalizedQuery = normalizeTitle(query);
+  if (!first || !normalizedQuery) return first;
+
+  const exact = results.find((result) => normalizeTitle(result.title) === normalizedQuery);
+  if (exact) return exact;
+
+  const prefixed = results.find((result) => {
+    const normalizedTitle = normalizeTitle(result.title);
+    return (
+      normalizedTitle.startsWith(`${normalizedQuery} `) ||
+      normalizedQuery.startsWith(`${normalizedTitle} `)
+    );
+  });
+  return prefixed ?? first;
+}
+
+/**
+ * A result card is an anchor that labels itself (`title` / `aria-label`) or wraps
+ * nested card markup. Nav, breadcrumb, related-rail and footer links to
+ * `/anime/<slug-id>` are bare text anchors and carry neither, so they never enter
+ * the result set — which matters because resolve picks from these results.
+ *
+ * This deliberately keys on structure rather than a container class name; class
+ * names are exactly what breaks on the next anidb.app reskin.
+ */
+function hasResultCardEvidence(attrs: string, body: string): boolean {
+  if (extractAttribute(attrs, "title") ?? extractAttribute(attrs, "aria-label")) return true;
+  return /<[a-z][^>]*>/i.test(body);
+}
+
+function parseAnidbShowIdFromHref(href: string | undefined): string | null {
+  const decoded = decodeHtmlEntities(href ?? "").trim();
+  const match = /^(?:(?:https?:)?\/\/anidb\.app)?\/anime\/([^/?#]+)(?:[/?#].*)?$/i.exec(decoded);
+  const id = (match?.[1] ?? "").trim();
+  return looksLikeAnidbShowId(id) ? id : null;
+}
+
+function extractAnidbTitle(attrs: string, body: string): string {
+  const anchorTitle = extractAttribute(attrs, "title") ?? extractAttribute(attrs, "aria-label");
+  const imageAlt = IMAGE_ALT_PATTERN.exec(body)?.[1];
+  const nestedText = body.replace(/<script\b[\s\S]*?<\/script>/gi, " ").replace(/<[^>]+>/g, " ");
+  return decodeHtmlEntities(anchorTitle ?? imageAlt ?? nestedText)
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Attribute patterns are precompiled and anchored on a start-or-whitespace
+ * boundary. A `\b` boundary also matches after `-` and `:`, which would let
+ * `data-href` / `xlink:href` / `data-original-title` shadow the real attribute
+ * and pin the wrong AniDB show id.
+ */
+const ATTRIBUTE_PATTERNS = {
+  href: /(?:^|\s)href\s*=\s*["']([^"']*)["']/i,
+  title: /(?:^|\s)title\s*=\s*["']([^"']*)["']/i,
+  "aria-label": /(?:^|\s)aria-label\s*=\s*["']([^"']*)["']/i,
+} as const;
+
+const IMAGE_ALT_PATTERN = /<img\b[^>]*\salt\s*=\s*["']([^"']*)["']/i;
+
+function extractAttribute(
+  attrs: string,
+  name: keyof typeof ATTRIBUTE_PATTERNS,
+): string | undefined {
+  const value = ATTRIBUTE_PATTERNS[name].exec(attrs)?.[1];
+  return value?.trim() ? value : undefined;
+}
+
+const HTML_ENTITY_PATTERN = /&(?:#x([0-9a-f]+)|#(\d+)|(amp|lt|gt|quot|apos));/gi;
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+};
+
+function decodeCodePoint(raw: string, codePoint: number): string {
+  // Reject out-of-range values and the lone-surrogate block, which would
+  // otherwise produce an ill-formed title string.
+  if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) return raw;
+  if (codePoint >= 0xd800 && codePoint <= 0xdfff) return raw;
+  return String.fromCodePoint(codePoint);
+}
+
+/** Single pass, so `&amp;lt;` decodes to the literal `&lt;` and never to `<`. */
+function decodeHtmlEntities(value: string): string {
+  return value.replace(
+    HTML_ENTITY_PATTERN,
+    (raw: string, hex?: string, decimal?: string, named?: string) => {
+      if (hex !== undefined) return decodeCodePoint(raw, Number.parseInt(hex, 16));
+      if (decimal !== undefined) return decodeCodePoint(raw, Number.parseInt(decimal, 10));
+      return NAMED_ENTITIES[named?.toLowerCase() ?? ""] ?? raw;
+    },
+  );
+}
+
+function normalizeTitle(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}

--- a/packages/providers/src/anidb/browse-parser.ts
+++ b/packages/providers/src/anidb/browse-parser.ts
@@ -116,7 +116,28 @@ export function chooseAnidbSearchMatch(
  */
 function hasResultCardEvidence(attrs: string, body: string): boolean {
   if (extractAttribute(attrs, "title") ?? extractAttribute(attrs, "aria-label")) return true;
-  return /<[a-z][^>]*>/i.test(body);
+  return hasNestedElement(body);
+}
+
+/**
+ * Scanned rather than matched with `/<[a-z][^>]*>/`. That pattern is quadratic on
+ * input like `<a<a<a…` with no `>` — every `<a` restarts a scan to end of input —
+ * and this runs on fetched provider markup we do not control. Walking `<` offsets
+ * against one precomputed last `>` is linear and answers the same question.
+ */
+function hasNestedElement(body: string): boolean {
+  const lastClose = body.lastIndexOf(">");
+  if (lastClose < 2) return false;
+  for (
+    let index = body.indexOf("<");
+    index !== -1 && index < lastClose;
+    index = body.indexOf("<", index + 1)
+  ) {
+    const code = body.charCodeAt(index + 1);
+    const startsTagName = (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+    if (startsTagName) return true;
+  }
+  return false;
 }
 
 function parseAnidbShowIdFromHref(href: string | undefined): string | null {
@@ -129,7 +150,10 @@ function parseAnidbShowIdFromHref(href: string | undefined): string | null {
 function extractAnidbTitle(attrs: string, body: string): string {
   const anchorTitle = extractAttribute(attrs, "title") ?? extractAttribute(attrs, "aria-label");
   const imageAlt = IMAGE_ALT_PATTERN.exec(body)?.[1];
-  const nestedText = body.replace(/<script\b[\s\S]*?<\/script>/gi, " ").replace(/<[^>]+>/g, " ");
+  // `</script\s*>`, not `</script>`: HTML permits whitespace before the closing
+  // angle bracket, and a `</script >` that this filter misses would leak script
+  // source into a title.
+  const nestedText = body.replace(/<script\b[\s\S]*?<\/script\s*>/gi, " ").replace(/<[^>]+>/g, " ");
   return decodeHtmlEntities(anchorTitle ?? imageAlt ?? nestedText)
     .replace(/\s+/g, " ")
     .trim();

--- a/packages/providers/src/anidb/browse-parser.ts
+++ b/packages/providers/src/anidb/browse-parser.ts
@@ -150,7 +150,7 @@ function parseAnidbShowIdFromHref(href: string | undefined): string | null {
 function extractAnidbTitle(attrs: string, body: string): string {
   const anchorTitle = extractAttribute(attrs, "title") ?? extractAttribute(attrs, "aria-label");
   const imageAlt = IMAGE_ALT_PATTERN.exec(body)?.[1];
-  const nestedText = stripScriptBlocks(body).replace(/<[^>]+>/g, " ");
+  const nestedText = stripTags(stripScriptBlocks(body));
   const decoded = decodeHtmlEntities(anchorTitle ?? imageAlt ?? nestedText);
   // A raw ESC/BEL byte in the response body is the other half of the entity
   // vector closed in decodeCodePoint(); `\s` matches neither, so without this
@@ -218,6 +218,34 @@ function stripScriptBlocks(body: string): string {
     if (closeEnd === -1) return `${out + body.slice(cursor, open)} `;
     out += `${body.slice(cursor, open)} `;
     cursor = closeEnd + 1;
+  }
+}
+
+/**
+ * Replaces `/<[^>]+>/g` for the same reason as stripScriptBlocks: on a body of
+ * many `<` with no `>`, every `<` restarts a scan to end of input. Here the
+ * failing `indexOf(">")` can happen at most once, because it returns
+ * immediately, so the walk stays linear.
+ *
+ * Faithful to the regex it replaces: a tag needs at least one character between
+ * the brackets, so a literal `<>` is text, and an unclosed `<` keeps the rest of
+ * the string as text rather than discarding it.
+ */
+function stripTags(value: string): string {
+  let out = "";
+  let cursor = 0;
+  for (;;) {
+    const open = value.indexOf("<", cursor);
+    if (open === -1) return out + value.slice(cursor);
+    const close = value.indexOf(">", open + 1);
+    if (close === -1) return out + value.slice(cursor);
+    if (close === open + 1) {
+      out += value.slice(cursor, close + 1);
+      cursor = close + 1;
+      continue;
+    }
+    out += `${value.slice(cursor, open)} `;
+    cursor = close + 1;
   }
 }
 

--- a/packages/providers/src/anidb/browse-parser.ts
+++ b/packages/providers/src/anidb/browse-parser.ts
@@ -151,9 +151,29 @@ function extractAnidbTitle(attrs: string, body: string): string {
   const anchorTitle = extractAttribute(attrs, "title") ?? extractAttribute(attrs, "aria-label");
   const imageAlt = IMAGE_ALT_PATTERN.exec(body)?.[1];
   const nestedText = body.replace(SCRIPT_BLOCK_PATTERN, " ").replace(/<[^>]+>/g, " ");
-  return decodeHtmlEntities(anchorTitle ?? imageAlt ?? nestedText)
-    .replace(/\s+/g, " ")
-    .trim();
+  const decoded = decodeHtmlEntities(anchorTitle ?? imageAlt ?? nestedText);
+  // A raw ESC/BEL byte in the response body is the other half of the entity
+  // vector closed in decodeCodePoint(); `\s` matches neither, so without this
+  // they would survive into terminal output.
+  return stripControlCharacters(decoded).replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Drops C0/C1 controls but keeps tab/LF/CR, which the whitespace collapse below
+ * turns into a single space -- stripping them outright would weld "Foo\nBar"
+ * into "FooBar". Written as a code-point scan rather than a regex: a character
+ * class of raw control characters is exactly what `no-control-regex` forbids,
+ * and the scan reuses the same predicate the entity decoder checks.
+ */
+function stripControlCharacters(value: string): string {
+  let out = "";
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    const isCollapsibleWhitespace = codePoint === 0x09 || codePoint === 0x0a || codePoint === 0x0d;
+    if (isControlCodePoint(codePoint) && !isCollapsibleWhitespace) continue;
+    out += character;
+  }
+  return out;
 }
 
 /**
@@ -202,7 +222,17 @@ function decodeCodePoint(raw: string, codePoint: number): string {
   // otherwise produce an ill-formed title string.
   if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) return raw;
   if (codePoint >= 0xd800 && codePoint <= 0xdfff) return raw;
+  // Refuse to manufacture control characters. `&#27;` is plain ASCII in the
+  // response body, so a provider needs no raw ESC byte to smuggle one -- the
+  // decoder would mint it. These titles are printed straight to a terminal,
+  // where ESC drives cursor movement, screen clears, and OSC 52 clipboard
+  // writes. C0 (0x00-0x1f, 0x7f) and C1 (0x80-0x9f) are left as inert text.
+  if (isControlCodePoint(codePoint)) return raw;
   return String.fromCodePoint(codePoint);
+}
+
+function isControlCodePoint(codePoint: number): boolean {
+  return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
 }
 
 /** Single pass, so `&amp;lt;` decodes to the literal `&lt;` and never to `<`. */

--- a/packages/providers/src/anidb/browse-parser.ts
+++ b/packages/providers/src/anidb/browse-parser.ts
@@ -150,10 +150,7 @@ function parseAnidbShowIdFromHref(href: string | undefined): string | null {
 function extractAnidbTitle(attrs: string, body: string): string {
   const anchorTitle = extractAttribute(attrs, "title") ?? extractAttribute(attrs, "aria-label");
   const imageAlt = IMAGE_ALT_PATTERN.exec(body)?.[1];
-  // `</script\s*>`, not `</script>`: HTML permits whitespace before the closing
-  // angle bracket, and a `</script >` that this filter misses would leak script
-  // source into a title.
-  const nestedText = body.replace(/<script\b[\s\S]*?<\/script\s*>/gi, " ").replace(/<[^>]+>/g, " ");
+  const nestedText = body.replace(SCRIPT_BLOCK_PATTERN, " ").replace(/<[^>]+>/g, " ");
   return decodeHtmlEntities(anchorTitle ?? imageAlt ?? nestedText)
     .replace(/\s+/g, " ")
     .trim();
@@ -172,6 +169,15 @@ const ATTRIBUTE_PATTERNS = {
 } as const;
 
 const IMAGE_ALT_PATTERN = /<img\b[^>]*\salt\s*=\s*["']([^"']*)["']/i;
+
+/**
+ * An HTML end tag's name ends at whitespace, `/`, or `>`, and anything up to the
+ * `>` is then ignored — so `</script>`, `</script >`, `</script\t\n bar>` and
+ * `</script/>` all close a script, while `</scriptfoo>` does not. Matching only
+ * `</script>` (or only `</script\s*>`) leaves script source in the anchor body,
+ * where it becomes the title.
+ */
+const SCRIPT_BLOCK_PATTERN = /<script\b[\s\S]*?<\/script(?:[\s/][^>]*)?>/gi;
 
 function extractAttribute(
   attrs: string,

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -2,6 +2,17 @@ import type { ProviderRuntimeContext } from "@kunai/types";
 
 import { expandHlsMasterPlaylist } from "../shared/hls-ladder";
 import { TTLCache } from "../shared/provider-cache";
+import { anidbNumericId, parseAnidbBrowseHtml, type AnidbSearchResult } from "./browse-parser";
+
+export {
+  anidbNumericId,
+  chooseAnidbSearchMatch,
+  looksLikeAnidbShowId,
+  parseAnidbBrowseHtml,
+  parseAnidbSeasonEvidence,
+  type AnidbSearchResult,
+  type AnidbSeasonEvidence,
+} from "./browse-parser";
 
 export const ANIDB_BASE = "https://anidb.app";
 export const ANIDB_REFERER = "https://anidb.app/";
@@ -10,12 +21,6 @@ export const ANIDB_USER_AGENT =
 
 const episodeCache = new TTLCache<string, readonly AnidbEpisodeEntry[]>(1_800_000);
 const languageCache = new TTLCache<string, readonly AnidbLanguageEntry[]>(300_000);
-
-export type AnidbSearchResult = {
-  readonly id: string;
-  readonly title: string;
-  readonly numericId: number;
-};
 
 export type AnidbEpisodeEntry = {
   readonly id: number;
@@ -36,28 +41,6 @@ export type AnidbStreamLink = {
   readonly protocol: "hls";
   readonly container: "m3u8";
 };
-
-/** `slug-1234` show ids used by anidb.app / ani-cli. */
-export function looksLikeAnidbShowId(value: string | undefined): value is string {
-  if (!value?.trim()) return false;
-  return /^[a-z0-9]+(?:-[a-z0-9]+)*-\d+$/i.test(value.trim());
-}
-
-export function anidbNumericId(showId: string): number | null {
-  const match = /-(\d+)$/.exec(showId.trim());
-  if (!match?.[1]) return null;
-  const numeric = Number(match[1]);
-  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
-}
-
-function decodeHtmlEntities(value: string): string {
-  return value
-    .replace(/&#039;/g, "'")
-    .replace(/&quot;/g, '"')
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">");
-}
 
 /**
  * anidb.app HTML/JSON often CF-blocks Bun fetch. Prefer curl with a browser UA
@@ -120,22 +103,10 @@ export async function searchAnidb(
 ): Promise<readonly AnidbSearchResult[]> {
   const trimmed = query.trim();
   if (!trimmed) return [];
-  const url = `${ANIDB_BASE}/browse?q=${encodeURIComponent(trimmed)}`;
-  const page = await anidbFetchText(url, { signal });
-  const results: AnidbSearchResult[] = [];
-  const seen = new Set<string>();
-  const pattern = /anime\/([a-z0-9-]+-\d+)"[^>]*alt="([^"]+)"/gi;
-  let match: RegExpExecArray | null;
-  while ((match = pattern.exec(page)) !== null) {
-    const id = match[1];
-    const title = decodeHtmlEntities(match[2] ?? "").trim();
-    if (!id || !title || seen.has(id)) continue;
-    seen.add(id);
-    const numericId = anidbNumericId(id);
-    if (!numericId) continue;
-    results.push({ id, title, numericId });
-  }
-  return results;
+  const page = await anidbFetchText(`${ANIDB_BASE}/browse?q=${encodeURIComponent(trimmed)}`, {
+    signal,
+  });
+  return parseAnidbBrowseHtml(page);
 }
 
 export async function fetchAnidbMalId(

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -43,6 +43,56 @@ export type AnidbStreamLink = {
 };
 
 /**
+ * curl-impersonate builds, most-recent browser first, then plain curl.
+ *
+ * Parity with ani-cli v5's `dep_ch_failover` list. anidb.app sits behind
+ * Cloudflare, which fingerprints the TLS handshake — a browser User-Agent over
+ * curl's own handshake is frequently still challenged, and a challenge page
+ * parses to zero search results. Where an impersonate build exists we use it.
+ */
+const ANIDB_CURL_CANDIDATES = [
+  "curl_firefox135",
+  "curl_chrome136",
+  "curl_chrome116",
+  "curl_ff117",
+  "curl",
+] as const;
+
+/**
+ * ani-cli sets these only on Darwin, and that restriction is load-bearing rather
+ * than incidental: Windows `curl.exe` links Schannel, which rejects
+ * `--tls13-ciphers` and does not understand OpenSSL cipher names, so passing
+ * them there fails the request outright instead of hardening it. Linux curl
+ * already negotiates an acceptable suite unaided.
+ */
+const ANIDB_CIPHERS =
+  "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305";
+const ANIDB_TLS13_CIPHERS =
+  "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256";
+
+/**
+ * An impersonate build already ships a matching handshake, so forcing ani-cli's
+ * list over it would undo the fingerprint it exists to provide.
+ */
+export function anidbCipherArgs(
+  impersonates: boolean,
+  platform: NodeJS.Platform = process.platform,
+): readonly string[] {
+  if (impersonates || platform !== "darwin") return [];
+  return ["--ciphers", ANIDB_CIPHERS, "--tls13-ciphers", ANIDB_TLS13_CIPHERS];
+}
+
+export function resolveAnidbCurl(
+  which: (command: string) => string | null = Bun.which,
+): { readonly path: string; readonly impersonates: boolean } | null {
+  for (const candidate of ANIDB_CURL_CANDIDATES) {
+    const path = which(candidate);
+    if (path) return { path, impersonates: candidate !== "curl" };
+  }
+  return null;
+}
+
+/**
  * anidb.app HTML/JSON often CF-blocks Bun fetch. Prefer curl with a browser UA
  * (ani-cli uses curl / curl-impersonate; plain curl works on this machine).
  */
@@ -50,8 +100,8 @@ export async function anidbFetchText(
   url: string,
   options: { readonly signal?: AbortSignal; readonly maxTimeSec?: number } = {},
 ): Promise<string> {
-  const curlPath = Bun.which("curl");
-  if (!curlPath) {
+  const curl = resolveAnidbCurl();
+  if (!curl) {
     const response = await fetch(url, {
       headers: { "User-Agent": ANIDB_USER_AGENT, Referer: ANIDB_REFERER },
       signal: options.signal ?? AbortSignal.timeout(15_000),
@@ -68,7 +118,7 @@ export async function anidbFetchText(
 
   const maxTime = String(options.maxTimeSec ?? 12);
   const args = [
-    curlPath,
+    curl.path,
     "-sL",
     "-A",
     ANIDB_USER_AGENT,
@@ -76,6 +126,7 @@ export async function anidbFetchText(
     `Referer: ${ANIDB_REFERER}`,
     "--max-time",
     maxTime,
+    ...anidbCipherArgs(curl.impersonates),
     url,
   ];
   const proc = Bun.spawn(args, {

--- a/packages/providers/src/anidb/direct.ts
+++ b/packages/providers/src/anidb/direct.ts
@@ -49,6 +49,8 @@ export {
   looksLikeAnidbShowId,
   parseAnidbBrowseHtml,
   parseAnidbSeasonEvidence,
+  anidbCipherArgs,
+  resolveAnidbCurl,
   searchAnidb,
   type AnidbSearchResult,
   type AnidbSeasonEvidence,

--- a/packages/providers/src/anidb/direct.ts
+++ b/packages/providers/src/anidb/direct.ts
@@ -27,6 +27,7 @@ import { selectReadyStream } from "../shared/startup-selection";
 import {
   ANIDB_REFERER,
   ANIDB_USER_AGENT,
+  chooseAnidbSearchMatch,
   fetchAnidbEpisodes,
   fetchAnidbMalId,
   looksLikeAnidbShowId,
@@ -39,9 +40,14 @@ import { anidbManifest, ANIDB_PROVIDER_ID } from "./manifest";
 export { ANIDB_PROVIDER_ID };
 export {
   anidbNumericId,
+  chooseAnidbSearchMatch,
   clearAnidbCachesForTest,
   looksLikeAnidbShowId,
+  parseAnidbBrowseHtml,
+  parseAnidbSeasonEvidence,
   searchAnidb,
+  type AnidbSearchResult,
+  type AnidbSeasonEvidence,
 } from "./client";
 
 function resolveAnidbShowIdFromInput(input: {
@@ -68,8 +74,7 @@ async function resolveAnidbShowId(
 
   const query = input.title.title?.trim() ?? "";
   if (!query) return null;
-  const results = await searchAnidb(query, signal);
-  return results[0]?.id ?? null;
+  return chooseAnidbSearchMatch(query, await searchAnidb(query, signal))?.id ?? null;
 }
 
 function buildStreamHeaders(referer: string): Record<string, string> {

--- a/packages/providers/src/anidb/direct.ts
+++ b/packages/providers/src/anidb/direct.ts
@@ -27,15 +27,19 @@ import { selectReadyStream } from "../shared/startup-selection";
 import {
   ANIDB_REFERER,
   ANIDB_USER_AGENT,
+  anidbNumericId,
   chooseAnidbSearchMatch,
   fetchAnidbEpisodes,
   fetchAnidbMalId,
   looksLikeAnidbShowId,
+  parseAnidbSeasonEvidence,
   resolveAnidbEpisodeStreams,
   searchAnidb,
+  type AnidbSearchResult,
   type AnidbStreamLink,
 } from "./client";
 import { anidbManifest, ANIDB_PROVIDER_ID } from "./manifest";
+import { routeAnidbSeason } from "./season-routing";
 
 export { ANIDB_PROVIDER_ID };
 export {
@@ -50,31 +54,32 @@ export {
   type AnidbSeasonEvidence,
 } from "./client";
 
-function resolveAnidbShowIdFromInput(input: {
-  readonly title: {
-    readonly id: string;
-    readonly title?: string;
-    readonly externalIds?: {
-      readonly providerNativeIds?: Record<string, string | undefined>;
-    };
-  };
-}): string | null {
+function directAnidbShowFromInput(input: {
+  readonly title: ProviderResolveInput["title"];
+}): AnidbSearchResult | null {
   const native = input.title.externalIds?.providerNativeIds?.[ANIDB_PROVIDER_ID];
-  if (looksLikeAnidbShowId(native)) return native;
-  if (looksLikeAnidbShowId(input.title.id)) return input.title.id;
-  return null;
+  const id = looksLikeAnidbShowId(native)
+    ? native
+    : looksLikeAnidbShowId(input.title.id)
+      ? input.title.id
+      : null;
+  if (!id) return null;
+  const numericId = anidbNumericId(id);
+  if (numericId === null) return null;
+  const title = input.title.title || id;
+  return { id, title, numericId, seasonEvidence: parseAnidbSeasonEvidence(title) };
 }
 
-async function resolveAnidbShowId(
+async function resolveAnidbShow(
   input: { readonly title: ProviderResolveInput["title"] },
   signal?: AbortSignal,
-): Promise<string | null> {
-  const direct = resolveAnidbShowIdFromInput(input);
+): Promise<AnidbSearchResult | null> {
+  const direct = directAnidbShowFromInput(input);
   if (direct) return direct;
 
   const query = input.title.title?.trim() ?? "";
   if (!query) return null;
-  return chooseAnidbSearchMatch(query, await searchAnidb(query, signal))?.id ?? null;
+  return chooseAnidbSearchMatch(query, await searchAnidb(query, signal));
 }
 
 function buildStreamHeaders(referer: string): Record<string, string> {
@@ -222,7 +227,7 @@ export const anidbProviderModule: CoreProviderModule = {
   },
 
   async listEpisodes(input, context) {
-    const showId = await resolveAnidbShowId(input, context.signal);
+    const showId = (await resolveAnidbShow(input, context.signal))?.id;
     if (!showId) return null;
     const episodes = await fetchAnidbEpisodes(showId, context.signal);
     if (episodes.length === 0) return [];
@@ -256,15 +261,31 @@ export const anidbProviderModule: CoreProviderModule = {
       });
     }
 
-    const showId = await resolveAnidbShowId(input, context.signal);
-    if (!showId) {
+    const baseShow = await resolveAnidbShow(input, context.signal);
+    if (!baseShow) {
       return createExhaustedResult(input, context, ANIDB_PROVIDER_ID, {
         code: "unsupported-title",
-        message: "AniDB requires a provider-native show id or searchable title",
+        message: "AniDB requires a validated provider-native show id or searchable title",
         retryable: false,
       });
     }
 
+    const route = await routeAnidbSeason({
+      base: baseShow,
+      episode: input.episode,
+      search: searchAnidb,
+      episodes: fetchAnidbEpisodes,
+      signal: context.signal,
+    });
+    if (!route) {
+      return createExhaustedResult(input, context, ANIDB_PROVIDER_ID, {
+        code: "not-found",
+        message: `No unambiguous AniDB season route for ${baseShow.id} season ${input.episode?.season ?? 1}`,
+        retryable: false,
+      });
+    }
+
+    const showId = route.routedShowId;
     const startedAt = context.now();
     const events: ProviderTraceEvent[] = [];
     const failures: ProviderFailure[] = [];
@@ -286,7 +307,20 @@ export const anidbProviderModule: CoreProviderModule = {
     const audioMode = resolveAnimeAudioIntent(
       input.preferredAudioLanguage ?? input.preferredPresentation ?? "original",
     ).catalogMode;
-    const episodeNumber = input.episode?.absoluteEpisode ?? input.episode?.episode ?? 1;
+    // Numbering is decided by routeAnidbSeason, which only uses absoluteEpisode
+    // when the routed title's own episode catalog confirms it.
+    const episodeNumber = route.episodeNumber;
+    const routeAttributes: Record<string, string | number | boolean | null> = {
+      requestedSeason: route.requestedSeason,
+      baseShowId: route.baseShowId,
+      routedShowId: route.routedShowId,
+      routeEvidence: route.evidence.kind,
+      numberingEvidence: route.numberingEvidence.kind,
+      numberingEvidenceReason:
+        route.numberingEvidence.kind === "cour" ? route.numberingEvidence.reason : null,
+      episodeNumber: route.episodeNumber,
+      usedAbsoluteEpisode: route.usedAbsoluteEpisode,
+    };
 
     try {
       const links = await resolveAnidbEpisodeStreams({
@@ -324,7 +358,7 @@ export const anidbProviderModule: CoreProviderModule = {
         type: "provider:success",
         providerId: ANIDB_PROVIDER_ID,
         message: `Resolved ${streams.length} AniDB stream(s)`,
-        attributes: { sourceId, showId, episodeNumber: String(episodeNumber) },
+        attributes: { sourceId, showId, ...routeAttributes },
       });
 
       return {
@@ -352,6 +386,10 @@ export const anidbProviderModule: CoreProviderModule = {
           startedAt,
           endedAt,
           steps: [
+            createTraceStep("provider", "Routed AniDB season identity", {
+              providerId: ANIDB_PROVIDER_ID,
+              attributes: routeAttributes,
+            }),
             createTraceStep("provider", "Resolved AniDB HLS ladder", {
               providerId: ANIDB_PROVIDER_ID,
               attributes: { streams: streams.length, showId },

--- a/packages/providers/src/anidb/season-routing.ts
+++ b/packages/providers/src/anidb/season-routing.ts
@@ -1,0 +1,170 @@
+/**
+ * Deterministic AniDB season routing.
+ *
+ * AniDB models each season as its own title, so a season-2 request against a
+ * base title must be routed to a sibling entry rather than resolved against the
+ * base. Two failure modes drive the design:
+ *
+ * - Resolving the wrong title silently is worse than not resolving at all, so an
+ *   ambiguous or unevidenced match returns `null` and the caller reports a
+ *   structured `not-found`.
+ * - A missing season label is NOT evidence that a title is absolute-numbered.
+ *   `absoluteEpisode` is consumed only when the routed title's own episode
+ *   catalog contains that exact number; everything else uses the one-based cour
+ *   episode and records why.
+ */
+
+import type { EpisodeIdentity } from "@kunai/types";
+
+import type { AnidbSearchResult } from "./browse-parser";
+import type { AnidbEpisodeEntry } from "./client";
+
+export type AnidbEpisodeNumberingEvidence =
+  | {
+      readonly kind: "absolute-episode-catalog";
+      readonly routedShowId: string;
+      readonly requestedAbsoluteEpisode: number;
+      readonly matchedEpisodeId: number;
+    }
+  | {
+      readonly kind: "cour";
+      readonly reason:
+        | "absolute-episode-not-supplied"
+        | "absolute-episode-not-in-routed-catalog"
+        | "routed-title-is-season-specific"
+        | "routed-season-sibling";
+      readonly requestedAbsoluteEpisode?: number;
+    };
+
+export type AnidbSeasonRouteEvidence =
+  | { readonly kind: "base-season"; readonly normalizedBaseTitle: string }
+  | {
+      readonly kind: "season-search";
+      readonly query: string;
+      readonly matchedTitle: string;
+      readonly matchedSeason: number;
+      readonly titleMatch: "exact" | "prefix";
+    };
+
+export interface AnidbSeasonRoute {
+  readonly requestedSeason: number;
+  readonly baseShowId: string;
+  readonly routedShowId: string;
+  readonly episodeNumber: number;
+  readonly usedAbsoluteEpisode: boolean;
+  readonly numberingEvidence: AnidbEpisodeNumberingEvidence;
+  readonly evidence: AnidbSeasonRouteEvidence;
+}
+
+type ScoredSeasonCandidate = {
+  readonly candidate: AnidbSearchResult;
+  readonly score: number;
+  readonly titleMatch: "exact" | "prefix";
+};
+
+export async function routeAnidbSeason(input: {
+  readonly base: AnidbSearchResult;
+  readonly episode?: EpisodeIdentity;
+  readonly search: (query: string, signal?: AbortSignal) => Promise<readonly AnidbSearchResult[]>;
+  readonly episodes: (
+    showId: string,
+    signal?: AbortSignal,
+  ) => Promise<readonly AnidbEpisodeEntry[]>;
+  readonly signal?: AbortSignal;
+}): Promise<AnidbSeasonRoute | null> {
+  const requestedSeason = positiveInteger(input.episode?.season) ?? 1;
+  const courEpisode = positiveInteger(input.episode?.episode) ?? 1;
+  const absoluteEpisode = positiveInteger(input.episode?.absoluteEpisode);
+  const baseEvidence = input.base.seasonEvidence;
+
+  if (requestedSeason === 1) {
+    let episodeNumber = courEpisode;
+    let numberingEvidence: AnidbEpisodeNumberingEvidence;
+
+    if (absoluteEpisode === null) {
+      numberingEvidence = { kind: "cour", reason: "absolute-episode-not-supplied" };
+    } else if (baseEvidence.seasonNumber !== null) {
+      // The title names its own season, so its episode numbers are per-season.
+      numberingEvidence = {
+        kind: "cour",
+        reason: "routed-title-is-season-specific",
+        requestedAbsoluteEpisode: absoluteEpisode,
+      };
+    } else {
+      const matchedEpisode = (await input.episodes(input.base.id, input.signal)).find(
+        (entry) => entry.number === absoluteEpisode,
+      );
+      if (matchedEpisode) {
+        episodeNumber = absoluteEpisode;
+        numberingEvidence = {
+          kind: "absolute-episode-catalog",
+          routedShowId: input.base.id,
+          requestedAbsoluteEpisode: absoluteEpisode,
+          matchedEpisodeId: matchedEpisode.id,
+        };
+      } else {
+        numberingEvidence = {
+          kind: "cour",
+          reason: "absolute-episode-not-in-routed-catalog",
+          requestedAbsoluteEpisode: absoluteEpisode,
+        };
+      }
+    }
+
+    return {
+      requestedSeason,
+      baseShowId: input.base.id,
+      routedShowId: input.base.id,
+      episodeNumber,
+      usedAbsoluteEpisode: numberingEvidence.kind === "absolute-episode-catalog",
+      numberingEvidence,
+      evidence: { kind: "base-season", normalizedBaseTitle: baseEvidence.normalizedBaseTitle },
+    };
+  }
+
+  const query = `${baseEvidence.normalizedBaseTitle} Season ${requestedSeason}`;
+  const candidates = (await input.search(query, input.signal))
+    .filter((candidate) => candidate.seasonEvidence.seasonNumber === requestedSeason)
+    .flatMap((candidate): ScoredSeasonCandidate[] => {
+      const normalized = candidate.seasonEvidence.normalizedBaseTitle;
+      const base = baseEvidence.normalizedBaseTitle;
+      if (normalized === base) return [{ candidate, score: 2, titleMatch: "exact" }];
+      if (normalized.startsWith(`${base} `)) {
+        return [{ candidate, score: 1, titleMatch: "prefix" }];
+      }
+      return [];
+    })
+    .sort(
+      (left, right) =>
+        right.score - left.score || left.candidate.id.localeCompare(right.candidate.id),
+    );
+
+  const selected = candidates[0];
+  if (!selected) return null;
+  // A tie means we cannot tell which sibling was asked for. Fail closed.
+  if (candidates[1]?.score === selected.score) return null;
+
+  return {
+    requestedSeason,
+    baseShowId: input.base.id,
+    routedShowId: selected.candidate.id,
+    episodeNumber: courEpisode,
+    usedAbsoluteEpisode: false,
+    numberingEvidence: {
+      kind: "cour",
+      reason: "routed-season-sibling",
+      ...(absoluteEpisode !== null ? { requestedAbsoluteEpisode: absoluteEpisode } : {}),
+    },
+    evidence: {
+      kind: "season-search",
+      query,
+      matchedTitle: selected.candidate.title,
+      matchedSeason: requestedSeason,
+      titleMatch: selected.titleMatch,
+    },
+  };
+}
+
+function positiveInteger(value: number | undefined): number | null {
+  return Number.isInteger(value) && Number(value) > 0 ? Number(value) : null;
+}

--- a/packages/providers/test/anidb-season-routing.test.ts
+++ b/packages/providers/test/anidb-season-routing.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AnidbEpisodeEntry } from "../src/anidb/client";
+import { parseAnidbSeasonEvidence, type AnidbSearchResult } from "../src/anidb/direct";
+import { routeAnidbSeason } from "../src/anidb/season-routing";
+
+function result(id: string, title: string): AnidbSearchResult {
+  const numericId = Number(id.match(/-(\d+)$/)?.[1]);
+  return { id, title, numericId, seasonEvidence: parseAnidbSeasonEvidence(title) };
+}
+
+const noEpisodes = async (): Promise<readonly AnidbEpisodeEntry[]> => [];
+
+describe("routeAnidbSeason", () => {
+  test("uses an absolute episode only after the routed base catalog confirms it", async () => {
+    const episodeLookups: string[] = [];
+    const route = await routeAnidbSeason({
+      base: result("catalog-confirmed-show-690", "Catalog Confirmed Show"),
+      episode: { season: 1, episode: 27, absoluteEpisode: 1085 },
+      search: async () => {
+        throw new Error("season one must not search for a sibling");
+      },
+      episodes: async (showId) => {
+        episodeLookups.push(showId);
+        return [{ id: 501085, number: 1085 }];
+      },
+    });
+
+    expect(episodeLookups).toEqual(["catalog-confirmed-show-690"]);
+    expect(route).toEqual({
+      requestedSeason: 1,
+      baseShowId: "catalog-confirmed-show-690",
+      routedShowId: "catalog-confirmed-show-690",
+      episodeNumber: 1085,
+      usedAbsoluteEpisode: true,
+      numberingEvidence: {
+        kind: "absolute-episode-catalog",
+        routedShowId: "catalog-confirmed-show-690",
+        requestedAbsoluteEpisode: 1085,
+        matchedEpisodeId: 501085,
+      },
+      evidence: { kind: "base-season", normalizedBaseTitle: "catalog confirmed show" },
+    });
+  });
+
+  test("a title without a season label uses cour numbering when its catalog does not confirm absolute numbering", async () => {
+    const route = await routeAnidbSeason({
+      base: result("plain-show-700", "Plain Show"),
+      episode: { season: 1, episode: 1, absoluteEpisode: 13 },
+      search: async () => {
+        throw new Error("season one must not search for a sibling");
+      },
+      episodes: async () => [
+        { id: 70001, number: 1 },
+        { id: 70002, number: 2 },
+      ],
+    });
+
+    expect(route).toMatchObject({
+      episodeNumber: 1,
+      usedAbsoluteEpisode: false,
+      numberingEvidence: {
+        kind: "cour",
+        reason: "absolute-episode-not-in-routed-catalog",
+        requestedAbsoluteEpisode: 13,
+      },
+    });
+  });
+
+  test("a catalog entry already labelled season two uses cour numbering without treating the title as an absolute base", async () => {
+    const route = await routeAnidbSeason({
+      base: result("solo-leveling-season-2-19837", "Solo Leveling Season 2"),
+      episode: { season: 1, episode: 1, absoluteEpisode: 13 },
+      search: async () => [],
+      episodes: async () => {
+        throw new Error("season-specific titles must not probe absolute numbering");
+      },
+    });
+
+    expect(route?.routedShowId).toBe("solo-leveling-season-2-19837");
+    expect(route?.episodeNumber).toBe(1);
+    expect(route?.usedAbsoluteEpisode).toBe(false);
+    expect(route?.numberingEvidence).toEqual({
+      kind: "cour",
+      reason: "routed-title-is-season-specific",
+      requestedAbsoluteEpisode: 13,
+    });
+  });
+
+  test("routes season two to the unique normalized sibling and uses cour episode", async () => {
+    const queries: string[] = [];
+    const route = await routeAnidbSeason({
+      base: result("solo-leveling-19413", "Solo Leveling"),
+      episode: { season: 2, episode: 1, absoluteEpisode: 13 },
+      search: async (query) => {
+        queries.push(query);
+        return [
+          result("solo-leveling-19413", "Solo Leveling"),
+          result("solo-leveling-season-2-19837", "Solo Leveling Season 2"),
+          result("solo-leveling-chibi-season-2-29999", "Solo Leveling Chibi Season 2"),
+        ];
+      },
+      episodes: async () => {
+        throw new Error("routed season siblings must use cour numbering without absolute lookup");
+      },
+    });
+
+    expect(queries).toEqual(["solo leveling Season 2"]);
+    expect(route).toEqual({
+      requestedSeason: 2,
+      baseShowId: "solo-leveling-19413",
+      routedShowId: "solo-leveling-season-2-19837",
+      episodeNumber: 1,
+      usedAbsoluteEpisode: false,
+      numberingEvidence: {
+        kind: "cour",
+        reason: "routed-season-sibling",
+        requestedAbsoluteEpisode: 13,
+      },
+      evidence: {
+        kind: "season-search",
+        query: "solo leveling Season 2",
+        matchedTitle: "Solo Leveling Season 2",
+        matchedSeason: 2,
+        titleMatch: "exact",
+      },
+    });
+  });
+
+  test("returns null when equally ranked season siblings are ambiguous", async () => {
+    const route = await routeAnidbSeason({
+      base: result("demo-1", "Demo"),
+      episode: { season: 2, episode: 1 },
+      search: async () => [
+        result("demo-season-2-2", "Demo Season 2"),
+        result("demo-second-season-3", "Demo 2nd Season"),
+      ],
+      episodes: noEpisodes,
+    });
+    expect(route).toBeNull();
+  });
+
+  test("returns null when no candidate carries the requested season evidence", async () => {
+    const route = await routeAnidbSeason({
+      base: result("demo-1", "Demo"),
+      episode: { season: 3, episode: 2, absoluteEpisode: 26 },
+      search: async () => [result("demo-special-9", "Demo Special")],
+      episodes: noEpisodes,
+    });
+    expect(route).toBeNull();
+  });
+});

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -162,6 +162,30 @@ describe("anidb browse parsing", () => {
     expect(performance.now() - startedAt).toBeLessThan(1_000);
   });
 
+  test("never emits terminal control characters, raw or entity-encoded", () => {
+    const ESC = String.fromCharCode(27);
+    const BEL = String.fromCharCode(7);
+    // These titles are printed to a terminal. ESC drives cursor movement, screen
+    // clears, and OSC 52 clipboard writes, so a provider must not be able to put
+    // one in a title -- least of all via `&#27;`, which is plain ASCII on the
+    // wire and would otherwise be minted into a real ESC by our own decoder.
+    const html = [
+      `<a href="/anime/raw-11" title="Raw${ESC}[2J${BEL}Title"></a>`,
+      '<a href="/anime/entity-12" title="Entity&#27;[2JTitle"></a>',
+      '<a href="/anime/hexentity-13" title="Hex&#x1b;[2JTitle"></a>',
+    ].join("");
+
+    const titles = parseAnidbBrowseHtml(html).map((result) => result.title);
+    expect(titles).toEqual(["Raw[2JTitle", "Entity&#27;[2JTitle", "Hex&#x1b;[2JTitle"]);
+    const controlCharacters = titles
+      .flatMap((title) => [...title])
+      .filter((character) => {
+        const codePoint = character.codePointAt(0) ?? 0;
+        return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+      });
+    expect(controlCharacters).toEqual([]);
+  });
+
   test("extracts deterministic season evidence", () => {
     expect(parseAnidbSeasonEvidence("Mob Psycho 100 3rd Season")).toEqual({
       seasonNumber: 3,

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -10,6 +10,8 @@ import {
   looksLikeAnidbShowId,
   parseAnidbBrowseHtml,
   parseAnidbSeasonEvidence,
+  anidbCipherArgs,
+  resolveAnidbCurl,
   searchAnidb,
 } from "../src/anidb/direct";
 import { anidbManifest, ANIDB_PROVIDER_ID } from "../src/anidb/manifest";
@@ -197,6 +199,59 @@ describe("anidb browse parsing", () => {
       label: "S2",
       normalizedBaseTitle: "demon slayer",
     });
+  });
+});
+
+describe("anidb curl selection", () => {
+  // Parity with ani-cli v5 `dep_ch_failover`. anidb.app is behind Cloudflare,
+  // which fingerprints the TLS handshake, so a browser UA over curl's own
+  // handshake still gets challenged -- and a challenge page parses to zero
+  // search results, which is a release blocker for the default provider.
+  test("prefers the newest curl-impersonate build over plain curl", () => {
+    const present = new Set(["curl", "curl_chrome116", "curl_firefox135"]);
+    expect(resolveAnidbCurl((cmd) => (present.has(cmd) ? `/usr/bin/${cmd}` : null))).toEqual({
+      path: "/usr/bin/curl_firefox135",
+      impersonates: true,
+    });
+  });
+
+  test("falls back through older impersonate builds before plain curl", () => {
+    const present = new Set(["curl", "curl_ff117"]);
+    expect(resolveAnidbCurl((cmd) => (present.has(cmd) ? `/usr/bin/${cmd}` : null))).toEqual({
+      path: "/usr/bin/curl_ff117",
+      impersonates: true,
+    });
+  });
+
+  test("marks plain curl as non-impersonating so cipher flags are applied", () => {
+    expect(resolveAnidbCurl((cmd) => (cmd === "curl" ? "/usr/bin/curl" : null))).toEqual({
+      path: "/usr/bin/curl",
+      impersonates: false,
+    });
+  });
+
+  test("reports no curl at all so the caller can fall back to fetch", () => {
+    expect(resolveAnidbCurl(() => null)).toBeNull();
+  });
+
+  // ani-cli sets cipher flags only on Darwin. Windows curl.exe links Schannel,
+  // which rejects --tls13-ciphers and OpenSSL cipher names outright, so sending
+  // them there fails the request rather than hardening it.
+  test("sends ani-cli's cipher flags on macOS only", () => {
+    expect(anidbCipherArgs(false, "darwin")).toEqual([
+      "--ciphers",
+      expect.stringContaining("ECDHE-ECDSA-AES128-GCM-SHA256"),
+      "--tls13-ciphers",
+      expect.stringContaining("TLS_AES_128_GCM_SHA256"),
+    ]);
+    expect(anidbCipherArgs(false, "win32")).toEqual([]);
+    expect(anidbCipherArgs(false, "linux")).toEqual([]);
+  });
+
+  test("never overrides an impersonate build's own handshake", () => {
+    for (const platform of ["darwin", "win32", "linux"] as const) {
+      expect(anidbCipherArgs(true, platform)).toEqual([]);
+    }
   });
 });
 

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -138,6 +138,24 @@ describe("anidb browse parsing", () => {
     expect(results[0]?.id).toBe("onigiri-3942");
   });
 
+  test("strips script content behind a whitespace-padded closing tag", () => {
+    // `</script >` is legal HTML. A filter matching only `</script>` leaves the
+    // script source in the anchor body, which then becomes the title.
+    const html =
+      '<a href="/anime/scripted-77"><script>var leaked = 1;</script ><span>Real Title</span></a>';
+    // Filtering only `</script>` leaves "var leaked = 1; Real Title" as the title.
+    expect(parseAnidbBrowseHtml(html).map((result) => result.title)).toEqual(["Real Title"]);
+  });
+
+  test("classifies card evidence in linear time on adversarial markup", () => {
+    // `<a` repeated with no closing `>` is the quadratic case for a
+    // `/<[a-z][^>]*>/` scan. Budget is generous; a regression blows past it.
+    const hostile = `<a href="/anime/hostile-9">${"<a".repeat(60_000)}</a>`;
+    const startedAt = performance.now();
+    expect(parseAnidbBrowseHtml(hostile)).toEqual([]);
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
+  });
+
   test("extracts deterministic season evidence", () => {
     expect(parseAnidbSeasonEvidence("Mob Psycho 100 3rd Season")).toEqual({
       seasonNumber: 3,

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -164,6 +164,15 @@ describe("anidb browse parsing", () => {
     expect(performance.now() - startedAt).toBeLessThan(1_000);
   });
 
+  test("strips script blocks in linear time on repeated unterminated end tags", () => {
+    // The lazy-body + optional-tail regex this replaced was polynomial here:
+    // each `</script\t` repetition re-scanned to end of input.
+    const hostile = `<a href="/anime/redos-10" title="T"><script>${"</script\t".repeat(40_000)}</a>`;
+    const startedAt = performance.now();
+    expect(parseAnidbBrowseHtml(hostile).map((result) => result.title)).toEqual(["T"]);
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
+  });
+
   test("never emits terminal control characters, raw or entity-encoded", () => {
     const ESC = String.fromCharCode(27);
     const BEL = String.fromCharCode(7);

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -2,11 +2,17 @@ import { describe, expect, test } from "bun:test";
 
 import {
   anidbNumericId,
-  looksLikeAnidbShowId,
-  searchAnidb,
+  chooseAnidbSearchMatch,
   clearAnidbCachesForTest,
+  looksLikeAnidbShowId,
+  parseAnidbBrowseHtml,
+  parseAnidbSeasonEvidence,
+  searchAnidb,
 } from "../src/anidb/direct";
 import { anidbManifest, ANIDB_PROVIDER_ID } from "../src/anidb/manifest";
+
+const fixture = (name: string) =>
+  Bun.file(new URL(`./fixtures/anidb/${name}`, import.meta.url)).text();
 
 describe("anidb id helpers", () => {
   test("accepts slug-numeric show ids", () => {
@@ -20,6 +26,11 @@ describe("anidb id helpers", () => {
     expect(anidbNumericId("onigiri-3942")).toBe(3942);
     expect(anidbNumericId("nope")).toBeNull();
   });
+
+  test("rejects a non-positive numeric suffix", () => {
+    expect(looksLikeAnidbShowId("bad-0")).toBe(false);
+    expect(anidbNumericId("bad-0")).toBeNull();
+  });
 });
 
 describe("anidb manifest", () => {
@@ -31,24 +42,154 @@ describe("anidb manifest", () => {
   });
 });
 
-describe("anidb search parsing", () => {
-  test("parses browse HTML fixtures", async () => {
+describe("anidb browse parsing", () => {
+  test("parses legacy relative links whose title lives in image alt", async () => {
+    expect(parseAnidbBrowseHtml(await fixture("browse-legacy.html"))).toEqual([
+      {
+        id: "onigiri-3942",
+        title: "Onigiri & Friends",
+        numericId: 3942,
+        seasonEvidence: {
+          seasonNumber: null,
+          label: null,
+          normalizedBaseTitle: "onigiri friends",
+        },
+      },
+    ]);
+  });
+
+  test("captures the complete opening tag so title after href wins over image alt and nested text", async () => {
+    expect(parseAnidbBrowseHtml(await fixture("browse-current.html"))).toEqual([
+      {
+        id: "solo-leveling-19413",
+        title: "Solo Leveling",
+        numericId: 19413,
+        seasonEvidence: {
+          seasonNumber: null,
+          label: null,
+          normalizedBaseTitle: "solo leveling",
+        },
+      },
+      {
+        id: "solo-leveling-season-2-19837",
+        title: "Solo Leveling Season 2",
+        numericId: 19837,
+        seasonEvidence: {
+          seasonNumber: 2,
+          label: "Season 2",
+          normalizedBaseTitle: "solo leveling",
+        },
+      },
+    ]);
+  });
+
+  test("decodes numeric entities and rejects non-positive suffixes", () => {
+    const html = [
+      '<a href="/anime/rock-and-roll-42"><img alt="Rock &#39;n&#x20;Roll"></a>',
+      '<a href="/anime/zero-0"><img alt="Zero"></a>',
+      '<a href="/anime/plain-identifier"><img alt="Plain"></a>',
+    ].join("");
+    expect(parseAnidbBrowseHtml(html).map((result) => result.title)).toEqual(["Rock 'n Roll"]);
+  });
+
+  test("never lets a prefixed attribute shadow href or title", () => {
+    const html = [
+      '<a data-href="/anime/hostile-666" href="/anime/real-123" title="Real Show"></a>',
+      '<a xlink:href="/anime/hostile-777" href="/anime/other-124"><img alt="Other Show"></a>',
+      '<a href="/anime/third-125" data-original-title="Tooltip junk" title="Third Show"></a>',
+    ].join("");
+    expect(parseAnidbBrowseHtml(html).map((result) => [result.id, result.title])).toEqual([
+      ["real-123", "Real Show"],
+      ["other-124", "Other Show"],
+      ["third-125", "Third Show"],
+    ]);
+  });
+
+  test("accepts protocol-relative anidb hrefs", () => {
+    expect(
+      parseAnidbBrowseHtml('<a href="//anidb.app/anime/relative-88" title="Relative"></a>'),
+    ).toEqual([
+      {
+        id: "relative-88",
+        title: "Relative",
+        numericId: 88,
+        seasonEvidence: { seasonNumber: null, label: null, normalizedBaseTitle: "relative" },
+      },
+    ]);
+  });
+
+  test("decodes each entity exactly once and rejects lone surrogates", () => {
+    const html = [
+      '<a href="/anime/escaped-1" title="Literal &amp;lt;tag&amp;gt; &amp; &amp;#39;quote&amp;#39;"></a>',
+      '<a href="/anime/surrogate-2" title="Lone &#xD800; surrogate"></a>',
+    ].join("");
+    expect(parseAnidbBrowseHtml(html).map((result) => result.title)).toEqual([
+      "Literal &lt;tag&gt; & &#39;quote&#39;",
+      "Lone &#xD800; surrogate",
+    ]);
+  });
+
+  test("ignores nav, breadcrumb, related and footer anime links around the result grid", async () => {
+    const results = parseAnidbBrowseHtml(await fixture("browse-with-page-chrome.html"));
+    expect(results.map((result) => result.id)).toEqual(["onigiri-3942", "onigiri-tabetai-4501"]);
+    expect(results[0]?.id).toBe("onigiri-3942");
+  });
+
+  test("extracts deterministic season evidence", () => {
+    expect(parseAnidbSeasonEvidence("Mob Psycho 100 3rd Season")).toEqual({
+      seasonNumber: 3,
+      label: "3rd Season",
+      normalizedBaseTitle: "mob psycho 100",
+    });
+    expect(parseAnidbSeasonEvidence("Demon Slayer S2")).toEqual({
+      seasonNumber: 2,
+      label: "S2",
+      normalizedBaseTitle: "demon slayer",
+    });
+  });
+});
+
+describe("chooseAnidbSearchMatch", () => {
+  const parse = (html: string) => parseAnidbBrowseHtml(html);
+  const card = (id: string, title: string) =>
+    `<a href="/anime/${id}" title="${title}"><article></article></a>`;
+
+  test("prefers an exact normalized title match over document order", () => {
+    const results = parse(
+      [card("wrong-first-1", "Onigiri Tabetai"), card("onigiri-3942", "Onigiri!")].join(""),
+    );
+    expect(chooseAnidbSearchMatch("onigiri", results)?.id).toBe("onigiri-3942");
+  });
+
+  test("falls back to a prefix match when nothing matches exactly", () => {
+    const results = parse(
+      [card("unrelated-9", "Bleach"), card("solo-19413", "Solo Leveling Origins")].join(""),
+    );
+    expect(chooseAnidbSearchMatch("solo leveling", results)?.id).toBe("solo-19413");
+  });
+
+  test("falls back to the first result when no title evidence matches", () => {
+    const results = parse([card("first-1", "Alpha"), card("second-2", "Beta")].join(""));
+    expect(chooseAnidbSearchMatch("nothing comparable", results)?.id).toBe("first-1");
+  });
+
+  test("returns null for an empty result set", () => {
+    expect(chooseAnidbSearchMatch("anything", [])).toBeNull();
+  });
+});
+
+describe("anidb search delegation", () => {
+  test("searchAnidb returns the shared browse parser contract", async () => {
     clearAnidbCachesForTest();
-    const originalWhich = Bun.which.bind(Bun);
-    Bun.which = ((_cmd: string) => null) as typeof Bun.which;
+    const page = await fixture("browse-current.html");
+    const originalWhich = Bun.which;
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () =>
-      new Response(
-        `<a href="/anime/onigiri-3942" alt="Onigiri"><a href="/anime/demo-21" alt="Demo Title">`,
-        { status: 200 },
-      )) as unknown as typeof fetch;
 
     try {
-      const results = await searchAnidb("onigiri");
-      expect(results).toEqual([
-        { id: "onigiri-3942", title: "Onigiri", numericId: 3942 },
-        { id: "demo-21", title: "Demo Title", numericId: 21 },
-      ]);
+      Bun.which = ((_cmd: string) => null) as typeof Bun.which;
+      globalThis.fetch = (async () =>
+        new Response(page, { status: 200 })) as unknown as typeof fetch;
+      expect(await searchAnidb("solo leveling")).toEqual(parseAnidbBrowseHtml(page));
     } finally {
       globalThis.fetch = originalFetch;
       Bun.which = originalWhich;

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -138,12 +138,18 @@ describe("anidb browse parsing", () => {
     expect(results[0]?.id).toBe("onigiri-3942");
   });
 
-  test("strips script content behind a whitespace-padded closing tag", () => {
-    // `</script >` is legal HTML. A filter matching only `</script>` leaves the
-    // script source in the anchor body, which then becomes the title.
-    const html =
-      '<a href="/anime/scripted-77"><script>var leaked = 1;</script ><span>Real Title</span></a>';
-    // Filtering only `</script>` leaves "var leaked = 1; Real Title" as the title.
+  test("strips script blocks behind every legal end-tag form", () => {
+    // An end tag's name ends at whitespace, `/`, or `>`; the rest is ignored.
+    // Missing any of these leaves "var leaked = 1; Real Title" as the title.
+    for (const endTag of ["</script>", "</script >", "</script\t\n bar>", "</script/>"]) {
+      const html = `<a href="/anime/scripted-77"><script>var leaked = 1;${endTag}<span>Real Title</span></a>`;
+      expect(parseAnidbBrowseHtml(html).map((result) => result.title)).toEqual(["Real Title"]);
+    }
+  });
+
+  test("does not treat a longer tag name as a script end tag", () => {
+    // `</scriptfoo>` closes nothing; over-broad stripping would swallow the title.
+    const html = '<a href="/anime/notscript-78"><span>Real Title</span><scriptfoo></scriptfoo></a>';
     expect(parseAnidbBrowseHtml(html).map((result) => result.title)).toEqual(["Real Title"]);
   });
 

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
+import type { ProviderRuntimeContext } from "@kunai/types";
+
 import {
   anidbNumericId,
+  anidbProviderModule,
   chooseAnidbSearchMatch,
   clearAnidbCachesForTest,
   looksLikeAnidbShowId,
@@ -194,5 +197,147 @@ describe("anidb search delegation", () => {
       globalThis.fetch = originalFetch;
       Bun.which = originalWhich;
     }
+  });
+});
+
+describe("anidb direct resolve season routing", () => {
+  const CONTEXT: ProviderRuntimeContext = {
+    providerId: "anidb",
+    now: () => new Date().toISOString(),
+  };
+
+  function anidbFetchStub(routes: {
+    readonly browse?: string;
+    readonly episodesByNumericId: Record<string, { id: number; number: number }[]>;
+  }) {
+    return (async (input: unknown) => {
+      const url = String(
+        typeof input === "string" ? input : ((input as { url?: string })?.url ?? input),
+      );
+      if (url.includes("/browse?")) {
+        return new Response(routes.browse ?? "", { status: 200 });
+      }
+      const episodesMatch = /\/api\/frontend\/anime\/(\d+)\/episodes/.exec(url);
+      if (episodesMatch?.[1]) {
+        return new Response(
+          JSON.stringify({ episodes: routes.episodesByNumericId[episodesMatch[1]] ?? [] }),
+          { status: 200 },
+        );
+      }
+      if (/\/api\/frontend\/episode\/\d+\/languages/.test(url)) {
+        return new Response(
+          JSON.stringify({
+            languages: [
+              { code: "jpn", name: "Japanese", embed_url: "https://anidb.app/embed/jpn-1" },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/embed/")) {
+        return new Response("file: 'https://cdn.example/stream.m3u8'", { status: 200 });
+      }
+      if (url.includes("stream.m3u8")) {
+        return new Response("#EXTM3U\n#EXTINF:4,\nseg0.ts\n", { status: 200 });
+      }
+      throw new Error(`unexpected anidb request: ${url}`);
+    }) as unknown as typeof fetch;
+  }
+
+  async function resolveWithStub(
+    input: Parameters<typeof anidbProviderModule.resolve>[0],
+    stub: typeof fetch,
+  ) {
+    clearAnidbCachesForTest();
+    const originalWhich = Bun.which;
+    const originalFetch = globalThis.fetch;
+    try {
+      Bun.which = ((_cmd: string) => null) as typeof Bun.which;
+      globalThis.fetch = stub;
+      return await anidbProviderModule.resolve(input, CONTEXT);
+    } finally {
+      globalThis.fetch = originalFetch;
+      Bun.which = originalWhich;
+      clearAnidbCachesForTest();
+    }
+  }
+
+  test("routes a season-2 request to the sibling title and uses cour numbering", async () => {
+    const result = await resolveWithStub(
+      {
+        title: {
+          id: "solo-leveling-19413",
+          kind: "anime",
+          title: "Solo Leveling",
+        },
+        episode: { season: 2, episode: 1, absoluteEpisode: 13 },
+        mediaKind: "anime",
+        preferredAudioLanguage: "ja",
+        intent: "play",
+        allowedRuntimes: ["direct-http"],
+      } as Parameters<typeof anidbProviderModule.resolve>[0],
+      anidbFetchStub({
+        browse: [
+          '<a href="/anime/solo-leveling-19413" title="Solo Leveling"><article></article></a>',
+          '<a href="/anime/solo-leveling-season-2-19837" title="Solo Leveling Season 2"><article></article></a>',
+        ].join(""),
+        episodesByNumericId: { "19837": [{ id: 9001, number: 1 }] },
+      }),
+    );
+
+    expect(result.status).toBe("resolved");
+    expect(result.trace.steps).toContainEqual(
+      expect.objectContaining({
+        message: "Routed AniDB season identity",
+        attributes: expect.objectContaining({
+          requestedSeason: 2,
+          baseShowId: "solo-leveling-19413",
+          routedShowId: "solo-leveling-season-2-19837",
+          numberingEvidence: "cour",
+          numberingEvidenceReason: "routed-season-sibling",
+          episodeNumber: 1,
+          usedAbsoluteEpisode: false,
+        }),
+      }),
+    );
+    expect(result.externalIds?.providerNativeIds?.anidb).toBe("solo-leveling-season-2-19837");
+  });
+
+  test("an unlabelled title whose catalog lacks the absolute episode falls back to cour numbering", async () => {
+    const result = await resolveWithStub(
+      {
+        title: { id: "plain-show-700", kind: "anime", title: "Plain Show" },
+        episode: { season: 1, episode: 1, absoluteEpisode: 13 },
+        mediaKind: "anime",
+        preferredAudioLanguage: "ja",
+        intent: "play",
+        allowedRuntimes: ["direct-http"],
+      } as Parameters<typeof anidbProviderModule.resolve>[0],
+      anidbFetchStub({
+        episodesByNumericId: {
+          "700": [
+            { id: 70001, number: 1 },
+            { id: 70002, number: 2 },
+          ],
+        },
+      }),
+    );
+
+    expect(result.status).toBe("resolved");
+    expect(result.trace.steps).toContainEqual(
+      expect.objectContaining({
+        message: "Routed AniDB season identity",
+        attributes: expect.objectContaining({
+          requestedSeason: 1,
+          baseShowId: "plain-show-700",
+          routedShowId: "plain-show-700",
+          numberingEvidence: "cour",
+          numberingEvidenceReason: "absolute-episode-not-in-routed-catalog",
+          episodeNumber: 1,
+          usedAbsoluteEpisode: false,
+        }),
+      }),
+    );
+    expect(result.externalIds?.providerNativeIds?.anidb).toBe("plain-show-700");
   });
 });

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -173,6 +173,14 @@ describe("anidb browse parsing", () => {
     expect(performance.now() - startedAt).toBeLessThan(1_000);
   });
 
+  test("strips tags in linear time on unclosed angle brackets", () => {
+    // `/<[^>]+>/g` restarted a scan to end of input at every `<`.
+    const hostile = `<a href="/anime/tagredos-14" title="T">${"<".repeat(200_000)}</a>`;
+    const startedAt = performance.now();
+    expect(parseAnidbBrowseHtml(hostile).map((result) => result.title)).toEqual(["T"]);
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
+  });
+
   test("never emits terminal control characters, raw or entity-encoded", () => {
     const ESC = String.fromCharCode(27);
     const BEL = String.fromCharCode(7);

--- a/packages/providers/test/fixtures/anidb/browse-current.html
+++ b/packages/providers/test/fixtures/anidb/browse-current.html
@@ -1,0 +1,14 @@
+<section class="anime-grid">
+  <a href="https://anidb.app/anime/solo-leveling-19413" title="Solo Leveling">
+    <article>
+      <img src="/covers/19413.jpg" alt="Wrong image-alt title" />
+      <span class="anime-title">Wrong nested title</span>
+    </article>
+  </a>
+  <a href="https://anidb.app/anime/solo-leveling-season-2-19837">
+    <article><span class="anime-title">Solo Leveling Season 2</span></article>
+  </a>
+  <a href="https://anidb.app/anime/bad-0">
+    <article><span class="anime-title">Bad Zero Suffix</span></article>
+  </a>
+</section>

--- a/packages/providers/test/fixtures/anidb/browse-legacy.html
+++ b/packages/providers/test/fixtures/anidb/browse-legacy.html
@@ -1,0 +1,11 @@
+<section class="legacy-grid">
+  <a href="/anime/onigiri-3942">
+    <img src="/covers/3942.jpg" alt="Onigiri &amp; Friends" />
+  </a>
+  <a href="/anime/onigiri-3942">
+    <img src="/covers/3942-small.jpg" alt="Duplicate Onigiri" />
+  </a>
+  <a href="/anime/not-a-valid-id">
+    <img src="/covers/invalid.jpg" alt="Invalid" />
+  </a>
+</section>

--- a/packages/providers/test/fixtures/anidb/browse-with-page-chrome.html
+++ b/packages/providers/test/fixtures/anidb/browse-with-page-chrome.html
@@ -1,0 +1,24 @@
+<nav class="site-nav">
+  <a href="/anime/browse-101">Browse</a>
+  <a href="https://anidb.app/anime/seasonal-102">Seasonal</a>
+</nav>
+<ol class="breadcrumb">
+  <li><a href="/anime/home-103">Home</a></li>
+  <li><a href="/anime/anime-index-104">Anime</a></li>
+</ol>
+<aside class="related-rail">
+  <a href="/anime/related-pick-105">Related pick</a>
+</aside>
+<section class="results">
+  <a href="https://anidb.app/anime/onigiri-3942" title="Onigiri">
+    <article>
+      <img src="/covers/3942.jpg" alt="Onigiri" />
+    </article>
+  </a>
+  <a href="https://anidb.app/anime/onigiri-tabetai-4501">
+    <article><span>Onigiri Tabetai</span></article>
+  </a>
+</section>
+<footer>
+  <a href="/anime/footer-106">Footer link</a>
+</footer>


### PR DESCRIPTION
## Scope

Makes the default anime route tell the truth: the AniDB browse parser, catalog routing, provider-native identity, season routing, and release signoff.

- **Browse parsing** — one fixture-testable parser handles both AniDB card generations (legacy relative `/anime/<slug-id>` with the title in image `alt`, and current absolute links carrying the title on the anchor). Search and resolve share it, so markup drift cannot silently affect only one path. Dedupes by validated slug, decodes entities, rejects rows without a positive numeric suffix.
- **Candidate scoping** — the parser only accepts anchors that look like result cards. Previously every `/anime/<slug-id>` anchor in the document qualified, so a nav, breadcrumb, or "related" link could become `results[0]` and pin the wrong show for every downstream episode resolve. Covered by `browse-with-page-chrome.html`.
- **Catalog routing** — an advanced AniDB search no longer falls through to the registry's default TMDB catalog. It reports unsupported-filter evidence or a diagnosed provider-native fallback instead of silently changing catalog identity.
- **Provider-native identity** — an AllAnime lookup can only populate an AllAnime identity. It is never stored under `providerNativeIds.anidb` or returned as an AniDB title ID.
- **Season routing** — season 1 keeps the base identity; season > 1 resolves a deterministic sibling from validated AniDB results, recording requested season, base identity, routed identity, and evidence in the trace.
- **Release signoff** — cases derive configured defaults from production config and look up the registered production module, resolving through the real engine. Fails if a default is unregistered, if a case tests a different provider than the configured default, if default search returns nothing, or if the engine yields no candidate.

## Non-goals

Provider hardening for AllManga, Miruro, and Videasy (planned as a separate change, not started). No new runtime entrypoint. UI episode numbers stay 1-based; synthetic numbering stays below the provider/resolve boundary.

## Base

Branch off `main`. **Bottom of a three-PR stack** — merge this one first.

## Verification

Run from the worktree root on the rebased head:

| Gate | Result |
| --- | --- |
| `bun run typecheck` | 14/14 tasks |
| `bun run lint` | 12/12, 0 warnings 0 errors |
| `bun run fmt` | clean, no files changed |
| `bun run test` | unit **3743 pass / 0 fail** (608 files); providers 252 pass; integration 87 pass / 0 fail (134 ran, 47 skipped) |
| `bun run build` | 10/10 tasks |
| `bun run verify:doc-paths` | 45 docs, all paths resolve |
| `bun run verify:doc-coverage` | every code area routed |
| `git diff --check` | clean |

The 47 integration skips are the repository's existing baseline (install.ps1, docker installer, compiled-binary smoke), not exclusions added here.

## Not verified

**The live AniDB gates were not run.** `bun run test:live:anidb` and `bun run test:live:release-signoff` were deliberately deprioritized — live provider health is being handled as a separate pass. This is an honest gap, not a pass: the deterministic fixture tests are the only thing standing behind the parser and identity changes in this PR.

## Docs

`.docs/providers.md` updated with the default AniDB route truth.

## Release blockers still open (not addressed here)

- **AllAnime reaches a valid episode catalog and extracts zero streams** — belongs to the unstarted provider-hardening work.
- **Tracker sync capability truth** — the tracker-sync work is unstarted, so any Connect action advertising sync without a working OAuth/client contract still violates a release stop condition.
