### PR TITLE
fix(playback): recover mid-playback state and reject stale mpv work

### DIFF
--- a/.changeset/mid-playback-state-recovery.md
+++ b/.changeset/mid-playback-state-recovery.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Recover active playback from transient buffer, stall, and seek states while rejecting stale mpv cycle events and presence updates.

--- a/.docs/mpv-in-process-reconnect.md
+++ b/.docs/mpv-in-process-reconnect.md
@@ -31,10 +31,10 @@ If reconnect **fails** or limits are hit, the cycle ends and the usual `Playback
 
 ## Configuration (`~/.config/kunai/config.json`)
 
-| Field | Default | Meaning |
-| --- | --- | --- |
-| `mpvInProcessStreamReconnect` | `true` | Master switch. `false` disables automatic same-URL reloads (manual **Ctrl+r** / shell refresh still work). |
-| `mpvInProcessStreamReconnectMaxAttempts` | `3` | Max reload attempts **per episode play**. Set `0` to disable (same as turning off retries). |
+| Field                                    | Default | Meaning                                                                                                    |
+| ---------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------- |
+| `mpvInProcessStreamReconnect`            | `true`  | Master switch. `false` disables automatic same-URL reloads (manual **Ctrl+r** / shell refresh still work). |
+| `mpvInProcessStreamReconnectMaxAttempts` | `3`     | Max reload attempts **per episode play**. Set `0` to disable (same as turning off retries).                |
 
 ## Relationship to other recovery
 
@@ -42,7 +42,43 @@ If reconnect **fails** or limits are hit, the cycle ends and the usual `Playback
 - **Libavformat reconnect** flags (`--demuxer-lavf-o=…`) are complementary; they only help when the backend supports them.
 - **`keep-open=always`** is **not** used: it can suppress `end-file` and break autoplay/session hand-off. Reconnect is explicit IPC instead.
 
+## Generations and stale work
+
+Every mpv process and playback cycle carries a monotonic generation
+(`{ process, cycle }`, `apps/cli/src/domain/playback/playback-generation.ts`).
+Endpoint waits, IPC opens, property callbacks, `file-loaded`, end-file,
+reconnect completions, and recovery work all capture the generation that created
+them and compare it against the active one before mutating session state.
+
+Stale work closes any handle it just created and returns without touching
+status, presence, diagnostics, or the shell. Replacing or stopping a session
+increments the generation **before** cleanup, so a late IPC event from the
+previous cycle cannot revive a session the user already replaced or stopped.
+Reconnect budgets and backoff above are unchanged by this.
+
+## Status recovery contract
+
+One authoritative transition policy owns current playback status
+(`apps/cli/src/app/playback/playback-status-policy.ts`):
+
+- Fresh `playback-progress` is recovery evidence **only** from `buffering`,
+  `stalled`, or `seeking`, and returns that session to `playing`.
+- It never overrides `paused`, `stopped`, `finished`, a replaced session, or a
+  terminal fallback/failure state that has not accepted a new stream.
+  `playback-resumed` is the only paused-to-playing transition; stop stays
+  authoritative.
+- Genuine stall and provider-fallback evidence stays in the diagnostics record
+  after status recovers, so the UI can still explain what happened.
+
+Header, loading shell, diagnostics, and presence consume that one status. They
+format it differently but never infer a second state machine. Note the two
+distinct predicates in `SessionState.ts`: `isPlaybackSessionActive()` means "a
+session exists" and includes the bootstrap states `loading`/`ready`, while
+`isPlaybackTransportStarted()` means "bootstrap is over" and does not. Surfaces
+deciding whether to keep a loading presentation need the latter.
+
 ## Telemetry and UI
 
 - Diagnostics / shell may show **`mpv-in-process-reconnect`** events (`started` | `complete` | `failed`) with attempt number and a short `detail` (trigger + error when failed).
 - Seek policy lives in `apps/cli/src/infra/player/mpv-in-process-reconnect.ts` (`computeInProcessReconnectSeek`).
+- Presence updates from a superseded generation are dropped rather than sent.

--- a/.docs/presence-integrations.md
+++ b/.docs/presence-integrations.md
@@ -50,6 +50,14 @@ are skipped to avoid unnecessary Discord IPC churn.
 
 Kunai no longer replaces finished playback with a generic "Browsing Kunai" activity.
 
+Presence follows the session's accepted current status rather than raw player
+events. Each update carries the playback generation that produced it, and an
+update from a superseded process or cycle is dropped instead of sent — a late
+event from a replaced or stopped session cannot repaint presence with the
+previous title. Presence therefore agrees with the header, loading shell, and
+diagnostics by construction, because all four read the same authoritative
+status.
+
 ## Binge session indicator
 
 Discord exposes only one timestamp pair per activity, so episode progress and a separate session

--- a/.docs/testing-strategy.md
+++ b/.docs/testing-strategy.md
@@ -157,6 +157,10 @@ untouched.
 - prefer deterministic tests over integration theater
 - isolate volatile network and provider drift behind fixtures and contracts
 - keep slow or brittle end-to-end behavior out of the critical path unless it validates something no lower layer can
+- test staleness by driving generations, not by racing timers: playback work is
+  stamped with `{ process, cycle }`, so a "late event from a replaced session"
+  test sets an older generation and asserts the state did not move. Deferred
+  promises resolved in a controlled order beat `setTimeout` for the same reason.
 
 ## Testing Pyramid For This Repo
 

--- a/apps/cli/src/app-shell/diagnostics-panel-lines.ts
+++ b/apps/cli/src/app-shell/diagnostics-panel-lines.ts
@@ -119,6 +119,7 @@ function buildCurrentPlaybackLines(insight: DiagnosticsInsight): ShellPanelLine[
     { label: "Mode", detail: evidence.mode, tone: "neutral" },
     { label: "Provider", detail: evidence.provider, tone: "neutral" },
     { label: "Playback state", detail: evidence.playbackStatus, tone: "neutral" },
+    { label: "Playback generation", detail: evidence.playbackGeneration, tone: "neutral" },
     { label: "Source", detail: evidence.sourceState, tone: "neutral" },
     { label: "Cache", detail: evidence.cacheState, tone: "neutral" },
     { label: "Subtitles", detail: evidence.subtitleOutcome, tone: "neutral" },

--- a/apps/cli/src/app-shell/ink-shell.tsx
+++ b/apps/cli/src/app-shell/ink-shell.tsx
@@ -110,7 +110,14 @@ import { useDebouncedViewportPolicy, useShellDimensions } from "./use-viewport-p
 
 export { openPlaybackShell } from "./playback-mount-shell";
 
-const ACTIVE_PLAYBACK_STATUSES = ["ready", "buffering", "seeking", "stalled", "playing"] as const;
+const ACTIVE_PLAYBACK_STATUSES = [
+  "ready",
+  "buffering",
+  "seeking",
+  "stalled",
+  "playing",
+  "paused",
+] as const;
 // Statuses where mpv owns the session and `q` means stop, not cancel. `ready`
 // is deliberately absent: bootstrap can sit in `ready` before first frame, and
 // cancel must stay available there (it always has been).

--- a/apps/cli/src/app-shell/playback-mount-shell.tsx
+++ b/apps/cli/src/app-shell/playback-mount-shell.tsx
@@ -24,6 +24,7 @@ import {
 import type { DecodedTrackSelection } from "@/domain/playback/track-capabilities";
 import { formatQueueEntryLabel } from "@/domain/queue/queue-entry-label";
 import type { SessionState } from "@/domain/session/SessionState";
+import { isPlaybackSessionActive } from "@/domain/session/SessionState";
 import { peekTitleDetail } from "@/services/catalog/TitleDetailService";
 import { buildRuntimeHealthSnapshot } from "@/services/diagnostics/runtime-health";
 import { isEpisodeDownloaded } from "@/services/offline/offline-episode-index";
@@ -277,12 +278,7 @@ export function PlaybackRootContent(input: PlaybackRootContentInput) {
   const { state, handlers, canGoNext, canGoPrevious, canToggleAutoplay, canStopAfterCurrent } =
     input;
   useEffect(preloadTracksPanelModules, []);
-  const playbackIsActive =
-    state.playbackStatus === "ready" ||
-    state.playbackStatus === "buffering" ||
-    state.playbackStatus === "seeking" ||
-    state.playbackStatus === "stalled" ||
-    state.playbackStatus === "playing";
+  const playbackIsActive = isPlaybackSessionActive(state.playbackStatus);
   const [telemetrySnapshot, setTelemetrySnapshot] = useState<PlaybackTelemetrySnapshot | null>(
     null,
   );

--- a/apps/cli/src/app-shell/root-shell-state.ts
+++ b/apps/cli/src/app-shell/root-shell-state.ts
@@ -1,4 +1,5 @@
 import type { OverlayState, SessionState, StateTransition } from "@/domain/session/SessionState";
+import { isPlaybackSessionActive } from "@/domain/session/SessionState";
 
 import type { KeyScope } from "./keybindings";
 import type { RootContentKind } from "./root-content-state";
@@ -79,14 +80,7 @@ export function resolveRootShellSurface(
     return "error";
   }
   const rootOverlay = getRootOwnedOverlay(state);
-  if (
-    state.playbackStatus === "loading" ||
-    state.playbackStatus === "ready" ||
-    state.playbackStatus === "buffering" ||
-    state.playbackStatus === "seeking" ||
-    state.playbackStatus === "stalled" ||
-    state.playbackStatus === "playing"
-  ) {
+  if (isPlaybackSessionActive(state.playbackStatus)) {
     if (rootOverlay) {
       return "root-overlay";
     }

--- a/apps/cli/src/app-shell/workflows/shell-workflows.ts
+++ b/apps/cli/src/app-shell/workflows/shell-workflows.ts
@@ -31,6 +31,7 @@ import { createOfflineLibraryEngine } from "@/domain/offline/OfflineLibraryEngin
 import { resolveProviderLaneFromMetadata } from "@/domain/provider-lane";
 import { planEpisodeQueue } from "@/domain/queue/QueuePlanner";
 import type { SessionState } from "@/domain/session/SessionState";
+import { isPlaybackSessionActive } from "@/domain/session/SessionState";
 import {
   encodePlaybackTargetRef,
   parsePlaybackTargetRef,
@@ -789,16 +790,13 @@ type ActionHandler = (container: Container) => Promise<ShellWorkflowResult>;
 
 async function handleTitleControlMenu(container: Container): Promise<"handled"> {
   const state = container.stateManager.getState();
-  const surface =
-    state.playbackStatus === "playing"
-      ? "playing"
-      : state.playbackStatus === "loading" ||
-          state.playbackStatus === "ready" ||
-          state.playbackStatus === "buffering"
-        ? "loading"
-        : state.activeModals.some((overlay) => overlay.type === "library")
-          ? "library"
-          : "browse";
+  // An active session — including paused — keeps the title-control playback
+  // route. Only a session that does not exist falls through to library/browse.
+  const surface = isPlaybackSessionActive(state.playbackStatus)
+    ? "playing"
+    : state.activeModals.some((overlay) => overlay.type === "library")
+      ? "library"
+      : "browse";
   const { openTitleControlMenu } =
     await import("@/app-shell/title-control/open-title-control-menu");
   await openTitleControlMenu(container, surface);

--- a/apps/cli/src/app/compiled-smoke/run-compiled-smoke.ts
+++ b/apps/cli/src/app/compiled-smoke/run-compiled-smoke.ts
@@ -41,7 +41,7 @@ async function playOnce(
     url,
     displayTitle,
     playbackMode,
-    onPlaybackEvent: (event) => {
+    onPlaybackEvent: ({ event }) => {
       appendRuntimeEvidence({ type: "playback-event", event: event.type });
       if (event.type === "playback-started" || event.type === "player-ready") {
         sawPlaybackStart = true;
@@ -140,7 +140,7 @@ async function runQueueManual(container: Container): Promise<number> {
     url: fx.streamUrl,
     displayTitle: fx.claimedTitle,
     playbackMode: "autoplay-chain",
-    onPlaybackEvent: (event) => {
+    onPlaybackEvent: ({ event }) => {
       appendRuntimeEvidence({ type: "playback-event", event: event.type });
       if (event.type === "playback-started") {
         acknowledged = attempt.acknowledgeStarted();
@@ -173,7 +173,7 @@ async function runAutoNext(container: Container): Promise<number> {
     url: fx.firstStreamUrl,
     displayTitle: `${fx.title} Ep1`,
     playbackMode: "autoplay-chain",
-    onPlaybackEvent: (event) => {
+    onPlaybackEvent: ({ event }) => {
       appendRuntimeEvidence({ type: "playback-event", event: event.type });
       if (event.type === "playback-started" || event.type === "player-ready") {
         sawPlaybackStart = true;
@@ -186,7 +186,7 @@ async function runAutoNext(container: Container): Promise<number> {
     url: fx.secondStreamUrl,
     displayTitle: `${fx.title} Ep2`,
     playbackMode: "autoplay-chain",
-    onPlaybackEvent: (event) => {
+    onPlaybackEvent: ({ event }) => {
       appendRuntimeEvidence({ type: "playback-event", event: event.type });
       if (event.type === "playback-started" || event.type === "player-ready") {
         sawPlaybackStart = true;
@@ -227,7 +227,7 @@ async function runFailedHandoff(container: Container): Promise<number> {
     url: fx.streamUrl,
     displayTitle: fx.title,
     playbackMode: "autoplay-chain",
-    onPlaybackEvent: (event) => {
+    onPlaybackEvent: ({ event }) => {
       appendRuntimeEvidence({ type: "playback-event", event: event.type });
       if (event.type === "playback-started") sawStart = true;
     },
@@ -299,7 +299,7 @@ async function runShutdownRestore(container: Container): Promise<number> {
     url: fx.streamUrl,
     displayTitle: fx.title,
     playbackMode: "autoplay-chain",
-    onPlaybackEvent: (event) => {
+    onPlaybackEvent: ({ event }) => {
       appendRuntimeEvidence({ type: "playback-event", event: event.type });
     },
   });

--- a/apps/cli/src/app/playback/PlaybackPhase.ts
+++ b/apps/cli/src/app/playback/PlaybackPhase.ts
@@ -106,6 +106,11 @@ import {
   startFromEpisodeSelection,
 } from "@/app/playback/playback-start-intent";
 import {
+  transitionPlaybackStatus,
+  type PlaybackStatusDecision,
+  type PlaybackStatusSignal,
+} from "@/app/playback/playback-status-policy";
+import {
   applyPlaybackControlTrackSelection,
   buildTrackOverrideDiagnosticContext,
 } from "@/app/playback/playback-track-selection-policy";
@@ -460,6 +465,32 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
       context: { ...correlation, reason },
       run: () => context.container.presence.clearPlayback(reason),
     });
+  }
+
+  /**
+   * The single writer of player-driven playback status. Reads the authoritative
+   * snapshot, asks the pure policy, and writes back only when the policy says
+   * the status or generation actually moved.
+   */
+  private applyPlaybackStatusSignal(
+    context: PhaseContext,
+    signal: PlaybackStatusSignal,
+  ): PlaybackStatusDecision {
+    const { stateManager } = context.container;
+    const state = stateManager.getState();
+    const decision = transitionPlaybackStatus(
+      { status: state.playbackStatus, generation: state.playbackGeneration },
+      signal,
+    );
+    if (decision.accepted && decision.statusChanged) {
+      stateManager.dispatch({
+        type: "SET_PLAYBACK_STATUS",
+        status: decision.snapshot.status,
+        generation: decision.snapshot.generation,
+        clearFeedback: decision.clearFeedback,
+      });
+    }
+    return decision;
   }
 
   /** Dispatches the error status to the UI and waits for the user to dismiss it. */
@@ -3817,10 +3848,7 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
             correlation,
           );
         },
-        setPlaybackStatus: (status) => {
-          stateManager.dispatch({ type: "SET_PLAYBACK_STATUS", status });
-        },
-        getPlaybackStatus: () => stateManager.getState().playbackStatus,
+        applyPlaybackStatusSignal: (signal) => this.applyPlaybackStatusSignal(context, signal),
         onTrackChanged: (event) => {
           const currentStream = stateManager.getState().stream;
           if (currentStream && event.trackType === "sub" && event.id === 0) {

--- a/apps/cli/src/app/playback/PlaybackPhase.ts
+++ b/apps/cli/src/app/playback/PlaybackPhase.ts
@@ -60,6 +60,7 @@ import {
   canAutoContinueIntoRecommendation,
   canAdvanceIntoRecommendation,
 } from "@/app/playback/playback-postplay-policy";
+import { isPlaybackPresenceUpdateCurrent } from "@/app/playback/playback-presence-freshness";
 import {
   playbackAudioPreference,
   playbackEpisodeCatalogLanguages,
@@ -109,6 +110,7 @@ import {
   transitionPlaybackStatus,
   type PlaybackStatusDecision,
   type PlaybackStatusSignal,
+  type PlaybackStatusSnapshot,
 } from "@/app/playback/playback-status-policy";
 import {
   applyPlaybackControlTrackSelection,
@@ -413,6 +415,7 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
     context: PhaseContext,
     task: string,
     activity: Parameters<PhaseContext["container"]["presence"]["updatePlayback"]>[0],
+    expected: PlaybackStatusSnapshot | null,
     correlation?: DiagnosticCorrelation,
   ): void {
     runBackgroundTask({
@@ -427,7 +430,19 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
         episode: activity.episode.episode,
       },
       run: () => {
-        const shellTitle = context.container.stateManager.getState().currentTitle;
+        const state = context.container.stateManager.getState();
+        // Read authoritative state immediately before the external mutation:
+        // this task was queued, and the session may have moved on since.
+        if (
+          expected &&
+          !isPlaybackPresenceUpdateCurrent(
+            { status: state.playbackStatus, generation: state.playbackGeneration },
+            expected,
+          )
+        ) {
+          return Promise.resolve();
+        }
+        const shellTitle = state.currentTitle;
         const detailPoster = peekTitleDetail(activity.title.id, activity.title.type)?.artwork
           ?.poster;
         const enrichedTitle =
@@ -3665,13 +3680,16 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
     });
 
     const playbackProviderId = successfulProviderId ?? stateManager.getState().provider;
+    // One cycle has one start instant. Recomputing it per update made every
+    // queued presence write claim playback had just begun.
+    const presenceStartedAtMs = Date.now();
     const presenceBase = () => ({
       mode: stateManager.getState().mode,
       title,
       episode,
       providerId: playbackProviderId,
       stream,
-      startedAtMs: Date.now(),
+      startedAtMs: presenceStartedAtMs,
     });
 
     const ledgerProviderId = playbackProviderId;
@@ -3787,10 +3805,11 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
             context,
             "presence.updatePlaybackLaunch",
             { ...presenceBase(), positionSeconds, subtitleCount },
+            null,
             correlation,
           );
         },
-        onPresenceStarted: ({ positionSeconds, durationSeconds }) => {
+        onPresenceStarted: ({ positionSeconds, durationSeconds, snapshot }) => {
           this.updatePresenceInBackground(
             context,
             "presence.updatePlaybackStarted",
@@ -3800,19 +3819,21 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
               durationSeconds,
               subtitleCount: undefined,
             },
+            snapshot,
             correlation,
           );
         },
-        onPresenceProgress: ({ positionSeconds, durationSeconds }) => {
+        onPresenceProgress: ({ positionSeconds, durationSeconds, snapshot }) => {
           this.playbackLedger?.onProgress(positionSeconds, durationSeconds);
           this.updatePresenceInBackground(
             context,
             "presence.updatePlaybackProgress",
             { ...presenceBase(), positionSeconds, durationSeconds },
+            snapshot,
             correlation,
           );
         },
-        onPresenceSubtitles: ({ positionSeconds, durationSeconds, trackCount }) => {
+        onPresenceSubtitles: ({ positionSeconds, durationSeconds, trackCount, snapshot }) => {
           this.updatePresenceInBackground(
             context,
             "presence.updatePlaybackSubtitles",
@@ -3822,10 +3843,11 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
               durationSeconds,
               subtitleCount: trackCount,
             },
+            snapshot,
             correlation,
           );
         },
-        onPresencePaused: ({ positionSeconds, durationSeconds }) => {
+        onPresencePaused: ({ positionSeconds, durationSeconds, snapshot }) => {
           this.playbackLedger?.onPaused(positionSeconds, durationSeconds);
           this.updatePresenceInBackground(
             context,
@@ -3836,15 +3858,17 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
               durationSeconds,
               paused: true,
             },
+            snapshot,
             correlation,
           );
         },
-        onPresenceResumed: ({ positionSeconds, durationSeconds }) => {
+        onPresenceResumed: ({ positionSeconds, durationSeconds, snapshot }) => {
           this.playbackLedger?.onResumed(positionSeconds, durationSeconds);
           this.updatePresenceInBackground(
             context,
             "presence.updatePlaybackResumed",
             { ...presenceBase(), positionSeconds, durationSeconds },
+            snapshot,
             correlation,
           );
         },

--- a/apps/cli/src/app/playback/playback-bootstrap-presenter.ts
+++ b/apps/cli/src/app/playback/playback-bootstrap-presenter.ts
@@ -1,4 +1,5 @@
 import type { LoadingShellStage, LoadingShellState } from "@/app-shell/types";
+import { isPlaybackTransportStarted, type PlaybackStatus } from "@/domain/session/SessionState";
 import type { DiagnosticEvent } from "@/services/diagnostics/diagnostic-event";
 import {
   formatStartupPhaseBreakdown,
@@ -118,16 +119,14 @@ function dominantPhaseLabelFromEvents(
 }
 
 export function buildPlaybackBootstrapPresentation(input: {
-  readonly playbackStatus: string;
+  readonly playbackStatus: PlaybackStatus;
   readonly playbackDetail?: string | null;
   readonly recentEvents: readonly DiagnosticEvent[];
 }): PlaybackBootstrapPresentation {
   const startupStage = latestPlaybackStartupStage(input.recentEvents);
-  const isActivePlayback =
-    input.playbackStatus === "playing" ||
-    input.playbackStatus === "buffering" ||
-    input.playbackStatus === "seeking" ||
-    input.playbackStatus === "stalled";
+  // Bootstrap-over, not session-exists: `loading` / `ready` must keep the
+  // loading presentation, so this cannot use isPlaybackSessionActive().
+  const isActivePlayback = isPlaybackTransportStarted(input.playbackStatus);
 
   const operation: LoadingShellState["operation"] = isActivePlayback
     ? "playing"

--- a/apps/cli/src/app/playback/playback-presence-freshness.ts
+++ b/apps/cli/src/app/playback/playback-presence-freshness.ts
@@ -1,0 +1,28 @@
+// =============================================================================
+// Playback Presence Freshness
+//
+// Presence updates are queued as background work, so the state they were built
+// from can change before they execute. Discord shows one status at a time, and
+// publishing a stale one is worse than publishing nothing: it can announce
+// "playing" for a session the user paused, stopped, or replaced.
+// =============================================================================
+
+import { isSamePlaybackGeneration } from "@/domain/playback/playback-generation";
+
+import type { PlaybackStatusSnapshot } from "./playback-status-policy";
+
+export type PlaybackPresenceExpectation = PlaybackStatusSnapshot;
+
+/**
+ * Exact equality on both status and generation. A queued update is publishable
+ * only if nothing about the authoritative snapshot moved since it was scheduled.
+ */
+export function isPlaybackPresenceUpdateCurrent(
+  current: PlaybackStatusSnapshot,
+  expected: PlaybackPresenceExpectation,
+): boolean {
+  return (
+    current.status === expected.status &&
+    isSamePlaybackGeneration(current.generation, expected.generation)
+  );
+}

--- a/apps/cli/src/app/playback/playback-status-policy.ts
+++ b/apps/cli/src/app/playback/playback-status-policy.ts
@@ -1,0 +1,169 @@
+// =============================================================================
+// Playback Status Policy
+//
+// The single player-event-to-status table. Pure: no shell, no service, no
+// service implementation imports. Every player-driven status transition goes
+// through `transitionPlaybackStatus`, so freshness (generation) and authority
+// (pause/stop/finish) are decided in exactly one place.
+// =============================================================================
+
+import {
+  isPlaybackGenerationAfter,
+  isSamePlaybackGeneration,
+  type PlaybackGeneration,
+} from "@/domain/playback/playback-generation";
+import type { PlaybackStatus } from "@/domain/session/SessionState";
+import type { EndReason } from "@/domain/types";
+import type { PlayerPlaybackEvent } from "@/infra/player/PlayerService";
+
+export type PlaybackStatusSnapshot = {
+  readonly status: PlaybackStatus;
+  readonly generation: PlaybackGeneration;
+};
+
+export type PlaybackStatusSignal =
+  | {
+      readonly kind: "activate";
+      readonly generation: PlaybackGeneration;
+      readonly status: "loading";
+    }
+  | {
+      readonly kind: "player-event";
+      readonly generation: PlaybackGeneration;
+      readonly event: PlayerPlaybackEvent;
+    }
+  | {
+      readonly kind: "startup-stall";
+      readonly generation: PlaybackGeneration;
+    }
+  | {
+      readonly kind: "completed";
+      readonly generation: PlaybackGeneration;
+      readonly endReason: EndReason;
+    };
+
+export type PlaybackStatusDecision = {
+  readonly accepted: boolean;
+  readonly snapshot: PlaybackStatusSnapshot;
+  /** True when the accepted snapshot must be written back (status or generation moved). */
+  readonly statusChanged: boolean;
+  readonly clearFeedback: boolean;
+};
+
+/** Nothing a player can say revives a session the product already ended. */
+function isTerminal(status: PlaybackStatus): boolean {
+  return status === "idle" || status === "finished" || status === "error";
+}
+
+/** The transient degraded states fresh progress is allowed to recover from. */
+function isRecoverable(status: PlaybackStatus): boolean {
+  return status === "buffering" || status === "stalled" || status === "seeking";
+}
+
+function reject(current: PlaybackStatusSnapshot): PlaybackStatusDecision {
+  return { accepted: false, snapshot: current, statusChanged: false, clearFeedback: false };
+}
+
+function accept(
+  current: PlaybackStatusSnapshot,
+  next: PlaybackStatusSnapshot,
+  clearFeedback = false,
+): PlaybackStatusDecision {
+  const statusChanged =
+    next.status !== current.status ||
+    !isSamePlaybackGeneration(next.generation, current.generation);
+  return {
+    accepted: true,
+    snapshot: next,
+    statusChanged,
+    clearFeedback: statusChanged && clearFeedback,
+  };
+}
+
+/** Accepted, but carries no authority to move the status (telemetry, copy, tracks). */
+function informational(current: PlaybackStatusSnapshot): PlaybackStatusDecision {
+  return { accepted: true, snapshot: current, statusChanged: false, clearFeedback: false };
+}
+
+function statusForEndReason(endReason: EndReason): PlaybackStatus {
+  if (endReason === "eof") return "finished";
+  if (endReason === "quit") return "idle";
+  return "error";
+}
+
+/**
+ * Only `playback-resumed` leaves `paused`. Progress and `playback-started` are
+ * rejected outright so they cannot drive presence, history, or feedback either.
+ */
+function transitionFromPaused(
+  current: PlaybackStatusSnapshot,
+  event: PlayerPlaybackEvent,
+): PlaybackStatusDecision {
+  if (event.type === "playback-resumed") {
+    return accept(current, { status: "playing", generation: current.generation });
+  }
+  if (event.type === "playback-progress" || event.type === "playback-started") {
+    return reject(current);
+  }
+  return informational(current);
+}
+
+function transitionFromActive(
+  current: PlaybackStatusSnapshot,
+  event: PlayerPlaybackEvent,
+): PlaybackStatusDecision {
+  const to = (status: PlaybackStatus, clearFeedback = false) =>
+    accept(current, { status, generation: current.generation }, clearFeedback);
+
+  switch (event.type) {
+    case "network-buffering":
+      return to("buffering");
+    case "stream-stalled":
+    case "ipc-stalled":
+      return to("stalled");
+    case "seek-stalled":
+      return to("seeking");
+    case "playback-started":
+    case "playback-resumed":
+      return to("playing");
+    case "playback-paused":
+      return to("paused");
+    case "playback-progress":
+      return isRecoverable(current.status) ? to("playing", true) : informational(current);
+    case "player-ready":
+      return current.status === "loading" ? to("ready") : informational(current);
+    default:
+      return informational(current);
+  }
+}
+
+export function transitionPlaybackStatus(
+  current: PlaybackStatusSnapshot,
+  signal: PlaybackStatusSignal,
+): PlaybackStatusDecision {
+  if (signal.kind === "activate") {
+    if (!isPlaybackGenerationAfter(signal.generation, current.generation)) return reject(current);
+    return accept(current, { status: signal.status, generation: signal.generation });
+  }
+
+  // Everything below is work produced by one specific generation. Only that
+  // exact generation may speak; newer generations enter through `activate`.
+  if (!isSamePlaybackGeneration(signal.generation, current.generation)) return reject(current);
+
+  if (isTerminal(current.status)) return reject(current);
+
+  if (signal.kind === "completed") {
+    return accept(current, {
+      status: statusForEndReason(signal.endReason),
+      generation: current.generation,
+    });
+  }
+
+  if (signal.kind === "startup-stall") {
+    return accept(current, { status: "stalled", generation: current.generation });
+  }
+
+  return current.status === "paused"
+    ? transitionFromPaused(current, signal.event)
+    : transitionFromActive(current, signal.event);
+}

--- a/apps/cli/src/app/playback/run-mpv-playback-session.ts
+++ b/apps/cli/src/app/playback/run-mpv-playback-session.ts
@@ -7,10 +7,16 @@ import {
   shouldAbortPlaybackBeforeLaunch,
 } from "@/app/playback/mpv-session-lifecycle";
 import { STARTUP_STALL_TIMEOUT_MS } from "@/app/playback/playback-source-failover";
+import type {
+  PlaybackStatusDecision,
+  PlaybackStatusSignal,
+  PlaybackStatusSnapshot,
+} from "@/app/playback/playback-status-policy";
 import {
   formatPlaybackStreamRoute,
   playbackStartupStageForPlayerEvent,
 } from "@/app/playback/policies/startup-stage-policy";
+import type { PlaybackGeneration } from "@/domain/playback/playback-generation";
 import type {
   EpisodeInfo,
   PlaybackResult,
@@ -44,28 +50,34 @@ export type MpvPlaybackSessionHooks = {
   readonly onPresenceStarted: (input: {
     readonly positionSeconds: number;
     readonly durationSeconds: number;
+    readonly snapshot: PlaybackStatusSnapshot;
   }) => void;
   readonly onPresenceProgress: (input: {
     readonly positionSeconds: number;
     readonly durationSeconds: number;
+    readonly snapshot: PlaybackStatusSnapshot;
   }) => void;
   readonly onPresenceSubtitles: (input: {
     readonly positionSeconds: number;
     readonly durationSeconds: number;
     readonly trackCount: number;
+    readonly snapshot: PlaybackStatusSnapshot;
   }) => void;
   readonly onPresencePaused: (input: {
     readonly positionSeconds: number;
     readonly durationSeconds: number;
+    readonly snapshot: PlaybackStatusSnapshot;
   }) => void;
   readonly onPresenceResumed: (input: {
     readonly positionSeconds: number;
     readonly durationSeconds: number;
+    readonly snapshot: PlaybackStatusSnapshot;
   }) => void;
-  readonly setPlaybackStatus: (
-    status: "buffering" | "stalled" | "seeking" | "playing" | "ready" | "finished",
-  ) => void;
-  readonly getPlaybackStatus: () => string;
+  /**
+   * The only way this loop moves playback status. Submits a generation-bearing
+   * signal to the transition policy and reports whether it was accepted.
+   */
+  readonly applyPlaybackStatusSignal: (signal: PlaybackStatusSignal) => PlaybackStatusDecision;
   readonly onTrackChanged: (event: Extract<PlayerPlaybackEvent, { type: "track-changed" }>) => void;
   readonly onShareCopied: NonNullable<PlayerOptions["shareLinkContext"]>["onCopied"];
   readonly onPlayerReady: () => void;
@@ -122,6 +134,8 @@ export async function runMpvPlaybackSession(
   let startupStallFired = false;
   let startupStallArmed = false;
   let confirmedPlaybackStartNotified = false;
+  /** Installed synchronously by `onGenerationActivated`, before any player event. */
+  let activeGeneration: PlaybackGeneration | null = null;
 
   const clearBootstrapStallTimer = () => {
     if (bootstrapStallTimer !== null) {
@@ -136,8 +150,14 @@ export async function runMpvPlaybackSession(
     clearBootstrapStallTimer();
     bootstrapStallTimer = setTimeout(() => {
       if (startupStallFired) return;
+      if (!activeGeneration) return;
+      // An old watchdog must not abort a replacement generation.
+      const decision = hooks.applyPlaybackStatusSignal({
+        kind: "startup-stall",
+        generation: activeGeneration,
+      });
+      if (!decision.accepted) return;
       startupStallFired = true;
-      hooks.setPlaybackStatus("stalled");
       const route = formatPlaybackStreamRoute(stream);
       hooks.onFeedback({
         detail: "Startup stalled — trying next source",
@@ -176,12 +196,32 @@ export async function runMpvPlaybackSession(
         ...input.shareLinkContext,
         onCopied: hooks.onShareCopied,
       },
+      onGenerationActivated: (generation) => {
+        activeGeneration = generation;
+        hooks.applyPlaybackStatusSignal({ kind: "activate", generation, status: "loading" });
+      },
       onPlayerReady: () => {
+        if (!activeGeneration) return;
+        const decision = hooks.applyPlaybackStatusSignal({
+          kind: "player-event",
+          generation: activeGeneration,
+          event: { type: "player-ready" },
+        });
+        if (!decision.accepted) return;
         hooks.onFeedback({ detail: "Player controls ready" });
-        hooks.setPlaybackStatus("ready");
         hooks.onPlayerReady();
       },
-      onPlaybackEvent: (event) => {
+      onPlaybackEvent: ({ generation, event }) => {
+        // Freshness and authority are decided first: a rejected event performs
+        // no startup mark, feedback, presence, history, or track side effect.
+        const decision = hooks.applyPlaybackStatusSignal({
+          kind: "player-event",
+          generation,
+          event,
+        });
+        if (!decision.accepted) return;
+        const snapshot = decision.snapshot;
+
         const startupStage = playbackStartupStageForPlayerEvent(event);
         if (startupStage) hooks.onStartupMark?.(startupStage);
 
@@ -209,14 +249,7 @@ export async function runMpvPlaybackSession(
           );
         }
 
-        if (event.type === "network-buffering") {
-          hooks.setPlaybackStatus("buffering");
-        } else if (event.type === "stream-stalled" || event.type === "ipc-stalled") {
-          hooks.setPlaybackStatus("stalled");
-        } else if (event.type === "seek-stalled") {
-          hooks.setPlaybackStatus("seeking");
-        } else if (event.type === "playback-started") {
-          hooks.setPlaybackStatus("playing");
+        if (event.type === "playback-started") {
           if (!confirmedPlaybackStartNotified) {
             confirmedPlaybackStartNotified = true;
             hooks.onConfirmedPlaybackStart?.();
@@ -224,6 +257,7 @@ export async function runMpvPlaybackSession(
           hooks.onPresenceStarted({
             positionSeconds: latestPresencePositionSeconds,
             durationSeconds: latestPresenceDurationSeconds,
+            snapshot,
           });
         } else if (event.type === "playback-progress") {
           latestPresencePositionSeconds = event.positionSeconds;
@@ -231,22 +265,26 @@ export async function runMpvPlaybackSession(
           hooks.onPresenceProgress({
             positionSeconds: latestPresencePositionSeconds,
             durationSeconds: latestPresenceDurationSeconds,
+            snapshot,
           });
         } else if (event.type === "late-subtitles-attached") {
           hooks.onPresenceSubtitles({
             positionSeconds: latestPresencePositionSeconds,
             durationSeconds: latestPresenceDurationSeconds,
             trackCount: event.trackCount,
+            snapshot,
           });
         } else if (event.type === "playback-paused") {
           hooks.onPresencePaused({
             positionSeconds: latestPresencePositionSeconds,
             durationSeconds: latestPresenceDurationSeconds,
+            snapshot,
           });
         } else if (event.type === "playback-resumed") {
           hooks.onPresenceResumed({
             positionSeconds: latestPresencePositionSeconds,
             durationSeconds: latestPresenceDurationSeconds,
+            snapshot,
           });
         } else if (event.type === "track-changed") {
           hooks.onTrackChanged(event);
@@ -254,15 +292,24 @@ export async function runMpvPlaybackSession(
       },
     });
 
-    hooks.setPlaybackStatus("finished");
-    if (startupStallFired) {
-      return {
-        ...result,
-        suspectedDeadStream: true,
-        endReason: result.endReason === "eof" ? result.endReason : "error",
-      };
+    // The startup watchdog rewrites the result before completion is applied, so
+    // a watchdog failure completes as `error` rather than briefly as `finished`.
+    const finalResult = startupStallFired
+      ? {
+          ...result,
+          suspectedDeadStream: true,
+          endReason: result.endReason === "eof" ? result.endReason : ("error" as const),
+        }
+      : result;
+
+    if (activeGeneration) {
+      hooks.applyPlaybackStatusSignal({
+        kind: "completed",
+        generation: activeGeneration,
+        endReason: finalResult.endReason,
+      });
     }
-    return result;
+    return finalResult;
   } finally {
     clearBootstrapStallTimer();
   }

--- a/apps/cli/src/domain/playback/playback-generation.ts
+++ b/apps/cli/src/domain/playback/playback-generation.ts
@@ -1,0 +1,34 @@
+// =============================================================================
+// Playback Generation
+//
+// A monotonic (process, cycle) pair that identifies one mpv process and one
+// playback cycle inside it. Every asynchronous playback boundary captures the
+// generation that created it and compares before mutating current state, so a
+// replaced, stopped, or disposed session cannot be revived by late work.
+// =============================================================================
+
+export type PlaybackGeneration = {
+  readonly process: number;
+  readonly cycle: number;
+};
+
+export const INITIAL_PLAYBACK_GENERATION: PlaybackGeneration = {
+  process: 0,
+  cycle: 0,
+};
+
+export function isSamePlaybackGeneration(
+  left: PlaybackGeneration,
+  right: PlaybackGeneration,
+): boolean {
+  return left.process === right.process && left.cycle === right.cycle;
+}
+
+/** Lexicographic: a newer process always wins, then a newer cycle inside it. */
+export function isPlaybackGenerationAfter(
+  candidate: PlaybackGeneration,
+  current: PlaybackGeneration,
+): boolean {
+  if (candidate.process !== current.process) return candidate.process > current.process;
+  return candidate.cycle > current.cycle;
+}

--- a/apps/cli/src/domain/playback/playback-generation.ts
+++ b/apps/cli/src/domain/playback/playback-generation.ts
@@ -32,3 +32,8 @@ export function isPlaybackGenerationAfter(
   if (candidate.process !== current.process) return candidate.process > current.process;
   return candidate.cycle > current.cycle;
 }
+
+/** Human-readable form for diagnostics surfaces: `process 4 · cycle 9`. */
+export function formatPlaybackGeneration(generation: PlaybackGeneration): string {
+  return `process ${generation.process} · cycle ${generation.cycle}`;
+}

--- a/apps/cli/src/domain/session/SessionState.ts
+++ b/apps/cli/src/domain/session/SessionState.ts
@@ -7,6 +7,10 @@
 
 import type { TitleDetail } from "../catalog/title-detail";
 import { videoMetaFromSearchResult } from "../media/video-meta";
+import {
+  INITIAL_PLAYBACK_GENERATION,
+  type PlaybackGeneration,
+} from "../playback/playback-generation";
 import type { PlaybackProblem } from "../playback/playback-problem";
 import type { TrackCapabilityGroup, TrackCapabilitySection } from "../playback/track-capabilities";
 import type {
@@ -171,6 +175,8 @@ export interface SessionState {
   /** Bumped on explicit user provider switches so playback can bypass soft fallbacks and stale streams. */
   readonly providerSwitchSeq: number;
   readonly playbackStatus: PlaybackStatus;
+  /** Freshness identity of the mpv process/cycle that owns `playbackStatus`. */
+  readonly playbackGeneration: PlaybackGeneration;
   readonly playbackError: string | null;
   readonly playbackDetail: string | null;
   readonly playbackNote: string | null;
@@ -227,7 +233,14 @@ export type StateTransition =
   | { type: "SET_SESSION_AUTOSKIP_PAUSED"; paused: boolean }
   | { type: "SET_SESSION_STOP_AFTER_CURRENT"; enabled: boolean }
   | { type: "SET_STREAM"; stream: StreamInfo | null }
-  | { type: "SET_PLAYBACK_STATUS"; status: PlaybackStatus; error?: string }
+  | {
+      type: "SET_PLAYBACK_STATUS";
+      status: PlaybackStatus;
+      error?: string;
+      /** Omitted by lifecycle writers (resolve/loading/idle/error); the current generation is retained. */
+      generation?: PlaybackGeneration;
+      clearFeedback?: boolean;
+    }
   | { type: "SET_PLAYBACK_FEEDBACK"; detail?: string | null; note?: string | null }
   | { type: "SET_WATCH_TIME_SUMMARY"; summary: string | null }
   | { type: "SET_PLAYBACK_PROBLEM"; problem: PlaybackProblem }
@@ -305,6 +318,7 @@ export function createInitialState(
     stream: null,
     providerSwitchSeq: 0,
     playbackStatus: "idle",
+    playbackGeneration: INITIAL_PLAYBACK_GENERATION,
     playbackError: null,
     playbackDetail: null,
     playbackNote: null,
@@ -492,15 +506,17 @@ export function reduceState(state: SessionState, transition: StateTransition): S
 
     case "SET_PLAYBACK_STATUS":
       const keepPlaybackFeedback =
-        transition.status === "loading" ||
-        transition.status === "buffering" ||
-        transition.status === "seeking" ||
-        transition.status === "stalled" ||
-        transition.status === "playing" ||
-        transition.status === "paused";
+        transition.clearFeedback !== true &&
+        (transition.status === "loading" ||
+          transition.status === "buffering" ||
+          transition.status === "seeking" ||
+          transition.status === "stalled" ||
+          transition.status === "playing" ||
+          transition.status === "paused");
       return {
         ...state,
         playbackStatus: transition.status,
+        playbackGeneration: transition.generation ?? state.playbackGeneration,
         playbackError: transition.error ?? null,
         playbackDetail: keepPlaybackFeedback ? state.playbackDetail : null,
         playbackNote: keepPlaybackFeedback ? state.playbackNote : null,

--- a/apps/cli/src/domain/session/SessionState.ts
+++ b/apps/cli/src/domain/session/SessionState.ts
@@ -66,6 +66,25 @@ export function isPlaybackSessionActive(status: PlaybackStatus): boolean {
   );
 }
 
+/**
+ * Narrower than {@link isPlaybackSessionActive}: the session not only exists, it
+ * has left bootstrap and mpv owns a stream. `loading` and `ready` are excluded
+ * precisely because they are the bootstrap states — surfaces that decide whether
+ * to keep showing a loading presentation must not treat them as started, or the
+ * loading shell reports itself as playing while it is still loading.
+ *
+ * `paused` counts: transport is not advancing, but bootstrap is over.
+ */
+export function isPlaybackTransportStarted(status: PlaybackStatus): boolean {
+  return (
+    status === "buffering" ||
+    status === "seeking" ||
+    status === "stalled" ||
+    status === "playing" ||
+    status === "paused"
+  );
+}
+
 export type SearchStatus = "idle" | "loading" | "ready" | "error";
 
 export interface EpisodeNavigationState {

--- a/apps/cli/src/domain/session/command-registry.ts
+++ b/apps/cli/src/domain/session/command-registry.ts
@@ -2,7 +2,7 @@ import { isLocalPlaybackStream } from "@/domain/playback/local-playback-stream";
 import { getModeSwitchTarget } from "@/domain/session/mode-target";
 
 import { rankFuzzyMatches } from "./fuzzy-match";
-import type { SessionState } from "./SessionState";
+import { isPlaybackSessionActive, type SessionState } from "./SessionState";
 
 export type AppCommandId =
   | "setup"
@@ -990,13 +990,7 @@ function resolveCommandState(
   );
   const hasResolvedStream = Boolean(state.stream?.url);
   const playbackCanRecover =
-    state.playbackStatus === "loading" ||
-    state.playbackStatus === "ready" ||
-    state.playbackStatus === "buffering" ||
-    state.playbackStatus === "seeking" ||
-    state.playbackStatus === "stalled" ||
-    state.playbackStatus === "playing" ||
-    state.playbackStatus === "error";
+    isPlaybackSessionActive(state.playbackStatus) || state.playbackStatus === "error";
 
   switch (id) {
     case "setup":

--- a/apps/cli/src/infra/player/PersistentMpvSession.ts
+++ b/apps/cli/src/infra/player/PersistentMpvSession.ts
@@ -154,6 +154,13 @@ export class PersistentMpvSession {
   private mpvUnregister: (() => void) | null = null;
   private ipcSession: MpvIpcSession | null = null;
   private activeCycle: PlayerCycleState | null = null;
+  /**
+   * Set synchronously by close()/termination, before any await. Bootstrap work
+   * that was already in flight for the outgoing process checks this after each
+   * await, so a late endpoint wait or IPC open cannot install a resource,
+   * publish an event, or activate player control on a retired session.
+   */
+  private retired = false;
   private readonly subtitleManager = new PersistentSubtitleManager();
   private readonly propertyRouter = new PersistentMpvPropertyRouter({
     getActiveCycle: () => this.activeCycle,
@@ -469,6 +476,7 @@ export class PersistentMpvSession {
     this.clearReadyWorkFallback();
     this.pendingReadyWork = null;
     this.alive = false;
+    this.retired = true;
 
     const target = this.mpv;
 
@@ -599,6 +607,9 @@ export class PersistentMpvSession {
     {
       const ipcBootstrapStarted = Date.now();
       const ready = await this.runtime.waitForIpcEndpoint(this.ipcEndpoint, 5_000);
+      // The session was closed while this wait was outstanding; opening IPC now
+      // would resurrect a process that is already being torn down.
+      if (this.retired) return;
       const waitedMs = Date.now() - ipcBootstrapStarted;
       if (!ready) {
         this.currentCycleOptions().onPlaybackEvent?.({
@@ -610,8 +621,9 @@ export class PersistentMpvSession {
         return;
       }
 
+      let openedIpcSession: MpvIpcSession;
       try {
-        this.ipcSession = await this.runtime.openIpcSession({
+        openedIpcSession = await this.runtime.openIpcSession({
           endpoint: this.ipcEndpoint,
           onPropertyUpdate: ({ name, value, observedAt }) => {
             this.propertyRouter.handlePropertyUpdate({ name, value, observedAt });
@@ -657,6 +669,13 @@ export class PersistentMpvSession {
         await this.terminateAfterIpcBootstrapFailure(proc);
         return;
       }
+
+      if (this.retired) {
+        // Close the handle we just created exactly once and install nothing.
+        await openedIpcSession.close().catch(() => {});
+        return;
+      }
+      this.ipcSession = openedIpcSession;
 
       dbg("mpv-ipc", "ipc-bootstrap-complete", {
         ipcTransport: mpvIpcTransportTag(this.ipcEndpoint),
@@ -1231,6 +1250,7 @@ export class PersistentMpvSession {
 
     this.terminationPromise = (async () => {
       this.alive = false;
+      this.retired = true;
       this.clearReadyWorkFallback();
       this.pendingReadyWork = null;
       this.watchdog?.stop();

--- a/apps/cli/src/infra/player/PersistentMpvSession.ts
+++ b/apps/cli/src/infra/player/PersistentMpvSession.ts
@@ -1,6 +1,10 @@
 import { existsSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 
+import {
+  isSamePlaybackGeneration,
+  type PlaybackGeneration,
+} from "@/domain/playback/playback-generation";
 import type {
   PlaybackResult,
   PlaybackTimingMetadata,
@@ -197,7 +201,26 @@ export class PersistentMpvSession {
   private skippedSegments = new Set<string>();
   private currentOptions: PlayerCycleOptions;
   private watchdog: PlaybackWatchdog | null = null;
-  private pendingReadyWork: PlayerCycleOptions | null = null;
+  /**
+   * One playback cycle inside this process. Every deferred continuation captures
+   * it and rechecks before mutating, so a replacement cycle cannot be driven by
+   * the previous cycle's file load, ready work, or reconnect.
+   */
+  private cycleGeneration: PlaybackGeneration = { process: 1, cycle: 0 };
+  /**
+   * The single outstanding `loadfile`. mpv's `file-loaded` carries no identity,
+   * so at most one owner may exist: a replacement retires the previous owner
+   * before issuing its own load, and an unowned `file-loaded` is ignored.
+   */
+  private pendingFileLoad: { readonly id: number; readonly generation: PlaybackGeneration } | null =
+    null;
+  private nextFileLoadId = 1;
+  /** The generation whose file is actually loaded; property/end-file routing uses this. */
+  private loadedFileGeneration: PlaybackGeneration | null = null;
+  private pendingReadyWork: {
+    readonly options: PlayerCycleOptions;
+    readonly generation: PlaybackGeneration;
+  } | null = null;
   private readyWorkFallbackTimer: ReturnType<typeof setTimeout> | null = null;
   private terminationPromise: Promise<void> | null = null;
   private terminated = false;
@@ -240,6 +263,7 @@ export class PersistentMpvSession {
     seekSeconds: number;
     shouldSeek: boolean;
     trigger: InProcessReconnectTrigger;
+    generation: PlaybackGeneration;
   } | null = null;
 
   private constructor(
@@ -379,6 +403,10 @@ export class PersistentMpvSession {
       return await cycle.promise;
     }
 
+    // Replacement admission: retire the previous owner, then install exactly one.
+    const generation = this.advanceCycleGeneration();
+    const fileLoadId = this.installPendingFileLoad(generation);
+
     await this.subtitleManager.removeExternalSubtitles(this.ipcSession);
     options.onPlaybackEvent?.({ type: "resolving-playback" });
     this.queueReadyWork(options, { armFallback: false });
@@ -408,6 +436,7 @@ export class PersistentMpvSession {
         command: "loadfile",
         error: `stream unreachable: ${preflight.reason}`,
       });
+      this.clearPendingFileLoadIf(fileLoadId, generation);
       cycle.telemetry.endReason = "error";
       this.activeCycle = null;
       cycle.resolve({
@@ -428,6 +457,8 @@ export class PersistentMpvSession {
     }
 
     if (!loadResult?.ok) {
+      // Compare id and generation so an older rejection cannot erase a newer owner.
+      this.clearPendingFileLoadIf(fileLoadId, generation);
       void this.ipcSession?.send(["set_property", "user-data/kunai-loading", ""], 500);
       options.onPlaybackEvent?.({
         type: "ipc-command-failed",
@@ -477,6 +508,8 @@ export class PersistentMpvSession {
     this.pendingReadyWork = null;
     this.alive = false;
     this.retired = true;
+    this.retirePendingFileLoad();
+    this.loadedFileGeneration = null;
 
     const target = this.mpv;
 
@@ -591,6 +624,10 @@ export class PersistentMpvSession {
     this.mpv = proc;
     this.mpvUnregister = registerMpvProcess(proc);
     this.alive = true;
+    // The first file is loaded from argv and never passes through IPC loadfile,
+    // so it needs its owner seeded here or its file-loaded would be unowned.
+    this.cycleGeneration = { process: this.cycleGeneration.process, cycle: 1 };
+    this.installPendingFileLoad(this.cycleGeneration);
     this.initialOptions.onPlaybackEvent?.({ type: "mpv-process-started" });
     this.hasLoadedFile = true;
     this.resetCycleState();
@@ -632,10 +669,19 @@ export class PersistentMpvSession {
             void this.handlePlaybackEnded(reason, observedAt, fileError);
           },
           onFileLoaded: () => {
+            const pending = this.pendingFileLoad;
+            // mpv's file-loaded carries no identity. Without a pending owner it
+            // belongs to a load nobody is waiting for, so it must do nothing.
+            if (!pending) return;
+            this.pendingFileLoad = null;
+            if (!this.isGenerationCurrent(pending.generation)) return;
+            this.loadedFileGeneration = pending.generation;
+
             void this.ipcSession?.send(["set_property", "user-data/kunai-loading", ""], 300);
             const reconnect = this.pendingInProcessReconnect;
             if (reconnect) {
               this.pendingInProcessReconnect = null;
+              if (!this.isGenerationCurrent(reconnect.generation)) return;
               void this.finishInProcessReconnectAfterLoad(reconnect);
               return;
             }
@@ -797,13 +843,51 @@ export class PersistentMpvSession {
     }
   }
 
+  isGenerationCurrent(generation: PlaybackGeneration): boolean {
+    return isSamePlaybackGeneration(generation, this.cycleGeneration);
+  }
+
+  /** Starts a new cycle generation and retires anything the previous one owned. */
+  private advanceCycleGeneration(): PlaybackGeneration {
+    this.cycleGeneration = {
+      process: this.cycleGeneration.process,
+      cycle: this.cycleGeneration.cycle + 1,
+    };
+    this.retirePendingFileLoad();
+    this.loadedFileGeneration = null;
+    this.pendingInProcessReconnect = null;
+    return this.cycleGeneration;
+  }
+
+  /** Installs the one pending load owner, retiring any previous owner first. */
+  private installPendingFileLoad(generation: PlaybackGeneration): number {
+    this.retirePendingFileLoad();
+    const id = this.nextFileLoadId++;
+    this.pendingFileLoad = { id, generation };
+    return id;
+  }
+
+  private retirePendingFileLoad(): void {
+    this.pendingFileLoad = null;
+  }
+
+  /** Clears the pending owner only when it is exactly the one that failed. */
+  private clearPendingFileLoadIf(id: number, generation: PlaybackGeneration): void {
+    const pending = this.pendingFileLoad;
+    if (!pending) return;
+    if (pending.id !== id) return;
+    if (!isSamePlaybackGeneration(pending.generation, generation)) return;
+    this.pendingFileLoad = null;
+  }
+
   private queueReadyWork(options: PlayerCycleOptions, opts: { armFallback?: boolean } = {}): void {
-    this.pendingReadyWork = options;
+    const generation = this.cycleGeneration;
+    this.pendingReadyWork = { options, generation };
     this.clearReadyWorkFallback();
     if (!this.ipcSession) {
       this.pendingReadyWork = null;
       this.acceptPlaybackPropertiesForActiveCycle();
-      void this.runReadyWork(options);
+      void this.runReadyWork(options, generation);
       return;
     }
     if (opts.armFallback !== false) {
@@ -826,11 +910,15 @@ export class PersistentMpvSession {
   private drainPendingReadyWork(expected?: PlayerCycleOptions): void {
     const pending = this.pendingReadyWork;
     if (!pending) return;
-    if (expected && pending !== expected) return;
+    if (expected && pending.options !== expected) return;
+    if (!this.isGenerationCurrent(pending.generation)) {
+      this.pendingReadyWork = null;
+      return;
+    }
     this.pendingReadyWork = null;
     this.clearReadyWorkFallback();
     this.acceptPlaybackPropertiesForActiveCycle();
-    void this.runReadyWork(pending);
+    void this.runReadyWork(pending.options, pending.generation);
   }
 
   private acceptPlaybackPropertiesForActiveCycle(): void {
@@ -839,7 +927,10 @@ export class PersistentMpvSession {
     }
   }
 
-  private async runReadyWork(options: PlayerCycleOptions): Promise<void> {
+  private async runReadyWork(
+    options: PlayerCycleOptions,
+    generation: PlaybackGeneration,
+  ): Promise<void> {
     const executor = new PersistentReadyWorkExecutor({
       getIpcSession: () => this.ipcSession,
       getInitialOptions: () => this.initialOptions,
@@ -866,9 +957,10 @@ export class PersistentMpvSession {
         dbg("mpv-ipc", `${command}-failed`, { error });
       },
       subtitleManager: this.subtitleManager,
+      isGenerationCurrent: (candidate) => this.isGenerationCurrent(candidate),
     });
 
-    await executor.execute(options, this.activeCycle);
+    await executor.execute(options, this.activeCycle, generation);
   }
 
   private clearReadyWorkFallback(): void {
@@ -1251,6 +1343,8 @@ export class PersistentMpvSession {
     this.terminationPromise = (async () => {
       this.alive = false;
       this.retired = true;
+      this.retirePendingFileLoad();
+      this.loadedFileGeneration = null;
       this.clearReadyWorkFallback();
       this.pendingReadyWork = null;
       this.watchdog?.stop();
@@ -1325,6 +1419,10 @@ export class PersistentMpvSession {
     this.abortResumeChoiceWaitForCycleEnd();
     this.clearReadyWorkFallback();
     this.pendingReadyWork = null;
+    // end-file before file-loaded: that load will never arrive, so retire its
+    // owner. A later unowned file-loaded is then correctly ignored.
+    this.retirePendingFileLoad();
+    this.loadedFileGeneration = null;
     if (!this.nearEofFired) {
       this.nearEofFired = true;
       this.currentCycleOptions().onNearEof?.();
@@ -1445,7 +1543,16 @@ export class PersistentMpvSession {
       active.telemetry.endReason = savedEndReason;
       active.telemetry.maxTrustedProgressSeconds = savedMaxTrusted;
       active.telemetry.lastReliableProgressSeconds = savedLastReliable;
-      this.pendingInProcessReconnect = { seekSeconds, shouldSeek, trigger };
+      // Reconnect reloads the same cycle: keep its generation, but retire the
+      // previous pending owner so two load owners never coexist.
+      const reconnectGeneration = this.cycleGeneration;
+      this.pendingInProcessReconnect = {
+        seekSeconds,
+        shouldSeek,
+        trigger,
+        generation: reconnectGeneration,
+      };
+      const reconnectLoadId = this.installPendingFileLoad(reconnectGeneration);
       this.clearReadyWorkFallback();
       this.pendingReadyWork = null;
 
@@ -1464,8 +1571,10 @@ export class PersistentMpvSession {
         12_000,
       );
       if (!loadResult.ok) {
+        this.clearPendingFileLoadIf(reconnectLoadId, reconnectGeneration);
         throw new Error(loadResult.error ?? "loadfile failed");
       }
+      if (!this.isGenerationCurrent(reconnectGeneration)) return false;
 
       this.reconnectBackoffUntilMs = 0;
       void this.ipcSession.send(["set_property", "user-data/kunai-loading", ""], 500);

--- a/apps/cli/src/infra/player/PlayerService.ts
+++ b/apps/cli/src/infra/player/PlayerService.ts
@@ -4,6 +4,7 @@
 // MPV abstraction for media playback.
 // =============================================================================
 
+import type { PlaybackGeneration } from "@/domain/playback/playback-generation";
 import type { PlaybackResult, ShellMode, StreamInfo, TitleInfo } from "@/domain/types";
 import type { PlaybackTimingMetadata } from "@/domain/types";
 import type { SubtitleTrack } from "@/domain/types";
@@ -70,6 +71,16 @@ export type PlayerPlaybackEvent =
       detail?: string;
     };
 
+/**
+ * The public shape of a player event. `PlayerServiceImpl` is the only place raw
+ * `PlayerPlaybackEvent` callbacks are turned into envelopes, so every consumer
+ * above it can tell which mpv process/cycle produced the event.
+ */
+export type PlayerPlaybackEventEnvelope = {
+  readonly generation: PlaybackGeneration;
+  readonly event: PlayerPlaybackEvent;
+};
+
 export interface PlayerOptions {
   url: string;
   headers?: Record<string, string>;
@@ -102,7 +113,9 @@ export interface PlayerOptions {
   skipCredits?: boolean;
   onProgress?: (seconds: number) => void;
   onPlayerReady?: () => void;
-  onPlaybackEvent?: (event: PlayerPlaybackEvent) => void;
+  /** Fired synchronously, before the first await, with the generation this play owns. */
+  onGenerationActivated?: (generation: PlaybackGeneration) => void;
+  onPlaybackEvent?: (input: PlayerPlaybackEventEnvelope) => void;
   /** Called once when playback enters the last ~30 s (autoplay-chain mode only). */
   onNearEof?: () => void;
   /** When aborted, `play()` rejects before spawning mpv. */
@@ -130,7 +143,8 @@ export interface PlayerService {
     startAt?: number;
     policy?: LocalPlaybackPolicyInput;
     onPlayerReady?: () => void;
-    onPlaybackEvent?: (event: PlayerPlaybackEvent) => void;
+    onGenerationActivated?: (generation: PlaybackGeneration) => void;
+    onPlaybackEvent?: (input: PlayerPlaybackEventEnvelope) => void;
   }): Promise<PlaybackResult>;
 }
 

--- a/apps/cli/src/infra/player/PlayerServiceImpl.ts
+++ b/apps/cli/src/infra/player/PlayerServiceImpl.ts
@@ -6,6 +6,11 @@
 
 import { stat } from "node:fs/promises";
 
+import {
+  INITIAL_PLAYBACK_GENERATION,
+  isSamePlaybackGeneration,
+  type PlaybackGeneration,
+} from "@/domain/playback/playback-generation";
 import type { PlaybackResult, StreamInfo } from "@/domain/types";
 import type { Logger } from "@/infra/logger/Logger";
 import type { Tracer } from "@/infra/tracer/Tracer";
@@ -40,7 +45,12 @@ import {
 import type { PlayerPresentationPort } from "./player-presentation-port";
 import { nonInteractivePlayerPresentation } from "./player-presentation-port";
 import type { MpvRequestedAction, PlayerControlService } from "./PlayerControlService";
-import type { PlayerOptions, PlayerPlaybackEvent, PlayerService } from "./PlayerService";
+import type {
+  PlayerOptions,
+  PlayerPlaybackEvent,
+  PlayerPlaybackEventEnvelope,
+  PlayerService,
+} from "./PlayerService";
 
 export class PlayerServiceImpl implements PlayerService {
   private persistentSession: PersistentMpvSession | null = null;
@@ -52,6 +62,14 @@ export class PlayerServiceImpl implements PlayerService {
   private shuttingDown = false;
   /** One app playback intent owns the mpv handoff at a time. */
   private playbackInFlight = false;
+  /**
+   * Freshness identity of the mpv process/cycle this service currently owns.
+   * Every asynchronous boundary captures it and compares before publishing, so
+   * a replaced, stopped, or released session cannot speak through late work.
+   */
+  private currentGeneration: PlaybackGeneration = INITIAL_PLAYBACK_GENERATION;
+  /** Which generation installed the control the app is currently holding. */
+  private activeControlGeneration: PlaybackGeneration | null = null;
 
   constructor(
     private deps: {
@@ -69,7 +87,40 @@ export class PlayerServiceImpl implements PlayerService {
 
   beginShutdown(): void {
     this.shuttingDown = true;
+    this.invalidateProcessGeneration();
     this.stopActiveHlsRelay("session-release");
+  }
+
+  private isCurrentGeneration(generation: PlaybackGeneration): boolean {
+    return isSamePlaybackGeneration(generation, this.currentGeneration);
+  }
+
+  /**
+   * Retires the whole mpv process. Nothing produced by the outgoing process —
+   * IPC opens, endpoint waits, process exit, property callbacks — is current
+   * afterwards, so late work returns instead of publishing.
+   */
+  private invalidateProcessGeneration(): void {
+    this.currentGeneration = { process: this.currentGeneration.process + 1, cycle: 0 };
+  }
+
+  /**
+   * Installs the generation this play owns. Reusing the persistent process
+   * keeps the process number and takes the next cycle; a new OS process takes
+   * the next process number at cycle 1.
+   */
+  private activateGeneration(reuseProcess: boolean): PlaybackGeneration {
+    this.currentGeneration = reuseProcess
+      ? { process: this.currentGeneration.process, cycle: this.currentGeneration.cycle + 1 }
+      : { process: this.currentGeneration.process + 1, cycle: 1 };
+    return this.currentGeneration;
+  }
+
+  /** True when `play()` can hand this stream to the already running mpv process. */
+  private willReusePersistentProcess(options: PlayerOptions): boolean {
+    return (
+      options.playbackMode === "autoplay-chain" && (this.persistentSession?.isReusable() ?? false)
+    );
   }
 
   killActiveMpvProcessesSync(): void {
@@ -87,15 +138,32 @@ export class PlayerServiceImpl implements PlayerService {
       throw new PlaybackAbortedError("playback already in progress");
     }
 
+    // Admission is settled; allocate and publish the generation before the
+    // first await so no consumer can observe an event from an unknown cycle.
+    const reuseProcess = this.willReusePersistentProcess(options);
+    const retiredGeneration = reuseProcess ? null : this.currentGeneration;
+    const generation = this.activateGeneration(reuseProcess);
+    options.onGenerationActivated?.(generation);
+
     this.playbackInFlight = true;
     try {
-      return await this.playOwned(stream, options);
+      return await this.playOwned(stream, options, generation, retiredGeneration);
     } finally {
       this.playbackInFlight = false;
     }
   }
 
-  private async playOwned(stream: StreamInfo, options: PlayerOptions): Promise<PlaybackResult> {
+  private async playOwned(
+    stream: StreamInfo,
+    options: PlayerOptions,
+    generation: PlaybackGeneration,
+    retiredGeneration: PlaybackGeneration | null,
+  ): Promise<PlaybackResult> {
+    const publish = this.wrapPlaybackEventHandler(
+      generation,
+      options.onPlaybackEvent,
+      options.correlation,
+    );
     let terminalHlsFailure: { readonly detail?: string; readonly httpStatus?: number } | null =
       null;
     const materialized = await materializePlaybackMediaForPlayback(
@@ -164,16 +232,16 @@ export class PlayerServiceImpl implements PlayerService {
     }
     let playbackStream = materialized.stream;
     if (materialized.kind === "dash-mpd") {
-      options.onPlaybackEvent?.({ type: "media-materialized", kind: "dash-mpd" });
+      publish({ type: "media-materialized", kind: "dash-mpd" });
     } else if (materialized.kind === "hls-manifest") {
-      options.onPlaybackEvent?.({ type: "media-materialized", kind: "hls-manifest" });
+      publish({ type: "media-materialized", kind: "hls-manifest" });
     }
 
     // Stop any prior cycle relay before starting a new one (autoplay-chain source swaps).
     this.stopActiveHlsRelay("session-release");
     playbackStream = this.maybeStartHlsRelay(playbackStream, options);
 
-    options.onPlaybackEvent?.({ type: "launching-player" });
+    publish({ type: "launching-player" });
     const presentation = this.deps.presentation ?? nonInteractivePlayerPresentation;
     if (!presentation.isInteractiveShellMounted()) {
       process.stderr.write(`Starting playback: ${options.displayTitle}\n`);
@@ -217,8 +285,20 @@ export class PlayerServiceImpl implements PlayerService {
       const urlKind = materialized.kind === "none" ? "remote" : "local";
       const result =
         options.playbackMode === "autoplay-chain"
-          ? await this.playAutoplayChainStream(playbackStream, options, urlKind)
-          : await this.playOneShotStream(playbackStream, options, urlKind);
+          ? await this.playAutoplayChainStream(
+              playbackStream,
+              options,
+              urlKind,
+              publish,
+              retiredGeneration,
+            )
+          : await this.playOneShotStream(
+              playbackStream,
+              options,
+              urlKind,
+              publish,
+              retiredGeneration,
+            );
 
       this.deps.logger.info("MPV playback complete", {
         watchedSeconds: result.watchedSeconds,
@@ -308,13 +388,28 @@ export class PlayerServiceImpl implements PlayerService {
     // Invalidate a create() already awaiting IPC before observing its result.
     // Otherwise shutdown/recovery can see `persistentSession === null`, return,
     // and let that late create publish a live mpv after teardown completed.
+    // Generation is invalidated synchronously here, before any await, so this
+    // stays the single release/disposal invalidation authority.
+    const retired = this.currentGeneration;
+    this.invalidateProcessGeneration();
+    await this.retirePersistentSession(retired);
+  }
+
+  /**
+   * Releases the persistent session that `retiredGeneration` owned. The caller
+   * has already moved `currentGeneration` past it, so this must never allocate,
+   * clear, or compare-and-swap the generation that is active now.
+   */
+  private async retirePersistentSession(
+    retiredGeneration: PlaybackGeneration | null,
+  ): Promise<void> {
     this.persistentSessionEpoch += 1;
     if (this.persistentSessionRelease) {
       await this.persistentSessionRelease;
       return;
     }
 
-    const release = this.releasePersistentSessionOwned();
+    const release = this.releasePersistentSessionOwned(retiredGeneration);
     this.persistentSessionRelease = release;
     try {
       await release;
@@ -325,7 +420,9 @@ export class PlayerServiceImpl implements PlayerService {
     }
   }
 
-  private async releasePersistentSessionOwned(): Promise<void> {
+  private async releasePersistentSessionOwned(
+    retiredGeneration: PlaybackGeneration | null,
+  ): Promise<void> {
     const pendingCreation = this.persistentSessionCreation;
     let session = this.persistentSession;
     if (!session && pendingCreation) {
@@ -343,9 +440,30 @@ export class PlayerServiceImpl implements PlayerService {
     if (this.persistentSession === session) {
       this.persistentSession = null;
     }
-    this.deps.playerControl.setActive(null);
+    this.clearActiveControlFor(retiredGeneration);
     this.stopActiveHlsRelay("session-release");
     await this.flushDeferredMaterializedCleanups();
+  }
+
+  /** Publishes a control only while its generation is current, and records the owner. */
+  private setActiveControlFor(
+    generation: PlaybackGeneration,
+    control: Parameters<PlayerControlService["setActive"]>[0],
+  ): void {
+    if (!this.isCurrentGeneration(generation)) return;
+    this.activeControlGeneration = control ? generation : null;
+    this.deps.playerControl.setActive(control);
+  }
+
+  /**
+   * Retirement clears only the control it owned. A replacement that already
+   * installed its own control keeps it.
+   */
+  private clearActiveControlFor(retiredGeneration: PlaybackGeneration | null): void {
+    const owner = this.activeControlGeneration;
+    if (owner && retiredGeneration && !isSamePlaybackGeneration(owner, retiredGeneration)) return;
+    this.activeControlGeneration = null;
+    this.deps.playerControl.setActive(null);
   }
 
   private deferMaterializedCleanup(cleanup: () => Promise<void>): void {
@@ -376,7 +494,8 @@ export class PlayerServiceImpl implements PlayerService {
     startAt?: number;
     policy?: LocalPlaybackPolicyInput;
     onPlayerReady?: () => void;
-    onPlaybackEvent?: (event: PlayerPlaybackEvent) => void;
+    onGenerationActivated?: (generation: PlaybackGeneration) => void;
+    onPlaybackEvent?: (input: PlayerPlaybackEventEnvelope) => void;
   }): Promise<PlaybackResult> {
     if (this.shuttingDown) {
       throw new PlaybackAbortedError("player shutting down");
@@ -385,30 +504,43 @@ export class PlayerServiceImpl implements PlayerService {
       throw new PlaybackAbortedError("playback already in progress");
     }
 
+    // Order matters and is load-bearing: capture the persistent generation being
+    // retired, install this one-shot generation, publish it — all before the
+    // first await — so retiring the persistent session cannot invalidate it.
+    const retiredPersistentGeneration = this.currentGeneration;
+    const localGeneration = this.activateGeneration(false);
+    options.onGenerationActivated?.(localGeneration);
+
     this.playbackInFlight = true;
     try {
-      return await this.playLocalOwned(options);
+      return await this.playLocalOwned(options, localGeneration, retiredPersistentGeneration);
     } finally {
       this.playbackInFlight = false;
     }
   }
 
-  private async playLocalOwned(options: {
-    source: LocalPlaybackSource;
-    attach?: boolean;
-    startAt?: number;
-    policy?: LocalPlaybackPolicyInput;
-    onPlayerReady?: () => void;
-    onPlaybackEvent?: (event: PlayerPlaybackEvent) => void;
-  }): Promise<PlaybackResult> {
+  private async playLocalOwned(
+    options: {
+      source: LocalPlaybackSource;
+      attach?: boolean;
+      startAt?: number;
+      policy?: LocalPlaybackPolicyInput;
+      onPlayerReady?: () => void;
+      onGenerationActivated?: (generation: PlaybackGeneration) => void;
+      onPlaybackEvent?: (input: PlayerPlaybackEventEnvelope) => void;
+    },
+    localGeneration: PlaybackGeneration,
+    retiredPersistentGeneration: PlaybackGeneration,
+  ): Promise<PlaybackResult> {
+    const publish = this.wrapPlaybackEventHandler(localGeneration, options.onPlaybackEvent);
     // Local playback is one-shot. Retire an idle autoplay-chain process first
     // so only the local player owns controls and a visible mpv window.
-    await this.releasePersistentSession();
+    await this.retirePersistentSession(retiredPersistentGeneration);
     const subtitlePath = await this.resolveReadableSubtitlePath(
       options.source.subtitlePath ?? null,
     );
     const displayTitle = formatLocalPlaybackTitle(options.source);
-    options.onPlaybackEvent?.({ type: "launching-player" });
+    publish({ type: "launching-player" });
     this.deps.logger.info("Launching local MPV", {
       title: displayTitle,
       filePath: options.source.filePath,
@@ -441,9 +573,9 @@ export class PlayerServiceImpl implements PlayerService {
       skipIntro: policy.skipIntro,
       skipPreview: policy.skipPreview,
       skipCredits: policy.skipCredits,
-      onControlReady: (control) => this.deps.playerControl.setActive(control),
+      onControlReady: (control) => this.setActiveControlFor(localGeneration, control),
       onPlayerReady: options.onPlayerReady,
-      onPlaybackEvent: this.wrapPlaybackEventHandler(options.onPlaybackEvent),
+      onPlaybackEvent: publish,
       mpv: {
         ...this.deps.mpv,
         startupPriority: this.deps.config.startupPriority,
@@ -474,8 +606,11 @@ export class PlayerServiceImpl implements PlayerService {
     stream: StreamInfo,
     options: PlayerOptions,
     urlKind: "remote" | "local",
+    publish: (event: PlayerPlaybackEvent) => void,
+    retiredGeneration: PlaybackGeneration | null,
   ): Promise<PlaybackResult> {
-    await this.releasePersistentSession();
+    const generation = this.currentGeneration;
+    await this.retirePersistentSession(retiredGeneration);
     return await (this.deps.launchMpv ?? launchMpv)({
       url: stream.url,
       urlKind,
@@ -497,9 +632,9 @@ export class PlayerServiceImpl implements PlayerService {
       skipIntro: options.skipIntro,
       skipPreview: options.skipPreview,
       skipCredits: options.skipCredits,
-      onControlReady: (control) => this.deps.playerControl.setActive(control),
+      onControlReady: (control) => this.setActiveControlFor(generation, control),
       onPlayerReady: options.onPlayerReady,
-      onPlaybackEvent: this.wrapPlaybackEventHandler(options.onPlaybackEvent, options.correlation),
+      onPlaybackEvent: publish,
       mpv: {
         ...this.deps.mpv,
         startupPriority: this.deps.config.startupPriority,
@@ -511,9 +646,12 @@ export class PlayerServiceImpl implements PlayerService {
     stream: StreamInfo,
     options: PlayerOptions,
     urlKind: "remote" | "local",
+    publish: (event: PlayerPlaybackEvent) => void,
+    retiredGeneration: PlaybackGeneration | null,
   ): Promise<PlaybackResult> {
+    const generation = this.currentGeneration;
     if (this.persistentSession && !this.persistentSession.isReusable()) {
-      await this.releasePersistentSession();
+      await this.retirePersistentSession(retiredGeneration);
     }
 
     const resumePromptAt = options.resumePromptAt ?? 0;
@@ -543,7 +681,7 @@ export class PlayerServiceImpl implements PlayerService {
       skipCredits: options.skipCredits,
       autoNextEnabled: true,
       onPlayerReady: options.onPlayerReady,
-      onPlaybackEvent: this.wrapPlaybackEventHandler(options.onPlaybackEvent, options.correlation),
+      onPlaybackEvent: publish,
       onMpvActionRequest: (action: MpvRequestedAction) => {
         this.deps.playerControl.signalPlaybackAction(action);
       },
@@ -561,7 +699,7 @@ export class PlayerServiceImpl implements PlayerService {
           startupPriority: this.deps.config.startupPriority,
         },
         kitsuneConfig: this.deps.config.getRaw(),
-        onControlReady: (control) => this.deps.playerControl.setActive(control),
+        onControlReady: (control) => this.setActiveControlFor(generation, control),
       });
       this.persistentSessionCreation = creation;
       let created: PersistentMpvSession;
@@ -597,11 +735,19 @@ export class PlayerServiceImpl implements PlayerService {
     return result;
   }
 
+  /**
+   * The single public boundary. Raw `PlayerPlaybackEvent` callbacks live only
+   * below this line; above it every consumer receives an envelope carrying the
+   * generation that produced the event. A retired generation returns here, so
+   * it can publish neither a public event nor a diagnostic.
+   */
   private wrapPlaybackEventHandler(
-    handler: ((event: PlayerPlaybackEvent) => void) | undefined,
+    generation: PlaybackGeneration,
+    handler: ((input: PlayerPlaybackEventEnvelope) => void) | undefined,
     correlation: PlayerOptions["correlation"] = undefined,
   ): (event: PlayerPlaybackEvent) => void {
     return (event) => {
+      if (!this.isCurrentGeneration(generation)) return;
       const failureClass = classifyPlaybackFailureFromEvent(event);
       const diagnosticFailureClass = mapPlaybackFailureToDiagnosticFailure(failureClass);
       this.deps.diagnostics.record(
@@ -621,7 +767,7 @@ export class PlayerServiceImpl implements PlayerService {
           },
         }),
       );
-      handler?.(event);
+      handler?.({ generation, event });
     };
   }
 

--- a/apps/cli/src/infra/player/PlayerServiceImpl.ts
+++ b/apps/cli/src/infra/player/PlayerServiceImpl.ts
@@ -44,7 +44,11 @@ import {
 } from "./playback-failure-classifier";
 import type { PlayerPresentationPort } from "./player-presentation-port";
 import { nonInteractivePlayerPresentation } from "./player-presentation-port";
-import type { MpvRequestedAction, PlayerControlService } from "./PlayerControlService";
+import type {
+  ActivePlayerControl,
+  MpvRequestedAction,
+  PlayerControlService,
+} from "./PlayerControlService";
 import type {
   PlayerOptions,
   PlayerPlaybackEvent,
@@ -102,6 +106,17 @@ export class PlayerServiceImpl implements PlayerService {
    */
   private invalidateProcessGeneration(): void {
     this.currentGeneration = { process: this.currentGeneration.process + 1, cycle: 0 };
+  }
+
+  /**
+   * Retires the current file/cycle while leaving the process number intact, so
+   * the reusable persistent process can still accept the next accepted cycle.
+   */
+  private invalidateCycleGeneration(): void {
+    this.currentGeneration = {
+      process: this.currentGeneration.process,
+      cycle: this.currentGeneration.cycle + 1,
+    };
   }
 
   /**
@@ -452,7 +467,31 @@ export class PlayerServiceImpl implements PlayerService {
   ): void {
     if (!this.isCurrentGeneration(generation)) return;
     this.activeControlGeneration = control ? generation : null;
-    this.deps.playerControl.setActive(control);
+    this.deps.playerControl.setActive(control ? this.guardControlGenerations(control) : null);
+  }
+
+  /**
+   * Stop is authoritative, so it retires its generation *before* the command
+   * leaves for mpv. Otherwise the events mpv emits while quitting — end-file,
+   * a final progress tick, a reconnect completion — would still look current
+   * and could revive a session the user just stopped.
+   */
+  private guardControlGenerations(control: ActivePlayerControl): ActivePlayerControl {
+    return {
+      ...control,
+      stop: async (reason?: string) => {
+        this.invalidateProcessGeneration();
+        await control.stop(reason);
+      },
+      ...(control.stopCurrentFile
+        ? {
+            stopCurrentFile: async (reason?: string) => {
+              this.invalidateCycleGeneration();
+              await control.stopCurrentFile?.(reason);
+            },
+          }
+        : {}),
+    };
   }
 
   /**

--- a/apps/cli/src/infra/player/persistent-ready-work-executor.ts
+++ b/apps/cli/src/infra/player/persistent-ready-work-executor.ts
@@ -1,3 +1,4 @@
+import type { PlaybackGeneration } from "@/domain/playback/playback-generation";
 import type { PlaybackTimingMetadata, SubtitleTrack } from "@/domain/types";
 import { collectAdditionalSubtitleTracks, shouldApplyStartAtSeek } from "@/mpv";
 
@@ -47,16 +48,26 @@ export type PersistentReadyWorkExecutorDeps = {
   handleSegmentSkipProgress(options: PersistentReadyWorkOptions): Promise<void>;
   onIpcCommandFailure?(command: string, error: string): void;
   subtitleManager: PersistentSubtitleManager;
+  /** False once a replacement cycle has taken over the generation this work belongs to. */
+  isGenerationCurrent(generation: PlaybackGeneration): boolean;
 };
 
 export class PersistentReadyWorkExecutor {
   constructor(private readonly deps: PersistentReadyWorkExecutorDeps) {}
 
+  /**
+   * Ready work is a chain of awaited IPC commands. A replacement can land at any
+   * boundary, so the generation is passed in explicitly — never read from
+   * mutable current state — and rechecked before every mutation and command.
+   */
   async execute(
     options: PersistentReadyWorkOptions,
     cycle: PersistentReadyWorkCycle | null,
+    generation: PlaybackGeneration,
   ): Promise<void> {
     if (!cycle) return;
+    const isCurrent = () => this.deps.isGenerationCurrent(generation);
+    if (!isCurrent()) return;
 
     if (!cycle.playerReadyNotified) {
       cycle.playerReadyNotified = true;
@@ -72,6 +83,7 @@ export class PersistentReadyWorkExecutor {
     );
     try {
       const unpauseResult = await ipcSession.send(["set_property", "pause", false], 500);
+      if (!isCurrent()) return;
       if (!unpauseResult.ok) {
         this.deps.onIpcCommandFailure?.("unpause", unpauseResult.error);
       }
@@ -85,6 +97,7 @@ export class PersistentReadyWorkExecutor {
           ["set_property", "force-media-title", options.displayTitle],
           1_000,
         );
+        if (!isCurrent()) return;
         if (!titleResult.ok) {
           this.deps.onIpcCommandFailure?.("set-title", titleResult.error);
         }
@@ -99,6 +112,7 @@ export class PersistentReadyWorkExecutor {
           options.displayTitle,
           options.resumeChoiceTimeLabel,
         );
+        if (!isCurrent()) return;
       }
 
       const seekTarget = resolvePersistentStartSeekTarget(options, choice);
@@ -110,6 +124,7 @@ export class PersistentReadyWorkExecutor {
           noteTrustedSeek(cycle.telemetry, target);
         } else {
           const seekResult = await ipcSession.send(["seek", target, "absolute"], 2_000);
+          if (!isCurrent()) return;
           if (seekResult.ok) {
             this.deps.setCurrentPositionSeconds(target);
             noteTrustedSeek(cycle.telemetry, target);
@@ -117,9 +132,10 @@ export class PersistentReadyWorkExecutor {
         }
       }
     } finally {
-      this.deps.setResumeSeekPending(false);
+      if (isCurrent()) this.deps.setResumeSeekPending(false);
     }
 
+    if (!isCurrent()) return;
     const initialOptions = this.deps.getInitialOptions();
     if (
       this.deps.getSubtitlesAttachedAtSpawn() &&
@@ -140,6 +156,7 @@ export class PersistentReadyWorkExecutor {
         },
       );
     }
+    if (!isCurrent()) return;
     this.deps.setSubtitlesAttachedAtSpawn(false);
     await this.deps.handleSegmentSkipProgress(options);
   }

--- a/apps/cli/src/services/diagnostics/diagnostics-insight.ts
+++ b/apps/cli/src/services/diagnostics/diagnostics-insight.ts
@@ -1,4 +1,5 @@
 import { describePlaybackSubtitleStatus } from "@/app/playback/subtitle-status";
+import { formatPlaybackGeneration } from "@/domain/playback/playback-generation";
 import type { PlaybackProblemAction } from "@/domain/playback/playback-problem";
 import type { SessionState } from "@/domain/session/SessionState";
 import { buildPlaybackSourceInventoryDiagnosticsSummary } from "@/services/playback/PlaybackSourceInventoryProjection";
@@ -63,6 +64,8 @@ export type DiagnosticsCurrentPlaybackEvidence = {
   readonly mode: string;
   readonly provider: string;
   readonly playbackStatus: string;
+  /** Formatted current generation, e.g. `process 4 · cycle 9`. */
+  readonly playbackGeneration: string;
   readonly sourceState: string;
   readonly cacheState: string;
   readonly subtitleOutcome: string;
@@ -576,6 +579,7 @@ function buildCurrentPlaybackEvidence(
     mode: state.mode,
     provider: state.provider,
     playbackStatus: state.playbackStatus,
+    playbackGeneration: formatPlaybackGeneration(state.playbackGeneration),
     sourceState: state.stream?.url ? "stream resolved" : "no stream yet",
     cacheState: cacheFallback
       ? "kept cached stream after fresh lookup failed"

--- a/apps/cli/test/integration/queue-playback-lifecycle.test.ts
+++ b/apps/cli/test/integration/queue-playback-lifecycle.test.ts
@@ -19,6 +19,11 @@ import {
   playlistAdvanceFromQueueIntent,
   resolvePlaylistAutoNextCountdown,
 } from "@/app/playback/playback-outcome";
+import {
+  transitionPlaybackStatus,
+  type PlaybackStatusSignal,
+  type PlaybackStatusSnapshot,
+} from "@/app/playback/playback-status-policy";
 import { createQueuePlaybackAttempt } from "@/app/playback/queue-playback-attempt";
 import { runMpvPlaybackSession } from "@/app/playback/run-mpv-playback-session";
 import { QueueService } from "@/domain/queue/QueueService";
@@ -99,11 +104,14 @@ function enqueueAnime(
   });
 }
 
+const FAKE_GENERATION = { process: 1, cycle: 1 } as const;
+
 function fakePlayer(events: readonly PlayerPlaybackEvent[]): PlayerService {
   return {
     play: async (_stream, playOptions: PlayerOptions) => {
+      playOptions.onGenerationActivated?.(FAKE_GENERATION);
       for (const event of events) {
-        playOptions.onPlaybackEvent?.(event);
+        playOptions.onPlaybackEvent?.({ generation: FAKE_GENERATION, event });
       }
       return FINISHED;
     },
@@ -116,6 +124,10 @@ function fakePlayer(events: readonly PlayerPlaybackEvent[]): PlayerService {
 }
 
 function noopHooks(overrides: { onConfirmedPlaybackStart?: () => void } = {}) {
+  let statusSnapshot: PlaybackStatusSnapshot = {
+    status: "loading",
+    generation: { process: 0, cycle: 0 },
+  };
   return {
     onFeedback: () => undefined,
     onPresenceLaunch: () => undefined,
@@ -124,8 +136,11 @@ function noopHooks(overrides: { onConfirmedPlaybackStart?: () => void } = {}) {
     onPresenceSubtitles: () => undefined,
     onPresencePaused: () => undefined,
     onPresenceResumed: () => undefined,
-    setPlaybackStatus: () => undefined,
-    getPlaybackStatus: () => "idle",
+    applyPlaybackStatusSignal: (signal: PlaybackStatusSignal) => {
+      const decision = transitionPlaybackStatus(statusSnapshot, signal);
+      if (decision.accepted && decision.statusChanged) statusSnapshot = decision.snapshot;
+      return decision;
+    },
     onTrackChanged: () => undefined,
     onShareCopied: () => undefined,
     onPlayerReady: () => undefined,

--- a/apps/cli/test/live/offline-beta.smoke.ts
+++ b/apps/cli/test/live/offline-beta.smoke.ts
@@ -293,7 +293,7 @@ try {
   if (libraryReady) {
     const playPromise = container.player.playLocal({
       source: playable.source,
-      onPlaybackEvent: (event) => {
+      onPlaybackEvent: ({ event }) => {
         if (event.type === "playback-started") {
           playbackStarted = true;
           container.player.killActiveMpvProcessesSync();

--- a/apps/cli/test/unit/app-shell/playback-status-recovery-shell.test.tsx
+++ b/apps/cli/test/unit/app-shell/playback-status-recovery-shell.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveRootShellSurface } from "@/app-shell/root-shell-state";
+import { buildPlaybackBootstrapPresentation } from "@/app/playback/playback-bootstrap-presenter";
+import { resolveCommands, type AppCommandId } from "@/domain/session/command-registry";
+import { createInitialState, isPlaybackSessionActive } from "@/domain/session/SessionState";
+import type { SessionState } from "@/domain/session/SessionState";
+import { buildDiagnosticsInsight } from "@/services/diagnostics/diagnostics-insight";
+
+function baseState(): SessionState {
+  return createInitialState("vidking", "allanime", {
+    anime: { audio: "original", subtitle: "en" },
+    series: { audio: "original", subtitle: "none" },
+    movie: { audio: "original", subtitle: "en" },
+  });
+}
+
+function playbackState(status: SessionState["playbackStatus"]): SessionState {
+  return {
+    ...baseState(),
+    view: "playback",
+    playbackStatus: status,
+    playbackGeneration: { process: 4, cycle: 9 },
+    currentTitle: { id: "1396", name: "Breaking Bad", type: "series" },
+    currentEpisode: { season: 1, episode: 1 },
+    stream: { url: "https://cdn.example/a.m3u8", headers: {}, timestamp: 1 },
+  };
+}
+
+describe("paused playback stays an active session across surfaces", () => {
+  test("the shared selector treats paused as active", () => {
+    expect(isPlaybackSessionActive("paused")).toBe(true);
+  });
+
+  test("paused playback keeps the playback surface mounted", () => {
+    const mount = { hasRootContent: false, hasMountedScreen: true };
+    expect(resolveRootShellSurface(playbackState("paused"), mount)).toBe(
+      resolveRootShellSurface(playbackState("playing"), mount),
+    );
+  });
+
+  test("paused playback keeps playback-scoped commands available", () => {
+    const paused = resolveCommands(playbackState("paused"));
+    const playing = resolveCommands(playbackState("playing"));
+    const enabled = (commands: ReturnType<typeof resolveCommands>) =>
+      commands.filter((command) => command.enabled).map((command) => command.id);
+
+    for (const id of ["stop", "recover", "diagnostics"] as AppCommandId[]) {
+      if (!enabled(playing).includes(id)) continue;
+      expect(enabled(paused)).toContain(id);
+    }
+  });
+
+  test("paused playback stays in the playback bootstrap view without claiming transport advances", () => {
+    const paused = buildPlaybackBootstrapPresentation({
+      playbackStatus: "paused",
+      playbackDetail: null,
+      recentEvents: [],
+    });
+
+    // Paused is an active playback session, not a resolve/bootstrap state.
+    expect(paused.operation).toBe("playing");
+  });
+});
+
+describe("recovered playback renders healthy state", () => {
+  test("a recovered playing status carries no stale degraded copy", () => {
+    const recovered: SessionState = {
+      ...playbackState("playing"),
+      playbackDetail: null,
+      playbackNote: null,
+    };
+
+    expect(recovered.playbackDetail).toBeNull();
+    expect(recovered.playbackNote).toBeNull();
+    expect(
+      resolveRootShellSurface(recovered, { hasRootContent: false, hasMountedScreen: true }),
+    ).toBe("playback");
+  });
+});
+
+describe("diagnostics current evidence", () => {
+  test("reports the same status and generation the session holds", () => {
+    const insight = buildDiagnosticsInsight({
+      state: playbackState("playing"),
+      recentEvents: [],
+    });
+
+    expect(insight.currentPlaybackEvidence.playbackStatus).toBe("playing");
+    expect(insight.currentPlaybackEvidence.playbackGeneration).toBe("process 4 · cycle 9");
+  });
+
+  test("activating a newer generation does not delete earlier event evidence", () => {
+    const events = [
+      {
+        id: "e1",
+        at: 1,
+        category: "playback",
+        message: "Stream stalled",
+        operation: "mpv.network.sample",
+        status: "failed",
+        severity: "degraded",
+      },
+      {
+        id: "e2",
+        at: 2,
+        category: "playback",
+        message: "Trying another source",
+        operation: "playback.provider.fallback",
+        status: "started",
+        severity: "degraded",
+      },
+    ] as never;
+
+    const insight = buildDiagnosticsInsight({
+      state: { ...playbackState("playing"), playbackGeneration: { process: 5, cycle: 1 } },
+      recentEvents: events,
+    });
+
+    expect(insight.currentPlaybackEvidence.playbackGeneration).toBe("process 5 · cycle 1");
+    // Historical evidence survives a newer generation.
+    expect(insight.developerEvidence.recentEvents.length).toBe(2);
+  });
+});

--- a/apps/cli/test/unit/app/playback-presence-freshness.test.ts
+++ b/apps/cli/test/unit/app/playback-presence-freshness.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import { isPlaybackPresenceUpdateCurrent } from "@/app/playback/playback-presence-freshness";
+import type { PlaybackStatusSnapshot } from "@/app/playback/playback-status-policy";
+
+const GEN = { process: 2, cycle: 7 } as const;
+
+function snapshot(
+  status: PlaybackStatusSnapshot["status"],
+  generation: PlaybackStatusSnapshot["generation"] = GEN,
+): PlaybackStatusSnapshot {
+  return { status, generation };
+}
+
+describe("isPlaybackPresenceUpdateCurrent", () => {
+  test("an unchanged snapshot is still current", () => {
+    expect(isPlaybackPresenceUpdateCurrent(snapshot("playing"), snapshot("playing"))).toBe(true);
+  });
+
+  test("a queued update is discarded when the generation changed before execution", () => {
+    expect(
+      isPlaybackPresenceUpdateCurrent(
+        snapshot("playing", { process: 2, cycle: 8 }),
+        snapshot("playing"),
+      ),
+    ).toBe(false);
+  });
+
+  test("a queued update is discarded when the process changed before execution", () => {
+    expect(
+      isPlaybackPresenceUpdateCurrent(
+        snapshot("playing", { process: 3, cycle: 1 }),
+        snapshot("playing"),
+      ),
+    ).toBe(false);
+  });
+
+  test("a playing update is discarded once playback became paused", () => {
+    expect(isPlaybackPresenceUpdateCurrent(snapshot("paused"), snapshot("playing"))).toBe(false);
+  });
+
+  test("a paused update is discarded once playback resumed", () => {
+    expect(isPlaybackPresenceUpdateCurrent(snapshot("playing"), snapshot("paused"))).toBe(false);
+  });
+
+  test("a playing update is discarded once playback stopped", () => {
+    expect(isPlaybackPresenceUpdateCurrent(snapshot("idle"), snapshot("playing"))).toBe(false);
+  });
+
+  test("a stall-recovery update scheduled against the recovered playing snapshot is current", () => {
+    // The policy recovered buffering -> playing, and presence was scheduled with
+    // that accepted snapshot, so it must still be publishable.
+    expect(isPlaybackPresenceUpdateCurrent(snapshot("playing"), snapshot("playing"))).toBe(true);
+    expect(isPlaybackPresenceUpdateCurrent(snapshot("playing"), snapshot("buffering"))).toBe(false);
+  });
+});

--- a/apps/cli/test/unit/app/playback-status-policy.test.ts
+++ b/apps/cli/test/unit/app/playback-status-policy.test.ts
@@ -1,0 +1,461 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  transitionPlaybackStatus,
+  type PlaybackStatusSnapshot,
+} from "@/app/playback/playback-status-policy";
+import {
+  INITIAL_PLAYBACK_GENERATION,
+  isPlaybackGenerationAfter,
+  isSamePlaybackGeneration,
+  type PlaybackGeneration,
+} from "@/domain/playback/playback-generation";
+import { createInitialState, reduceState } from "@/domain/session/SessionState";
+
+const GEN: PlaybackGeneration = { process: 2, cycle: 7 };
+
+function snapshot(
+  status: PlaybackStatusSnapshot["status"],
+  generation: PlaybackGeneration = GEN,
+): PlaybackStatusSnapshot {
+  return { status, generation };
+}
+
+describe("playback generation comparison", () => {
+  test("initial generation is process 0 / cycle 0", () => {
+    expect(INITIAL_PLAYBACK_GENERATION).toEqual({ process: 0, cycle: 0 });
+  });
+
+  test("same generation compares equal", () => {
+    expect(isSamePlaybackGeneration({ process: 1, cycle: 2 }, { process: 1, cycle: 2 })).toBe(true);
+    expect(isSamePlaybackGeneration({ process: 1, cycle: 2 }, { process: 1, cycle: 3 })).toBe(
+      false,
+    );
+    expect(isSamePlaybackGeneration({ process: 1, cycle: 2 }, { process: 2, cycle: 2 })).toBe(
+      false,
+    );
+  });
+
+  test("comparison is lexicographic on process then cycle", () => {
+    expect(isPlaybackGenerationAfter({ process: 2, cycle: 0 }, { process: 1, cycle: 99 })).toBe(
+      true,
+    );
+    expect(isPlaybackGenerationAfter({ process: 1, cycle: 99 }, { process: 2, cycle: 0 })).toBe(
+      false,
+    );
+    expect(isPlaybackGenerationAfter({ process: 1, cycle: 3 }, { process: 1, cycle: 2 })).toBe(
+      true,
+    );
+    expect(isPlaybackGenerationAfter({ process: 1, cycle: 2 }, { process: 1, cycle: 2 })).toBe(
+      false,
+    );
+  });
+});
+
+describe("transitionPlaybackStatus — fresh progress recovery", () => {
+  test.each(["buffering", "stalled", "seeking"] as const)(
+    "fresh progress recovers %s",
+    (status) => {
+      const decision = transitionPlaybackStatus(snapshot(status), {
+        kind: "player-event",
+        generation: GEN,
+        event: {
+          type: "playback-progress",
+          positionSeconds: 12,
+          durationSeconds: 24,
+        },
+      });
+
+      expect(decision).toEqual({
+        accepted: true,
+        snapshot: { status: "playing", generation: GEN },
+        statusChanged: true,
+        clearFeedback: true,
+      });
+    },
+  );
+
+  test.each(["paused", "idle", "finished", "error"] as const)(
+    "fresh progress is rejected in %s",
+    (status) => {
+      const decision = transitionPlaybackStatus(snapshot(status), {
+        kind: "player-event",
+        generation: GEN,
+        event: { type: "playback-progress", positionSeconds: 5, durationSeconds: 10 },
+      });
+
+      expect(decision.accepted).toBe(false);
+      expect(decision.snapshot).toEqual(snapshot(status));
+      expect(decision.statusChanged).toBe(false);
+      expect(decision.clearFeedback).toBe(false);
+    },
+  );
+
+  test("duplicate progress in playing is accepted without another status write", () => {
+    const decision = transitionPlaybackStatus(snapshot("playing"), {
+      kind: "player-event",
+      generation: GEN,
+      event: { type: "playback-progress", positionSeconds: 30, durationSeconds: 60 },
+    });
+
+    expect(decision.accepted).toBe(true);
+    expect(decision.statusChanged).toBe(false);
+    expect(decision.clearFeedback).toBe(false);
+    expect(decision.snapshot).toEqual(snapshot("playing"));
+  });
+});
+
+describe("transitionPlaybackStatus — generation freshness", () => {
+  test("an older cycle event is rejected", () => {
+    const decision = transitionPlaybackStatus(snapshot("buffering", { process: 2, cycle: 8 }), {
+      kind: "player-event",
+      generation: { process: 2, cycle: 7 },
+      event: { type: "playback-progress", positionSeconds: 1, durationSeconds: 2 },
+    });
+
+    expect(decision.accepted).toBe(false);
+    expect(decision.snapshot).toEqual(snapshot("buffering", { process: 2, cycle: 8 }));
+  });
+
+  test("an older process event is rejected", () => {
+    const decision = transitionPlaybackStatus(snapshot("buffering", { process: 3, cycle: 1 }), {
+      kind: "player-event",
+      generation: { process: 2, cycle: 99 },
+      event: { type: "playback-progress", positionSeconds: 1, durationSeconds: 2 },
+    });
+
+    expect(decision.accepted).toBe(false);
+  });
+
+  test("a newer-generation player event is rejected — activation is the only way in", () => {
+    const decision = transitionPlaybackStatus(snapshot("playing", { process: 2, cycle: 7 }), {
+      kind: "player-event",
+      generation: { process: 2, cycle: 8 },
+      event: { type: "playback-started" },
+    });
+
+    expect(decision.accepted).toBe(false);
+  });
+
+  test("activation accepts a strictly newer generation and writes loading", () => {
+    const decision = transitionPlaybackStatus(snapshot("playing", { process: 2, cycle: 7 }), {
+      kind: "activate",
+      generation: { process: 2, cycle: 8 },
+      status: "loading",
+    });
+
+    expect(decision).toEqual({
+      accepted: true,
+      snapshot: { status: "loading", generation: { process: 2, cycle: 8 } },
+      statusChanged: true,
+      clearFeedback: false,
+    });
+  });
+
+  test("activation with the same generation is rejected", () => {
+    const decision = transitionPlaybackStatus(snapshot("loading", GEN), {
+      kind: "activate",
+      generation: GEN,
+      status: "loading",
+    });
+
+    expect(decision.accepted).toBe(false);
+  });
+
+  test("activation with an older generation is rejected", () => {
+    const decision = transitionPlaybackStatus(snapshot("playing", { process: 3, cycle: 1 }), {
+      kind: "activate",
+      generation: { process: 2, cycle: 9 },
+      status: "loading",
+    });
+
+    expect(decision.accepted).toBe(false);
+  });
+
+  test("an activation that keeps the same status still requests a write for the generation", () => {
+    const decision = transitionPlaybackStatus(snapshot("loading", { process: 1, cycle: 1 }), {
+      kind: "activate",
+      generation: { process: 1, cycle: 2 },
+      status: "loading",
+    });
+
+    expect(decision.accepted).toBe(true);
+    expect(decision.statusChanged).toBe(true);
+    expect(decision.snapshot).toEqual({ status: "loading", generation: { process: 1, cycle: 2 } });
+  });
+});
+
+describe("transitionPlaybackStatus — pause is authoritative", () => {
+  test("playback-paused enters paused from active playback", () => {
+    const decision = transitionPlaybackStatus(snapshot("playing"), {
+      kind: "player-event",
+      generation: GEN,
+      event: { type: "playback-paused" },
+    });
+
+    expect(decision.accepted).toBe(true);
+    expect(decision.statusChanged).toBe(true);
+    expect(decision.snapshot).toEqual(snapshot("paused"));
+  });
+
+  test("playback-started does not leave paused", () => {
+    const decision = transitionPlaybackStatus(snapshot("paused"), {
+      kind: "player-event",
+      generation: GEN,
+      event: { type: "playback-started" },
+    });
+
+    expect(decision.accepted).toBe(false);
+    expect(decision.snapshot).toEqual(snapshot("paused"));
+  });
+
+  test("playback-resumed leaves paused", () => {
+    const decision = transitionPlaybackStatus(snapshot("paused"), {
+      kind: "player-event",
+      generation: GEN,
+      event: { type: "playback-resumed" },
+    });
+
+    expect(decision.accepted).toBe(true);
+    expect(decision.statusChanged).toBe(true);
+    expect(decision.snapshot).toEqual(snapshot("playing"));
+  });
+
+  test("buffer telemetry while paused is accepted but cannot change status", () => {
+    const decision = transitionPlaybackStatus(snapshot("paused"), {
+      kind: "player-event",
+      generation: GEN,
+      event: { type: "network-buffering", percent: 40 },
+    });
+
+    expect(decision.accepted).toBe(true);
+    expect(decision.statusChanged).toBe(false);
+    expect(decision.snapshot).toEqual(snapshot("paused"));
+  });
+});
+
+describe("transitionPlaybackStatus — degraded states", () => {
+  test("network-buffering enters buffering", () => {
+    const decision = transitionPlaybackStatus(snapshot("playing"), {
+      kind: "player-event",
+      generation: GEN,
+      event: { type: "network-buffering", percent: 10 },
+    });
+    expect(decision.snapshot).toEqual(snapshot("buffering"));
+  });
+
+  test.each(["stream-stalled", "ipc-stalled"] as const)("%s enters stalled", (type) => {
+    const decision = transitionPlaybackStatus(snapshot("playing"), {
+      kind: "player-event",
+      generation: GEN,
+      event:
+        type === "stream-stalled"
+          ? { type: "stream-stalled", secondsWithoutProgress: 9 }
+          : { type: "ipc-stalled", command: "get_property", error: "timeout" },
+    });
+    expect(decision.snapshot).toEqual(snapshot("stalled"));
+  });
+
+  test("seek-stalled enters seeking", () => {
+    const decision = transitionPlaybackStatus(snapshot("playing"), {
+      kind: "player-event",
+      generation: GEN,
+      event: { type: "seek-stalled", secondsSeeking: 4 },
+    });
+    expect(decision.snapshot).toEqual(snapshot("seeking"));
+  });
+
+  test("player-ready enters ready from loading", () => {
+    const decision = transitionPlaybackStatus(snapshot("loading"), {
+      kind: "player-event",
+      generation: GEN,
+      event: { type: "player-ready" },
+    });
+    expect(decision.snapshot).toEqual(snapshot("ready"));
+  });
+
+  test("player-ready cannot demote active playback", () => {
+    const decision = transitionPlaybackStatus(snapshot("playing"), {
+      kind: "player-event",
+      generation: GEN,
+      event: { type: "player-ready" },
+    });
+    expect(decision.accepted).toBe(true);
+    expect(decision.statusChanged).toBe(false);
+    expect(decision.snapshot).toEqual(snapshot("playing"));
+  });
+
+  test.each(["idle", "finished", "error"] as const)(
+    "terminal %s rejects player events",
+    (status) => {
+      const decision = transitionPlaybackStatus(snapshot(status), {
+        kind: "player-event",
+        generation: GEN,
+        event: { type: "playback-started" },
+      });
+      expect(decision.accepted).toBe(false);
+    },
+  );
+});
+
+describe("transitionPlaybackStatus — startup stall", () => {
+  test("a current startup-stall enters stalled", () => {
+    const decision = transitionPlaybackStatus(snapshot("loading"), {
+      kind: "startup-stall",
+      generation: GEN,
+    });
+    expect(decision.accepted).toBe(true);
+    expect(decision.snapshot).toEqual(snapshot("stalled"));
+  });
+
+  test("an old startup-stall cannot abort a replacement generation", () => {
+    const decision = transitionPlaybackStatus(snapshot("playing", { process: 2, cycle: 8 }), {
+      kind: "startup-stall",
+      generation: { process: 2, cycle: 7 },
+    });
+    expect(decision.accepted).toBe(false);
+    expect(decision.snapshot).toEqual(snapshot("playing", { process: 2, cycle: 8 }));
+  });
+});
+
+describe("transitionPlaybackStatus — completion", () => {
+  test("eof completes as finished", () => {
+    const decision = transitionPlaybackStatus(snapshot("playing"), {
+      kind: "completed",
+      generation: GEN,
+      endReason: "eof",
+    });
+    expect(decision.accepted).toBe(true);
+    expect(decision.snapshot).toEqual(snapshot("finished"));
+  });
+
+  test("quit completes as idle", () => {
+    const decision = transitionPlaybackStatus(snapshot("playing"), {
+      kind: "completed",
+      generation: GEN,
+      endReason: "quit",
+    });
+    expect(decision.snapshot).toEqual(snapshot("idle"));
+  });
+
+  test.each(["error", "unknown"] as const)("%s completes as error", (endReason) => {
+    const decision = transitionPlaybackStatus(snapshot("playing"), {
+      kind: "completed",
+      generation: GEN,
+      endReason,
+    });
+    expect(decision.snapshot).toEqual(snapshot("error"));
+  });
+
+  test("a late old completion cannot overwrite a replacement", () => {
+    const decision = transitionPlaybackStatus(snapshot("playing", { process: 3, cycle: 1 }), {
+      kind: "completed",
+      generation: { process: 2, cycle: 9 },
+      endReason: "eof",
+    });
+    expect(decision.accepted).toBe(false);
+    expect(decision.snapshot).toEqual(snapshot("playing", { process: 3, cycle: 1 }));
+  });
+
+  test("completion into an already terminal status is rejected", () => {
+    const decision = transitionPlaybackStatus(snapshot("idle"), {
+      kind: "completed",
+      generation: GEN,
+      endReason: "eof",
+    });
+    expect(decision.accepted).toBe(false);
+  });
+});
+
+function initialState() {
+  return createInitialState("vidking", "allanime", {
+    anime: { audio: "original", subtitle: "en" },
+    series: { audio: "original", subtitle: "none" },
+    movie: { audio: "original", subtitle: "en" },
+  });
+}
+
+describe("SessionState playback generation", () => {
+  test("initial state starts at the initial generation", () => {
+    expect(initialState().playbackGeneration).toEqual(INITIAL_PLAYBACK_GENERATION);
+  });
+
+  test("an accepted activation writes status and generation atomically", () => {
+    const next = reduceState(initialState(), {
+      type: "SET_PLAYBACK_STATUS",
+      status: "loading",
+      generation: { process: 1, cycle: 1 },
+    });
+
+    expect(next.playbackStatus).toBe("loading");
+    expect(next.playbackGeneration).toEqual({ process: 1, cycle: 1 });
+  });
+
+  test("a lifecycle dispatch that omits generation retains the current generation", () => {
+    let state = reduceState(initialState(), {
+      type: "SET_PLAYBACK_STATUS",
+      status: "loading",
+      generation: { process: 4, cycle: 9 },
+    });
+    state = reduceState(state, { type: "SET_PLAYBACK_STATUS", status: "idle" });
+
+    expect(state.playbackStatus).toBe("idle");
+    expect(state.playbackGeneration).toEqual({ process: 4, cycle: 9 });
+  });
+
+  test("clearFeedback clears detail and note while preserving playbackProblem", () => {
+    let state = reduceState(initialState(), {
+      type: "SET_PLAYBACK_STATUS",
+      status: "buffering",
+      generation: { process: 1, cycle: 1 },
+    });
+    state = reduceState(state, {
+      type: "SET_PLAYBACK_FEEDBACK",
+      detail: "Buffering…",
+      note: "slow network",
+    });
+    state = reduceState(state, {
+      type: "SET_PLAYBACK_PROBLEM",
+      problem: {
+        stage: "provider-resolve",
+        severity: "recoverable",
+        cause: "provider-fallback",
+        userMessage: "Trying another source",
+        recommendedAction: "try-next-provider",
+        secondaryActions: ["diagnostics"],
+      },
+    });
+
+    const recovered = reduceState(state, {
+      type: "SET_PLAYBACK_STATUS",
+      status: "playing",
+      generation: { process: 1, cycle: 1 },
+      clearFeedback: true,
+    });
+
+    expect(recovered.playbackDetail).toBeNull();
+    expect(recovered.playbackNote).toBeNull();
+    expect(recovered.playbackProblem).toEqual(state.playbackProblem);
+  });
+
+  test("a status write without clearFeedback keeps active-state feedback", () => {
+    let state = reduceState(initialState(), {
+      type: "SET_PLAYBACK_STATUS",
+      status: "playing",
+      generation: { process: 1, cycle: 1 },
+    });
+    state = reduceState(state, {
+      type: "SET_PLAYBACK_FEEDBACK",
+      detail: "Playing",
+      note: "1080p",
+    });
+    const next = reduceState(state, {
+      type: "SET_PLAYBACK_STATUS",
+      status: "buffering",
+      generation: { process: 1, cycle: 1 },
+    });
+
+    expect(next.playbackDetail).toBe("Playing");
+    expect(next.playbackNote).toBe("1080p");
+  });
+});

--- a/apps/cli/test/unit/app/playback/run-mpv-playback-session.test.ts
+++ b/apps/cli/test/unit/app/playback/run-mpv-playback-session.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
+import {
+  transitionPlaybackStatus,
+  type PlaybackStatusDecision,
+  type PlaybackStatusSignal,
+  type PlaybackStatusSnapshot,
+} from "@/app/playback/playback-status-policy";
 import { runMpvPlaybackSession } from "@/app/playback/run-mpv-playback-session";
+import { INITIAL_PLAYBACK_GENERATION } from "@/domain/playback/playback-generation";
 import type { EpisodeInfo, PlaybackResult, StreamInfo, TitleInfo } from "@/domain/types";
 import type {
   PlayerOptions,
@@ -26,33 +33,92 @@ const FINISHED: PlaybackResult = {
   playerExitSignal: null,
 };
 
-function noopHooks() {
+const GEN_1 = { process: 1, cycle: 1 } as const;
+const GEN_2 = { process: 1, cycle: 2 } as const;
+
+/**
+ * A real policy-backed status store: the point of these tests is the wiring
+ * between the session loop and the policy, so the policy itself is not faked.
+ */
+function createStatusStore() {
+  let snapshot: PlaybackStatusSnapshot = {
+    status: "loading",
+    generation: INITIAL_PLAYBACK_GENERATION,
+  };
+  const writes: PlaybackStatusSnapshot[] = [];
+  const clearFeedbackWrites: boolean[] = [];
+
   return {
-    onFeedback: () => undefined,
-    onPresenceLaunch: () => undefined,
-    onPresenceStarted: () => undefined,
-    onPresenceProgress: () => undefined,
-    onPresenceSubtitles: () => undefined,
-    onPresencePaused: () => undefined,
-    onPresenceResumed: () => undefined,
-    setPlaybackStatus: () => undefined,
-    getPlaybackStatus: () => "idle",
-    onTrackChanged: () => undefined,
-    onShareCopied: () => undefined,
-    onPlayerReady: () => undefined,
+    get snapshot() {
+      return snapshot;
+    },
+    writes,
+    clearFeedbackWrites,
+    apply(signal: PlaybackStatusSignal): PlaybackStatusDecision {
+      const decision = transitionPlaybackStatus(snapshot, signal);
+      if (decision.accepted && decision.statusChanged) {
+        snapshot = decision.snapshot;
+        writes.push(decision.snapshot);
+        clearFeedbackWrites.push(decision.clearFeedback);
+      }
+      return decision;
+    },
   };
 }
 
-async function runWithPlayerEvents(
-  events: readonly PlayerPlaybackEvent[],
-  options: { onConfirmedStart?: () => void } = {},
-): Promise<PlaybackResult> {
+type Emit = (event: PlayerPlaybackEvent, generation?: { process: number; cycle: number }) => void;
+
+type Harness = {
+  readonly store: ReturnType<typeof createStatusStore>;
+  /** State at the moment mpv returned, before the completion signal is applied. */
+  readonly beforeCompletion: {
+    readonly snapshot: PlaybackStatusSnapshot;
+    readonly writes: readonly PlaybackStatusSnapshot[];
+    readonly clearFeedbackWrites: readonly boolean[];
+  };
+  readonly presence: string[];
+  readonly presenceSnapshots: PlaybackStatusSnapshot[];
+  readonly feedback: unknown[];
+  readonly tracks: PlayerPlaybackEvent[];
+  readonly confirmedStarts: number;
+  readonly result: PlaybackResult;
+};
+
+async function runSession(
+  script: (emit: Emit, store: ReturnType<typeof createStatusStore>) => void,
+  options: {
+    readonly result?: PlaybackResult;
+    readonly activation?: { process: number; cycle: number };
+  } = {},
+): Promise<Harness> {
+  const store = createStatusStore();
+  const presence: string[] = [];
+  const presenceSnapshots: PlaybackStatusSnapshot[] = [];
+  const feedback: unknown[] = [];
+  const tracks: PlayerPlaybackEvent[] = [];
+  let confirmedStarts = 0;
+  const activation = options.activation ?? GEN_1;
+
+  let beforeCompletion: Harness["beforeCompletion"] = {
+    snapshot: store.snapshot,
+    writes: [],
+    clearFeedbackWrites: [],
+  };
+
   const player: PlayerService = {
     play: async (_stream, playOptions: PlayerOptions) => {
-      for (const event of events) {
-        playOptions.onPlaybackEvent?.(event);
-      }
-      return FINISHED;
+      playOptions.onGenerationActivated?.(activation);
+      script(
+        (event, generation) =>
+          playOptions.onPlaybackEvent?.({ generation: generation ?? activation, event }),
+        store,
+      );
+      beforeCompletion = {
+        snapshot: store.snapshot,
+        writes: [...store.writes],
+        clearFeedbackWrites: [...store.clearFeedbackWrites],
+      };
+      return options.result ?? FINISHED;
     },
     releasePersistentSession: async () => undefined,
     killActiveMpvProcessesSync: () => undefined,
@@ -61,7 +127,14 @@ async function runWithPlayerEvents(
     playLocal: async () => FINISHED,
   };
 
-  return runMpvPlaybackSession({
+  const record =
+    (name: string) =>
+    (input: { snapshot?: PlaybackStatusSnapshot } = {}) => {
+      presence.push(name);
+      if (input.snapshot) presenceSnapshots.push(input.snapshot);
+    };
+
+  const result = await runMpvPlaybackSession({
     stream: STREAM,
     title: TITLE,
     episode: EPISODE,
@@ -78,30 +151,198 @@ async function runWithPlayerEvents(
     },
     timing: null,
     hooks: {
-      ...noopHooks(),
-      onConfirmedPlaybackStart: options.onConfirmedStart,
+      onFeedback: (update) => feedback.push(update),
+      onPresenceLaunch: () => presence.push("launch"),
+      onPresenceStarted: record("started"),
+      onPresenceProgress: record("progress"),
+      onPresenceSubtitles: record("subtitles"),
+      onPresencePaused: record("paused"),
+      onPresenceResumed: record("resumed"),
+      applyPlaybackStatusSignal: (signal) => store.apply(signal),
+      onTrackChanged: (event) => tracks.push(event),
+      onShareCopied: () => undefined,
+      onPlayerReady: () => undefined,
+      onConfirmedPlaybackStart: () => {
+        confirmedStarts += 1;
+      },
     },
   });
+
+  return {
+    store,
+    beforeCompletion,
+    presence,
+    presenceSnapshots,
+    feedback,
+    tracks,
+    confirmedStarts,
+    result,
+  };
 }
 
 describe("runMpvPlaybackSession queue acknowledgement boundary", () => {
   test("mpv process start does not acknowledge", async () => {
-    const onConfirmedStart = mock();
-    await runWithPlayerEvents([{ type: "mpv-process-started" }], { onConfirmedStart });
-    expect(onConfirmedStart).not.toHaveBeenCalled();
+    const harness = await runSession((emit) => emit({ type: "mpv-process-started" }));
+    expect(harness.confirmedStarts).toBe(0);
   });
 
   test("ipc-connected does not acknowledge", async () => {
-    const onConfirmedStart = mock();
-    await runWithPlayerEvents([{ type: "ipc-connected" }], { onConfirmedStart });
-    expect(onConfirmedStart).not.toHaveBeenCalled();
+    const harness = await runSession((emit) => emit({ type: "ipc-connected" }));
+    expect(harness.confirmedStarts).toBe(0);
   });
 
   test("playback-started acknowledges once", async () => {
-    const onConfirmedStart = mock();
-    await runWithPlayerEvents([{ type: "playback-started" }, { type: "playback-started" }], {
-      onConfirmedStart,
+    const harness = await runSession((emit) => {
+      emit({ type: "playback-started" });
+      emit({ type: "playback-started" });
     });
-    expect(onConfirmedStart).toHaveBeenCalledTimes(1);
+    expect(harness.confirmedStarts).toBe(1);
+  });
+});
+
+describe("runMpvPlaybackSession generation activation", () => {
+  test("activation writes the generation before any player event", async () => {
+    const harness = await runSession(() => undefined, { activation: GEN_2 });
+    expect(harness.store.writes[0]).toEqual({ status: "loading", generation: GEN_2 });
+  });
+});
+
+describe("runMpvPlaybackSession degraded-state recovery", () => {
+  test("started → buffering → progress ends playing and clears feedback", async () => {
+    const harness = await runSession((emit) => {
+      emit({ type: "playback-started" });
+      emit({ type: "network-buffering", percent: 12 });
+      emit({ type: "playback-progress", positionSeconds: 5, durationSeconds: 100 });
+    });
+
+    expect(harness.beforeCompletion.snapshot).toEqual({ status: "playing", generation: GEN_1 });
+    expect(harness.beforeCompletion.clearFeedbackWrites.at(-1)).toBe(true);
+  });
+
+  test("started → stream-stalled → progress recovers", async () => {
+    const harness = await runSession((emit) => {
+      emit({ type: "playback-started" });
+      emit({ type: "stream-stalled", secondsWithoutProgress: 12 });
+      emit({ type: "playback-progress", positionSeconds: 8, durationSeconds: 100 });
+    });
+    expect(harness.beforeCompletion.snapshot.status).toBe("playing");
+  });
+
+  test("started → seek-stalled → progress recovers", async () => {
+    const harness = await runSession((emit) => {
+      emit({ type: "playback-started" });
+      emit({ type: "seek-stalled", secondsSeeking: 6 });
+      emit({ type: "playback-progress", positionSeconds: 400, durationSeconds: 1000 });
+    });
+    expect(harness.beforeCompletion.snapshot.status).toBe("playing");
+  });
+
+  test("repeated playing progress updates presence without duplicate status writes", async () => {
+    const harness = await runSession((emit) => {
+      emit({ type: "playback-started" });
+      emit({ type: "playback-progress", positionSeconds: 1, durationSeconds: 100 });
+      emit({ type: "playback-progress", positionSeconds: 2, durationSeconds: 100 });
+      emit({ type: "playback-progress", positionSeconds: 3, durationSeconds: 100 });
+    });
+
+    expect(harness.presence.filter((entry) => entry === "progress")).toHaveLength(3);
+    // activate(loading) + playing. Progress in `playing` must not write again.
+    expect(harness.beforeCompletion.writes.map((write) => write.status)).toEqual([
+      "loading",
+      "playing",
+    ]);
+  });
+});
+
+describe("runMpvPlaybackSession pause authority", () => {
+  test("progress while paused stays paused and does not update presence", async () => {
+    const harness = await runSession((emit) => {
+      emit({ type: "playback-started" });
+      emit({ type: "playback-paused" });
+      emit({ type: "playback-progress", positionSeconds: 10, durationSeconds: 100 });
+      emit({ type: "playback-progress", positionSeconds: 11, durationSeconds: 100 });
+      emit({ type: "playback-started" });
+    });
+
+    expect(harness.beforeCompletion.snapshot.status).toBe("paused");
+    expect(harness.presence.filter((entry) => entry === "progress")).toHaveLength(0);
+  });
+
+  test("resume returns to playing and emits resumed presence with the playing snapshot", async () => {
+    const harness = await runSession((emit) => {
+      emit({ type: "playback-started" });
+      emit({ type: "playback-paused" });
+      emit({ type: "playback-resumed" });
+    });
+
+    expect(harness.beforeCompletion.snapshot.status).toBe("playing");
+    expect(harness.presence).toContain("resumed");
+    expect(harness.presenceSnapshots.at(-1)).toEqual({ status: "playing", generation: GEN_1 });
+  });
+});
+
+describe("runMpvPlaybackSession stale-generation rejection", () => {
+  test("old-cycle work after a replacement activation cannot touch status, presence, or tracks", async () => {
+    const harness = await runSession((emit, store) => {
+      emit({ type: "playback-started" });
+      // A replacement cycle activates and takes the session over.
+      store.apply({ kind: "activate", generation: GEN_2, status: "loading" });
+      // Everything below still carries the retired GEN_1.
+      emit({ type: "playback-progress", positionSeconds: 9, durationSeconds: 90 });
+      emit({ type: "track-changed", trackType: "sub", id: 0 });
+      emit({ type: "playback-paused" });
+      emit({ type: "late-subtitles-attached", trackCount: 3 });
+    });
+
+    expect(harness.beforeCompletion.snapshot).toEqual({ status: "loading", generation: GEN_2 });
+    expect(harness.presence.filter((entry) => entry === "progress")).toHaveLength(0);
+    expect(harness.presence).not.toContain("paused");
+    expect(harness.presence).not.toContain("subtitles");
+    expect(harness.tracks).toEqual([]);
+  });
+
+  test("a stale completion cannot overwrite the replacement", async () => {
+    const harness = await runSession((emit, store) => {
+      emit({ type: "playback-started" });
+      store.apply({ kind: "activate", generation: GEN_2, status: "loading" });
+    });
+    expect(harness.store.snapshot).toEqual({ status: "loading", generation: GEN_2 });
+  });
+
+  test("a stale event cannot acknowledge the queue", async () => {
+    const harness = await runSession((emit, store) => {
+      store.apply({ kind: "activate", generation: GEN_2, status: "loading" });
+      emit({ type: "playback-started" });
+    });
+    expect(harness.confirmedStarts).toBe(0);
+  });
+});
+
+describe("runMpvPlaybackSession completion", () => {
+  test("eof completes as finished after the result is final", async () => {
+    const harness = await runSession(() => undefined, { result: FINISHED });
+    expect(harness.store.snapshot.status).toBe("finished");
+  });
+
+  test("a quit result completes as idle and late progress cannot revive it", async () => {
+    const captured: Emit[] = [];
+    const harness = await runSession(
+      (emit) => {
+        captured.push(emit);
+        emit({ type: "playback-started" });
+      },
+      { result: { ...FINISHED, endReason: "quit" } },
+    );
+
+    expect(harness.store.snapshot.status).toBe("idle");
+    captured[0]?.({ type: "playback-progress", positionSeconds: 40, durationSeconds: 100 });
+    expect(harness.store.snapshot.status).toBe("idle");
+  });
+
+  test("an error result completes as error rather than finished", async () => {
+    const harness = await runSession(() => undefined, {
+      result: { ...FINISHED, endReason: "error" },
+    });
+    expect(harness.store.snapshot.status).toBe("error");
   });
 });

--- a/apps/cli/test/unit/app/session-controller-shutdown.test.ts
+++ b/apps/cli/test/unit/app/session-controller-shutdown.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 
 import { SessionController } from "@/app/session/SessionController";
 
+import { readRepoFile } from "../../support/repo-scan";
+
 describe("SessionController shutdown", () => {
   test("releases persistent player session even when presence shutdown fails", async () => {
     const calls: string[] = [];
@@ -99,5 +101,39 @@ describe("SessionController shutdown", () => {
     expect(calls).toContain("player:release");
     expect(calls).toContain("presence");
     expect(calls).toContain("diagnostic:Session shutdown cleanup failed");
+  });
+
+  test("player cleanup is delegated to releasePersistentSession, never to another method", async () => {
+    const calls: string[] = [];
+    const controller = new SessionController({
+      workControl: { cancelActive() {} },
+      presence: { async shutdown() {} },
+      player: {
+        beginShutdown() {
+          calls.push("beginShutdown");
+        },
+        async releasePersistentSession() {
+          calls.push("releasePersistentSession");
+        },
+        killActiveMpvProcessesSync() {
+          calls.push("killActiveMpvProcessesSync");
+        },
+      },
+      diagnosticsService: { record() {} },
+    } as never);
+
+    await controller.releaseExternalResources();
+
+    // releasePersistentSession is the single release/disposal invalidation
+    // authority: nothing else may reorder mpv teardown around it.
+    expect(calls).toEqual(["releasePersistentSession"]);
+  });
+
+  test("disposeContainer stays database/background disposal and never acquires mpv ownership", () => {
+    const source = readRepoFile("apps/cli/src/container/dispose-container.ts");
+
+    expect(source).not.toContain("player");
+    expect(source).not.toContain("mpv");
+    expect(source).toContain("backgroundWorkScheduler");
   });
 });

--- a/apps/cli/test/unit/domain/session/SessionState.test.ts
+++ b/apps/cli/test/unit/domain/session/SessionState.test.ts
@@ -5,6 +5,7 @@ import { parseCommand, resolveCommands } from "@/domain/session/command-registry
 import {
   createInitialState,
   isPlaybackSessionActive,
+  isPlaybackTransportStarted,
   reduceState,
 } from "@/domain/session/SessionState";
 
@@ -15,6 +16,24 @@ describe("SessionState playback activity", () => {
     expect(isPlaybackSessionActive("idle")).toBeFalse();
     expect(isPlaybackSessionActive("finished")).toBeFalse();
     expect(isPlaybackSessionActive("error")).toBeFalse();
+  });
+
+  test("transport-started excludes the bootstrap states a session-active check includes", () => {
+    // The distinction that matters: both are true for a live session, but only
+    // isPlaybackSessionActive() counts loading/ready. Collapsing the two makes
+    // the loading shell announce itself as playing mid-bootstrap.
+    for (const bootstrapping of ["loading", "ready"] as const) {
+      expect(isPlaybackSessionActive(bootstrapping)).toBeTrue();
+      expect(isPlaybackTransportStarted(bootstrapping)).toBeFalse();
+    }
+
+    for (const started of ["buffering", "seeking", "stalled", "playing", "paused"] as const) {
+      expect(isPlaybackTransportStarted(started)).toBeTrue();
+    }
+
+    for (const inactive of ["idle", "finished", "error"] as const) {
+      expect(isPlaybackTransportStarted(inactive)).toBeFalse();
+    }
   });
 });
 

--- a/apps/cli/test/unit/infra/player/PlayerServiceImpl.test.ts
+++ b/apps/cli/test/unit/infra/player/PlayerServiceImpl.test.ts
@@ -4,6 +4,7 @@ import type { PlaybackGeneration } from "@/domain/playback/playback-generation";
 import type { PlaybackResult, StreamInfo } from "@/domain/types";
 import { registerMpvProcess } from "@/infra/player/mpv-process-registry";
 import { PlaybackAbortedError } from "@/infra/player/playback-aborted";
+import type { ActivePlayerControl } from "@/infra/player/PlayerControlService";
 import type {
   PlayerPlaybackEvent,
   PlayerPlaybackEventEnvelope,
@@ -404,6 +405,86 @@ describe("PlayerServiceImpl playback generations", () => {
     expect(published.every((entry) => entry.generation === localGeneration)).toBe(true);
   });
 
+  test("whole-process stop invalidates the process before sending quit", async () => {
+    const events: DiagnosticEventInput[] = [];
+    const published: PlayerPlaybackEventEnvelope[] = [];
+    const order: string[] = [];
+    let activeControl: ActivePlayerControl | null = null;
+    const { service } = createService(events, {
+      presentation: { isInteractiveShellMounted: () => true },
+      playerControl: {
+        setActive: (control) => {
+          activeControl = control as ActivePlayerControl | null;
+        },
+      },
+      launchMpv: (async (options) => {
+        options.onControlReady?.({
+          id: "one-shot",
+          async stop() {
+            order.push("quit-sent");
+          },
+          async stopCurrentFile() {
+            order.push("stop-sent");
+          },
+        } as never);
+        return createPlaybackResult();
+      }) as typeof launchMpv,
+    });
+
+    let raw!: (event: PlayerPlaybackEvent) => void;
+    await service.play(createStream({ subtitle: undefined }), {
+      url: "https://cdn.example/show/episode.mp4",
+      displayTitle: "Episode 1",
+      onGenerationActivated: (generation) => {
+        raw = internals(service).wrapPlaybackEventHandler.bind(service)(generation, (input) =>
+          published.push(input),
+        );
+      },
+    });
+
+    const before = internals(service).currentGeneration;
+    published.length = 0;
+    await activeControl!.stop("user");
+
+    expect(order).toEqual(["quit-sent"]);
+    expect(internals(service).currentGeneration.process).toBeGreaterThan(before.process);
+    raw({ type: "playback-progress", positionSeconds: 1, durationSeconds: 2 });
+    expect(published).toEqual([]);
+  });
+
+  test("current-file stop retires only the cycle, leaving the process reusable", async () => {
+    const events: DiagnosticEventInput[] = [];
+    let activeControl: ActivePlayerControl | null = null;
+    const { service } = createService(events, {
+      presentation: { isInteractiveShellMounted: () => true },
+      playerControl: {
+        setActive: (control) => {
+          activeControl = control as ActivePlayerControl | null;
+        },
+      },
+      launchMpv: (async (options) => {
+        options.onControlReady?.({
+          id: "one-shot",
+          async stop() {},
+          async stopCurrentFile() {},
+        } as never);
+        return createPlaybackResult();
+      }) as typeof launchMpv,
+    });
+
+    await service.play(createStream({ subtitle: undefined }), {
+      url: "https://cdn.example/show/episode.mp4",
+      displayTitle: "Episode 1",
+    });
+
+    const before = internals(service).currentGeneration;
+    await activeControl!.stopCurrentFile?.("user");
+    const after = internals(service).currentGeneration;
+
+    expect(after.process).toBe(before.process);
+    expect(after.cycle).toBeGreaterThan(before.cycle);
+  });
+
   test("retiring the persistent session does not invalidate the new local generation", async () => {
     const events: DiagnosticEventInput[] = [];
     const activations: PlaybackGeneration[] = [];
@@ -479,7 +560,9 @@ describe("PlayerServiceImpl shutdown", () => {
     ).resolves.toMatchObject({ endReason: "quit" });
 
     expect(lifecycle).toEqual(["close-persistent", "launch-local"]);
-    expect(activeControls).toEqual([null, { id: "local" }, null]);
+    expect(
+      activeControls.map((control) => (control as { id?: string } | null)?.id ?? null),
+    ).toEqual([null, "local", null]);
   });
 
   test("release waits for and closes a persistent player still being created", async () => {

--- a/apps/cli/test/unit/infra/player/PlayerServiceImpl.test.ts
+++ b/apps/cli/test/unit/infra/player/PlayerServiceImpl.test.ts
@@ -1,12 +1,43 @@
 import { describe, expect, test } from "bun:test";
 
+import type { PlaybackGeneration } from "@/domain/playback/playback-generation";
 import type { PlaybackResult, StreamInfo } from "@/domain/types";
 import { registerMpvProcess } from "@/infra/player/mpv-process-registry";
 import { PlaybackAbortedError } from "@/infra/player/playback-aborted";
-import type { PlayerPlaybackEvent, PlayerOptions } from "@/infra/player/PlayerService";
+import type {
+  PlayerPlaybackEvent,
+  PlayerPlaybackEventEnvelope,
+  PlayerOptions,
+} from "@/infra/player/PlayerService";
 import { PlayerServiceImpl } from "@/infra/player/PlayerServiceImpl";
 import type { launchMpv } from "@/mpv";
 import type { DiagnosticEventInput } from "@/services/diagnostics/diagnostic-event";
+
+/** Reaches the generation seams the service owns privately. */
+type GenerationInternals = {
+  readonly currentGeneration: PlaybackGeneration;
+  wrapPlaybackEventHandler(
+    generation: PlaybackGeneration,
+    handler: ((input: PlayerPlaybackEventEnvelope) => void) | undefined,
+    correlation?: PlayerOptions["correlation"],
+  ): (event: PlayerPlaybackEvent) => void;
+};
+
+function internals(service: PlayerServiceImpl): GenerationInternals {
+  return service as unknown as GenerationInternals;
+}
+
+const LOCAL_SOURCE = {
+  kind: "local" as const,
+  jobId: "job-1",
+  titleId: "title-1",
+  titleName: "Offline episode",
+  mediaKind: "series" as const,
+  providerId: "provider-1",
+  season: 1,
+  episode: 2,
+  filePath: "/media/episode-2.mkv",
+};
 
 function createPlaybackResult(): PlaybackResult {
   return {
@@ -219,26 +250,21 @@ describe("PlayerServiceImpl diagnostics", () => {
     expect(cleaned).toBe(true);
   });
 
-  test("runtime playback events keep diagnostic correlation", () => {
+  test("runtime playback events keep diagnostic correlation and arrive enveloped", () => {
     const events: DiagnosticEventInput[] = [];
     const { service } = createService(events);
-    const seen: PlayerPlaybackEvent[] = [];
-    const wrap = (
-      service as unknown as {
-        wrapPlaybackEventHandler: (
-          handler: (event: PlayerPlaybackEvent) => void,
-          correlation: PlayerOptions["correlation"],
-        ) => (event: PlayerPlaybackEvent) => void;
-      }
-    ).wrapPlaybackEventHandler.bind(service);
+    const seen: PlayerPlaybackEventEnvelope[] = [];
+    const generation = internals(service).currentGeneration;
+    const wrap = internals(service).wrapPlaybackEventHandler.bind(service);
 
-    wrap((event) => seen.push(event), {
+    wrap(generation, (input) => seen.push(input), {
       sessionId: "session-1",
       playbackCycleId: "playback-1",
       providerAttemptId: "attempt-1",
     })({ type: "mpv-process-started" });
 
-    expect(seen).toEqual([{ type: "mpv-process-started" }]);
+    // The raw event stays internal; the public value is the envelope.
+    expect(seen).toEqual([{ generation, event: { type: "mpv-process-started" } }]);
     expect(events[0]).toMatchObject({
       sessionId: "session-1",
       playbackCycleId: "playback-1",
@@ -247,6 +273,160 @@ describe("PlayerServiceImpl diagnostics", () => {
       message: "MPV runtime event",
       context: { event: "mpv-process-started" },
     });
+  });
+});
+
+describe("PlayerServiceImpl playback generations", () => {
+  test("play activates a generation synchronously, before the first await", async () => {
+    const events: DiagnosticEventInput[] = [];
+    const { service } = createService(events, {
+      presentation: { isInteractiveShellMounted: () => true },
+      launchMpv: (async () => createPlaybackResult()) as typeof launchMpv,
+    });
+    const activations: PlaybackGeneration[] = [];
+
+    const playing = service.play(createStream({ subtitle: undefined }), {
+      url: "https://cdn.example/show/episode.mp4",
+      displayTitle: "Episode 1",
+      onGenerationActivated: (generation) => activations.push(generation),
+    });
+
+    expect(activations).toEqual([{ process: 1, cycle: 1 }]);
+    await playing;
+  });
+
+  test("public play callbacks receive the activated generation with every event", async () => {
+    const events: DiagnosticEventInput[] = [];
+    const { service } = createService(events, {
+      presentation: { isInteractiveShellMounted: () => true },
+      launchMpv: (async (options) => {
+        options.onPlaybackEvent?.({ type: "playback-started" });
+        return createPlaybackResult();
+      }) as typeof launchMpv,
+    });
+    const activations: PlaybackGeneration[] = [];
+    const published: PlayerPlaybackEventEnvelope[] = [];
+
+    await service.play(createStream({ subtitle: undefined }), {
+      url: "https://cdn.example/show/episode.mp4",
+      displayTitle: "Episode 1",
+      onGenerationActivated: (generation) => activations.push(generation),
+      onPlaybackEvent: (input) => published.push(input),
+    });
+
+    const generation = activations[0];
+    expect(generation).toBeDefined();
+    expect(published.length).toBeGreaterThan(0);
+    expect(published.every((entry) => entry.generation === generation)).toBe(true);
+    expect(published.map((entry) => entry.event.type)).toContain("playback-started");
+    expect(published.map((entry) => entry.event.type)).toContain("launching-player");
+  });
+
+  test("a retired generation's raw callback cannot publish anything", () => {
+    const events: DiagnosticEventInput[] = [];
+    const { service } = createService(events);
+    const published: PlayerPlaybackEventEnvelope[] = [];
+    const stale = internals(service).currentGeneration;
+    const staleRaw = internals(service).wrapPlaybackEventHandler.bind(service)(stale, (input) =>
+      published.push(input),
+    );
+
+    staleRaw({ type: "playback-started" });
+    expect(published).toHaveLength(1);
+
+    const diagnosticsBefore = events.length;
+    service.beginShutdown();
+    void service.releasePersistentSession();
+
+    staleRaw({ type: "playback-progress", positionSeconds: 5, durationSeconds: 10 });
+    expect(published).toHaveLength(1);
+    expect(events.length).toBe(diagnosticsBefore);
+  });
+
+  test("playLocal activates its one-shot generation before retiring the persistent session", async () => {
+    const events: DiagnosticEventInput[] = [];
+    const order: string[] = [];
+    const activations: PlaybackGeneration[] = [];
+    const published: PlayerPlaybackEventEnvelope[] = [];
+    let releaseClose!: () => void;
+    const closeGate = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+
+    const { service } = createService(events, {
+      presentation: { isInteractiveShellMounted: () => true },
+      launchMpv: (async (options) => {
+        order.push("launch-local");
+        options.onPlaybackEvent?.({ type: "playback-started" });
+        return createPlaybackResult();
+      }) as typeof launchMpv,
+    });
+    (
+      service as unknown as { persistentSession: { isAlive(): boolean; close(): Promise<void> } }
+    ).persistentSession = {
+      isAlive: () => true,
+      async close() {
+        order.push("close-persistent");
+        await closeGate;
+      },
+    };
+
+    // Capture a raw callback belonging to the persistent generation being retired.
+    const retired = internals(service).currentGeneration;
+    const retiredRaw = internals(service).wrapPlaybackEventHandler.bind(service)(retired, (input) =>
+      published.push(input),
+    );
+
+    const local = service.playLocal({
+      source: LOCAL_SOURCE,
+      onGenerationActivated: (generation) => activations.push(generation),
+      onPlaybackEvent: (input) => published.push(input),
+    });
+
+    // Activation must already have happened, before the retirement await resolves.
+    expect(activations).toHaveLength(1);
+    expect(order).toEqual(["close-persistent"]);
+
+    // A retained persistent callback firing mid-retirement cannot publish into the local cycle.
+    retiredRaw({ type: "playback-progress", positionSeconds: 1, durationSeconds: 2 });
+    expect(published).toHaveLength(0);
+
+    releaseClose();
+    await local;
+
+    expect(order).toEqual(["close-persistent", "launch-local"]);
+    const localGeneration = activations[0];
+    expect(published.length).toBeGreaterThan(0);
+    expect(published.every((entry) => entry.generation === localGeneration)).toBe(true);
+
+    // And it still cannot publish after the local launch completed.
+    retiredRaw({ type: "playback-progress", positionSeconds: 3, durationSeconds: 4 });
+    expect(published.every((entry) => entry.generation === localGeneration)).toBe(true);
+  });
+
+  test("retiring the persistent session does not invalidate the new local generation", async () => {
+    const events: DiagnosticEventInput[] = [];
+    const activations: PlaybackGeneration[] = [];
+    const { service } = createService(events, {
+      presentation: { isInteractiveShellMounted: () => true },
+      launchMpv: (async () => createPlaybackResult()) as typeof launchMpv,
+    });
+    (
+      service as unknown as { persistentSession: { isAlive(): boolean; close(): Promise<void> } }
+    ).persistentSession = {
+      isAlive: () => true,
+      async close() {
+        await Bun.sleep(0);
+      },
+    };
+
+    await service.playLocal({
+      source: LOCAL_SOURCE,
+      onGenerationActivated: (generation) => activations.push(generation),
+    });
+
+    expect(activations).toHaveLength(1);
+    expect(internals(service).currentGeneration).toEqual(activations[0]!);
   });
 });
 

--- a/apps/cli/test/unit/infra/player/persistent-mpv-session-harness.test.ts
+++ b/apps/cli/test/unit/infra/player/persistent-mpv-session-harness.test.ts
@@ -17,6 +17,23 @@ function createStream(overrides: Partial<StreamInfo> = {}): StreamInfo {
   };
 }
 
+function createFakeProcess() {
+  let resolveExit!: (code: number) => void;
+  const handle = {
+    exited: new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    }),
+    killed: false,
+    exitCode: null as number | null,
+    kill() {
+      this.killed = true;
+      this.exitCode = 0;
+      resolveExit(0);
+    },
+  };
+  return { handle, endProcess: (code = 0) => resolveExit(code) };
+}
+
 function createHarness() {
   let callbacks!: CapturedCallbacks;
   let resolveExit!: (code: number) => void;
@@ -80,6 +97,131 @@ async function waitFor(predicate: () => boolean): Promise<void> {
   }
   throw new Error("Timed out waiting for fake mpv lifecycle condition");
 }
+
+/** Bootstrap teardown does real filesystem work, so poll on timer ticks. */
+async function waitForSettled(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 200; i++) {
+    if (predicate()) return;
+    await Bun.sleep(1);
+  }
+  throw new Error("Timed out waiting for mpv bootstrap teardown");
+}
+
+describe("PersistentMpvSession deferred bootstrap resources", () => {
+  test("an endpoint wait that resolves after the process died does not open an IPC session", async () => {
+    let releaseEndpointWait!: (ready: boolean) => void;
+    let waitStarted!: () => void;
+    const waitReached = new Promise<void>((resolve) => {
+      waitStarted = resolve;
+    });
+    let ipcOpens = 0;
+    let terminated = false;
+    const proc = createFakeProcess();
+    const runtime: PersistentMpvSessionRuntime = {
+      which: () => "/usr/bin/mpv",
+      spawn: () => proc.handle,
+      waitForIpcEndpoint: () =>
+        new Promise<boolean>((resolve) => {
+          releaseEndpointWait = resolve;
+          waitStarted();
+        }),
+      async openIpcSession() {
+        ipcOpens += 1;
+        throw new Error("must not open IPC for a dead process");
+      },
+    };
+
+    const creating = PersistentMpvSession.create({
+      stream: createStream(),
+      options: {
+        displayTitle: "Episode 1",
+        primarySubtitle: null,
+        onPlaybackEvent: (event) => {
+          if (event.type === "player-closed") terminated = true;
+        },
+      },
+      kitsuneConfig: { mpvInProcessStreamReconnect: false } as never,
+      onControlReady: () => {},
+      runtime,
+    });
+
+    await waitReached;
+    // mpv dies while the endpoint wait is still outstanding.
+    proc.endProcess(1);
+    await waitForSettled(() => terminated);
+
+    releaseEndpointWait(true);
+    const session = await creating;
+    await flushAsyncWork();
+
+    expect(ipcOpens).toBe(0);
+    expect(session.isAlive()).toBe(false);
+  });
+
+  test("an IPC session that opens after the process died is closed exactly once and never installed", async () => {
+    let releaseIpcOpen!: (session: MpvIpcSession) => void;
+    let openStarted!: () => void;
+    const openReached = new Promise<void>((resolve) => {
+      openStarted = resolve;
+    });
+    let closes = 0;
+    let sends = 0;
+    const publicEvents: string[] = [];
+    const controls: unknown[] = [];
+    const proc = createFakeProcess();
+    const staleIpc: MpvIpcSession = {
+      async send(command) {
+        sends += 1;
+        return { ok: true, command, requestId: 1, response: {} } satisfies MpvIpcCommandResult;
+      },
+      sendUnchecked() {
+        sends += 1;
+      },
+      async close() {
+        closes += 1;
+      },
+    };
+    const runtime: PersistentMpvSessionRuntime = {
+      which: () => "/usr/bin/mpv",
+      spawn: () => proc.handle,
+      waitForIpcEndpoint: async () => true,
+      openIpcSession: () =>
+        new Promise<MpvIpcSession>((resolve) => {
+          releaseIpcOpen = resolve;
+          openStarted();
+        }),
+    };
+
+    const creating = PersistentMpvSession.create({
+      stream: createStream(),
+      options: {
+        displayTitle: "Episode 1",
+        primarySubtitle: null,
+        onPlaybackEvent: (event) => publicEvents.push(event.type),
+      },
+      kitsuneConfig: { mpvInProcessStreamReconnect: false } as never,
+      onControlReady: (control) => controls.push(control),
+      runtime,
+    });
+
+    await openReached;
+    proc.endProcess(1);
+    // Wait for termination to actually complete rather than guessing at ticks.
+    await waitForSettled(() => publicEvents.includes("player-closed"));
+
+    publicEvents.length = 0;
+    controls.length = 0;
+    releaseIpcOpen(staleIpc);
+    const session = await creating;
+    await waitForSettled(() => closes > 0);
+
+    expect(closes).toBe(1);
+    expect(sends).toBe(0);
+    expect(publicEvents).toEqual([]);
+    expect(controls).toEqual([]);
+    expect(session.isAlive()).toBe(false);
+  });
+});
 
 describe("PersistentMpvSession fake IPC lifecycle harness", () => {
   test("updates autoskip policy during an active intro without leaving a stale automatic skip", async () => {

--- a/apps/cli/test/unit/infra/player/persistent-mpv-session-harness.test.ts
+++ b/apps/cli/test/unit/infra/player/persistent-mpv-session-harness.test.ts
@@ -85,6 +85,12 @@ function createHarness() {
   };
 }
 
+/** The session must never hold more than one pending `loadfile` owner. */
+function pendingLoadOwners(session: PersistentMpvSession): number {
+  const pending = (session as unknown as { pendingFileLoad: unknown }).pendingFileLoad;
+  return pending ? 1 : 0;
+}
+
 async function flushAsyncWork(): Promise<void> {
   await Bun.sleep(0);
   await Bun.sleep(0);
@@ -106,6 +112,63 @@ async function waitForSettled(predicate: () => boolean): Promise<void> {
   }
   throw new Error("Timed out waiting for mpv bootstrap teardown");
 }
+
+describe("PersistentMpvSession single pending load owner", () => {
+  async function createLoadedSession() {
+    const harness = createHarness();
+    const session = await PersistentMpvSession.create({
+      stream: createStream(),
+      options: { displayTitle: "Episode 1", primarySubtitle: null },
+      kitsuneConfig: { mpvInProcessStreamReconnect: false } as never,
+      onControlReady: () => {},
+      runtime: harness.runtime,
+    });
+    return { harness, session };
+  }
+
+  test("the initial argv-loaded file has a pending owner that the first file-loaded consumes", async () => {
+    const { harness } = await createLoadedSession();
+
+    harness.callbacks().onFileLoaded?.({ observedAt: 1 });
+    await flushAsyncWork();
+
+    // Consuming the owner clears the loading overlay and drains ready work.
+    expect(harness.commands).toContainEqual(["set_property", "user-data/kunai-loading", ""]);
+    expect(harness.commands).toContainEqual(["set_property", "pause", false]);
+  });
+
+  test("an unowned file-loaded is ignored entirely", async () => {
+    const { harness } = await createLoadedSession();
+
+    harness.callbacks().onFileLoaded?.({ observedAt: 1 });
+    await flushAsyncWork();
+    const afterFirst = harness.commands.length;
+
+    // The single owner was consumed; nothing owns this second event.
+    harness.callbacks().onFileLoaded?.({ observedAt: 2 });
+    await flushAsyncWork();
+
+    expect(harness.commands.length).toBe(afterFirst);
+  });
+
+  test("two pending load owners never coexist across a replacement", async () => {
+    const { harness, session } = await createLoadedSession();
+    harness.callbacks().onFileLoaded?.({ observedAt: 1 });
+    await flushAsyncWork();
+
+    harness.callbacks().onEndFile?.({ reason: "eof", observedAt: 2 });
+    await flushAsyncWork();
+
+    void session.play(createStream({ url: "https://video.example/episode-2.m3u8" }), {
+      displayTitle: "Episode 2",
+      primarySubtitle: null,
+    });
+    await flushAsyncWork();
+
+    const owners = pendingLoadOwners(session);
+    expect(owners).toBeLessThanOrEqual(1);
+  });
+});
 
 describe("PersistentMpvSession deferred bootstrap resources", () => {
   test("an endpoint wait that resolves after the process died does not open an IPC session", async () => {

--- a/apps/cli/test/unit/infra/player/persistent-ready-work-executor.test.ts
+++ b/apps/cli/test/unit/infra/player/persistent-ready-work-executor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import type { PlaybackGeneration } from "@/domain/playback/playback-generation";
 import type { MpvIpcCommandResult, MpvIpcSession } from "@/infra/player/mpv-ipc";
 import { createPlayerTelemetryState } from "@/infra/player/mpv-telemetry";
 import { PersistentReadyWorkExecutor } from "@/infra/player/persistent-ready-work-executor";
@@ -34,6 +35,8 @@ function createCycle(events: unknown[]) {
   };
 }
 
+const GENERATION: PlaybackGeneration = { process: 3, cycle: 8 };
+
 describe("PersistentReadyWorkExecutor", () => {
   test("skips redundant resume seek when loadfile already started at the same timestamp", async () => {
     const { ipc, commands } = createFakeIpc();
@@ -56,6 +59,7 @@ describe("PersistentReadyWorkExecutor", () => {
       waitResumeOrStartOverChoice: async () => "start",
       handleSegmentSkipProgress: async () => {},
       subtitleManager: new PersistentSubtitleManager(),
+      isGenerationCurrent: () => true,
     });
 
     await executor.execute(
@@ -66,6 +70,7 @@ describe("PersistentReadyWorkExecutor", () => {
         onPlaybackEvent: (event) => events.push(event),
       },
       createCycle(events),
+      GENERATION,
     );
 
     expect(commands.some((command) => command[0] === "seek")).toBe(false);
@@ -93,6 +98,7 @@ describe("PersistentReadyWorkExecutor", () => {
       waitResumeOrStartOverChoice: async () => "resume",
       handleSegmentSkipProgress: async () => {},
       subtitleManager: new PersistentSubtitleManager(),
+      isGenerationCurrent: () => true,
     });
 
     await executor.execute(
@@ -104,6 +110,7 @@ describe("PersistentReadyWorkExecutor", () => {
         offerResumeStartChoice: true,
       },
       createCycle([]),
+      GENERATION,
     );
 
     expect(commands).toContainEqual(["seek", 90, "absolute"]);
@@ -133,6 +140,7 @@ describe("PersistentReadyWorkExecutor", () => {
       waitResumeOrStartOverChoice: async () => "start",
       handleSegmentSkipProgress: async () => {},
       subtitleManager: new PersistentSubtitleManager(),
+      isGenerationCurrent: () => true,
     });
 
     await executor.execute(
@@ -142,6 +150,7 @@ describe("PersistentReadyWorkExecutor", () => {
         onPlaybackEvent: (event) => events.push(event),
       },
       createCycle(events),
+      GENERATION,
     );
 
     expect(commands.some((command) => command[0] === "sub-remove")).toBe(false);
@@ -149,5 +158,135 @@ describe("PersistentReadyWorkExecutor", () => {
     expect(events).toContainEqual({ type: "subtitle-inventory-ready", trackCount: 1 });
     expect(events).toContainEqual({ type: "subtitle-attached", trackCount: 1 });
     expect(subtitlesAttachedAtSpawn).toBe(false);
+  });
+});
+
+describe("PersistentReadyWorkExecutor stale-generation continuations", () => {
+  /**
+   * Holds one await boundary open, retires the generation while it is pending,
+   * then resolves it. Nothing after that boundary may run.
+   */
+  async function runWithRetirementAt(boundary: {
+    readonly gate: "unpause" | "title" | "resume-choice" | "seek" | "subtitles";
+  }): Promise<{ commands: readonly unknown[][]; events: unknown[]; skipRuns: number }> {
+    const commands: unknown[][] = [];
+    const events: unknown[] = [];
+    let current = true;
+    let skipRuns = 0;
+    let released = false;
+
+    const gateOn = (name: typeof boundary.gate) => async () => {
+      if (released || name !== boundary.gate) return;
+      released = true;
+      // The replacement takes over while this boundary is still pending.
+      current = false;
+    };
+
+    const ipc: MpvIpcSession = {
+      async send(command) {
+        commands.push([...command]);
+        const key = String(command[0]);
+        if (key === "set_property" && command[1] === "pause") await gateOn("unpause")();
+        if (key === "set_property" && command[1] === "force-media-title") await gateOn("title")();
+        if (key === "seek") await gateOn("seek")();
+        return {
+          ok: true,
+          command,
+          requestId: commands.length,
+          response: {},
+        } satisfies MpvIpcCommandResult;
+      },
+      sendUnchecked(command) {
+        commands.push([...command]);
+      },
+      async close() {},
+    };
+
+    const executor = new PersistentReadyWorkExecutor({
+      getIpcSession: () => ipc,
+      getInitialOptions: () => ({ displayTitle: "Other", primarySubtitle: null }),
+      getLoadStartAt: () => null,
+      getTitleAppliedViaArgs: () => false,
+      setTitleAppliedViaArgs: () => {},
+      getSubtitlesAttachedAtSpawn: () => false,
+      setSubtitlesAttachedAtSpawn: () => {},
+      setCurrentPositionSeconds: () => {},
+      setResumeSeekPending: () => {},
+      waitResumeOrStartOverChoice: async () => {
+        await gateOn("resume-choice")();
+        return "resume";
+      },
+      handleSegmentSkipProgress: async () => {
+        skipRuns += 1;
+      },
+      subtitleManager: new PersistentSubtitleManager(),
+      isGenerationCurrent: () => current,
+    });
+
+    await executor.execute(
+      {
+        displayTitle: "Episode 1",
+        primarySubtitle: null,
+        resumePromptAt: 90,
+        offerResumeStartChoice: true,
+        onPlaybackEvent: (event) => events.push(event),
+      },
+      createCycle(events),
+      GENERATION,
+    );
+
+    return { commands, events, skipRuns };
+  }
+
+  test("a retirement during the unpause command stops every later command", async () => {
+    const { commands, skipRuns } = await runWithRetirementAt({ gate: "unpause" });
+    expect(commands.map((command) => command[0])).toEqual(["set_property"]);
+    expect(skipRuns).toBe(0);
+  });
+
+  test("a retirement during the title update stops the resume prompt and seek", async () => {
+    const { commands, skipRuns } = await runWithRetirementAt({ gate: "title" });
+    expect(commands.some((command) => command[0] === "seek")).toBe(false);
+    expect(skipRuns).toBe(0);
+  });
+
+  test("a retirement during the resume-choice wait stops the seek", async () => {
+    const { commands, skipRuns } = await runWithRetirementAt({ gate: "resume-choice" });
+    expect(commands.some((command) => command[0] === "seek")).toBe(false);
+    expect(skipRuns).toBe(0);
+  });
+
+  test("a retirement during the seek stops subtitle replacement and segment-skip setup", async () => {
+    const { skipRuns } = await runWithRetirementAt({ gate: "seek" });
+    expect(skipRuns).toBe(0);
+  });
+
+  test("a stale execute does nothing at all, not even the ready notification", async () => {
+    const { ipc, commands } = createFakeIpc();
+    const events: unknown[] = [];
+    const executor = new PersistentReadyWorkExecutor({
+      getIpcSession: () => ipc,
+      getInitialOptions: () => ({ displayTitle: "Episode 1", primarySubtitle: null }),
+      getLoadStartAt: () => null,
+      getTitleAppliedViaArgs: () => true,
+      setTitleAppliedViaArgs: () => {},
+      getSubtitlesAttachedAtSpawn: () => false,
+      setSubtitlesAttachedAtSpawn: () => {},
+      setCurrentPositionSeconds: () => {},
+      setResumeSeekPending: () => {},
+      waitResumeOrStartOverChoice: async () => "start",
+      handleSegmentSkipProgress: async () => {},
+      subtitleManager: new PersistentSubtitleManager(),
+      isGenerationCurrent: () => false,
+    });
+
+    await executor.execute(
+      { displayTitle: "Episode 1", primarySubtitle: null, onPlaybackEvent: (e) => events.push(e) },
+      createCycle(events),
+      GENERATION,
+    );
+
+    expect(commands).toEqual([]);
+    expect(events).toEqual([]);
   });
 });

--- a/docs/users/playback-and-recovery.mdx
+++ b/docs/users/playback-and-recovery.mdx
@@ -113,6 +113,19 @@ Kunai monitors mpv through IPC and the Kunai bridge Lua script:
 - In-process stream reconnect after network-read-dead stalls (configurable)
 - Auto-skip overlay when timing metadata and autoskip are enabled
 
+When playback recovers on its own — buffering clears, a stall resolves, or a
+seek completes — the shell returns to playing as soon as fresh progress arrives,
+so a transient hiccup no longer leaves the header stuck on "buffering" for the
+rest of the episode. Recovery never overrides a deliberate state: pausing,
+stopping, or finishing stays exactly as you left it, and only resuming restarts
+playback. Diagnostics keep the record of the stall or the source switch even
+after playback looks healthy again, so `/diagnostics` can still explain what
+happened mid-episode.
+
+Starting a new episode or stopping playback retires the old mpv session
+immediately. Late events from that retired session are discarded rather than
+applied, so a replaced episode cannot be revived by the previous one's activity.
+
 Debug mpv for one run:
 
 ```sh


### PR DESCRIPTION
## Scope

Playback can no longer get permanently stuck in a transient state, and a retired mpv session can no longer mutate the live one.

- **Generations** — every mpv process and playback cycle carries a monotonic `{ process, cycle }`. Endpoint waits, IPC opens, property callbacks, `file-loaded`, end-file, reconnect completions, and recovery work capture the generation that created them and compare it before mutating session state. Stale work closes any handle it just created and returns without touching status, presence, diagnostics, or the shell. Replacing or stopping a session increments the generation **before** cleanup, so a late event cannot revive it.
- **One transition policy** — a pure policy owns current status. Fresh `playback-progress` is recovery evidence only from `buffering`, `stalled`, or `seeking`, returning that session to `playing`. It never overrides `paused`, `stopped`, `finished`, a replaced session, or a terminal fallback state. `playback-resumed` remains the only paused→playing transition; stop stays authoritative.
- **Evidence retention** — genuine stall and provider-fallback evidence stays in the diagnostics record after status recovers, so the UI can still explain what happened.
- **One authority, four consumers** — header, loading shell, diagnostics, and presence read the same status and generation. Presence drops updates from a superseded generation instead of sending them.

### A distinction worth knowing about

This adds `isPlaybackTransportStarted()` alongside the existing `isPlaybackSessionActive()`. They answer different questions: "a session exists" **includes** the bootstrap states `loading`/`ready`; "transport has started" does not. Collapsing them made the loading shell report `operation: "playing"` while still loading — caught by a pre-existing presenter test. `paused` counts as started (transport isn't advancing, but bootstrap is over). Both predicates are now pinned by a test asserting the difference, so the trap can't silently reopen.

## Non-goals

No timer or copy-only changes. Reconnect budgets and backoff are unchanged.

## Base

**Stacked on #26** (`fix/default-anidb-release-truth`). Merge #26 first; GitHub retargets this to `main` automatically. The diff shown here is this PR's own 7 commits.

## Verification

| Gate | Result |
| --- | --- |
| `bun run typecheck` | 14/14 tasks |
| `bun run lint` | 12/12, 0 warnings 0 errors |
| `bun run test` | unit **3834 pass / 0 fail** (611 files); providers 252 pass; integration 87 pass / 0 fail (134 ran, 47 skipped) |
| `bun run build` | 10/10 tasks |
| `bun run verify:doc-paths` | 45 docs resolve |
| `bun run verify:doc-coverage` | every code area routed |
| `git diff --check` | clean |

Tests run against #26's changes underneath, which is the point of stacking — no independent-branch run would have exercised them together.

The 47 integration skips are the repository's existing baseline, not exclusions added here.

## Docs and changeset

`.docs/mpv-in-process-reconnect.md` (generations + status recovery contract), `.docs/presence-integrations.md`, `.docs/testing-strategy.md`, `docs/users/playback-and-recovery.mdx`. Changeset: `.changeset/mid-playback-state-recovery.md` (patch).
