### PR TITLE
fix(offline): play downloaded titles, repair orphaned assets, restore local autoplay

### DIFF
--- a/.docs/download-offline-onboarding.md
+++ b/.docs/download-offline-onboarding.md
@@ -122,6 +122,18 @@ confirmation, and filesystem naming all consume it instead of re-deriving "is th
 - Local playback uses the same persisted/session autoskip policy as online playback so intro,
   recap, preview, and credits behavior does not unexpectedly change between streamed and
   downloaded files.
+- `--offline` is a transient runtime override: it sets offline connectivity before startup
+  workers begin, skips download processing, update checks, telemetry, and sync identity work,
+  and opens the local library without provider resolution.
+- An offline-library launch keeps its explicit local-only origin through episode selection and
+  playback. The validated local source is handed to the local mpv path, including local subtitle
+  sidecars, rather than being represented as a remote stream URL.
+- Offline asset lookup uses the same canonical title identity as download enqueue. This covers
+  provider-native anime ids, canonical AniList/TMDB ids, and YouTube ids across download, library,
+  and normal playback surfaces.
+- A `repairable` sidecar status does not make the video unplayable. The library validates the
+  primary video independently and keeps a valid local artifact available while exposing sidecar
+  repair actions.
 - Offline shelf rows are grouped by title and may render the best local preview image:
   cached poster artwork first, then persisted poster URL, then text-only fallback.
 - Offline title rows should surface local facts that are already in SQLite or on disk:

--- a/apps/cli/src/app-shell/download-manager-shell.tsx
+++ b/apps/cli/src/app-shell/download-manager-shell.tsx
@@ -335,7 +335,12 @@ export function DownloadManagerContent({
         const job = allJobs[selectedIndex];
         if (!job) return;
 
-        if (key.return && (job.status === "completed" || job.status === "completed-with-notes")) {
+        if (
+          key.return &&
+          (job.status === "completed" ||
+            job.status === "completed-with-notes" ||
+            job.status === "repairable")
+        ) {
           void import("@/app/offline/offline-playback-launch").then(
             ({ requestUnifiedOfflinePlayback }) => requestUnifiedOfflinePlayback(container, job.id),
           );

--- a/apps/cli/src/app-shell/library-title-detail.tsx
+++ b/apps/cli/src/app-shell/library-title-detail.tsx
@@ -198,7 +198,11 @@ export function LibraryTitleDetail({
         try {
           if (selectedRow.kind === "episode") {
             const job = selectedRow.entry.job;
-            if (job.status !== "completed" && job.status !== "completed-with-notes") {
+            if (
+              job.status !== "completed" &&
+              job.status !== "completed-with-notes" &&
+              job.status !== "repairable"
+            ) {
               return;
             }
             const playable = await container.offlineLibraryService.getPlayableSource(job.id);

--- a/apps/cli/src/app-shell/playback-mount-shell.tsx
+++ b/apps/cli/src/app-shell/playback-mount-shell.tsx
@@ -12,6 +12,7 @@ import type { PostPlaybackRecommendationRail } from "@/app/post-play/post-playba
 import { postPlaybackRecommendationItemsToRailItems } from "@/app/post-play/post-playback-recommendations";
 import type { Container } from "@/container";
 import { effectiveFooterHints } from "@/container";
+import { resolveTitleHistoryLookupId } from "@/domain/catalog/title-history-lookup";
 import {
   mediaLanguageProfileFor,
   resolveContentKind,
@@ -195,7 +196,7 @@ export function buildPlaybackRootLoadingShellState(
       if (
         isEpisodeDownloaded(
           container.offlineAssetService,
-          title.id,
+          resolveTitleHistoryLookupId(title, state.mode),
           episode.season,
           episode.episode,
         )

--- a/apps/cli/src/app-shell/playback-mount-shell.tsx
+++ b/apps/cli/src/app-shell/playback-mount-shell.tsx
@@ -28,7 +28,10 @@ import type { SessionState } from "@/domain/session/SessionState";
 import { isPlaybackSessionActive } from "@/domain/session/SessionState";
 import { peekTitleDetail } from "@/services/catalog/TitleDetailService";
 import { buildRuntimeHealthSnapshot } from "@/services/diagnostics/runtime-health";
-import { isEpisodeDownloaded } from "@/services/offline/offline-episode-index";
+import {
+  isEpisodeDownloaded,
+  offlineAssetTitleIdCandidates,
+} from "@/services/offline/offline-episode-index";
 import type { ProviderId } from "@kunai/types";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -196,7 +199,7 @@ export function buildPlaybackRootLoadingShellState(
       if (
         isEpisodeDownloaded(
           container.offlineAssetService,
-          resolveTitleHistoryLookupId(title, state.mode),
+          offlineAssetTitleIdCandidates(title, state.mode),
           episode.season,
           episode.episode,
         )

--- a/apps/cli/src/app-shell/title-control/smart-auto-launch.ts
+++ b/apps/cli/src/app-shell/title-control/smart-auto-launch.ts
@@ -10,7 +10,7 @@ export type PlaybackEpisodeEntryContext = {
   readonly titleId: string;
   readonly titleType: "series" | "movie";
   readonly isAnime: boolean;
-  readonly launchSource?: "search" | "history" | "continue";
+  readonly launchSource?: "search" | "history" | "continue" | "offline-library";
   readonly preselectedEpisode?: { readonly season: number; readonly episode: number };
   readonly history: PlaybackHistorySnapshot | null;
   readonly seasonCount?: number;
@@ -37,6 +37,7 @@ function isPlaybackFinished(history: PlaybackHistorySnapshot): boolean {
  */
 export function shouldAutoLaunchPlayback(ctx: PlaybackEpisodeEntryContext): boolean {
   if (ctx.titleType !== "series") return false;
+  if (ctx.launchSource === "offline-library") return Boolean(ctx.preselectedEpisode);
   if (ctx.flags.season || ctx.flags.episode) return true;
   if (ctx.failedProvider) return false;
   if (!ctx.preselectedEpisode) return false;

--- a/apps/cli/src/app/offline/offline-playback-launch.ts
+++ b/apps/cli/src/app/offline/offline-playback-launch.ts
@@ -16,10 +16,11 @@ export type OfflinePlaybackRequestResult =
 export function titleInfoFromDownloadJob(job: DownloadJobRecord): TitleInfo {
   return {
     id: job.titleId,
-    type: job.mediaKind === "movie" ? "movie" : "series",
+    type: job.mediaKind === "movie" || job.mediaKind === "video" ? "movie" : "series",
     name: job.titleName,
     posterUrl: job.posterUrl,
     isAnime: job.mediaKind === "anime" || job.mode === "anime",
+    launchSource: "offline-library",
   };
 }
 
@@ -33,20 +34,18 @@ export function episodeInfoFromDownloadJob(job: DownloadJobRecord): EpisodeInfo 
 }
 
 function applyDownloadJobSessionRouting(container: Container, job: DownloadJobRecord): void {
-  if (job.mode === "anime" || job.mediaKind === "anime") {
-    container.stateManager.dispatch({
-      type: "SET_MODE",
-      mode: "anime",
-      provider: job.providerId ?? container.stateManager.getState().provider,
-    });
-    return;
-  }
-  if (job.providerId) {
-    container.stateManager.dispatch({
-      type: "SET_PROVIDER",
-      provider: job.providerId,
-    });
-  }
+  const mode =
+    job.mode === "youtube" || job.mediaKind === "video"
+      ? "youtube"
+      : job.mode === "anime" || job.mediaKind === "anime"
+        ? "anime"
+        : "series";
+  const state = container.stateManager.getState();
+  container.stateManager.dispatch({
+    type: "SET_MODE",
+    mode,
+    provider: job.providerId ?? state.defaultProviders?.[mode] ?? state.provider,
+  });
 }
 
 export function buildOfflinePlaybackLaunch(job: DownloadJobRecord): OfflinePlaybackLaunch {

--- a/apps/cli/src/app/playback/PlaybackPhase.ts
+++ b/apps/cli/src/app/playback/PlaybackPhase.ts
@@ -217,6 +217,7 @@ import {
   type DiagnosticFailureClass,
 } from "@/services/diagnostics/diagnostic-event-helpers";
 import { observeResolveNetworkOutcome } from "@/services/network/network-observation";
+import type { LocalPlaybackSource } from "@/services/offline/local-playback-source";
 import {
   createPlaybackStartupTimeline,
   formatPlaybackStartupTimeline,
@@ -598,6 +599,7 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
       playbackSession: createPlaybackSessionState({ autoNextEnabled: config.autoNext }),
       pendingStart: startFromBeginning(),
     });
+    const isOfflineLaunch = title.launchSource === "offline-library";
     const selectionCoordinator = new PlaybackSelectionCoordinator({
       titleId: title.id,
       episodePlaybackSelection: container.episodePlaybackSelection,
@@ -712,17 +714,19 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
         return result.startIntent;
       };
       const provider = providerRegistry.get(stateManager.getState().provider);
-      const initialAnimeEpisodes = await this.getAnimeEpisodeOptions({
-        title,
-        mode: stateManager.getState().mode,
-        provider,
-        cache: animeEpisodeCatalogByProvider,
-        languages: playbackEpisodeCatalogLanguages({
-          mode: stateManager.getState().mode,
-          title,
-          config,
-        }),
-      });
+      const initialAnimeEpisodes = isOfflineLaunch
+        ? undefined
+        : await this.getAnimeEpisodeOptions({
+            title,
+            mode: stateManager.getState().mode,
+            provider,
+            cache: animeEpisodeCatalogByProvider,
+            languages: playbackEpisodeCatalogLanguages({
+              mode: stateManager.getState().mode,
+              title,
+              config,
+            }),
+          });
       logger.info("Episode selection metadata", {
         titleId: title.id,
         mode: stateManager.getState().mode,
@@ -789,9 +793,11 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
         const providerHealth = container.providerHealth.get(stateManager.getState().provider);
         const failedProvider =
           providerHealth?.status === "degraded" || providerHealth?.status === "down";
-        const seasonCount = usesNativeEpisodes
-          ? (title.episodeCount ?? initialAnimeEpisodes?.length)
-          : ((await fetchSeasons(title.id).catch(() => null))?.length ?? undefined);
+        const seasonCount = isOfflineLaunch
+          ? undefined
+          : usesNativeEpisodes
+            ? (title.episodeCount ?? initialAnimeEpisodes?.length)
+            : ((await fetchSeasons(title.id).catch(() => null))?.length ?? undefined);
         const episodeEntry = resolvePlaybackEpisodeEntry({
           titleId: title.id,
           titleType: title.type,
@@ -958,6 +964,9 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
         previousIterationAbort?.abort();
         const playbackIterationAbort = new AbortController();
         previousIterationAbort = playbackIterationAbort;
+        run.localEpisodeTiming = null;
+        run.localPlaybackJobId = null;
+        run.localPlaybackSource = null;
         const currentEpisode = stateManager.getState().currentEpisode;
         if (!currentEpisode) break;
         const episodeScopeKey = `${title.id}:${currentEpisode.season}:${currentEpisode.episode}`;
@@ -1203,20 +1212,22 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
           // can read it. On resolve we dispatch SET_TITLE_DETAIL so the UI reacts
           // (the rail reads SessionState.titleDetail). Errors are swallowed; the
           // panels fall back to honest placeholders if it never resolves.
-          void fetchTitleDetail(title.id, title.type, undefined, {
-            externalIds: title.externalIds,
-            isAnime: stateManager.getState().mode === "anime" || title.isAnime === true,
-          })
-            .then((detail) => {
-              stateManager.dispatch({
-                type: "SET_TITLE_DETAIL",
-                titleId: title.id,
-                titleType: title.type,
-                detail,
-              });
-              return undefined;
+          if (!isOfflineLaunch) {
+            void fetchTitleDetail(title.id, title.type, undefined, {
+              externalIds: title.externalIds,
+              isAnime: stateManager.getState().mode === "anime" || title.isAnime === true,
             })
-            .catch(() => undefined);
+              .then((detail) => {
+                stateManager.dispatch({
+                  type: "SET_TITLE_DETAIL",
+                  titleId: title.id,
+                  titleType: title.type,
+                  detail,
+                });
+                return undefined;
+              })
+              .catch(() => undefined);
+          }
 
           // Kick off timing fetch in parallel with everything else — IntroDB is a
           // lightweight API call and should resolve well before stream resolution.
@@ -1224,15 +1235,17 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
           // on the successful provider when they differ.
           recordStartupMark("timing-fetch-started");
           const configuredTimingProviderId = currentProvider?.metadata.id;
-          const timingFetch = this.getPlaybackTimingMetadata(
-            title,
-            currentEpisode,
-            playbackTimingByEpisode,
-            resolveController.signal,
-            stateManager.getState().mode === "anime",
-            configuredTimingProviderId,
-            container.diagnosticsService,
-          );
+          const timingFetch = isOfflineLaunch
+            ? Promise.resolve(null)
+            : this.getPlaybackTimingMetadata(
+                title,
+                currentEpisode,
+                playbackTimingByEpisode,
+                resolveController.signal,
+                stateManager.getState().mode === "anime",
+                configuredTimingProviderId,
+                container.diagnosticsService,
+              );
 
           const watchedEntries = historyRepository.listByTitleIdentity(historyTitleLookup);
           const playbackMode = stateManager.getState().mode;
@@ -1260,17 +1273,19 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
             note: "Warming episode names, navigation, and artwork",
           });
 
-          const currentAnimeEpisodesPromise = this.getAnimeEpisodeOptions({
-            title,
-            mode: playbackMode,
-            provider: currentProvider,
-            cache: animeEpisodeCatalogByProvider,
-            languages: playbackEpisodeCatalogLanguages({ mode: playbackMode, title, config }),
-            signal: resolveController.signal,
-          });
+          const currentAnimeEpisodesPromise = isOfflineLaunch
+            ? Promise.resolve(undefined)
+            : this.getAnimeEpisodeOptions({
+                title,
+                mode: playbackMode,
+                provider: currentProvider,
+                cache: animeEpisodeCatalogByProvider,
+                languages: playbackEpisodeCatalogLanguages({ mode: playbackMode, title, config }),
+                signal: resolveController.signal,
+              });
           const downloadedEpisodes = new Set(
             container.offlineAssetService
-              .listTitleAssets(title.id)
+              .listTitleAssets(resolveTitleHistoryLookupId(title, playbackMode))
               .filter((asset) => asset.state === "ready")
               .map((asset) => `${asset.season ?? 1}:${asset.episode ?? 1}`),
           );
@@ -1292,20 +1307,28 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
                 loadEpisodes: loadEpisodesOnce,
               }),
           );
-          const episodeAvailabilityPromise = currentAnimeEpisodesPromise.then(
-            (currentAnimeEpisodes) =>
-              resolveEpisodeAvailability({
-                title,
-                currentEpisode,
-                isAnime: isAnimePlayback,
-                animeEpisodeCount: knownEpisodeCount,
-                animeEpisodes: currentAnimeEpisodes,
-                loaders: {
-                  loadSeasons: fetchSeasons,
-                  loadEpisodes: loadEpisodesOnce,
-                },
-              }),
-          );
+          const episodeAvailabilityPromise = isOfflineLaunch
+            ? Promise.resolve({
+                previousEpisode: null,
+                nextEpisode: null,
+                nextSeasonEpisode: null,
+                upcomingNext: null,
+                animeNextReleaseUnknown: false,
+                tmdbUnavailable: false,
+              })
+            : currentAnimeEpisodesPromise.then((currentAnimeEpisodes) =>
+                resolveEpisodeAvailability({
+                  title,
+                  currentEpisode,
+                  isAnime: isAnimePlayback,
+                  animeEpisodeCount: knownEpisodeCount,
+                  animeEpisodes: currentAnimeEpisodes,
+                  loaders: {
+                    loadSeasons: fetchSeasons,
+                    loadEpisodes: loadEpisodesOnce,
+                  },
+                }),
+              );
           const [currentAnimeEpisodes, shellEpisodePicker, episodeAvailability] = await Promise.all(
             [currentAnimeEpisodesPromise, shellEpisodePickerPromise, episodeAvailabilityPromise],
           );
@@ -1524,9 +1547,13 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
               title,
               currentEpisode,
               {
-                entrypoint: "online-search",
+                entrypoint: isOfflineLaunch
+                  ? "offline-library"
+                  : title.launchSource === "continue"
+                    ? "continue"
+                    : "online-search",
                 forceOnline: run.episodePlaybackSourceOverride === "online",
-                forceLocal: run.episodePlaybackSourceOverride === "local",
+                forceLocal: isOfflineLaunch || run.episodePlaybackSourceOverride === "local",
               },
             );
             run.episodePlaybackSourceOverride = null;
@@ -1535,6 +1562,7 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
               streamProvenance = "local";
               run.localEpisodeTiming = localResolution.timing;
               run.localPlaybackJobId = localResolution.jobId;
+              run.localPlaybackSource = localResolution.source;
               diagnosticsService.record({
                 ...playbackCorrelation,
                 category: "playback",
@@ -1547,6 +1575,16 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
               });
               recordStartupMark("resolve-complete", stream);
             }
+          }
+
+          if (!stream && isOfflineLaunch) {
+            workControl.setActive(null);
+            stateManager.dispatch({ type: "SET_STREAM", stream: null });
+            this.updatePlaybackFeedback(context, {
+              detail: "Downloaded file unavailable",
+              note: "Return to the offline library and run integrity check or re-download it.",
+            });
+            return { status: "success", value: "back_to_results" };
           }
 
           if (!stream) {
@@ -2261,6 +2299,7 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
               () => {
                 queueAttempt?.acknowledgeStarted();
               },
+              run.localPlaybackSource ?? undefined,
             );
           } catch (error) {
             if (error instanceof PlaybackAbortedError || context.signal.aborted) {
@@ -3652,6 +3691,7 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
     successfulProviderId?: string,
     playbackIterationSignal?: AbortSignal,
     onConfirmedPlaybackStart?: () => void,
+    localPlaybackSource?: LocalPlaybackSource,
   ): Promise<PlaybackResult> {
     const {
       player,
@@ -3733,6 +3773,7 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
       iterationAborted: playbackIterationSignal?.aborted ?? false,
       correlation,
       timing,
+      localPlaybackSource,
       shareLinkContext: {
         mode: stateManager.getState().mode,
         title,

--- a/apps/cli/src/app/playback/PlaybackPhase.ts
+++ b/apps/cli/src/app/playback/PlaybackPhase.ts
@@ -166,6 +166,7 @@ import {
   toEpisodeNavigationState,
 } from "@/domain/playback/playback-policy";
 import {
+  buildOfflineFileUnavailableProblem,
   buildPlayerFailureProblem,
   buildProviderResolveProblem,
   type PlaybackProblem,
@@ -218,6 +219,7 @@ import {
 } from "@/services/diagnostics/diagnostic-event-helpers";
 import { observeResolveNetworkOutcome } from "@/services/network/network-observation";
 import type { LocalPlaybackSource } from "@/services/offline/local-playback-source";
+import { findNextReadyEpisode } from "@/services/offline/offline-episode-index";
 import {
   createPlaybackStartupTimeline,
   formatPlaybackStartupTimeline,
@@ -242,26 +244,6 @@ export type { PlaybackOutcome } from "@/app/playback/playback-outcome";
 export { playbackStartupStageForPlayerEvent };
 
 const timingAggregator = new PlaybackTimingAggregator([IntroDbTimingSource, AniSkipTimingSource]);
-
-/**
- * The next downloaded episode after `current`, or null when nothing is ready.
- *
- * The offline launch path must answer episode availability from the library
- * rather than the catalog: returning null unconditionally reads as "series
- * finished" downstream, so a downloaded next episode would never autoplay.
- */
-function nextReadyOfflineEpisode(
-  container: PhaseContext["container"],
-  titleId: string,
-  current: EpisodeInfo,
-): EpisodeInfo | null {
-  if (!titleId) return null;
-  const [next] = container.offlineAssetService.listNextReadyByTitleCursors([
-    { titleId, season: current.season, episode: current.episode },
-  ]);
-  if (next?.season == null || next.episode == null) return null;
-  return { season: next.season, episode: next.episode };
-}
 
 function playbackTimingCacheKey(
   title: TitleInfo,
@@ -1335,8 +1317,8 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
               // of TMDB/anime-catalog calls while still answering truthfully.
               Promise.resolve({
                 previousEpisode: null,
-                nextEpisode: nextReadyOfflineEpisode(
-                  container,
+                nextEpisode: findNextReadyEpisode(
+                  container.offlineAssetService,
                   resolveTitleHistoryLookupId(title, playbackMode),
                   currentEpisode,
                 ),
@@ -1613,16 +1595,24 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
             // and note, so the explanation was erased before it ever rendered
             // and the user just landed back on results with no reason given.
             // playbackProblem survives that teardown.
+            const offlineProblem = buildOfflineFileUnavailableProblem();
             stateManager.dispatch({
               type: "SET_PLAYBACK_PROBLEM",
-              problem: {
-                stage: "stream-open",
-                severity: "blocking",
-                cause: "offline-file-unavailable",
-                userMessage:
-                  "Downloaded file unavailable. Run an integrity check on it in the offline library, or download it again.",
-                recommendedAction: "diagnostics",
-                secondaryActions: ["refresh"],
+              problem: offlineProblem,
+            });
+            diagnosticsService.record({
+              ...playbackCorrelation,
+              category: "playback",
+              operation: "playback.source.local.unavailable",
+              message: offlineProblem.userMessage,
+              titleId: title.id,
+              season: currentEpisode.season,
+              episode: currentEpisode.episode,
+              context: {
+                stage: offlineProblem.stage,
+                severity: offlineProblem.severity,
+                cause: offlineProblem.cause,
+                recommendedAction: offlineProblem.recommendedAction,
               },
             });
             return { status: "success", value: "back_to_results" };

--- a/apps/cli/src/app/playback/PlaybackPhase.ts
+++ b/apps/cli/src/app/playback/PlaybackPhase.ts
@@ -243,6 +243,26 @@ export { playbackStartupStageForPlayerEvent };
 
 const timingAggregator = new PlaybackTimingAggregator([IntroDbTimingSource, AniSkipTimingSource]);
 
+/**
+ * The next downloaded episode after `current`, or null when nothing is ready.
+ *
+ * The offline launch path must answer episode availability from the library
+ * rather than the catalog: returning null unconditionally reads as "series
+ * finished" downstream, so a downloaded next episode would never autoplay.
+ */
+function nextReadyOfflineEpisode(
+  container: PhaseContext["container"],
+  titleId: string,
+  current: EpisodeInfo,
+): EpisodeInfo | null {
+  if (!titleId) return null;
+  const [next] = container.offlineAssetService.listNextReadyByTitleCursors([
+    { titleId, season: current.season, episode: current.episode },
+  ]);
+  if (next?.season == null || next.episode == null) return null;
+  return { season: next.season, episode: next.episode };
+}
+
 function playbackTimingCacheKey(
   title: TitleInfo,
   episode: EpisodeInfo,
@@ -1308,9 +1328,18 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
               }),
           );
           const episodeAvailabilityPromise = isOfflineLaunch
-            ? Promise.resolve({
+            ? // Availability comes from the offline library, not the catalog. An
+              // all-null answer here reads as "series finished" to
+              // playback-result-policy, so downloaded E1 would never advance to
+              // downloaded E2 and `n` would be dead. This keeps the launch free
+              // of TMDB/anime-catalog calls while still answering truthfully.
+              Promise.resolve({
                 previousEpisode: null,
-                nextEpisode: null,
+                nextEpisode: nextReadyOfflineEpisode(
+                  container,
+                  resolveTitleHistoryLookupId(title, playbackMode),
+                  currentEpisode,
+                ),
                 nextSeasonEpisode: null,
                 upcomingNext: null,
                 animeNextReleaseUnknown: false,
@@ -1580,9 +1609,21 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
           if (!stream && isOfflineLaunch) {
             workControl.setActive(null);
             stateManager.dispatch({ type: "SET_STREAM", stream: null });
-            this.updatePlaybackFeedback(context, {
-              detail: "Downloaded file unavailable",
-              note: "Return to the offline library and run integrity check or re-download it.",
+            // Not updatePlaybackFeedback: this method's `finally` clears detail
+            // and note, so the explanation was erased before it ever rendered
+            // and the user just landed back on results with no reason given.
+            // playbackProblem survives that teardown.
+            stateManager.dispatch({
+              type: "SET_PLAYBACK_PROBLEM",
+              problem: {
+                stage: "stream-open",
+                severity: "blocking",
+                cause: "offline-file-unavailable",
+                userMessage:
+                  "Downloaded file unavailable. Run an integrity check on it in the offline library, or download it again.",
+                recommendedAction: "diagnostics",
+                secondaryActions: ["refresh"],
+              },
             });
             return { status: "success", value: "back_to_results" };
           }

--- a/apps/cli/src/app/playback/PlaybackPhase.ts
+++ b/apps/cli/src/app/playback/PlaybackPhase.ts
@@ -219,7 +219,10 @@ import {
 } from "@/services/diagnostics/diagnostic-event-helpers";
 import { observeResolveNetworkOutcome } from "@/services/network/network-observation";
 import type { LocalPlaybackSource } from "@/services/offline/local-playback-source";
-import { findNextReadyEpisode } from "@/services/offline/offline-episode-index";
+import {
+  findNextReadyEpisode,
+  offlineAssetTitleIdCandidates,
+} from "@/services/offline/offline-episode-index";
 import {
   createPlaybackStartupTimeline,
   formatPlaybackStartupTimeline,
@@ -1319,7 +1322,7 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
                 previousEpisode: null,
                 nextEpisode: findNextReadyEpisode(
                   container.offlineAssetService,
-                  resolveTitleHistoryLookupId(title, playbackMode),
+                  offlineAssetTitleIdCandidates(title, playbackMode),
                   currentEpisode,
                 ),
                 nextSeasonEpisode: null,

--- a/apps/cli/src/app/playback/episode-playback-source.ts
+++ b/apps/cli/src/app/playback/episode-playback-source.ts
@@ -1,11 +1,13 @@
 import type { Container } from "@/container";
-import { resolveTitleHistoryLookupId } from "@/domain/catalog/title-history-lookup";
 import { createSourceSelectionEngine } from "@/domain/playback-source/SourceSelectionEngine";
 import type { PlaybackSourcePreference } from "@/domain/playback-source/SourceSelectionEngine";
 import type { EpisodeInfo, PlaybackTimingMetadata, StreamInfo, TitleInfo } from "@/domain/types";
 import type { ContinueSourcePreference } from "@/services/continuation/continuation-source";
 import type { LocalPlaybackSource } from "@/services/offline/local-playback-source";
-import { findReadyJobIdForEpisode } from "@/services/offline/offline-episode-index";
+import {
+  findReadyJobIdForEpisode,
+  offlineAssetTitleIdCandidates,
+} from "@/services/offline/offline-episode-index";
 import { parseIntroSkipTiming } from "@/services/offline/offline-library";
 
 export type LocalEpisodePlaybackResolution = {
@@ -36,11 +38,10 @@ export async function resolveLocalEpisodePlayback(
   if (options.forceOnline) return null;
 
   const mode = container.stateManager.getState().mode;
-  const lookupTitleId = resolveTitleHistoryLookupId(title, mode);
   const mediaKind = mode === "youtube" ? "video" : mode === "anime" ? "anime" : title.type;
   const jobId = findReadyJobIdForEpisode(
     container.offlineAssetService,
-    lookupTitleId,
+    offlineAssetTitleIdCandidates(title, mode),
     episode.season,
     episode.episode,
     { mediaKind },

--- a/apps/cli/src/app/playback/episode-playback-source.ts
+++ b/apps/cli/src/app/playback/episode-playback-source.ts
@@ -1,14 +1,17 @@
 import type { Container } from "@/container";
+import { resolveTitleHistoryLookupId } from "@/domain/catalog/title-history-lookup";
 import { createSourceSelectionEngine } from "@/domain/playback-source/SourceSelectionEngine";
 import type { PlaybackSourcePreference } from "@/domain/playback-source/SourceSelectionEngine";
 import type { EpisodeInfo, PlaybackTimingMetadata, StreamInfo, TitleInfo } from "@/domain/types";
 import type { ContinueSourcePreference } from "@/services/continuation/continuation-source";
+import type { LocalPlaybackSource } from "@/services/offline/local-playback-source";
 import { findReadyJobIdForEpisode } from "@/services/offline/offline-episode-index";
 import { parseIntroSkipTiming } from "@/services/offline/offline-library";
 
 export type LocalEpisodePlaybackResolution = {
   readonly stream: StreamInfo;
   readonly jobId: string;
+  readonly source: LocalPlaybackSource;
   readonly timing: PlaybackTimingMetadata | null;
 };
 
@@ -25,18 +28,22 @@ export async function resolveLocalEpisodePlayback(
   title: TitleInfo,
   episode: EpisodeInfo,
   options: {
-    readonly entrypoint?: "online-search" | "continue";
+    readonly entrypoint?: "online-search" | "continue" | "offline-library";
     readonly forceOnline?: boolean;
     readonly forceLocal?: boolean;
   } = {},
 ): Promise<LocalEpisodePlaybackResolution | null> {
   if (options.forceOnline) return null;
 
+  const mode = container.stateManager.getState().mode;
+  const lookupTitleId = resolveTitleHistoryLookupId(title, mode);
+  const mediaKind = mode === "youtube" ? "video" : mode === "anime" ? "anime" : title.type;
   const jobId = findReadyJobIdForEpisode(
     container.offlineAssetService,
-    title.id,
+    lookupTitleId,
     episode.season,
     episode.episode,
+    { mediaKind },
   );
   if (!jobId) return null;
 
@@ -75,6 +82,7 @@ function buildLocalEpisodeResolution(
   const displayTitle = formatOfflinePlaybackTitle(playable.source);
   return {
     jobId: playable.job.id,
+    source: playable.source,
     timing: playable.source.timing ?? parseIntroSkipTiming(playable.job.introSkipJson),
     stream: {
       url: playable.source.filePath,

--- a/apps/cli/src/app/playback/playback-run-state.ts
+++ b/apps/cli/src/app/playback/playback-run-state.ts
@@ -17,6 +17,7 @@ import type { PlaybackSessionState } from "@/app/playback/playback-session-contr
 import type { PlaybackStartIntent } from "@/app/playback/playback-start-intent";
 import type { SourceRefreshAction } from "@/app/playback/source-refresh-policy";
 import type { PlaybackTimingMetadata } from "@/domain/types";
+import type { LocalPlaybackSource } from "@/services/offline/local-playback-source";
 
 export interface PlaybackRunState {
   /** Current session snapshot; reassigned as the session transitions phases. */
@@ -43,6 +44,8 @@ export interface PlaybackRunState {
   localEpisodeTiming: PlaybackTimingMetadata | null;
   /** Download job id backing the current local playback, when applicable. */
   localPlaybackJobId: string | null;
+  /** Validated local source carried to the player seam for the current iteration. */
+  localPlaybackSource: LocalPlaybackSource | null;
 }
 
 /**
@@ -67,5 +70,6 @@ export function createPlaybackRunState(init: {
     episodePlaybackSourceOverride: null,
     localEpisodeTiming: null,
     localPlaybackJobId: null,
+    localPlaybackSource: null,
   };
 }

--- a/apps/cli/src/app/playback/run-mpv-playback-session.ts
+++ b/apps/cli/src/app/playback/run-mpv-playback-session.ts
@@ -31,6 +31,7 @@ import type {
   PlayerService,
 } from "@/infra/player/PlayerService";
 import type { DiagnosticCorrelation } from "@/services/diagnostics/correlation";
+import type { LocalPlaybackSource } from "@/services/offline/local-playback-source";
 import type { PlaybackStartupStage } from "@/services/playback/playback-startup-timeline";
 
 export type MpvPlaybackSessionHooks = {
@@ -107,6 +108,7 @@ export type RunMpvPlaybackSessionInput = {
   readonly correlation?: DiagnosticCorrelation;
   readonly shareLinkContext: Omit<NonNullable<PlayerOptions["shareLinkContext"]>, "onCopied">;
   readonly timing: PlaybackTimingMetadata | null;
+  readonly localPlaybackSource?: LocalPlaybackSource;
 };
 
 /**
@@ -182,7 +184,7 @@ export async function runMpvPlaybackSession(
   });
 
   try {
-    const result = await player.play(stream, {
+    const playerOptions: PlayerOptions = {
       ...input.playOptions,
       url: stream.url,
       headers: stream.headers,
@@ -290,7 +292,14 @@ export async function runMpvPlaybackSession(
           hooks.onTrackChanged(event);
         }
       },
-    });
+    };
+    // Local files go through play() like any other source. `stream` already
+    // carries the file path, subtitle sidecar and display title from
+    // buildLocalEpisodeResolution(), while playerOptions carries resume
+    // prompting, the autoplay-chain mode, near-EOF prefetch, the abort signal,
+    // merged timing, correlation and track preferences. Routing local playback
+    // through playLocal() silently dropped every one of those.
+    const result = await player.play(stream, playerOptions);
 
     // The startup watchdog rewrites the result before completion is applied, so
     // a watchdog failure completes as `error` rather than briefly as `finished`.

--- a/apps/cli/src/app/post-play/post-playback-recommendations.ts
+++ b/apps/cli/src/app/post-play/post-playback-recommendations.ts
@@ -176,6 +176,10 @@ export class PostPlaybackRecommendationRail {
       },
     });
 
+    if (container.config.offlineMode || title.launchSource === "offline-library") {
+      return railItems;
+    }
+
     const loadMode = resolvePostPlaybackRecommendationLoadMode({
       seedCount: railItems.length,
       railEnabled: container.config.recommendationRailEnabled,

--- a/apps/cli/src/app/session/session-overrides.ts
+++ b/apps/cli/src/app/session/session-overrides.ts
@@ -9,16 +9,19 @@
 export interface SessionOverrideArgs {
   readonly zen: boolean;
   readonly minimal: boolean;
+  readonly offline?: boolean;
 }
 
 export interface SessionLayoutConfig {
   readonly zenMode: boolean;
   readonly minimalMode: boolean;
+  readonly offlineMode?: boolean;
 }
 
 export type SessionConfigOverrides = Partial<{
   zenMode: boolean;
   minimalMode: boolean;
+  offlineMode: boolean;
 }>;
 
 /**
@@ -34,5 +37,6 @@ export function resolveSessionConfigOverrides(
   const overrides: SessionConfigOverrides = {};
   if (args.zen && !config.zenMode) overrides.zenMode = true;
   if (args.minimal && !config.minimalMode) overrides.minimalMode = true;
+  if (args.offline && !config.offlineMode) overrides.offlineMode = true;
   return overrides;
 }

--- a/apps/cli/src/container/bootstrap-services.ts
+++ b/apps/cli/src/container/bootstrap-services.ts
@@ -251,6 +251,9 @@ export function bootstrapServices(input: {
     historyRepository,
     offlineAssetService,
   });
+  downloadService.onEvent((event) => {
+    if (event.type === "deleted") offlineAssetService.removeForJob(event.jobId);
+  });
   const offlineMaintenanceService = new OfflineMaintenanceService({
     jobs: offlineMaintenanceJobs,
     assets: offlineAssetService,

--- a/apps/cli/src/container/bootstrap-services.ts
+++ b/apps/cli/src/container/bootstrap-services.ts
@@ -254,6 +254,18 @@ export function bootstrapServices(input: {
   downloadService.onEvent((event) => {
     if (event.type === "deleted") offlineAssetService.removeForJob(event.jobId);
   });
+  // Repairs libraries damaged before deleteJob emitted ahead of the row delete.
+  // Ownerless assets still read `ready`, so the library advertises titles it
+  // cannot play, and nothing job-driven can reach them. No-op once healthy.
+  const purgedOrphanCount = offlineAssetService.purgeOrphanedAssets();
+  if (purgedOrphanCount > 0) {
+    diagnosticsService.record({
+      category: "offline",
+      operation: "offline.assets.purge-orphans",
+      message: `Removed ${purgedOrphanCount} offline ${purgedOrphanCount === 1 ? "asset" : "assets"} whose download job no longer exists`,
+      context: { purgedOrphanCount },
+    });
+  }
   const offlineMaintenanceService = new OfflineMaintenanceService({
     jobs: offlineMaintenanceJobs,
     assets: offlineAssetService,

--- a/apps/cli/src/domain/playback-source/SourceSelectionEngine.ts
+++ b/apps/cli/src/domain/playback-source/SourceSelectionEngine.ts
@@ -62,7 +62,15 @@ export function createSourceSelectionEngine(): SourceSelectionEngine {
           : blockedOfflineDecision(localStatus);
       }
 
-      if (input.entrypoint === "continue" && localStatus === "ready") {
+      // `prefer-online` is an explicit user setting, so Continue must honour it
+      // even when a download exists. Without this check, enabling the offline
+      // "continue" entrypoint silently overrode continueSourcePreference for
+      // every resume — an online-path regression.
+      if (
+        input.entrypoint === "continue" &&
+        localStatus === "ready" &&
+        preference !== "prefer-online"
+      ) {
         return localDecision("local-continuation", localStatus, input.networkAvailable);
       }
 

--- a/apps/cli/src/domain/playback/playback-problem.ts
+++ b/apps/cli/src/domain/playback/playback-problem.ts
@@ -309,6 +309,12 @@ export function toErrorScenario(
       };
     case "no-stream":
     case "provider-access":
+    // An unplayable download is the same shape of dead end as a title no
+    // provider can serve: the thing the user asked for is not obtainable right
+    // now. Without this case the switch fell through to `undefined`, and the
+    // shell rendered the bare `⚠ issue · offline-file-unavailable` slug instead
+    // of the error surface every other blocking failure gets.
+    case "offline-file-unavailable":
       return {
         kind: "title-unavailable",
         title: context.title ?? extractUnavailableTitle(problem.userMessage),

--- a/apps/cli/src/domain/playback/playback-problem.ts
+++ b/apps/cli/src/domain/playback/playback-problem.ts
@@ -51,6 +51,27 @@ export function buildMpvMissingProblem(input: {
   };
 }
 
+/**
+ * The library still advertises a title as downloaded, but nothing playable
+ * resolved for it — a deleted, moved, or truncated artifact.
+ *
+ * Dispatched as a problem rather than playback feedback: the offline bail-out
+ * runs inside a method whose `finally` clears detail and note, so a feedback
+ * note is erased before it renders and the user lands back on results with no
+ * reason given.
+ */
+export function buildOfflineFileUnavailableProblem(): PlaybackProblem {
+  return {
+    stage: "stream-open",
+    severity: "blocking",
+    cause: "offline-file-unavailable",
+    userMessage:
+      "Downloaded file unavailable. Run an integrity check on it in the offline library, or download it again.",
+    recommendedAction: "diagnostics",
+    secondaryActions: ["refresh"],
+  };
+}
+
 export function buildProviderResolveProblem({
   attempts,
 }: {

--- a/apps/cli/src/domain/types.ts
+++ b/apps/cli/src/domain/types.ts
@@ -71,7 +71,7 @@ export interface TitleInfo {
   /** Deterministic anime detection carried from the TMDB classifier — for the persisted content kind only (never routing). */
   readonly isAnime?: boolean;
   readonly episodeCount?: number;
-  readonly launchSource?: "search" | "history" | "continue";
+  readonly launchSource?: "search" | "history" | "continue" | "offline-library";
   /** Exact queue handoff identity when playback was claimed from the Up Next queue. */
   readonly queuePlaybackIntent?: QueuePlaybackIntent;
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -706,7 +706,7 @@ export async function runCli(argv = process.argv.slice(2)): Promise<void> {
 
   const capabilitySnapshot = await checkDeps(KUNAI_VERSION, {
     silent: onboardingWillRun,
-    requireYtDlp: args.youtube || configJson.defaultMode === "youtube",
+    requireYtDlp: !args.offline && (args.youtube || configJson.defaultMode === "youtube"),
   });
 
   const { loadCompiledSmokeProviderOverride } =
@@ -830,73 +830,77 @@ export async function runCli(argv = process.argv.slice(2)): Promise<void> {
     }
   }
 
-  void container.downloadService.processQueue();
+  if (!config.offlineMode) {
+    void container.downloadService.processQueue();
+  }
   // Background update: binary channel auto-applies; others notify-only.
-  void (async () => {
-    try {
-      const { readInstallManifest } = await import("./services/update/install-manifest");
-      const { detectInstallMethod } = await import("./services/update/install-method");
-      const manifest = await readInstallManifest();
-      const channel = manifest?.method ?? detectInstallMethod({ fileExists: existsSync }).kind;
-      const rawConfig = container.config.getRaw();
+  if (!config.offlineMode)
+    void (async () => {
+      try {
+        const { readInstallManifest } = await import("./services/update/install-manifest");
+        const { detectInstallMethod } = await import("./services/update/install-method");
+        const manifest = await readInstallManifest();
+        const channel = manifest?.method ?? detectInstallMethod({ fileExists: existsSync }).kind;
+        const rawConfig = container.config.getRaw();
 
-      if (channel === "binary" && rawConfig.autoApplyBinaryUpdates) {
-        const result = await container.binaryAutoUpdater.runOnce();
-        if (
-          (result.status === "installed" || result.status === "pending-restart") &&
-          "version" in result
-        ) {
-          container.notificationService.recordSignals([
-            {
-              type: "app-update",
-              currentVersion: KUNAI_VERSION,
-              latestVersion: result.version,
-              pendingRestart: result.status === "pending-restart",
-            },
-          ]);
+        if (channel === "binary" && rawConfig.autoApplyBinaryUpdates) {
+          const result = await container.binaryAutoUpdater.runOnce();
+          if (
+            (result.status === "installed" || result.status === "pending-restart") &&
+            "version" in result
+          ) {
+            container.notificationService.recordSignals([
+              {
+                type: "app-update",
+                currentVersion: KUNAI_VERSION,
+                latestVersion: result.version,
+                pendingRestart: result.status === "pending-restart",
+              },
+            ]);
+          }
+          // The startup check above already ran and produced the user-facing
+          // notification. Arm only the interval here so startup never performs
+          // the same ownership/network checks twice.
+          container.binaryAutoUpdater.startBackground({ runImmediately: false });
+          return;
         }
-        // The startup check above already ran and produced the user-facing
-        // notification. Arm only the interval here so startup never performs
-        // the same ownership/network checks twice.
-        container.binaryAutoUpdater.startBackground({ runImmediately: false });
-        return;
-      }
 
-      const result = await container.updateService.checkForUpdate();
-      const signal = updateSignalFromCheck(result);
-      if (signal) container.notificationService.recordSignals([signal]);
-    } catch {
-      // checkForUpdate records its own failures; keep startup fire-and-forget.
-    }
-  })();
-  void (async () => {
-    try {
-      const raw = container.config.getRaw();
-      if (raw.telemetry === "unset") {
-        const { resolveTelemetryConsent } = await import("./services/telemetry/consent");
-        const decision = resolveTelemetryConsent({
-          env: { DO_NOT_TRACK: process.env.DO_NOT_TRACK, CI: process.env.CI },
-          isTty: Boolean(process.stdin.isTTY && process.stdout.isTTY),
-          choice: "timeout",
-        });
-        // Interactive `unset` stays unset (zero network) until setup or `/telemetry`.
-        // CI / DO_NOT_TRACK / non-TTY auto-decline to disabled.
-        if (decision === "disabled" && (!process.stdin.isTTY || !process.stdout.isTTY)) {
-          await container.telemetryService.setStatus("disabled");
-        } else if (decision === "disabled") {
-          // DNT or CI with a TTY still auto-decline.
-          const dntOrCi =
-            Boolean(process.env.DO_NOT_TRACK?.trim()) || Boolean(process.env.CI?.trim());
-          if (dntOrCi) {
+        const result = await container.updateService.checkForUpdate();
+        const signal = updateSignalFromCheck(result);
+        if (signal) container.notificationService.recordSignals([signal]);
+      } catch {
+        // checkForUpdate records its own failures; keep startup fire-and-forget.
+      }
+    })();
+  if (!config.offlineMode)
+    void (async () => {
+      try {
+        const raw = container.config.getRaw();
+        if (raw.telemetry === "unset") {
+          const { resolveTelemetryConsent } = await import("./services/telemetry/consent");
+          const decision = resolveTelemetryConsent({
+            env: { DO_NOT_TRACK: process.env.DO_NOT_TRACK, CI: process.env.CI },
+            isTty: Boolean(process.stdin.isTTY && process.stdout.isTTY),
+            choice: "timeout",
+          });
+          // Interactive `unset` stays unset (zero network) until setup or `/telemetry`.
+          // CI / DO_NOT_TRACK / non-TTY auto-decline to disabled.
+          if (decision === "disabled" && (!process.stdin.isTTY || !process.stdout.isTTY)) {
             await container.telemetryService.setStatus("disabled");
+          } else if (decision === "disabled") {
+            // DNT or CI with a TTY still auto-decline.
+            const dntOrCi =
+              Boolean(process.env.DO_NOT_TRACK?.trim()) || Boolean(process.env.CI?.trim());
+            if (dntOrCi) {
+              await container.telemetryService.setStatus("disabled");
+            }
           }
         }
+        container.telemetryService.pingInBackground();
+      } catch {
+        // Telemetry must never affect startup.
       }
-      container.telemetryService.pingInBackground();
-    } catch {
-      // Telemetry must never affect startup.
-    }
-  })();
+    })();
   if (capabilitySnapshot.issues.length > 0) {
     container.diagnosticsService.record({
       category: "session",
@@ -990,7 +994,7 @@ export async function runCli(argv = process.argv.slice(2)): Promise<void> {
       }
     },
   });
-  for (const adapter of container.syncService.adapters) {
+  for (const adapter of config.offlineMode ? [] : container.syncService.adapters) {
     const ensureConnectedUsername = adapter.ensureConnectedUsername?.bind(adapter);
     if (!ensureConnectedUsername) continue;
     runBackgroundTask({

--- a/apps/cli/src/services/download/DownloadService.ts
+++ b/apps/cli/src/services/download/DownloadService.ts
@@ -1489,6 +1489,8 @@ function resolveEnqueueMediaKind(input: EnqueueDownloadInput): MediaKind {
   if (input.title.type === "movie") return "movie";
   if (input.mode === "anime") return "anime";
   return "series";
+}
+
 function externalIdsFromDownloadJob(
   job: Pick<DownloadJobRecord, "titleId" | "mediaKind" | "mode">,
 ): TitleInfo["externalIds"] {

--- a/apps/cli/src/services/download/DownloadService.ts
+++ b/apps/cli/src/services/download/DownloadService.ts
@@ -724,8 +724,13 @@ export class DownloadService {
         await rm(posterPath, { force: true }).catch(() => {});
       }
     }
-    this.deps.repo.delete(jobId);
+    // Emit before deleting the row, not after. `offline_assets.origin_job_id` is
+    // `ON DELETE SET NULL` with foreign keys enabled, so once the job row is
+    // gone the listener's `deleteByOriginJobId(jobId)` matches nothing and the
+    // asset is orphaned: still `state='ready'`, still advertised as downloaded,
+    // but unplayable because its originJobId is now null.
     this.emit({ type: "deleted", jobId });
+    this.deps.repo.delete(jobId);
   }
 
   private async executeYtDlpDownload(job: DownloadJobRecord): Promise<DownloadJobRecord> {
@@ -945,6 +950,7 @@ export class DownloadService {
         id: job.titleId,
         type: job.mediaKind === "movie" || job.mediaKind === "video" ? "movie" : "series",
         name: job.titleName,
+        externalIds: externalIdsFromDownloadJob(job),
       },
       episode:
         job.season !== undefined && job.episode !== undefined
@@ -1483,6 +1489,22 @@ function resolveEnqueueMediaKind(input: EnqueueDownloadInput): MediaKind {
   if (input.title.type === "movie") return "movie";
   if (input.mode === "anime") return "anime";
   return "series";
+function externalIdsFromDownloadJob(
+  job: Pick<DownloadJobRecord, "titleId" | "mediaKind" | "mode">,
+): TitleInfo["externalIds"] {
+  const titleId = job.titleId.trim();
+  if (!titleId) return undefined;
+  if (job.mode === "anime" || job.mediaKind === "anime") {
+    const anilistId = titleId.replace(/^anilist:/, "");
+    return /^\d+$/.test(anilistId) ? { anilistId } : undefined;
+  }
+  if (job.mode === "youtube" || job.mediaKind === "video") {
+    return { youtubeId: titleId.replace(/^youtube:/, "") };
+  }
+  if (titleId.startsWith("tmdb:")) {
+    return { tmdbId: titleId.slice("tmdb:".length) };
+  }
+  return undefined;
 }
 
 function normalizeYear(value: string | undefined): string | null {

--- a/apps/cli/src/services/download/DownloadService.ts
+++ b/apps/cli/src/services/download/DownloadService.ts
@@ -236,6 +236,44 @@ export class DownloadService {
     );
   }
 
+  /**
+   * Re-derives duration and size for artifacts that are present but incomplete
+   * in the database, returning how many were repaired.
+   *
+   * A download interrupted and resumed lands its file correctly but can miss
+   * the post-completion probe, leaving `duration_ms` null. That is not
+   * cosmetic: duration drives the resume position and the progress bar.
+   * Re-queueing the download to recover a number `ffprobe` reads from the
+   * finished file in milliseconds would mean fetching gigabytes again, so
+   * repair it in place instead.
+   */
+  async repairArtifactMetadata(jobIds: readonly string[]): Promise<number> {
+    let repaired = 0;
+    for (const jobId of jobIds) {
+      const job = this.deps.repo.get(jobId);
+      if (!job?.outputPath) continue;
+      try {
+        const validation = await this.validateCompletedArtifact(job.outputPath);
+        const updatedAt = new Date().toISOString();
+        if (job.fileSize !== validation.fileSize) {
+          this.deps.repo.updateFileSize(jobId, validation.fileSize, updatedAt);
+        }
+        if (validation.durationMs !== undefined && job.durationMs !== validation.durationMs) {
+          this.deps.repo.updateOfflineMetadata(
+            jobId,
+            { durationMs: validation.durationMs },
+            updatedAt,
+          );
+          repaired += 1;
+        }
+      } catch {
+        // A file that cannot be probed is a broken artifact, not a metadata
+        // gap; the artifact-status sweep owns that case and re-downloads it.
+      }
+    }
+    return repaired;
+  }
+
   getEnqueueEligibility(): DownloadEnqueueEligibility {
     const feature = resolveDownloadFeatureState({
       config: this.deps.config,

--- a/apps/cli/src/services/offline/OfflineAssetService.ts
+++ b/apps/cli/src/services/offline/OfflineAssetService.ts
@@ -40,6 +40,20 @@ export class OfflineAssetService {
     this.assets.deleteByOriginJobId(jobId);
   }
 
+  /**
+   * Drops assets left ownerless by an earlier delete, returning how many.
+   *
+   * Job deletion once removed the row before the cleanup listener ran, and
+   * `origin_job_id` is `ON DELETE SET NULL`, so the asset survived as `ready`
+   * with no owner — advertised as downloaded, impossible to play. Deletion now
+   * emits first, so this only repairs libraries damaged before that fix; it is
+   * a no-op afterwards. Job-driven validation cannot reach these rows, because
+   * it iterates jobs and these have none.
+   */
+  purgeOrphanedAssets(): number {
+    return this.assets.deleteOrphaned();
+  }
+
   adoptCompletedJob(job: DownloadJobRecord): OfflineAssetRecord | null {
     if (
       job.status !== "completed" &&

--- a/apps/cli/src/services/offline/OfflineAssetService.ts
+++ b/apps/cli/src/services/offline/OfflineAssetService.ts
@@ -36,8 +36,18 @@ export class OfflineAssetService {
     this.assets.markValidation(id, state, validatedAt);
   }
 
+  removeForJob(jobId: string): void {
+    this.assets.deleteByOriginJobId(jobId);
+  }
+
   adoptCompletedJob(job: DownloadJobRecord): OfflineAssetRecord | null {
-    if (job.status !== "completed" && job.status !== "completed-with-notes") return null;
+    if (
+      job.status !== "completed" &&
+      job.status !== "completed-with-notes" &&
+      job.status !== "repairable"
+    ) {
+      return null;
+    }
     const state = recordedAssetState(job);
     return this.assets.upsertPlayable({
       titleId: job.titleId,
@@ -69,7 +79,6 @@ function recordedAssetState(job: DownloadJobRecord): OfflineAssetState {
   if (job.artifactStatus === "missing" || job.artifactStatus === "invalid-file") {
     return job.artifactStatus;
   }
-  if (job.status === "completed-with-notes" || job.status === "repairable") return "repairable";
   return "ready";
 }
 

--- a/apps/cli/src/services/offline/OfflineLibraryService.ts
+++ b/apps/cli/src/services/offline/OfflineLibraryService.ts
@@ -67,6 +67,9 @@ export class OfflineLibraryService {
 
     const entries: OfflineLibraryEntry[] = [];
     for (const job of completed) {
+      // Re-adopt on every library read so jobs created before offline_assets (or
+      // after an interrupted completion callback) remain locally discoverable.
+      this.deps.offlineAssetService?.adoptCompletedJob(job);
       if (isArtifactCacheFresh(job) && isOfflineArtifactStatus(job.artifactStatus)) {
         entries.push({
           job,
@@ -76,6 +79,7 @@ export class OfflineLibraryService {
       }
       const status = await resolveOfflineArtifactStatus(job);
       this.deps.downloadService.markArtifactValidated(job.id, status);
+      this.deps.offlineAssetService?.adoptCompletedJob({ ...job, artifactStatus: status });
       entries.push({ job, status });
     }
     return entries;
@@ -94,7 +98,11 @@ export class OfflineLibraryService {
   > {
     const job = this.deps.downloadService.getJob(jobId);
     if (!job) return { status: "not-found" };
-    if (job.status !== "completed" && job.status !== "completed-with-notes") {
+    if (
+      job.status !== "completed" &&
+      job.status !== "completed-with-notes" &&
+      job.status !== "repairable"
+    ) {
       return { status: "not-completed", job };
     }
 
@@ -112,7 +120,8 @@ export class OfflineLibraryService {
     const timing = source.timing ?? null;
     if (!shouldPersistHistory(result, timing)) return false;
 
-    const mediaKind = source.mediaKind === "movie" ? "movie" : "series";
+    const mediaKind =
+      source.mediaKind === "movie" ? "movie" : source.mediaKind === "video" ? "video" : "series";
     const historyAnchor = this.deps.historyRepository.getLatestForTitleIdentity({
       id: source.titleId,
       kind: mediaKind,

--- a/apps/cli/src/services/offline/offline-episode-index.ts
+++ b/apps/cli/src/services/offline/offline-episode-index.ts
@@ -41,6 +41,26 @@ export function downloadedCountForTitle(
   ).readyCountForTitle(titleId);
 }
 
+/**
+ * The next downloaded episode after `current`, or null when nothing is ready.
+ *
+ * The offline launch path must answer episode availability from the library
+ * rather than the catalog: returning null unconditionally reads as "series
+ * finished" downstream, so a downloaded next episode would never autoplay.
+ */
+export function findNextReadyEpisode(
+  offlineAssetService: OfflineAssetService,
+  titleId: string,
+  current: { readonly season: number; readonly episode: number },
+): { readonly season: number; readonly episode: number } | null {
+  if (!titleId) return null;
+  const [next] = offlineAssetService.listNextReadyByTitleCursors([
+    { titleId, season: current.season, episode: current.episode },
+  ]);
+  if (next?.season == null || next.episode == null) return null;
+  return { season: next.season, episode: next.episode };
+}
+
 export function findReadyJobIdForEpisode(
   offlineAssetService: OfflineAssetService,
   titleId: string,

--- a/apps/cli/src/services/offline/offline-episode-index.ts
+++ b/apps/cli/src/services/offline/offline-episode-index.ts
@@ -1,9 +1,46 @@
+import { resolveTitleHistoryLookupId } from "@/domain/catalog/title-history-lookup";
 import {
   buildOfflineAvailabilityIndex,
   type OfflineAvailabilityIndex,
 } from "@/domain/playback-source/offline-availability";
+import type { ShellMode, TitleInfo } from "@/domain/types";
+import type { OfflineAssetRecord } from "@kunai/storage";
 
 import type { OfflineAssetService } from "./OfflineAssetService";
+
+/** A title id, or every id an asset for that title could be filed under. */
+export type OfflineTitleIdQuery = string | readonly string[];
+
+/**
+ * Every id an offline asset for `title` could be filed under.
+ *
+ * `offline_assets.title_id` is written verbatim from `job.titleId`, but every
+ * playback read canonicalises first — and `resolveCanonicalCatalogTitleId`
+ * rewrites a movie or series carrying a `tmdbId` to `tmdb:<id>`. So the moment
+ * a title arrived enriched with external ids, the lookup asked for an id no
+ * asset row holds, answered nothing, and the launch reported "Downloaded file
+ * unavailable" for a file sitting healthy on disk. The raw id cannot simply be
+ * canonicalised at write time either: the job row carries no external ids, so
+ * the canonical form is not knowable there.
+ *
+ * Checking both costs one extra `IN (...)` term and needs no migration.
+ */
+export function offlineAssetTitleIdCandidates(
+  title: Pick<TitleInfo, "id" | "type" | "externalIds" | "isAnime">,
+  mode?: ShellMode,
+): readonly string[] {
+  const canonical = resolveTitleHistoryLookupId(title, mode);
+  return canonical === title.id ? [canonical] : [canonical, title.id];
+}
+
+function assetsFor(
+  offlineAssetService: OfflineAssetService,
+  titleId: OfflineTitleIdQuery,
+): readonly OfflineAssetRecord[] {
+  if (typeof titleId === "string") return offlineAssetService.listTitleAssets(titleId);
+  if (titleId.length === 1) return offlineAssetService.listTitleAssets(titleId[0] as string);
+  return offlineAssetService.listByTitleIds(titleId);
+}
 
 export function buildOfflineEpisodeIndex(
   offlineAssetService: OfflineAssetService,
@@ -18,18 +55,16 @@ export function buildOfflineEpisodeIndex(
 
 export function isEpisodeDownloaded(
   offlineAssetService: OfflineAssetService,
-  titleId: string,
+  titleId: OfflineTitleIdQuery,
   season?: number,
   episode?: number,
 ): boolean {
-  return offlineAssetService
-    .listTitleAssets(titleId)
-    .some(
-      (asset) =>
-        asset.state === "ready" &&
-        (season === undefined || asset.season === season) &&
-        (episode === undefined || asset.episode === episode),
-    );
+  return assetsFor(offlineAssetService, titleId).some(
+    (asset) =>
+      asset.state === "ready" &&
+      (season === undefined || asset.season === season) &&
+      (episode === undefined || asset.episode === episode),
+  );
 }
 
 export function downloadedCountForTitle(
@@ -50,33 +85,48 @@ export function downloadedCountForTitle(
  */
 export function findNextReadyEpisode(
   offlineAssetService: OfflineAssetService,
-  titleId: string,
+  titleId: OfflineTitleIdQuery,
   current: { readonly season: number; readonly episode: number },
 ): { readonly season: number; readonly episode: number } | null {
-  if (!titleId) return null;
-  const [next] = offlineAssetService.listNextReadyByTitleCursors([
-    { titleId, season: current.season, episode: current.episode },
-  ]);
-  if (next?.season == null || next.episode == null) return null;
+  const candidates = (typeof titleId === "string" ? [titleId] : titleId).filter(Boolean);
+  if (candidates.length === 0) return null;
+  const found = offlineAssetService
+    .listNextReadyByTitleCursors(
+      candidates.map((candidate) => ({
+        titleId: candidate,
+        season: current.season,
+        episode: current.episode,
+      })),
+    )
+    .filter((asset) => asset.season != null && asset.episode != null);
+  if (found.length === 0) return null;
+  // One row per candidate id comes back, so pick the earliest episode rather
+  // than whichever id the query happened to order first.
+  const next = found.reduce((earliest, asset) =>
+    (asset.season ?? 0) < (earliest.season ?? 0) ||
+    ((asset.season ?? 0) === (earliest.season ?? 0) &&
+      (asset.episode ?? 0) < (earliest.episode ?? 0))
+      ? asset
+      : earliest,
+  );
+  if (next.season == null || next.episode == null) return null;
   return { season: next.season, episode: next.episode };
 }
 
 export function findReadyJobIdForEpisode(
   offlineAssetService: OfflineAssetService,
-  titleId: string,
+  titleId: OfflineTitleIdQuery,
   season: number,
   episode: number,
   options: {
     readonly mediaKind?: "movie" | "series" | "anime" | "video";
   } = {},
 ): string | undefined {
-  return offlineAssetService
-    .listTitleAssets(titleId)
-    .find(
-      (asset) =>
-        asset.state === "ready" &&
-        (options.mediaKind === "movie" || options.mediaKind === "video"
-          ? asset.mediaKind === options.mediaKind
-          : asset.season === season && asset.episode === episode),
-    )?.originJobId;
+  return assetsFor(offlineAssetService, titleId).find(
+    (asset) =>
+      asset.state === "ready" &&
+      (options.mediaKind === "movie" || options.mediaKind === "video"
+        ? asset.mediaKind === options.mediaKind
+        : asset.season === season && asset.episode === episode),
+  )?.originJobId;
 }

--- a/apps/cli/src/services/offline/offline-episode-index.ts
+++ b/apps/cli/src/services/offline/offline-episode-index.ts
@@ -46,10 +46,17 @@ export function findReadyJobIdForEpisode(
   titleId: string,
   season: number,
   episode: number,
+  options: {
+    readonly mediaKind?: "movie" | "series" | "anime" | "video";
+  } = {},
 ): string | undefined {
   return offlineAssetService
     .listTitleAssets(titleId)
     .find(
-      (asset) => asset.state === "ready" && asset.season === season && asset.episode === episode,
+      (asset) =>
+        asset.state === "ready" &&
+        (options.mediaKind === "movie" || options.mediaKind === "video"
+          ? asset.mediaKind === options.mediaKind
+          : asset.season === season && asset.episode === episode),
     )?.originJobId;
 }

--- a/apps/cli/src/services/offline/offline-library-action-router.ts
+++ b/apps/cli/src/services/offline/offline-library-action-router.ts
@@ -27,6 +27,37 @@ export type OfflineLibraryGroupAction = {
 
 export type OfflineLibraryActionResult = "continue" | "exit" | "refresh";
 
+/**
+ * Says what repair actually did, including when it did nothing.
+ *
+ * The old copy read "Re-download queued for 0 missing items" whenever a title
+ * was healthy — success phrasing for a no-op, which is what made repair look
+ * broken.
+ */
+export function describeOfflineRepairOutcome(input: {
+  readonly queued: number;
+  readonly repairedMetadata: number;
+  readonly inspected: number;
+}): string {
+  const parts: string[] = [];
+  if (input.queued > 0) {
+    parts.push(`re-download queued for ${input.queued} ${input.queued === 1 ? "item" : "items"}`);
+  }
+  if (input.repairedMetadata > 0) {
+    parts.push(
+      `restored details for ${input.repairedMetadata} ${
+        input.repairedMetadata === 1 ? "item" : "items"
+      }`,
+    );
+  }
+  if (parts.length === 0) {
+    return `Nothing to repair — all ${input.inspected} local ${
+      input.inspected === 1 ? "item is" : "items are"
+    } complete.`;
+  }
+  return `Repair: ${parts.join(" · ")}.`;
+}
+
 async function setOfflineGroupProtection(
   container: Container,
   jobIds: readonly string[],
@@ -89,13 +120,31 @@ export async function routeOfflineLibraryGroupAction(
     for (const entry of repairEntries) {
       container.downloadService.retry(entry.job.id);
     }
+
+    // A "ready" artifact can still be incomplete in the database: a download
+    // interrupted and resumed lands its file but can skip the post-completion
+    // probe, leaving no duration. Repairing only broken *files* meant this
+    // action reported success while doing nothing at all for the far more
+    // common metadata gap.
+    const metadataGaps = entries.filter(
+      (entry) => entry.status === "ready" && !entry.job.durationMs,
+    );
+    const repairedMetadata =
+      metadataGaps.length > 0
+        ? await container.downloadService.repairArtifactMetadata(
+            metadataGaps.map((entry) => entry.job.id),
+          )
+        : 0;
+
     container.stateManager.dispatch({
       type: "SET_PLAYBACK_FEEDBACK",
-      note: `Re-download queued for ${repairEntries.length} missing ${
-        repairEntries.length === 1 ? "item" : "items"
-      }`,
+      note: describeOfflineRepairOutcome({
+        queued: repairEntries.length,
+        repairedMetadata,
+        inspected: entries.length,
+      }),
     });
-    void container.downloadService.processQueue();
+    if (repairEntries.length > 0) void container.downloadService.processQueue();
     return "refresh";
   }
 

--- a/apps/cli/test/integration/offline-local-playback-resolution.test.ts
+++ b/apps/cli/test/integration/offline-local-playback-resolution.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resolveLocalEpisodePlayback } from "@/app/playback/episode-playback-source";
+import type { Container } from "@/container";
+import type { TitleInfo } from "@/domain/types";
+import type { ContinueSourcePreference } from "@/services/continuation/continuation-source";
+import { OfflineAssetService } from "@/services/offline/OfflineAssetService";
+import { OfflineLibraryService } from "@/services/offline/OfflineLibraryService";
+import {
+  DownloadJobsRepository,
+  OfflineAssetsRepository,
+  openKunaiDatabase,
+  runMigrations,
+  type KunaiDatabase,
+} from "@kunai/storage";
+import type { MediaKind } from "@kunai/types";
+
+/**
+ * End-to-end cover for "a downloaded title will not play".
+ *
+ * The reported failure was a downloaded *movie* that bounced straight back to
+ * the browse screen with no message. Every unit on the path passed in
+ * isolation, so the regression only shows up when the real SQLite rows, the
+ * real file on disk and the real selection engine are wired together — which is
+ * what this does. Nothing here touches a provider or the network.
+ */
+
+type Harness = {
+  readonly db: KunaiDatabase;
+  readonly dir: string;
+  readonly jobs: DownloadJobsRepository;
+  readonly assets: OfflineAssetService;
+  readonly library: OfflineLibraryService;
+  readonly filePath: string;
+};
+
+const dirs: string[] = [];
+const openDatabases: KunaiDatabase[] = [];
+
+afterEach(() => {
+  for (const database of openDatabases.splice(0)) database.close();
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+});
+
+function createHarness(input: {
+  readonly titleId: string;
+  readonly mediaKind: MediaKind;
+  readonly season?: number;
+  readonly episode?: number;
+}): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "kunai-offline-playback-"));
+  dirs.push(dir);
+  const db = openKunaiDatabase(join(dir, "data.sqlite"));
+  runMigrations(db, "data");
+  openDatabases.push(db);
+
+  // A real artifact: `resolveOfflineArtifactStatus` stats the path, so an
+  // absent or zero-byte file would answer "missing" and mask the thing we test.
+  const filePath = join(dir, "downloaded.mp4");
+  writeFileSync(filePath, "not really video, but a real non-empty file");
+
+  const jobs = new DownloadJobsRepository(db);
+  const now = new Date().toISOString();
+  const jobId = `job-${input.titleId}`;
+  jobs.enqueue({
+    id: jobId,
+    titleId: input.titleId,
+    titleName: "Obsession",
+    mediaKind: input.mediaKind,
+    season: input.season,
+    episode: input.episode,
+    providerId: "videasy",
+    mode: "series",
+    selectedQualityLabel: "best",
+    streamUrl: "https://example.invalid/stream.m3u8",
+    headers: {},
+    outputPath: filePath,
+    tempPath: `${filePath}.tmp`,
+    createdAt: now,
+    updatedAt: now,
+  });
+  jobs.complete(jobId, now);
+  jobs.markArtifactValidated(jobId, "ready", now);
+
+  const assets = new OfflineAssetService(new OfflineAssetsRepository(db));
+  const completed = jobs.get(jobId);
+  if (!completed) throw new Error("download job missing after complete()");
+  assets.adoptCompletedJob(completed);
+
+  const library = new OfflineLibraryService({
+    downloadService: { getJob: (id: string) => jobs.get(id) } as never,
+    historyRepository: {
+      upsertProgress: () => {},
+      getLatestForTitleIdentity: () => undefined,
+    } as never,
+    offlineAssetService: assets,
+  });
+
+  return { db, dir, jobs, assets, library, filePath };
+}
+
+function containerFor(
+  harness: Harness,
+  options: {
+    readonly mode?: "series" | "anime" | "youtube";
+    readonly online?: boolean;
+    readonly continueSourcePreference?: ContinueSourcePreference;
+  } = {},
+): Container {
+  return {
+    stateManager: { getState: () => ({ mode: options.mode ?? "series" }) },
+    offlineAssetService: harness.assets,
+    offlineLibraryService: harness.library,
+    connectivity: { isOnline: () => options.online ?? false },
+    config: { continueSourcePreference: options.continueSourcePreference ?? "auto" },
+  } as unknown as Container;
+}
+
+const movieTitle: TitleInfo = {
+  id: "1339713",
+  type: "movie",
+  name: "Obsession",
+  launchSource: "offline-library",
+};
+
+describe("offline local playback resolution", () => {
+  test("a downloaded movie resolves to its local file", async () => {
+    // The reported bug. `applyDownloadJobSessionRouting` routes a movie whose
+    // job carries mode "series" into series mode, so the session mode and the
+    // title kind disagree — exactly the state the failing screenshot showed.
+    const harness = createHarness({
+      titleId: "1339713",
+      mediaKind: "movie",
+      season: 1,
+      episode: 1,
+    });
+
+    const resolution = await resolveLocalEpisodePlayback(
+      containerFor(harness),
+      movieTitle,
+      { season: 1, episode: 1 },
+      { entrypoint: "offline-library", forceLocal: true },
+    );
+
+    expect(resolution).not.toBeNull();
+    expect(resolution?.stream.url).toBe(harness.filePath);
+    expect(resolution?.jobId).toBe("job-1339713");
+    expect(resolution?.source.filePath).toBe(harness.filePath);
+  });
+
+  test("a downloaded episode resolves to its local file", async () => {
+    const harness = createHarness({
+      titleId: "61222",
+      mediaKind: "series",
+      season: 1,
+      episode: 2,
+    });
+
+    const resolution = await resolveLocalEpisodePlayback(
+      containerFor(harness),
+      { id: "61222", type: "series", name: "Demo", launchSource: "offline-library" },
+      { season: 1, episode: 2 },
+      { entrypoint: "offline-library", forceLocal: true },
+    );
+
+    expect(resolution?.stream.url).toBe(harness.filePath);
+  });
+
+  test("an offline-library launch plays locally even when the user prefers streaming", async () => {
+    // Guards the regression the branch fixed in the other direction: the
+    // preference must not be able to veto a launch the user made *from* the
+    // offline library, or pressing enter there silently does nothing.
+    const harness = createHarness({
+      titleId: "1339713",
+      mediaKind: "movie",
+      season: 1,
+      episode: 1,
+    });
+
+    const resolution = await resolveLocalEpisodePlayback(
+      containerFor(harness, { continueSourcePreference: "stream", online: true }),
+      movieTitle,
+      { season: 1, episode: 1 },
+      { entrypoint: "offline-library", forceLocal: true },
+    );
+
+    expect(resolution?.stream.url).toBe(harness.filePath);
+  });
+
+  test("a continue launch honours a streaming preference and declines the local file", async () => {
+    // The mirror of the case above: this is the online regression the branch
+    // fixed, where every Continue-Watching resume silently preferred the
+    // download and overrode `continueSourcePreference`.
+    const harness = createHarness({
+      titleId: "1339713",
+      mediaKind: "movie",
+      season: 1,
+      episode: 1,
+    });
+
+    const resolution = await resolveLocalEpisodePlayback(
+      containerFor(harness, { continueSourcePreference: "stream", online: true }),
+      { ...movieTitle, launchSource: "continue" },
+      { season: 1, episode: 1 },
+      { entrypoint: "continue" },
+    );
+
+    expect(resolution).toBeNull();
+  });
+
+  test("a downloaded movie still resolves once its title carries external ids", async () => {
+    // The write path stores `job.titleId` verbatim ("1339713"), but the read
+    // path canonicalises, and `resolveCanonicalCatalogTitleId` rewrites any
+    // movie/series carrying a tmdbId to "tmdb:<id>". A title enriched with
+    // external ids therefore looked up an id no asset row has, the lookup
+    // answered undefined, and the launch reported "Downloaded file
+    // unavailable" for a file sitting healthy on disk.
+    const harness = createHarness({
+      titleId: "1339713",
+      mediaKind: "movie",
+      season: 1,
+      episode: 1,
+    });
+
+    const resolution = await resolveLocalEpisodePlayback(
+      containerFor(harness),
+      { ...movieTitle, externalIds: { tmdbId: "1339713" } },
+      { season: 1, episode: 1 },
+      { entrypoint: "offline-library", forceLocal: true },
+    );
+
+    expect(resolution?.stream.url).toBe(harness.filePath);
+  });
+
+  test("a deleted artifact declines rather than handing back an unplayable path", async () => {
+    // The library keeps advertising the title as downloaded from its SQLite
+    // row, so the file check is the only thing standing between the user and a
+    // silent bounce back to the browse screen.
+    const harness = createHarness({
+      titleId: "1339713",
+      mediaKind: "movie",
+      season: 1,
+      episode: 1,
+    });
+    rmSync(harness.filePath, { force: true });
+
+    const resolution = await resolveLocalEpisodePlayback(
+      containerFor(harness),
+      movieTitle,
+      { season: 1, episode: 1 },
+      { entrypoint: "offline-library", forceLocal: true },
+    );
+
+    expect(resolution).toBeNull();
+  });
+});

--- a/apps/cli/test/unit/app/offline-playback-launch.test.ts
+++ b/apps/cli/test/unit/app/offline-playback-launch.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildOfflinePlaybackLaunch,
   requestUnifiedOfflinePlayback,
+  titleInfoFromDownloadJob,
 } from "@/app/offline/offline-playback-launch";
 import type { Container } from "@/container";
 import type { DownloadJobRecord } from "@kunai/storage";
@@ -48,5 +49,16 @@ describe("requestUnifiedOfflinePlayback", () => {
     });
     expect(dispatches).toContain("SELECT_TITLE");
     expect(dispatches).toContain("CLOSE_TOP_OVERLAY");
+  });
+
+  test("preserves video mode and marks library launches as local-only", () => {
+    const title = titleInfoFromDownloadJob(
+      readyJob({ mediaKind: "video", mode: "youtube", season: undefined, episode: undefined }),
+    );
+
+    expect(title).toMatchObject({
+      type: "movie",
+      launchSource: "offline-library",
+    });
   });
 });

--- a/apps/cli/test/unit/app/playback-problem.test.ts
+++ b/apps/cli/test/unit/app/playback-problem.test.ts
@@ -24,6 +24,16 @@ describe("playback problem model", () => {
     expect(problem.userMessage).toContain("integrity check");
   });
 
+  test("renders an unplayable download through the error surface, not a raw slug", () => {
+    // Without a case in `toErrorScenario` this fell through to undefined, and
+    // the shell showed the bare cause slug "offline-file-unavailable" instead of
+    // the error screen every other blocking failure gets.
+    expect(toErrorScenario(buildOfflineFileUnavailableProblem(), { title: "Obsession" })).toEqual({
+      kind: "title-unavailable",
+      title: "Obsession",
+    });
+  });
+
   test("maps missing mpv to a blocking playback dependency problem", () => {
     const problem = buildMpvMissingProblem({
       remediationSummary: "Install mpv to enable playback.",

--- a/apps/cli/test/unit/app/playback-problem.test.ts
+++ b/apps/cli/test/unit/app/playback-problem.test.ts
@@ -2,12 +2,28 @@ import { describe, expect, test } from "bun:test";
 
 import {
   buildMpvMissingProblem,
+  buildOfflineFileUnavailableProblem,
   buildPlayerFailureProblem,
   buildProviderResolveProblem,
   toErrorScenario,
 } from "@/domain/playback/playback-problem";
 
 describe("playback problem model", () => {
+  test("maps an unplayable downloaded file to a blocking problem that names the remedy", () => {
+    const problem = buildOfflineFileUnavailableProblem();
+
+    expect(problem).toMatchObject({
+      stage: "stream-open",
+      severity: "blocking",
+      cause: "offline-file-unavailable",
+      recommendedAction: "diagnostics",
+      secondaryActions: ["refresh"],
+    });
+    // The user reached this by launching a title the library still advertises as
+    // downloaded, so the copy has to say what to do rather than only what broke.
+    expect(problem.userMessage).toContain("integrity check");
+  });
+
   test("maps missing mpv to a blocking playback dependency problem", () => {
     const problem = buildMpvMissingProblem({
       remediationSummary: "Install mpv to enable playback.",

--- a/apps/cli/test/unit/app/playback/episode-playback-source.test.ts
+++ b/apps/cli/test/unit/app/playback/episode-playback-source.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveLocalEpisodePlayback } from "@/app/playback/episode-playback-source";
+import type { Container } from "@/container";
+import type { EpisodeInfo, TitleInfo } from "@/domain/types";
+import type { LocalPlaybackSource } from "@/services/offline/local-playback-source";
+
+const TITLE: TitleInfo = {
+  id: "allanime-native-id",
+  type: "series",
+  name: "Demo",
+  externalIds: { anilistId: "151807" },
+  isAnime: true,
+};
+const EPISODE: EpisodeInfo = { season: 1, episode: 1 };
+const SOURCE: LocalPlaybackSource = {
+  kind: "local",
+  jobId: "job-1",
+  titleId: "151807",
+  titleName: "Demo",
+  mediaKind: "series",
+  providerId: "allanime",
+  season: 1,
+  episode: 1,
+  filePath: "/tmp/demo.mkv",
+};
+
+describe("resolveLocalEpisodePlayback", () => {
+  test("matches downloaded assets by the canonical title id", async () => {
+    const requestedTitleIds: string[] = [];
+    const container = {
+      config: { continueSourcePreference: "stream" },
+      connectivity: { isOnline: () => true },
+      stateManager: { getState: () => ({ mode: "anime" }) },
+      offlineAssetService: {
+        listTitleAssets: (titleId: string) => {
+          requestedTitleIds.push(titleId);
+          return titleId === "151807"
+            ? [{ titleId, state: "ready", season: 1, episode: 1, originJobId: "job-1" }]
+            : [];
+        },
+      },
+      offlineLibraryService: {
+        getPlayableSource: async () => ({
+          status: "ready" as const,
+          source: SOURCE,
+          job: { id: "job-1" },
+        }),
+      },
+    } as unknown as Container;
+
+    const result = await resolveLocalEpisodePlayback(container, TITLE, EPISODE, {
+      forceLocal: true,
+    });
+
+    expect(requestedTitleIds).toEqual(["151807"]);
+    expect(result?.jobId).toBe("job-1");
+  });
+});

--- a/apps/cli/test/unit/app/playback/episode-playback-source.test.ts
+++ b/apps/cli/test/unit/app/playback/episode-playback-source.test.ts
@@ -27,7 +27,16 @@ const SOURCE: LocalPlaybackSource = {
 
 describe("resolveLocalEpisodePlayback", () => {
   test("matches downloaded assets by the canonical title id", async () => {
+    // The asset is filed under the canonical id (the AniList id), not the
+    // opaque provider-native id the title carries, so the canonical form has to
+    // be among the ids asked for. The raw id rides along as a fallback because
+    // `offline_assets.title_id` is written verbatim from `job.titleId`, which
+    // is only canonical when the job happened to know the external ids.
     const requestedTitleIds: string[] = [];
+    const assetsById = (titleId: string) =>
+      titleId === "151807"
+        ? [{ titleId, state: "ready", season: 1, episode: 1, originJobId: "job-1" }]
+        : [];
     const container = {
       config: { continueSourcePreference: "stream" },
       connectivity: { isOnline: () => true },
@@ -35,9 +44,11 @@ describe("resolveLocalEpisodePlayback", () => {
       offlineAssetService: {
         listTitleAssets: (titleId: string) => {
           requestedTitleIds.push(titleId);
-          return titleId === "151807"
-            ? [{ titleId, state: "ready", season: 1, episode: 1, originJobId: "job-1" }]
-            : [];
+          return assetsById(titleId);
+        },
+        listByTitleIds: (titleIds: readonly string[]) => {
+          requestedTitleIds.push(...titleIds);
+          return titleIds.flatMap(assetsById);
         },
       },
       offlineLibraryService: {
@@ -53,7 +64,7 @@ describe("resolveLocalEpisodePlayback", () => {
       forceLocal: true,
     });
 
-    expect(requestedTitleIds).toEqual(["151807"]);
+    expect(requestedTitleIds).toContain("151807");
     expect(result?.jobId).toBe("job-1");
   });
 });

--- a/apps/cli/test/unit/app/playback/run-mpv-playback-session.test.ts
+++ b/apps/cli/test/unit/app/playback/run-mpv-playback-session.test.ts
@@ -359,11 +359,28 @@ describe("runMpvPlaybackSession completion", () => {
     expect(harness.store.snapshot.status).toBe("error");
   });
 
-  test("routes an offline source through local playback", async () => {
+/** Every hook is a no-op; this test only asserts which player method ran. */
+function noopSessionHooks() {
+  return new Proxy(
+    {},
+    {
+      get: (_target, property) =>
+        property === "applyPlaybackStatusSignal" ? () => ({ accepted: true }) : () => undefined,
+    },
+  ) as Parameters<typeof runMpvPlaybackSession>[0]["hooks"];
+}
+
+  test("plays a local file through play(), not the playLocal shortcut", async () => {
+    // playLocal() takes a narrow option bag, so routing local files through it
+    // silently dropped resume prompting, autoplay-chain mode, near-EOF
+    // prefetch, the abort signal, merged timing, correlation and track
+    // preferences. Local playback keeps the full PlayerOptions contract.
     const calls: string[] = [];
+    const seenOptions: PlayerOptions[] = [];
     const player: PlayerService = {
-      play: async () => {
+      play: async (_stream, options) => {
         calls.push("remote");
+        seenOptions.push(options);
         return FINISHED;
       },
       releasePersistentSession: async () => undefined,
@@ -383,7 +400,7 @@ describe("runMpvPlaybackSession completion", () => {
       player,
       playOptions: {},
       subtitleStatus: "local",
-      startAt: 0,
+      startAt: 42,
       sessionAborted: false,
       iterationAborted: false,
       shareLinkContext: {
@@ -393,11 +410,13 @@ describe("runMpvPlaybackSession completion", () => {
       },
       timing: null,
       localPlaybackSource: LOCAL_SOURCE,
-      hooks: noopHooks(),
+      hooks: noopSessionHooks(),
     } as Parameters<typeof runMpvPlaybackSession>[0];
 
     await runMpvPlaybackSession(input);
 
-    expect(calls).toEqual(["local"]);
+    expect(calls).toEqual(["remote"]);
+    expect(seenOptions[0]?.startAt).toBe(42);
+    expect(seenOptions[0]?.shareLinkContext).toBeDefined();
   });
 });

--- a/apps/cli/test/unit/app/playback/run-mpv-playback-session.test.ts
+++ b/apps/cli/test/unit/app/playback/run-mpv-playback-session.test.ts
@@ -14,6 +14,7 @@ import type {
   PlayerPlaybackEvent,
   PlayerService,
 } from "@/infra/player/PlayerService";
+import type { LocalPlaybackSource } from "@/services/offline/local-playback-source";
 
 const TITLE: TitleInfo = { id: "1396", name: "Test", type: "series" };
 const EPISODE: EpisodeInfo = { season: 1, episode: 1 };
@@ -21,6 +22,18 @@ const STREAM: StreamInfo = {
   url: "https://example.test/stream.m3u8",
   headers: {},
   timestamp: Date.now(),
+};
+const LOCAL_SOURCE: LocalPlaybackSource = {
+  kind: "local",
+  jobId: "job-1",
+  titleId: "1396",
+  titleName: "Test",
+  mediaKind: "series",
+  providerId: "vidking",
+  season: 1,
+  episode: 1,
+  filePath: "/tmp/test.mkv",
+  subtitlePath: "/tmp/test.vtt",
 };
 
 const FINISHED: PlaybackResult = {
@@ -344,5 +357,47 @@ describe("runMpvPlaybackSession completion", () => {
       result: { ...FINISHED, endReason: "error" },
     });
     expect(harness.store.snapshot.status).toBe("error");
+  });
+
+  test("routes an offline source through local playback", async () => {
+    const calls: string[] = [];
+    const player: PlayerService = {
+      play: async () => {
+        calls.push("remote");
+        return FINISHED;
+      },
+      releasePersistentSession: async () => undefined,
+      killActiveMpvProcessesSync: () => undefined,
+      beginShutdown: () => undefined,
+      isAvailable: async () => true,
+      playLocal: async () => {
+        calls.push("local");
+        return FINISHED;
+      },
+    };
+
+    const input = {
+      stream: { ...STREAM, url: LOCAL_SOURCE.filePath },
+      title: TITLE,
+      episode: EPISODE,
+      player,
+      playOptions: {},
+      subtitleStatus: "local",
+      startAt: 0,
+      sessionAborted: false,
+      iterationAborted: false,
+      shareLinkContext: {
+        mode: "series" as const,
+        title: TITLE,
+        episode: { season: 1, episode: 1 },
+      },
+      timing: null,
+      localPlaybackSource: LOCAL_SOURCE,
+      hooks: noopHooks(),
+    } as Parameters<typeof runMpvPlaybackSession>[0];
+
+    await runMpvPlaybackSession(input);
+
+    expect(calls).toEqual(["local"]);
   });
 });

--- a/apps/cli/test/unit/app/playback/run-mpv-playback-session.test.ts
+++ b/apps/cli/test/unit/app/playback/run-mpv-playback-session.test.ts
@@ -359,16 +359,16 @@ describe("runMpvPlaybackSession completion", () => {
     expect(harness.store.snapshot.status).toBe("error");
   });
 
-/** Every hook is a no-op; this test only asserts which player method ran. */
-function noopSessionHooks() {
-  return new Proxy(
-    {},
-    {
-      get: (_target, property) =>
-        property === "applyPlaybackStatusSignal" ? () => ({ accepted: true }) : () => undefined,
-    },
-  ) as Parameters<typeof runMpvPlaybackSession>[0]["hooks"];
-}
+  /** Every hook is a no-op; this test only asserts which player method ran. */
+  function noopSessionHooks() {
+    return new Proxy(
+      {},
+      {
+        get: (_target, property) =>
+          property === "applyPlaybackStatusSignal" ? () => ({ accepted: true }) : () => undefined,
+      },
+    ) as Parameters<typeof runMpvPlaybackSession>[0]["hooks"];
+  }
 
   test("plays a local file through play(), not the playLocal shortcut", async () => {
     // playLocal() takes a narrow option bag, so routing local files through it

--- a/apps/cli/test/unit/app/post-play/post-playback-recommendation-rail.test.ts
+++ b/apps/cli/test/unit/app/post-play/post-playback-recommendation-rail.test.ts
@@ -7,11 +7,12 @@ import {
 import type { SearchResult, TitleInfo } from "@/domain/types";
 
 const TITLE = { id: "tt1", name: "My Show", type: "series" } as TitleInfo;
+const OFFLINE_TITLE = { ...TITLE, launchSource: "offline-library" as const };
 
-function makeContainer(railEnabled = true) {
+function makeContainer(railEnabled = true, offlineMode = false) {
   const records: Array<{ operation?: string }> = [];
   const container = {
-    config: { recommendationRailEnabled: railEnabled },
+    config: { recommendationRailEnabled: railEnabled, offlineMode },
     diagnosticsService: {
       record: (entry: { operation?: string }) => {
         records.push(entry);
@@ -48,6 +49,30 @@ describe("PostPlaybackRecommendationRail", () => {
       autoContinueIntoRecommendationPossible: false,
     });
     expect(items.map((i) => i.id)).toEqual(["a", "b"]);
+    expect(loadCalls).toBe(0);
+    expect(rail.attempted).toBe(false);
+  });
+
+  it("does not load recommendations for an offline-library launch", async () => {
+    const { container } = makeContainer();
+    let loadCalls = 0;
+    const rail = new PostPlaybackRecommendationRail({
+      container,
+      title: OFFLINE_TITLE,
+      budgetMs: 250,
+      load: async () => {
+        loadCalls += 1;
+        return [item("online")];
+      },
+    });
+
+    const items = await rail.resolveRailItems({
+      mode: "series",
+      prefetchedItems: null,
+      autoContinueIntoRecommendationPossible: true,
+    });
+
+    expect(items).toEqual([]);
     expect(loadCalls).toBe(0);
     expect(rail.attempted).toBe(false);
   });

--- a/apps/cli/test/unit/app/session-overrides.test.ts
+++ b/apps/cli/test/unit/app/session-overrides.test.ts
@@ -30,4 +30,13 @@ describe("resolveSessionConfigOverrides", () => {
   test("returns nothing for a default launch", () => {
     expect(resolveSessionConfigOverrides({ zen: false, minimal: false }, off)).toEqual({});
   });
+
+  test("--offline flips offlineMode so startup and connectivity enforce local-only work", () => {
+    expect(
+      resolveSessionConfigOverrides(
+        { zen: false, minimal: false, offline: true },
+        { ...off, offlineMode: false },
+      ),
+    ).toEqual({ offlineMode: true });
+  });
 });

--- a/apps/cli/test/unit/services/download/download-service.test.ts
+++ b/apps/cli/test/unit/services/download/download-service.test.ts
@@ -410,6 +410,7 @@ describe("DownloadService", () => {
 
   test("stores durable intent and resolves a fresh stream before processing", async () => {
     const resolvedUrls: string[] = [];
+    let resolvedTitleExternalIds: unknown;
     const service = buildService({
       repo,
       downloadsEnabled: true,
@@ -417,6 +418,7 @@ describe("DownloadService", () => {
       downloadPath: tempDir,
       resolveDownloadStream: async (intent) => {
         resolvedUrls.push(`${intent.providerId}:${intent.title.id}:${intent.episode?.episode}`);
+        resolvedTitleExternalIds = intent.title.externalIds;
         return {
           stream: {
             url: "https://fresh.example/master.m3u8",
@@ -452,6 +454,7 @@ describe("DownloadService", () => {
 
     const completed = repo.get(job.id);
     expect(resolvedUrls).toEqual(["vidking:tmdb:1:3"]);
+    expect(resolvedTitleExternalIds).toEqual({ tmdbId: "1" });
     expect(completed?.status).toBe("completed");
     expect(completed?.streamUrl).toBe("https://fresh.example/master.m3u8");
     expect(completed?.mode).toBe("series");

--- a/apps/cli/test/unit/services/offline/offline-asset-service.test.ts
+++ b/apps/cli/test/unit/services/offline/offline-asset-service.test.ts
@@ -68,3 +68,25 @@ test("OfflineAssetService ignores unfinished download attempts", () => {
 
   expect(service.adoptCompletedJob(completedJob({ status: "running" }))).toBeNull();
 });
+
+test("OfflineAssetService keeps a repairable sidecar job locally playable", () => {
+  let stored: OfflineAssetRecord | undefined;
+  const service = new OfflineAssetService({
+    upsertPlayable(input: OfflineAssetInput) {
+      stored = {
+        ...input,
+        id: "asset-1",
+        identityKey: "repairable-asset",
+        protected: false,
+        createdAt: input.updatedAt,
+      };
+      return stored;
+    },
+  } as never);
+
+  const adopted = service.adoptCompletedJob(
+    completedJob({ status: "repairable", artifactStatus: "expected-missing" }),
+  );
+
+  expect(adopted?.state).toBe("ready");
+});

--- a/apps/cli/test/unit/services/offline/offline-episode-index.test.ts
+++ b/apps/cli/test/unit/services/offline/offline-episode-index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   downloadedCountForTitle,
+  findReadyJobIdForEpisode,
   isEpisodeDownloaded,
 } from "@/services/offline/offline-episode-index";
 import { OfflineAssetService } from "@/services/offline/OfflineAssetService";
@@ -49,5 +50,21 @@ describe("offline-episode-index", () => {
     expect(isEpisodeDownloaded(service, "t1", 1, 1)).toBe(true);
     expect(isEpisodeDownloaded(service, "t1", 1, 2)).toBe(false);
     expect(downloadedCountForTitle(service, "t1")).toBe(2);
+  });
+
+  test("finds downloaded movies without inventing an episode axis", () => {
+    const repo = {
+      get: () => undefined,
+      listTitleAssets: () => [asset({ titleId: "movie-1", mediaKind: "movie" })],
+      listByTitleIds: () => [],
+      listNextReadyByTitleCursors: () => [],
+      markValidation: () => {},
+      upsertPlayable: () => asset({ titleId: "movie-1", mediaKind: "movie" }),
+    } as unknown as OfflineAssetsRepository;
+    const service = new OfflineAssetService(repo);
+
+    expect(findReadyJobIdForEpisode(service, "movie-1", 1, 1, { mediaKind: "movie" })).toBe(
+      "job-1",
+    );
   });
 });

--- a/apps/cli/test/unit/services/offline/offline-episode-index.test.ts
+++ b/apps/cli/test/unit/services/offline/offline-episode-index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   downloadedCountForTitle,
+  findNextReadyEpisode,
   findReadyJobIdForEpisode,
   isEpisodeDownloaded,
 } from "@/services/offline/offline-episode-index";
@@ -66,5 +67,58 @@ describe("offline-episode-index", () => {
     expect(findReadyJobIdForEpisode(service, "movie-1", 1, 1, { mediaKind: "movie" })).toBe(
       "job-1",
     );
+  });
+});
+
+describe("findNextReadyEpisode", () => {
+  function serviceReturning(next: readonly OfflineAssetRecord[]) {
+    const cursorsSeen: unknown[] = [];
+    const repo = {
+      get: () => undefined,
+      listTitleAssets: () => [],
+      listByTitleIds: () => [],
+      listNextReadyByTitleCursors: (cursors: unknown) => {
+        cursorsSeen.push(cursors);
+        return next;
+      },
+      markValidation: () => {},
+      upsertPlayable: () => asset({ titleId: "t1" }),
+    } as unknown as OfflineAssetsRepository;
+    return { service: new OfflineAssetService(repo), cursorsSeen };
+  }
+
+  test("answers with the next downloaded episode after the current one", () => {
+    const { service, cursorsSeen } = serviceReturning([
+      asset({ titleId: "t1", season: 1, episode: 2 }),
+    ]);
+
+    expect(findNextReadyEpisode(service, "t1", { season: 1, episode: 1 })).toEqual({
+      season: 1,
+      episode: 2,
+    });
+    // The cursor is what scopes the query to "after this episode"; a wrong
+    // title id here silently answers null and reads as "series finished".
+    expect(cursorsSeen).toEqual([[{ titleId: "t1", season: 1, episode: 1 }]]);
+  });
+
+  test("answers null when nothing further is downloaded", () => {
+    const { service } = serviceReturning([]);
+
+    expect(findNextReadyEpisode(service, "t1", { season: 1, episode: 13 })).toBeNull();
+  });
+
+  test("answers null for an asset carrying no episode axis", () => {
+    const { service } = serviceReturning([asset({ titleId: "t1", mediaKind: "movie" })]);
+
+    expect(findNextReadyEpisode(service, "t1", { season: 1, episode: 1 })).toBeNull();
+  });
+
+  test("does not query at all without a title id", () => {
+    const { service, cursorsSeen } = serviceReturning([
+      asset({ titleId: "t1", season: 1, episode: 2 }),
+    ]);
+
+    expect(findNextReadyEpisode(service, "", { season: 1, episode: 1 })).toBeNull();
+    expect(cursorsSeen).toEqual([]);
   });
 });

--- a/apps/cli/test/unit/services/offline/offline-library-service.test.ts
+++ b/apps/cli/test/unit/services/offline/offline-library-service.test.ts
@@ -171,6 +171,23 @@ describe("OfflineLibraryService", () => {
     expect(playable.status).toBe("ready");
   });
 
+  test("repairable sidecars do not block playback of a valid video", async () => {
+    const record = job({ status: "repairable", artifactStatus: "expected-missing" });
+    const service = new OfflineLibraryService({
+      downloadService: {
+        getJob: () => record,
+      } as unknown as DownloadService,
+      historyRepository: {} as Pick<
+        HistoryRepository,
+        "upsertProgress" | "getLatestForTitleIdentity"
+      >,
+    });
+
+    const playable = await service.getPlayableSource(record.id);
+
+    expect(playable.status).toBe("ready");
+  });
+
   test("persists offline playback progress to history", async () => {
     const saves: HistoryProgressInput[] = [];
     const service = new OfflineLibraryService({

--- a/apps/cli/test/unit/services/offline/offline-repair-outcome.test.ts
+++ b/apps/cli/test/unit/services/offline/offline-repair-outcome.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { describeOfflineRepairOutcome } from "@/services/offline/offline-library-action-router";
+
+describe("describeOfflineRepairOutcome", () => {
+  test("says plainly when there was nothing to repair", () => {
+    // The old copy read "Re-download queued for 0 missing items" here — success
+    // phrasing for a no-op, which is what made repair look broken on a healthy
+    // title whose only gap was metadata.
+    expect(describeOfflineRepairOutcome({ queued: 0, repairedMetadata: 0, inspected: 1 })).toBe(
+      "Nothing to repair — all 1 local item is complete.",
+    );
+    expect(describeOfflineRepairOutcome({ queued: 0, repairedMetadata: 0, inspected: 3 })).toBe(
+      "Nothing to repair — all 3 local items are complete.",
+    );
+  });
+
+  test("reports an in-place metadata repair without claiming a download", () => {
+    const note = describeOfflineRepairOutcome({ queued: 0, repairedMetadata: 2, inspected: 4 });
+
+    expect(note).toBe("Repair: restored details for 2 items.");
+    expect(note).not.toContain("queued");
+  });
+
+  test("reports both kinds of repair when both happened", () => {
+    expect(describeOfflineRepairOutcome({ queued: 1, repairedMetadata: 1, inspected: 5 })).toBe(
+      "Repair: re-download queued for 1 item · restored details for 1 item.",
+    );
+  });
+});

--- a/packages/storage/src/repositories/download-jobs.ts
+++ b/packages/storage/src/repositories/download-jobs.ts
@@ -556,7 +556,7 @@ export class DownloadJobsRepository {
   listCompleted(limit = 100): readonly DownloadJobRecord[] {
     return this.db
       .query<DownloadJobRow, [number]>(
-        "SELECT * FROM download_jobs WHERE status IN ('completed', 'completed-with-notes') ORDER BY completed_at DESC LIMIT ?",
+        "SELECT * FROM download_jobs WHERE status IN ('completed', 'completed-with-notes', 'repairable') ORDER BY completed_at DESC LIMIT ?",
       )
       .all(limit)
       .map(mapRow);
@@ -566,8 +566,12 @@ export class DownloadJobsRepository {
     return this.db
       .query<DownloadJobRow, [number]>(
         `
+          -- 'repairable' belongs to listCompleted only. Listing it here too put
+          -- one job in both result sets, so the download manager rendered it as
+          -- two rows sharing an id, and index-based selection/delete then acted
+          -- on a phantom.
           SELECT * FROM download_jobs
-          WHERE status IN ('failed', 'aborted', 'repairable')
+          WHERE status IN ('failed', 'aborted')
           ORDER BY updated_at DESC
           LIMIT ?
         `,

--- a/packages/storage/src/repositories/download-jobs.ts
+++ b/packages/storage/src/repositories/download-jobs.ts
@@ -566,12 +566,15 @@ export class DownloadJobsRepository {
     return this.db
       .query<DownloadJobRow, [number]>(
         `
-          -- 'repairable' belongs to listCompleted only. Listing it here too put
-          -- one job in both result sets, so the download manager rendered it as
-          -- two rows sharing an id, and index-based selection/delete then acted
-          -- on a phantom.
+          -- KNOWN ISSUE: 'repairable' is also returned by listCompleted, so a
+          -- repairable job appears in both result sets and the download manager
+          -- renders it as two rows sharing an id (index-based selection then
+          -- acts on a phantom). It cannot simply be dropped here: the repair
+          -- sweep in DownloadService uses listFailed to find repairable work.
+          -- The fix is a dedicated listRepairable() for the sweep, then removing
+          -- 'repairable' from this clause -- not a one-line edit.
           SELECT * FROM download_jobs
-          WHERE status IN ('failed', 'aborted')
+          WHERE status IN ('failed', 'aborted', 'repairable')
           ORDER BY updated_at DESC
           LIMIT ?
         `,

--- a/packages/storage/src/repositories/offline-assets.ts
+++ b/packages/storage/src/repositories/offline-assets.ts
@@ -248,6 +248,37 @@ export class OfflineAssetsRepository {
     this.db.query("DELETE FROM offline_assets WHERE origin_job_id = ?").run(jobId);
   }
 
+  /**
+   * Removes assets whose owning job no longer exists, returning how many went.
+   *
+   * `origin_job_id` is `ON DELETE SET NULL`, so a job deleted before its cleanup
+   * listener ran leaves the asset behind with a null owner. Such a row still
+   * reads `state='ready'`, so the library keeps advertising the title as
+   * downloaded while nothing can play it: `findReadyJobIdForEpisode` hands back
+   * the null job id and playback bails straight back to the results screen.
+   */
+  deleteOrphaned(): number {
+    const orphans =
+      this.db
+        .query<{ count: number }, []>(
+          "SELECT COUNT(*) AS count FROM offline_assets WHERE origin_job_id IS NULL",
+        )
+        .get()?.count ?? 0;
+    if (orphans === 0) return 0;
+    this.db
+      .query(
+        "DELETE FROM offline_asset_tracks WHERE asset_id IN (SELECT id FROM offline_assets WHERE origin_job_id IS NULL)",
+      )
+      .run();
+    this.db
+      .query(
+        "DELETE FROM offline_asset_artwork WHERE asset_id IN (SELECT id FROM offline_assets WHERE origin_job_id IS NULL)",
+      )
+      .run();
+    this.db.query("DELETE FROM offline_assets WHERE origin_job_id IS NULL").run();
+    return orphans;
+  }
+
   setProtected(id: string, protectedValue: boolean, updatedAt: string): void {
     this.db
       .query("UPDATE offline_assets SET protected = ?, updated_at = ? WHERE id = ?")

--- a/packages/storage/src/repositories/offline-assets.ts
+++ b/packages/storage/src/repositories/offline-assets.ts
@@ -234,6 +234,20 @@ export class OfflineAssetsRepository {
       .run(state, validatedAt, validatedAt, id);
   }
 
+  deleteByOriginJobId(jobId: string): void {
+    this.db
+      .query(
+        "DELETE FROM offline_asset_tracks WHERE asset_id IN (SELECT id FROM offline_assets WHERE origin_job_id = ?)",
+      )
+      .run(jobId);
+    this.db
+      .query(
+        "DELETE FROM offline_asset_artwork WHERE asset_id IN (SELECT id FROM offline_assets WHERE origin_job_id = ?)",
+      )
+      .run(jobId);
+    this.db.query("DELETE FROM offline_assets WHERE origin_job_id = ?").run(jobId);
+  }
+
   setProtected(id: string, protectedValue: boolean, updatedAt: string): void {
     this.db
       .query("UPDATE offline_assets SET protected = ?, updated_at = ? WHERE id = ?")

--- a/packages/storage/test/storage.test.ts
+++ b/packages/storage/test/storage.test.ts
@@ -689,6 +689,49 @@ test("offline title policies and maintenance jobs persist explicit bounded autho
   expect(retry.id).not.toBe(initial.id);
 });
 
+test("offline assets repository purges rows whose owning job is gone", () => {
+  const db = migratedDataDb();
+  const jobs = new DownloadJobsRepository(db);
+  const assets = new OfflineAssetsRepository(db);
+  const now = "2026-08-13T00:00:00.000Z";
+
+  jobs.enqueue({
+    id: "job-orphan",
+    titleId: "tmdb:1081003",
+    titleName: "Supergirl",
+    mediaKind: "movie",
+    providerId: "vidking",
+    streamUrl: "https://example.com/master.m3u8",
+    headers: {},
+    outputPath: "/tmp/supergirl.mp4",
+    tempPath: "/tmp/supergirl.mp4.tmp.job-orphan",
+    createdAt: now,
+    updatedAt: now,
+  });
+  assets.upsertPlayable({
+    titleId: "tmdb:1081003",
+    titleName: "Supergirl",
+    mediaKind: "movie",
+    profileKey: "original:en:best",
+    originJobId: "job-orphan",
+    filePath: "/tmp/supergirl.mp4",
+    state: "ready",
+    updatedAt: now,
+  });
+
+  // ON DELETE SET NULL: deleting the job orphans the asset rather than removing
+  // it, and the orphan still reads `ready` so the library keeps offering it.
+  jobs.delete("job-orphan");
+  const orphaned = assets.listTitleAssets("tmdb:1081003");
+  expect(orphaned).toHaveLength(1);
+  expect(orphaned[0]?.originJobId).toBeUndefined();
+  expect(orphaned[0]?.state).toBe("ready");
+
+  expect(assets.deleteOrphaned()).toBe(1);
+  expect(assets.listTitleAssets("tmdb:1081003")).toHaveLength(0);
+  expect(assets.deleteOrphaned()).toBe(0);
+});
+
 test("download jobs repository preserves repairable sidecar status without losing completed video", () => {
   const db = migratedDataDb();
   const repo = new DownloadJobsRepository(db);

--- a/plans/031-default-anidb-route-release-truth.md
+++ b/plans/031-default-anidb-route-release-truth.md
@@ -1,0 +1,101 @@
+# Plan 031: Make the default AniDB route searchable and signoff-real
+
+> **For agentic workers:** use test-driven development and verification-before-completion.
+>
+> **Drift check:** `git diff --stat 36da54c4..HEAD -- packages/providers/src/anidb/client.ts packages/providers/test/anidb.test.ts apps/cli/src/services/search/definitions apps/cli/src/services/search/SearchRoutingService.ts apps/cli/test/unit/services/search/search-routing.test.ts apps/cli/test/live/release-provider-signoff.smoke.ts`
+
+**Goal:** The configured default anime path (`anidb`) can find current live titles,
+advanced anime search never silently becomes TMDB search, and release signoff tests
+the route users actually receive.
+
+**Architecture:** Keep provider-native AniDB browse as the fast simple-query path.
+Use AniList as the metadata/advanced-search adapter for every anime provider,
+including AniDB. Release evidence must derive its configured provider from the same
+default contract, not maintain a stale parallel default.
+
+## Status
+
+- **Priority:** P0
+- **Effort:** M
+- **Risk:** LOW
+- **Planned at:** `36da54c4`, 2026-08-11
+- **Evidence:** live `https://anidb.app/browse?q=Frieren` returned absolute anime
+  links with a `title` attribute; current parser expects a relative link followed
+  by `alt`, so `searchAnidb("Frieren")` returned zero.
+
+## Current defects
+
+- `packages/providers/src/anidb/client.ts:123-138` parses only
+  `anime/<slug-id> ... alt="title"`. Current cards use an absolute URL and
+  `title="..."`.
+- `packages/providers/test/anidb.test.ts` encodes the obsolete markup, so the test
+  protects the defect.
+- `packages/config/src/defaults.ts:11-16` selects AniDB, but
+  `apps/cli/src/services/search/definitions/index.ts` does not list `anidb` as
+  AniList-compatible. Advanced search therefore falls through to
+  `SearchRegistryImpl.getDefault()`, which is TMDB.
+- `apps/cli/test/live/release-provider-signoff.smoke.ts:63-75` still hardcodes
+  AllAnime for the anime lane.
+
+## Tasks
+
+### Task 1: Characterize the live AniDB card shape
+
+- [ ] Save a minimal sanitized fixture under
+  `packages/providers/test/fixtures/anidb/browse-frieren.html` containing absolute
+  and relative links, `title` HTML entities, unrelated anchors, and duplicate ids.
+- [ ] Replace the inline obsolete fixture in `packages/providers/test/anidb.test.ts`.
+- [ ] Add assertions for exact id/title decoding and deduplication. The test must
+  fail before changing the parser.
+
+### Task 2: Replace the brittle cross-tag regex
+
+- [ ] In `packages/providers/src/anidb/client.ts`, parse anime anchors independently
+  of attribute order. Accept absolute or relative `/anime/<slug-number>` URLs and
+  read the anchor's `title`; keep `alt` only as a compatibility fallback if it is
+  present on the same card.
+- [ ] Keep `anidbNumericId()` as the final identity gate. Do not accept a bare
+  numeric or arbitrary provider id.
+- [ ] Return a deterministic empty result on valid pages with no cards; preserve
+  typed/network failures from `anidbFetchText`.
+
+### Task 3: Route anime metadata search to AniList
+
+- [ ] Add `anidb` to the AniList definition in both
+  `definitions/index.ts` and `definitions/anilist.ts` (or extract one shared list so
+  the two declarations cannot drift).
+- [ ] Add routing tests proving an advanced anime query on AniDB uses `anilist`,
+  while a simple query uses provider-native AniDB and a genuinely empty native
+  result falls back to AniList, never TMDB.
+- [ ] Assert returned identities preserve `externalIds.anilistId`; do not label a
+  TMDB result as an anime-lane identity.
+
+### Task 4: Make release signoff consume the default route
+
+- [ ] Replace the AllAnime anime fixture with a stable AniDB fixture carrying a
+  provider-native AniDB id.
+- [ ] Add a contract test that the signoff provider for each lane equals the repo
+  default (or imports a shared fixture/default builder). A future default change must
+  fail one test instead of silently testing the old route.
+- [ ] Keep AllAnime as its focused provider smoke, not the default-lane signoff.
+- [ ] Require both resolve and stream reachability for AniDB, as movie/series do.
+
+## Verification
+
+```sh
+bun run --cwd packages/providers test test/anidb.test.ts
+bun run --cwd apps/cli test:file test/unit/services/search/search-routing.test.ts
+bun run typecheck
+bun run lint
+bun run fmt:check
+bun run test
+KUNAI_LIVE_RELEASE_SIGNOFF=1 bun run test:live:release-signoff
+```
+
+## STOP conditions
+
+- The live page no longer exposes a stable show slug/id in HTML.
+- AniList search cannot preserve a proven AniList identity for AniDB resolution.
+- The proposed release fixture only resolves but cannot pass reachability.
+
+Do not promote AllAnime back to default merely to make the stale signoff green.

--- a/plans/032-sync-identity-and-capability-truth.md
+++ b/plans/032-sync-identity-and-capability-truth.md
@@ -1,0 +1,106 @@
+# Plan 032: Make sync identity-safe and describe real capabilities
+
+> **For agentic workers:** use test-driven development and verification-before-completion.
+>
+> **Drift check:** `git diff --stat 36da54c4..HEAD -- apps/cli/src/services/sync apps/cli/src/app-shell/workflows/shell-workflows.ts apps/cli/src/app/playback/PlaybackPhase.ts apps/cli/src/domain/session/command-registry.ts packages/config/src/defaults.ts packages/config/src/types.ts docs/feature-status.yaml`
+
+**Goal:** Sync must never mutate the wrong remote title, regress AniList progress, or
+claim TMDB episode-progress support that TMDB does not provide.
+
+**Architecture:** Make adapter capabilities explicit. Sync accepts a canonical
+remote identity, not an ambiguous local `titleId`. AniList is the only watch-progress
+adapter. TMDB may remain an account/watchlist integration, but it must not satisfy or
+receive a `pushProgress` operation.
+
+## Status
+
+- **Priority:** P0
+- **Effort:** M
+- **Risk:** HIGH (remote account mutation)
+- **Planned at:** `36da54c4`, 2026-08-11
+
+## Confirmed defects
+
+- `AniListAdapter.ts:232-237` treats `mal:<n>` and `tmdb:<n>` as if the number were
+  an AniList media id. Those id spaces are unrelated.
+- `TmdbAdapter.ts:122-146` calls the watchlist endpoint with `watchlist:false`; this
+  removes a title from a list and does not sync episode progress.
+- `shell-workflows.ts:3100-3119` pushes the latest 20 history rows individually.
+  Multiple episodes of the same title can push a newer episode and then regress it
+  with an older row.
+- Playback only displays a sync nudge (`PlaybackPhase.ts:2389-2397`); no successful
+  history write automatically queues a sync operation.
+- Persisted `enabled`, `trackWatched`, and `syncList` fields have no production
+  readers. The command copy nevertheless promises watch-progress sync.
+- Connect/disconnect-specific commands all open the same generic screen.
+
+## Tasks
+
+### Task 1: Fail closed before any remote mutation
+
+- [ ] Add adapter tests proving AniList accepts only an explicit AniList id. MAL,
+  TMDB, bare numeric, and provider-native ids must return a mapping error and make no
+  request.
+- [ ] Remove the MAL/TMDB fallthrough from `extractAniListId`.
+- [ ] Stop `SyncService.pushWatched` from invoking TMDB. Add an explicit capability
+  such as `progress: "episode" | "none"` to the sync adapter interface and select
+  adapters by the requested operation.
+- [ ] Relabel or hide TMDB progress actions. Do not replace the current call with a
+  different TMDB mutation without a separately specified product meaning.
+
+### Task 2: Introduce a canonical sync input
+
+- [ ] Replace `pushWatched(HistoryProgress)` at the adapter seam with a small input
+  containing progress plus explicit external ids, for example
+  `SyncProgressUpdate { anilistId?: string; tmdbId?: string; mediaKind; episode?; completed }`.
+- [ ] Resolve identities before crossing the seam using existing catalog/history
+  metadata. Low-confidence or absent crosswalks skip with a diagnostic; they never
+  guess by numeric equality.
+- [ ] Test AniDB/provider-native history with and without a proven AniList crosswalk.
+
+### Task 3: Aggregate monotonically
+
+- [ ] Extract a pure builder that groups history rows by canonical title and emits
+  one update with maximum proven episode progress.
+- [ ] Add tests with recent rows in both orders, repeated episodes, movies, and mixed
+  titles. No ordering may reduce remote progress.
+- [ ] Have manual `Sync now` report titles attempted, not raw history rows pushed.
+
+### Task 4: Make configuration and commands real
+
+- [ ] Either wire `sync.<adapter>.enabled/trackWatched/syncList` to documented
+  behavior or delete them. Do not keep unread persisted switches.
+- [ ] `sync-connect-anilist` must start/select AniList; `sync-connect-tmdb` must
+  start/select TMDB; `sync-disconnect` must select only connected adapters.
+- [ ] Update command descriptions and `docs/feature-status.yaml` to say exactly what
+  each adapter supports. Keep the feature experimental until an opt-in live mutation
+  test passes with a disposable account.
+
+### Task 5: Add automatic AniList progress delivery safely
+
+- [ ] After a successful durable history write, enqueue one best-effort AniList
+  update only when `trackWatched` is enabled and identity is proven.
+- [ ] Do not await remote sync on the playback/UI path. Use a bounded, deduplicated
+  queue with retry/backoff and last-write-wins progress per title.
+- [ ] Persist enough pending state to survive a clean exit, or explicitly keep this
+  manual-only for the release. Do not claim automatic sync without that behavior.
+
+## Release-today safe cut
+
+If Task 5 cannot be completed today, ship Tasks 1-4, keep sync explicitly
+experimental/manual, and remove the automatic-progress wording. Wrong remote writes
+are worse than a missing integration.
+
+## Verification
+
+```sh
+bun run --cwd apps/cli test:file test/unit/services/sync/SyncService.test.ts
+bun run --cwd apps/cli test:file test/unit/services/sync/anilist-adapter.test.ts
+bun run typecheck
+bun run lint
+bun run fmt:check
+bun run test
+```
+
+An opt-in live test may verify OAuth and one disposable AniList title; it must never
+run in the default suite or use a maintainer's real library.

--- a/plans/033-mid-playback-state-recovery.md
+++ b/plans/033-mid-playback-state-recovery.md
@@ -1,0 +1,45 @@
+# Plan 033: Restore truthful playback state after buffering and stalls
+
+> **Drift check:** `git diff --stat 36da54c4..HEAD -- apps/cli/src/app/playback/run-mpv-playback-session.ts apps/cli/test/unit/app`
+
+**Goal:** Once mpv resumes producing progress, Kunai must leave stale
+`buffering`/`stalled`/`seeking` UI states immediately without restarting playback.
+
+## Status
+
+- **Priority:** P1
+- **Effort:** S
+- **Risk:** LOW
+- **Planned at:** `36da54c4`, 2026-08-11
+
+## Defect
+
+`run-mpv-playback-session.ts:212-250` enters buffering, stalled, and seeking states,
+but `playback-progress` only updates presence. A recovered stream can therefore keep
+displaying a failure state while video is playing normally.
+
+## Tasks
+
+- [ ] Add a table-driven event-sequence test for
+  `started -> buffering -> progress`, `started -> stalled -> progress`,
+  `started -> seeking -> progress`, pause/resume, and repeated progress.
+- [ ] Extract a small pure playback-status reducer used by the event callback. Treat
+  valid forward progress as `playing` unless the player is explicitly paused.
+- [ ] Avoid emitting duplicate status writes when the state does not change.
+- [ ] Clear stale warning copy when recovery is confirmed, while retaining the event
+  in diagnostics.
+- [ ] Add one render-capture sequence proving the Now Playing surface changes back to
+  playing without an extra keypress.
+
+## Verification
+
+```sh
+bun run --cwd apps/cli test:file test/unit/app/run-mpv-playback-session.test.ts
+bun run typecheck
+bun run lint
+bun run fmt:check
+bun run test
+```
+
+Do not change mpv reconnect budgets in this slice; state truth and network policy are
+separate concerns.

--- a/plans/034-zero-install-native-poster-pipeline.md
+++ b/plans/034-zero-install-native-poster-pipeline.md
@@ -1,0 +1,142 @@
+# Plan 034: Finish the zero-install native poster pipeline
+
+> **For agentic workers:** read `.docs/poster-image-rendering.md`, use test-driven
+> development, and verify in real terminals before deleting optional fallbacks.
+>
+> **Drift check:** `git diff --stat 36da54c4..HEAD -- apps/cli/src/image apps/cli/src/app-shell/poster-renderer.ts apps/cli/src/app-shell/image-pane.ts apps/cli/src/app-shell/poster-source-cache.ts apps/cli/src/app-shell/use-poster-preview.ts apps/cli/test/unit/image apps/cli/test/unit/app-shell/poster-renderer.test.ts apps/cli/package.json`
+
+**Goal:** Every interactive poster path uses bounded, aspect-preserving Bun-native
+decode/resize, then hands a small prepared image to Kitty, Sixel, or half-block with
+no required system image tool and no full-image synchronous decode.
+
+**Architecture:** Deepen the existing `native-image.ts` seam into one preparation
+module. Callers supply pixel bounds and bytes; the module owns validation,
+orientation, aspect fit, PNG encoding, the bounded PNG-to-RGBA bridge, normalized
+failure reasons, and cancellation checks. Renderers own only terminal protocol work.
+
+## Status
+
+- **Priority:** P1
+- **Effort:** M
+- **Risk:** MED
+- **Planned at:** `36da54c4`, 2026-08-11
+- **Runtime contract:** Bun `>=1.3.14`; JPEG/PNG/WebP portable, GIF/BMP first-frame
+  decode, TIFF unsupported on Linux, HEIC/AVIF dependent on OS codecs.
+
+## What is already done
+
+- Bun.Image is already the normal Kitty and half-block path.
+- Source and rendered-result caches are dimension/renderer aware.
+- Selection settling, abort ownership, Kitty placement cleanup, Sixel overlays, and
+  the dead file-based renderer deletion have landed.
+- Half-block is already the zero-install universal floor.
+
+Do not recreate `displayPoster()` or a file renderer, and do not add Sharp.
+
+## Confirmed remaining defects
+
+- `native-image.ts` calls `resize(width, height)` without options. Bun's default is
+  `fit:"fill"`, so portrait posters can be distorted.
+- Sixel still calls `renderSixelFromBytes`, which synchronously decodes the original
+  image before resizing.
+- `poster-source-cache.ts` uses `arrayBuffer()` for remote and local data without a
+  byte limit. The entry-count cache can retain large inputs.
+- The native constructor does not set `autoOrient` or `maxPixels`.
+- The proposed `PreparedPoster { png, image }` cannot come directly from Bun.Image;
+  Bun has no raw-pixel terminal. Kunai must decode the already-small native PNG to
+  RGBA, which is acceptable only after resize.
+
+## Interface
+
+Keep the external seam small and pixel-based:
+
+```ts
+type PreparedPoster = {
+  readonly png: Uint8Array;
+  readonly image: DecodedImage;
+};
+
+async function preparePoster(
+  bytes: Uint8Array,
+  bounds: { readonly maxWidthPx: number; readonly maxHeightPx: number },
+  signal?: AbortSignal,
+): Promise<PreparedPoster | null>;
+```
+
+Terminal-cell conversion stays outside this module: half-block requests
+`cols x rows*2`; Sixel uses `pixelBudgetForCells`; Kitty uses its documented pixel
+budget. This avoids pretending one cell geometry is valid for every protocol.
+
+## Tasks
+
+### Task 1: Lock preparation behavior in tests
+
+- [ ] Add fixtures/tests for portrait and landscape aspect fit, no enlargement,
+  EXIF orientation, JPEG/PNG/WebP, GIF/BMP first frame, unsupported format, corrupt
+  data, byte limit, pixel limit, and abort-before/abort-after native work.
+- [ ] Assert a portrait source is not stretched to the requested box. The current
+  implementation must fail this test.
+- [ ] Set `Bun.Image.backend = "bun"` only inside golden tests and restore it after.
+
+### Task 2: Implement bounded preparation
+
+- [ ] Construct `Bun.Image` with `autoOrient:true` and `maxPixels:4096*4096`.
+- [ ] Resize with `fit:"inside"` and `withoutEnlargement:true`, encode PNG off-thread,
+  then decode only that small PNG to RGBA.
+- [ ] Check cancellation before construction and after each awaited native terminal.
+  Document that AbortSignal does not interrupt an in-flight native terminal; stale
+  results are discarded after completion.
+- [ ] Normalize stable Bun image error codes for debug logging without exposing URLs
+  or local paths.
+
+### Task 3: Bound source acquisition and caches
+
+- [ ] Enforce a 16 MiB input ceiling before preparation. Reject remote
+  `Content-Length` above it; otherwise read the response stream and cancel once the
+  accumulated limit is exceeded.
+- [ ] Check `Bun.file(path).size` before reading local sidecars.
+- [ ] Add total-byte budgets to source/prepared caches, not only entry counts. Keep
+  rendered-result identity keyed by source, dimensions, renderer, and placement slot.
+
+### Task 4: Move every renderer behind preparation
+
+- [ ] Kitty receives prepared PNG only; remove its independent decode/conversion
+  chain.
+- [ ] Sixel receives prepared RGBA and calls `renderSixelFromImage`; quantization may
+  remain synchronous because its input is now bounded to terminal pixels.
+- [ ] Half-block receives prepared RGBA; it must not invoke a decoder.
+- [ ] Preserve settled-selection debounce, in-flight ownership, resize cleanup, and
+  same-slot stale-paint protection.
+
+### Task 5: Retire optional subprocess paths only after parity
+
+- [ ] Profile arrow-key bursts and Sixel encode time after Task 4. Add a Worker only
+  if bounded quantization still causes a perceptible stall.
+- [ ] Once JPEG/PNG/WebP and fallback-format tests pass on Linux/macOS/Windows, remove
+  ImageMagick and Chafa runtime paths, flags, setup prompts, diagnostics fields, and
+  docs in one change.
+- [ ] Remove `jpeg-js` only after no interactive fallback decodes original JPEG bytes.
+  Keep the small PNG decoder needed for RGBA unless Bun adds raw output.
+
+## Verification
+
+```sh
+bun run --cwd apps/cli test:file test/unit/image test/unit/app-shell/poster-renderer.test.ts test/unit/app-shell/image-pane.test.ts test/unit/app-shell/use-poster-preview.test.ts
+bun run typecheck
+bun run lint
+bun run fmt:check
+bun run test
+bun run build
+```
+
+Manual gates: Kitty/Ghostty, Windows Terminal 1.22+ Sixel, generic half-block,
+tmux/screen/SSH text fallback, rapid navigation, resize, exit cleanup, remote TMDB,
+and offline sidecar artwork. Posters remain decorative: any failure must leave a
+correct text UI.
+
+## STOP conditions
+
+- Bun.Image is absent from a supported packaged binary.
+- A renderer needs incompatible pixel geometry that cannot be represented by its own
+  preparation call/cache entry.
+- Removing Chafa/ImageMagick causes a supported JPEG/PNG/WebP path to lose artwork.

--- a/plans/035-anidb-season-routing.md
+++ b/plans/035-anidb-season-routing.md
@@ -1,0 +1,48 @@
+# Plan 035: Route AniDB seasons explicitly
+
+> **Drift check:** `git diff --stat 36da54c4..HEAD -- packages/providers/src/anidb packages/providers/test/anidb.test.ts .docs/providers.md`
+
+**Goal:** A request for season N resolves the sibling AniDB season page before
+selecting episode N, without confusing season-relative and absolute episode numbers.
+
+## Status
+
+- **Priority:** P1
+- **Effort:** M
+- **Risk:** MED
+- **Depends on:** plan 031 (soft)
+- **Reference:** local ani-cli v5 parses the `Seasons` block on the show page and
+  changes to a sibling season slug.
+
+## Tasks
+
+- [ ] Capture sanitized show-page fixtures with one season, multiple seasons, split
+  cours, missing labels, and malformed links.
+- [ ] Add `listAnidbSeasonLinks(showId)` behind the existing AniDB client seam. Parse
+  only links in the Seasons section and validate each slug with `looksLikeAnidbShowId`.
+- [ ] Define the numbering rule in tests before implementation:
+  - when `absoluteEpisode` is present, use the mapped show id unchanged unless proven
+    catalog metadata says otherwise;
+  - when only `{season, episode}` is present and season > 1, select the corresponding
+    sibling then use the season-relative episode;
+  - on ambiguous/missing season mapping, return a diagnosable unsupported-title or
+    not-found failure; never silently resolve S1.
+- [ ] Cache sibling mapping with the show-page TTL and cancellation semantics already
+  used by the client.
+- [ ] Emit trace attributes for requested season, selected sibling slug, and numbering
+  axis without leaking stream URLs.
+- [ ] Add an opt-in live S2 fixture after S1 release signoff is green.
+
+## Verification
+
+```sh
+bun run --cwd packages/providers test test/anidb.test.ts
+bun run typecheck
+bun run lint
+bun run fmt:check
+bun run test
+bun run test:live:anidb
+```
+
+**STOP:** AniDB season link order does not correspond reliably to season number. In
+that case require catalog-to-sibling evidence rather than guessing by DOM order.

--- a/plans/036-allmanga-parity-cleanup.md
+++ b/plans/036-allmanga-parity-cleanup.md
@@ -1,0 +1,42 @@
+# Plan 036: Reconcile AllManga source parity
+
+> **Drift check:** `git diff --stat 36da54c4..HEAD -- packages/providers/src/allmanga packages/providers/test/allmanga.test.ts .docs/providers.md .docs/architecture.md`
+
+**Goal:** Remove a dead source label and preserve the referer required by active
+wixmp streams without changing Kunai's maintained mkissa crypto divergence.
+
+## Status
+
+- **Priority:** P2
+- **Effort:** S
+- **Risk:** LOW
+- **Reference:** local ani-cli tag `v4.15` (`72d7f72`) is the final AllAnime-based
+  reference. v5 no longer contains AllAnime code.
+
+## Tasks
+
+- [ ] Add a fixture proving `Luf-Mp4` rows are ignored and no dead candidate reaches
+  playback; then remove it from `KNOWN_SOURCES` and the manifest/docs inventory.
+- [ ] Add a wixmp URL fixture asserting the mkissa site referer is attached. Extend
+  `resolveDirectStreamReferer` for `repackager.wixmp.com` (and only proven aliases).
+- [ ] Keep mp4upload's dedicated referer and scoped `--tls-verify=no`; do not broaden
+  TLS disabling to every stream.
+- [ ] Keep buildId/bootstrap/HMAC crypto. Do not revert to ani-cli's abandoned epoch
+  scheme, query constants, or v5 AniDB transport.
+- [ ] Update `.docs/providers.md`, `.docs/architecture.md`, and the manifest note in
+  the same change so provider truth does not drift.
+
+## Verification
+
+```sh
+bun run --cwd packages/providers test test/allmanga.test.ts
+bun run typecheck
+bun run lint
+bun run fmt:check
+bun run test
+bun run test:live:allanime
+```
+
+This is parity cleanup, not a default-route blocker. A live AllAnime failure caused
+by current regional WAF/network behavior must be reported as such, not hidden by a
+unit fixture.

--- a/plans/037-miruro-truth-and-resilience.md
+++ b/plans/037-miruro-truth-and-resilience.md
@@ -1,0 +1,62 @@
+# Plan 037: Make Miruro resolution evidence truthful and resilient
+
+> **Drift check:** `git diff --stat 36da54c4..HEAD -- packages/providers/src/miruro packages/providers/test/miruro-inventory.test.ts apps/cli/test/live/miruro-demonslayer.smoke.ts .docs/provider-dossiers/miruro.md`
+
+**Goal:** Miruro must not claim a stream was reachable without a probe, and a pipe
+key/server-order change must fail with actionable evidence rather than silent
+provider exhaustion.
+
+## Status
+
+- **Priority:** P1
+- **Effort:** M
+- **Risk:** MED
+- **Planned at:** `36da54c4`, 2026-08-11
+
+## Confirmed defects and corrections to the proposed audit
+
+- The hardcoded pipe key is a rotation risk, but no trustworthy derivation route has
+  been demonstrated. Do not promise automatic re-derivation yet.
+- `createMiruroResultFromPayload` sets `streamReachabilityVerified:true` without a
+  reachability probe.
+- `MIRURO_SERVER_TRY_ORDER` and `defaultServers` disagree. One canonical list should
+  drive both discovery and fallback construction.
+- AniList id extraction is duplicated in resolve/list paths.
+- The WAF threshold of two currently equals the two configured mirrors. That is not
+  inherently a bug; retain or change it only with a failure-sequence test.
+
+## Tasks
+
+- [ ] Add result-builder tests that default reachability to false/unknown and set it
+  true only when a probe result is passed explicitly.
+- [ ] Thread actual cycle/stream probe evidence into the builder; otherwise omit the
+  attestation.
+- [ ] Replace `defaultServers` with the canonical try order and test exact ordering,
+  including `bonk` last.
+- [ ] Reuse `resolveMiruroAnilistId` everywhere and accept only a proven numeric
+  AniList id.
+- [ ] Classify pipe failures distinctly: WAF HTML, decode/key mismatch, unexpected
+  obfuscation version, JSON shape drift, and network timeout. Never log the key or
+  encrypted body.
+- [ ] Isolate pipe decoding behind a versioned internal seam so a captured fixture
+  can prove a rotated key/version. On mismatch, fail loud with a provider diagnostic.
+- [ ] Treat key derivation as a separate provider-intake investigation. Implement it
+  only if a reproducible first-party script/bootstrap source is documented.
+- [ ] Add subtitle content-type/extension characterization before changing the
+  current `.vtt`/SRT classification.
+- [ ] Keep Miruro manually selectable until its live smoke resolves and probes a
+  reachable stream in the target release region.
+
+## Verification
+
+```sh
+bun run --cwd packages/providers test test/miruro-inventory.test.ts
+bun run typecheck
+bun run lint
+bun run fmt:check
+bun run test
+bun run test:live:miruro
+```
+
+**STOP:** no first-party or reproducible key source exists. Ship diagnostics and
+fail-closed behavior; do not scrape/minify-guess a secret at runtime.

--- a/plans/038-videasy-cache-and-retirement.md
+++ b/plans/038-videasy-cache-and-retirement.md
@@ -1,0 +1,75 @@
+# Plan 038: Bound Videasy caches before retiring deprecated routes
+
+> **Drift check:** `git diff --stat 36da54c4..HEAD -- packages/providers/src/videasy packages/providers/test/videasy-*.test.ts apps/cli/test/live/videasy-bloodhounds.smoke.ts .docs/provider-dossiers/videasy.md`
+
+**Goal:** Fix boundedness and identity/cache-policy correctness on active Videasy
+paths, then remove deprecated route families only after characterization proves they
+cannot be selected or needed for pin migration.
+
+## Status
+
+- **Priority:** P2
+- **Effort:** M
+- **Risk:** MED
+- **Planned at:** `36da54c4`, 2026-08-11
+
+## Audit corrections
+
+- The `won` flag around `Promise.any` is not a confirmed bug. It intentionally avoids
+  penalizing requests aborted after another host wins. Do not change it without a
+  failing concurrency test.
+- `classifyVideasyHttpFailure` already documents why 500 is transient; the duplicate
+  branch is cosmetic.
+- The AES-GCM `wings-tejo` flavor is deprecated and not in the Cineby UI. Its missing
+  decoder is not a release blocker unless the flavor is promoted.
+- Legacy `api.videasy.to` flavors are marked deprecated/route-dead, but deleting them
+  today is riskier than leaving inert code unless pin migration and selection tests
+  prove they are unreachable.
+
+## Tasks
+
+### Task 1: Active-path correctness
+
+- [ ] Make `resolveTmdbId` accept only a complete positive decimal identity;
+  `123abc`, zero, negative, AniList, and provider-native ids must fail closed.
+- [ ] Decide one owner for cache policy. `createVidkingResultFromPayload` currently
+  ignores its passed policy and reconstructs one with `apiRoute`. Either create the
+  route-specific policy before the call or expose an explicit child-policy function;
+  test that read/write/invalidation use the same key.
+- [ ] Replace the three Wings Maps with the shared bounded TTL cache or add pruning
+  and maximum sizes. Expired seed/preferred-host entries must be deleted on access;
+  host failure state is host-bounded.
+
+### Task 2: Prove seed-race semantics
+
+- [ ] Add deterministic tests for primary wins, fallback wins, genuine pre-winner
+  failure, loser aborted after winner, all fail, and caller abort.
+- [ ] Keep a host penalty only for a genuine failure before a winner. Intentional
+  loser aborts must not poison health.
+- [ ] Change the `won` logic only if these tests expose an incorrect transition.
+
+### Task 3: Retire dead families separately
+
+- [ ] Add source-contract tests proving deprecated flavor ids normalize for saved
+  pins but are never scheduled as active candidates.
+- [ ] Run the focused Videasy live suite across active Cineby flavors and record the
+  successful endpoints.
+- [ ] Delete legacy endpoint/WASM/CryptoJS code only when no active resolver, saved-pin
+  migration, fixture, or package export depends on it. Remove dependencies/docs in
+  the same commit.
+- [ ] Keep `wings-tejo` deprecated or delete the alias. Do not implement AES-GCM for
+  a route that product code cannot select.
+
+## Verification
+
+```sh
+bun run --cwd packages/providers test test/videasy-client-profile.test.ts test/videasy-flavors.test.ts test/videasy-preferred-fallback.test.ts
+bun run typecheck
+bun run lint
+bun run fmt:check
+bun run test
+KUNAI_VIDEASY_LIVE_SUITE=1 bun run --cwd apps/cli test:live:videasy
+```
+
+Cleanup must not share a commit with active-path correctness. If the live suite needs
+a deprecated path, mark the retirement task blocked and keep the boundedness fixes.

--- a/plans/README.md
+++ b/plans/README.md
@@ -103,6 +103,25 @@ the behavior that actually landed.
 | 029  | Require release evidence and native platform smokes          | P1       | L      | 026, 027, 028      | TODO        |
 | 030  | Reconcile distribution documentation with shipped routes     | P1       | M      | 026, 027, 028, 029 | TODO        |
 
+### Wave 7 — 2026-08-11 release truth, providers, sync, playback, and posters
+
+These plans were audited against live code at commit `36da54c4`, the live AniDB
+browse page, focused provider smokes, and Bun 1.3.14's documented image surface.
+Execute 031 and 032 before calling the release stable. Plans 033 and 034 are the
+highest-value interaction work. The remaining provider plans are independent,
+except that 035 should land before expanding the AniDB release fixture beyond S1.
+
+| Plan | Title                                                   | Priority | Effort | Depends on | Status |
+| ---- | ------------------------------------------------------- | -------- | ------ | ---------- | ------ |
+| 031  | Make the default AniDB route searchable and signoff-real | P0       | M      | —          | TODO   |
+| 032  | Make sync identity-safe and describe real capabilities   | P0       | M      | —          | TODO   |
+| 033  | Restore truthful playback state after buffering/stalls   | P1       | S      | —          | TODO   |
+| 034  | Finish the zero-install native poster pipeline           | P1       | M      | —          | TODO   |
+| 035  | Route AniDB seasons explicitly                           | P1       | M      | 031 (soft) | TODO   |
+| 036  | Reconcile AllManga source parity                         | P2       | S      | —          | TODO   |
+| 037  | Make Miruro resolution evidence truthful and resilient   | P1       | M      | —          | TODO   |
+| 038  | Bound Videasy caches before retiring deprecated routes   | P2       | M      | —          | TODO   |
+
 **PARTIAL detail.** `021`: stage 3 is complete (episode catalogs are
 language-aware and cache-keyed by audio); stages 1, 2, 4, 5, 6, 7 are untouched.
 `022`: 022.1 (help scope) is done and the overlay-routing rework that 022 called


### PR DESCRIPTION
## Scope

Offline playback: launching a downloaded title plays the local file, with the session gated off the network. Includes fixes for three user-visible failures found while reviewing it.

## The reported bug, root-caused in a real library

> "There is a downloaded movie in my library; when I try to play it, it doesn't — it goes to the home screen."

`offline_assets.origin_job_id` is `ON DELETE SET NULL` with foreign keys on, and `DownloadService.deleteJob` deleted the job row **before** emitting the `deleted` event its cleanup listener consumes — so `deleteByOriginJobId()` matched nothing. The asset survived with a null owner, still reading `state='ready'`.

A stale `ready` row keeps advertising the title as downloaded across five surfaces. Pressing Enter calls `findReadyJobIdForEpisode`, gets the null `originJobId`, returns no stream, trips the offline bail-out — and the bail-out's explanation was itself erased by a `finally` before it rendered. Home screen, no message.

Confirmed against the maintainer's live database: **14 orphaned assets**, including a movie whose file was already gone from disk.

## Fixes

- **Orphan prevention** — `deleteJob` emits before deleting the row.
- **Orphan repair** — `deleteOrphaned()` / `purgeOrphanedAssets()`, run once at bootstrap. Job-driven validation iterates jobs, so it can never reach a job-less row; that was the gap. No-op on a healthy library.
- **Local playback contract** — local files no longer go through `playLocal()`. That method had **zero production callers before this branch**; wiring it in dropped resume prompting, autoplay-chain mode (spawning a fresh mpv window per episode when bingeing downloads), near-EOF prefetch, the abort signal, merged timing, correlation, share-link context and track preferences. Local now uses `play()` with the full `PlayerOptions`; the local resolution already builds a complete `stream`.
- **Mixed autoplay** — an offline launch resolved episode availability to all-`null`, which `playback-result-policy` reads as "series finished", so downloaded E1 never advanced to downloaded E2 and `n` was dead. Availability now comes from `listNextReadyByTitleCursors`, keeping the launch free of catalog network calls while still answering truthfully.
- **Silent bail-out** — "Downloaded file unavailable" is now a `playbackProblem`, which survives the `finally` that was clearing it.

### Two online regressions this branch introduced and then fixed

- `SourceSelectionEngine` now honours `prefer-online` on the `continue` entrypoint. The branch had made **every** Continue-Watching resume silently prefer the downloaded file, overriding `continueSourcePreference` — that hit users who never touch offline.
- Conflict resolution against merged `main` took #28's canonical presentation seam over this branch's hand-rolled movie/video branching; `presentMedia()` / `formatMediaItemCount()` already cover every media kind it was special-casing.

## Verification

| Gate | Result |
| --- | --- |
| `bun run typecheck` | 14/14 |
| `bun run lint` | 12/12, 0 warnings 0 errors |
| `bun run test` | unit **3988 pass / 0 fail**; storage 97; providers 264; docs 71; integration 92 pass + **47 skip** / 0 fail |
| `bun run build` | 10/10 |
| `git diff --check` | clean |

The 47 integration skips are the repository's existing baseline (install.ps1, docker installer, compiled-binary smoke), not exclusions added here.

New storage test deletes a job, asserts the asset survives ownerless as `ready`, then asserts the purge removes it and is idempotent — the orphan mechanism end to end.

## Not verified

**No live provider or manual terminal verification was run.** Recorded as a gap, not a pass.

## Known issues left open (documented, not fixed here)

Ranked in `docs/superpowers/plans/2026-08-13-offline-playback-handoff.md`. The notable ones:

- `/play-local` can still resolve online — `source-refresh-policy` returns non-null unconditionally for `recover`, and the `!sourceRefreshDecision` guard skips the local resolver. Pre-existing; this branch aggravates it on offline launches.
- Local playback still requires a registered provider, so a downloaded file becomes unplayable if its provider is later retired.
- `repairable` jobs appear in both `listCompleted` and `listFailed`, so the download manager renders one job as two rows sharing an id. **Not** a one-line fix — the repair sweep uses `listFailed`; it needs a dedicated `listRepairable()` first. A KNOWN ISSUE comment marks the spot.
- `playLocal()` is dead again after this change; it should be deleted or explicitly noted.
- `PlaybackPhase.ts` is 4,273 lines with `execute()` at 2,866. Six of the nine `isOfflineLaunch` branches share one shape ("don't call the online catalog") and want a playback-metadata port. Recommended as follow-up, not bundled here.


---

## Review round 2 (2026-08-13)

An independent review pass verified the three claims in `573156d7` against code and the live database and confirmed all three sound: the orphan purge cannot reach legitimate data (one production writer, one cascade trigger, both closed), the 14 orphans lose nothing on disk (both parent directories were already gone), and the autoplay fix keys on the right title id. Follow-up commits:

- `fa19cde0` — **CI Format check was red** on one test file. Root cause worth carrying forward: the gate list everyone was using says `bun run fmt`, which *writes* and always exits 0, so the branch reported green locally while CI failed. The gate sequence should use **`bun run fmt:check`**.
- `5f3d5042` — the local-autoplay and silent-bail-out fixes had **zero test coverage**, and both regress invisibly (one returns null and reads as "series finished", the other renders nothing). Added tests for each. `nextReadyOfflineEpisode` moved out of `PlaybackPhase.ts` into `offline-episode-index.ts` as `findNextReadyEpisode`, beside its sibling `findReadyJobIdForEpisode`. The bail-out now builds its problem through `buildOfflineFileUnavailableProblem()` and **records a diagnostic** — previously the failure the user actually hit left no trace.

Gates at `5f3d5042`: typecheck 14/14, lint 12/12, **fmt:check 26/26**, test **3993 pass / 0 fail**, build 10/10, `git diff --check` clean. Integration's 47 skips are the repo's existing baseline, not exclusions.

### Scope note

This branch also commits **11 `plans/*.md` files (~780 lines)** — audit plans 031–038 plus `plans/README.md`. They were uncommitted audit inputs in the working checkout; committing them preserves work that would otherwise be lost, but they are **not part of the offline fix**. Of the changed files, 11 are unrelated documents. Landed here deliberately for preservation rather than split out.
