### PR TITLE
chore: add GitHub Sponsors funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [KitsuneKode]


### PR DESCRIPTION
Adds `.github/FUNDING.yml` so the repository shows a **Sponsor** button.

The account already has a public sponsors listing (`sponsors-KitsuneKode`), so this file is the only missing piece — GitHub reads it to render the button in the repo header and on release pages.

Independent of the release-hardening stack (#26 → #27 → #28); based directly on `main` and mergeable in any order.