### PR TITLE
fix(doctor): report curl, which the default anime provider needs

### DIFF
--- a/.changeset/doctor-reports-curl.md
+++ b/.changeset/doctor-reports-curl.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Report `curl` in `kunai doctor` and setup. AniDB is the default anime provider and needs a curl (plain or curl-impersonate) to get past Cloudflare, so its absence could previously make anime search return nothing with no diagnostic anywhere.

--- a/.docs/quickstart.md
+++ b/.docs/quickstart.md
@@ -11,6 +11,12 @@ Use this doc for setup, local execution, and common environment issues. Architec
 - ImageMagick (`magick`) if you want Kitty/Ghostty non-PNG poster conversion
 - `yt-dlp` for YouTube playback and downloads/offline queue (must be on `PATH` for YouTube resolve/play and when downloads are enabled)
 - `ffprobe` optional—used only for quick validation of finished files, not downloading
+- `curl` for anime mode: AniDB is the default anime provider and sits behind
+  Cloudflare, which frequently blocks Bun's own fetch. Without a `curl` on
+  `PATH`, anime search can come back empty. A curl-impersonate build
+  (`curl_chrome136`, `curl_firefox135`, …) is preferred where available, since it
+  matches a browser TLS handshake; plain `curl` is used otherwise. `kunai doctor`
+  reports this as `curl=ok` / `curl=missing`.
 
 Deeper reference for terminal graphics, env overrides, and testing: [.docs/poster-image-rendering.md](poster-image-rendering.md).
 

--- a/apps/cli/src/app-shell/setup-shell.tsx
+++ b/apps/cli/src/app-shell/setup-shell.tsx
@@ -243,6 +243,14 @@ function SystemSlide({
       install: "Install ffprobe from your platform media-tools package when needed",
     },
     {
+      name: "curl",
+      status: snapshot.curl ? "ok" : "optional-missing",
+      detail: snapshot.curl
+        ? "Anime search ready"
+        : "Needed by AniDB, the default anime provider — anime search may return nothing",
+      install: "brew install curl  ·  pacman -S curl  ·  apt install curl",
+    },
+    {
       name: snapshot.image.renderer !== "none" ? "posters" : "posters (chafa/kitty)",
       status:
         snapshot.image.renderer !== "none" ? "ok" : snapshot.chafa ? "ok" : "optional-missing",

--- a/apps/cli/src/app-shell/workflows/setup-workflows.ts
+++ b/apps/cli/src/app-shell/workflows/setup-workflows.ts
@@ -7,6 +7,7 @@ import type { Container } from "@/container";
 import { getKunaiPaths } from "@/services/storage/storage-read-models";
 import { resolveTelemetryConsent } from "@/services/telemetry/consent";
 import { ensureInstallId } from "@/services/telemetry/install-id";
+import { probeCapabilities } from "@/ui";
 
 import { runSetupFlow } from "../setup-shell";
 
@@ -67,19 +68,10 @@ export async function runSetupWizard({
     return "skipped";
   }
 
-  const snapshot = container.capabilitySnapshot ?? {
-    mpv: Boolean(Bun.which("mpv")),
-    ffprobe: Boolean(Bun.which("ffprobe")),
-    ytDlp: Boolean(Bun.which("yt-dlp")),
-    chafa: Boolean(Bun.which("chafa")),
-    magick: Boolean(Bun.which("magick")),
-    image: {
-      renderer: "none",
-      terminal: "unknown",
-      available: false,
-    } as import("@/image").ImageCapability,
-    issues: [],
-  };
+  // Probe rather than hand-roll a snapshot: this literal used to duplicate
+  // probeCapabilities and drifted from it, and app-shell may not import the
+  // provider package, so it cannot ask AniDB which curl builds it can drive.
+  const snapshot = container.capabilitySnapshot ?? (await probeCapabilities());
 
   const defaultDownloadPath = join(dirname(getKunaiPaths().dataDbPath), "downloads");
   const { result } = runSetupFlow(snapshot);

--- a/apps/cli/src/services/update/native-installer/doctor.ts
+++ b/apps/cli/src/services/update/native-installer/doctor.ts
@@ -684,7 +684,7 @@ export function formatDoctorReportText(report: DoctorReport): string {
   lines.push("");
   lines.push("Dependencies");
   lines.push(
-    `  mpv=${report.dependencies.mpv ? "ok" : "missing"} yt-dlp=${report.dependencies.ytDlp ? "ok" : "missing"} ffprobe=${report.dependencies.ffprobe ? "ok" : "missing"}`,
+    `  mpv=${report.dependencies.mpv ? "ok" : "missing"} yt-dlp=${report.dependencies.ytDlp ? "ok" : "missing"} ffprobe=${report.dependencies.ffprobe ? "ok" : "missing"} curl=${report.dependencies.curl ? "ok" : "missing"}`,
   );
   lines.push("");
   lines.push("Storage");

--- a/apps/cli/src/ui.ts
+++ b/apps/cli/src/ui.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 
 import type { ImageCapability } from "@/image";
 import { detectImageCapability, isChafaAvailable } from "@/image";
+import { resolveAnidbCurl } from "@kunai/providers";
 import { getKunaiPaths } from "@kunai/storage";
 
 // ── Dependency check ───────────────────────────────────────────────────────
@@ -10,7 +11,7 @@ import { getKunaiPaths } from "@kunai/storage";
 export type CapabilitySeverity = "fatal" | "degraded";
 
 export interface CapabilityIssue {
-  readonly id: "mpv-missing" | "yt-dlp-missing" | "poster-rendering-unavailable";
+  readonly id: "mpv-missing" | "yt-dlp-missing" | "curl-missing" | "poster-rendering-unavailable";
   readonly severity: CapabilitySeverity;
   readonly message: string;
   readonly remediation: readonly string[];
@@ -21,6 +22,12 @@ export interface CapabilitySnapshot {
   /** Optional post-download probe (`ffprobe` on PATH); not required for the queue. */
   readonly ffprobe: boolean;
   readonly ytDlp: boolean;
+  /**
+   * A curl the AniDB provider can use — plain `curl` or a curl-impersonate
+   * build. AniDB is the default anime provider and anidb.app sits behind
+   * Cloudflare, so this is a real dependency of the default route, not a nicety.
+   */
+  readonly curl: boolean;
   readonly chafa: boolean;
   readonly magick: boolean;
   readonly image: ImageCapability;
@@ -40,7 +47,7 @@ function capabilityFingerprint(snapshot: CapabilitySnapshot): string {
     .map((issue) => `${issue.id}:${issue.severity}`)
     .sort()
     .join(",");
-  return `mpv:${snapshot.mpv ? "1" : "0"}|ffprobe:${snapshot.ffprobe ? "1" : "0"}|ytDlp:${snapshot.ytDlp ? "1" : "0"}|chafa:${snapshot.chafa ? "1" : "0"}|magick:${snapshot.magick ? "1" : "0"}|image:${snapshot.image.renderer}|terminal:${snapshot.image.terminal}|issues:${issueBits}`;
+  return `mpv:${snapshot.mpv ? "1" : "0"}|ffprobe:${snapshot.ffprobe ? "1" : "0"}|ytDlp:${snapshot.ytDlp ? "1" : "0"}|curl:${snapshot.curl ? "1" : "0"}|chafa:${snapshot.chafa ? "1" : "0"}|magick:${snapshot.magick ? "1" : "0"}|image:${snapshot.image.renderer}|terminal:${snapshot.image.terminal}|issues:${issueBits}`;
 }
 
 async function loadCapabilityNoticeState(): Promise<CapabilityNoticeState | null> {
@@ -67,15 +74,24 @@ async function saveCapabilityNoticeState(state: CapabilityNoticeState): Promise<
  * Prefer this for doctor and other inspection-only callers.
  */
 export async function probeCapabilities(
-  options: { requireYtDlp?: boolean } = {},
+  options: {
+    requireYtDlp?: boolean;
+    /** PATH lookup seam; defaults to the real one. Injected by tests. */
+    which?: (command: string) => string | null;
+  } = {},
 ): Promise<CapabilitySnapshot> {
   const requireYtDlp = options.requireYtDlp ?? false;
+  const which = options.which ?? ((command: string) => Bun.which(command));
   const issues: CapabilityIssue[] = [];
-  const mpv = Boolean(Bun.which("mpv"));
-  const ffprobe = Boolean(Bun.which("ffprobe"));
-  const ytDlp = Boolean(Bun.which("yt-dlp"));
+  const mpv = Boolean(which("mpv"));
+  const ffprobe = Boolean(which("ffprobe"));
+  const ytDlp = Boolean(which("yt-dlp"));
+  // Ask the provider which binaries it can actually drive: it prefers a
+  // curl-impersonate build over plain curl, so probing for the literal "curl"
+  // would report missing on a host that is fully capable.
+  const curl = resolveAnidbCurl(which) !== null;
   const chafa = isChafaAvailable();
-  const magick = Boolean(Bun.which("magick"));
+  const magick = Boolean(which("magick"));
   const image = detectImageCapability();
 
   if (!mpv) {
@@ -111,6 +127,26 @@ export async function probeCapabilities(
     });
   }
 
+  if (!curl) {
+    issues.push({
+      id: "curl-missing",
+      // Anime is one mode, so this degrades that route rather than blocking the
+      // shell — but it is the *default* anime route, so silence here means the
+      // user sees an empty AniDB search with no explanation.
+      severity: "degraded",
+      message:
+        "curl not found — AniDB (the default anime provider) sits behind Cloudflare and needs it; anime search may return nothing without it.",
+      remediation: [
+        "Arch:   sudo pacman -S curl",
+        "Debian: sudo apt install curl",
+        "Fedora: sudo dnf install curl",
+        "macOS:  brew install curl",
+        "Windows: curl.exe ships with Windows 10 1803+",
+        "Best:   install a curl-impersonate build to match a browser TLS handshake",
+      ],
+    });
+  }
+
   // Posters no longer gate on chafa or ImageMagick: the in-process half-block
   // renderer covers every truecolour terminal (including Windows Terminal
   // without chafa), and the kitty path decodes JPEG/PNG itself. chafa/magick
@@ -120,6 +156,7 @@ export async function probeCapabilities(
     mpv,
     ffprobe,
     ytDlp,
+    curl,
     chafa,
     magick,
     image,
@@ -158,3 +195,7 @@ export async function checkDeps(
 
   return snapshot;
 }
+
+export const __testing = {
+  capabilityFingerprint,
+};

--- a/apps/cli/test/unit/app-shell/setup-without-mpv.useinput.test.tsx
+++ b/apps/cli/test/unit/app-shell/setup-without-mpv.useinput.test.tsx
@@ -10,6 +10,7 @@ const MISSING_MPV: CapabilitySnapshot = {
   mpv: false,
   ffprobe: false,
   ytDlp: true,
+  curl: true,
   chafa: true,
   magick: true,
   image: {

--- a/apps/cli/test/unit/capability-curl.test.ts
+++ b/apps/cli/test/unit/capability-curl.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+
+import { __testing, probeCapabilities } from "@/ui";
+
+/**
+ * A PATH stub: every listed command resolves, everything else is absent.
+ *
+ * The real probe reads the host's PATH, so without this seam these assertions
+ * would depend on whatever the developer happens to have installed.
+ */
+function pathWith(...commands: readonly string[]) {
+  return (command: string) => (commands.includes(command) ? `/usr/bin/${command}` : null);
+}
+
+describe("probeCapabilities — curl for the default anime provider", () => {
+  test("reports curl present when plain curl is on PATH", async () => {
+    const snapshot = await probeCapabilities({ which: pathWith("curl") });
+
+    expect(snapshot.curl).toBe(true);
+    expect(snapshot.issues.map((issue) => issue.id)).not.toContain("curl-missing");
+  });
+
+  test("reports curl present when only a curl-impersonate build is on PATH", async () => {
+    // AniDB prefers an impersonate build over plain curl, so probing for the
+    // literal "curl" would report missing on a host that is fully capable.
+    const snapshot = await probeCapabilities({ which: pathWith("curl_chrome136") });
+
+    expect(snapshot.curl).toBe(true);
+    expect(snapshot.issues.map((issue) => issue.id)).not.toContain("curl-missing");
+  });
+
+  test("raises a degraded issue when no curl variant exists", async () => {
+    const snapshot = await probeCapabilities({ which: pathWith("mpv", "yt-dlp", "ffprobe") });
+
+    expect(snapshot.curl).toBe(false);
+    const issue = snapshot.issues.find((candidate) => candidate.id === "curl-missing");
+    expect(issue).toBeDefined();
+    // Anime is one mode, so a missing curl degrades rather than blocks the shell.
+    expect(issue?.severity).toBe("degraded");
+    // The message has to name what actually breaks; "curl not found" alone
+    // gives the user no reason to care.
+    expect(issue?.message).toContain("AniDB");
+    expect(issue?.remediation.length).toBeGreaterThan(0);
+  });
+
+  test("probes each dependency independently", async () => {
+    const snapshot = await probeCapabilities({ which: pathWith("curl") });
+
+    expect(snapshot.mpv).toBe(false);
+    expect(snapshot.ytDlp).toBe(false);
+    expect(snapshot.ffprobe).toBe(false);
+    expect(snapshot.curl).toBe(true);
+  });
+
+  test("defaults to the real PATH when no probe is injected", async () => {
+    const snapshot = await probeCapabilities();
+
+    expect(typeof snapshot.curl).toBe("boolean");
+  });
+
+  test("the probed flag reaches the capability fingerprint", async () => {
+    // The fingerprint decides whether the remediation notice is shown again, so
+    // a curl that appears or disappears has to change it — otherwise the user
+    // installs curl and is still told it is missing, or vice versa.
+    const withCurl = await probeCapabilities({ which: pathWith("curl") });
+    const withoutCurl = await probeCapabilities({ which: pathWith("mpv") });
+
+    expect(__testing.capabilityFingerprint(withCurl)).not.toBe(
+      __testing.capabilityFingerprint(withoutCurl),
+    );
+  });
+});

--- a/apps/cli/test/unit/run-doctor.test.ts
+++ b/apps/cli/test/unit/run-doctor.test.ts
@@ -21,6 +21,7 @@ function emptyCapabilities(): CapabilitySnapshot {
     mpv: true,
     ffprobe: true,
     ytDlp: true,
+    curl: true,
     chafa: true,
     magick: true,
     image: {

--- a/apps/cli/test/unit/services/update/native-installer/doctor.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/doctor.test.ts
@@ -36,6 +36,7 @@ function emptyCapabilities(overrides: Partial<CapabilitySnapshot> = {}): Capabil
     mpv: true,
     ffprobe: true,
     ytDlp: true,
+    curl: true,
     chafa: true,
     magick: true,
     image: {

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,10 +1,10 @@
 {
-  "syncedAt": "2026-08-13T07:35:44.093Z",
+  "syncedAt": "2026-08-13T11:52:12.378Z",
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceRevision": "467a6120",
+  "cliSourceRevision": "6359ece8",
   "cliSourceFingerprint": "787c49c9107036b9a9db043a1e17d5edd3b6e529a00e27029dd578c7cd9f970e",
-  "docsContentFingerprint": "5c956bd330ce5c2aed77bd1a3e7b630e4d742242b139b757739e189a6d6f34c8",
+  "docsContentFingerprint": "fef27a454ddd909b2dce89052178e6702695c995c239fb28468037331e70d26d",
   "featureStatusRevision": "cfb217102303c9ee08bc57588f58ac7e278e7c1bf9ca607ebac1c712c5eb129b",
   "commandCount": 81,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/docs/users/diagnostics-and-reporting.mdx
+++ b/docs/users/diagnostics-and-reporting.mdx
@@ -34,7 +34,7 @@ Press `/` and choose diagnostics, or type:
 
 The panel typically includes:
 
-- **Capabilities** — mpv, yt-dlp, ffprobe, poster renderer detection at startup
+- **Capabilities** — mpv, yt-dlp, ffprobe, curl, poster renderer detection at startup
 - **Provider** — resolve stages, failure classes, fallback timeline
 - **Cache** — hit/miss, stale revalidation, stream health events
 - **Subtitles** — attachment evidence and active track
@@ -126,6 +126,7 @@ Recorded once per session:
 
 - mpv found on PATH
 - yt-dlp / ffprobe availability
+- curl availability (needed by AniDB, the default anime provider)
 - Terminal poster support (Kitty vs chafa)
 - Platform opener availability
 


### PR DESCRIPTION
## Scope

`kunai doctor` reported `mpv`, `yt-dlp` and `ffprobe` but not `curl`.

AniDB is the **default** anime provider (`animeProvider: "anidb"` in
`packages/config/src/defaults.ts`), `anidb.app` sits behind Cloudflare, and Bun's
own `fetch` is frequently challenged there — a challenge page parses to zero
search results. So a host without curl could get an empty anime search with no
diagnostic on any surface.

## What changed

- `CapabilitySnapshot` gains `curl: boolean`.
- A `curl-missing` capability issue, `degraded` severity — anime is one mode, so
  it degrades that route rather than blocking the shell. The message names AniDB,
  because "curl not found" alone gives the user no reason to care.
- Reported in the doctor summary line, a setup dependency row, and the capability
  fingerprint.

### The probe asks the provider instead of guessing

`resolveAnidbCurl()` already owns the candidate list and prefers a
curl-impersonate build (`curl_firefox135`, `curl_chrome136`, …) over plain `curl`,
since Cloudflare fingerprints the TLS handshake. Probing for the literal `"curl"`
would report *missing* on a host running only `curl_chrome136` — a false negative
contradicting what the provider can actually do. So the probe calls
`resolveAnidbCurl`, keeping one source of truth.

### Three readers, not a bare declaration

Silent no-ops are this repo's stated house failure mode, so the new flag was
wired into every surface that already reads the snapshot:

| Surface | Before | After |
| --- | --- | --- |
| `doctor` summary | `mpv=ok yt-dlp=ok ffprobe=ok` | `… ffprobe=ok curl=ok` |
| setup dependency rows | mpv / yt-dlp / ffprobe / posters | + `curl` |
| capability fingerprint | no curl bit | includes curl |

The fingerprint matters on its own: it gates whether the remediation notice
reappears, so without it a user could install curl and still be told it was
missing.

### One incidental cleanup

`setup-workflows.ts` had an inline fallback snapshot duplicating
`probeCapabilities()`, and it had already drifted. It now calls
`probeCapabilities()`. This was not optional polish — `app-shell` may not import
`@kunai/providers` (enforced by `boundary-imports.test.ts`), so that literal
could not have probed curl itself.

## Verification

All from the worktree root:

| Gate | Result |
| --- | --- |
| `bun run typecheck` | 14/14 |
| `bun run lint` | 12/12 |
| `bun run fmt:check` | clean |
| `bun run test` — unit | **3986 pass / 0 fail** |
| `bun run test` — integration | **92 pass / 0 fail / 47 skip** |
| `bun run test` — providers | 264 pass |
| `bun run test` — docs | 71 pass |
| `bun run build` | 10/10 |
| `git diff --check` | clean |
| `verify:doc-paths` / `verify:doc-coverage` | pass |
| `check-codegen-freshness.ts` | fresh |

The integration suite's 47 skips are the repository's existing baseline, not
exclusions introduced here.

New tests: `apps/cli/test/unit/capability-curl.test.ts` (6), written failing
first. They inject a PATH stub, so they assert behaviour rather than whatever the
developer happens to have installed — including the impersonate-build case that a
naive probe would get wrong.

### Observed on the built binary

```
$ kunai doctor
  mpv=ok yt-dlp=ok ffprobe=ok curl=ok

$ env PATH=/nonexistent kunai doctor
  mpv=missing yt-dlp=missing ffprobe=missing curl=missing
  [warning] curl-missing: curl not found — AniDB (the default anime provider)
  sits behind Cloudflare and needs it; anime search may return nothing without it.
      - Arch:   sudo pacman -S curl
      ...
```

## Docs

`.docs/quickstart.md` (runtime tools) and
`docs/users/diagnostics-and-reporting.mdx` (capabilities list), plus regenerated
`apps/docs/lib/generated-metadata.json`. Changeset: `patch`.

## Release blockers

None introduced or discharged. This makes an existing dependency gap
*diagnosable*; it does not change provider behaviour.

https://claude.ai/code/session_012N9Tm1cSoB5pvYjrThFvsz