### PR TITLE
fix(videasy): enforce TMDB identity, own the route cache policy, and bound Wings transport

### DIFF
--- a/.changeset/videasy-cache-and-transport.md
+++ b/.changeset/videasy-cache-and-transport.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Harden Videasy's active path: TMDB identity must be a complete positive decimal, the selected-route cache policy has a single owner instead of being silently rebuilt, and Wings seed transport state is bounded. Cancelling a playback no longer marks both Wings hosts unhealthy for five minutes.

--- a/.docs/provider-dossiers/videasy.md
+++ b/.docs/provider-dossiers/videasy.md
@@ -1,5 +1,44 @@
 # Provider: Videasy
 
+## Production status (2026-08-13) — cache and transport hardening
+
+Plan 038's active-path correctness work landed. What changed:
+
+- **Identity.** The provider-local `resolveTmdbId` (and its twin in
+  `shared/direct-stream-source.ts`) were replaced by one shared
+  `resolveTmdbCatalogId()`. Complete positive decimals only; a bare numeric
+  `title.id` is still accepted because that is what `-i <id>` and the live smokes
+  actually pass.
+- **Cache policy.** `createVidkingResultFromPayload()` no longer ignores the policy
+  it is handed. `createVideasyRouteCachePolicy()` is the one builder, called only
+  after a route answers, and the selected source now carries `metadata.apiRoute`.
+- **Wings transport.** Seed / preferred-host / failure state moved onto the shared
+  `TTLCache` with hard ceilings (16 / 256 / 32). The seed and preferred-host maps
+  were previously unbounded and only ever pruned an entry that was asked for again.
+- **Caller abort no longer poisons host health.** This was a real bug: cancelling a
+  playback rejected every in-flight seed attempt, and the catch could not tell that
+  apart from a genuine failure, so both Wings hosts entered a five-minute penalty
+  box. Pinned by `videasy-wings-seed-race.test.ts`, which fails without the guard.
+- **HTTP 500 remains transient**, documented once in `classifyVideasyHttpFailure()`
+  and pinned by tests. **`wings-tejo` remains deprecated and unimplemented.**
+
+Deliberately **not** done, and why:
+
+- **The logical-request → selected-route cache index was not built.** The design plan
+  called for route-specific CLI cache keys with a logical alias index. The CLI's
+  stream-cache key is currently route-agnostic and _consistent_ — read, write, and
+  invalidation all derive the same preimage from the manifest `keyParts` — so there
+  is no key-mismatch bug to fix, and fragmenting the key by route would add cache
+  misses for a benefit no test could demonstrate. Stale entries whose route later
+  dies are already handled by cache-revalidation stream-health probes.
+- **The `wings-transport.ts` extraction was not performed.** The two confirmed
+  defects (boundedness, abort classification) are fixed and tested in place. Lifting
+  the transport into its own module with an injected clock remains worthwhile
+  cleanup, not a release blocker.
+- **Deprecated route/WASM deletion was not attempted.** It is separate non-blocking
+  cleanup and is explicitly not a release blocker; the routes are proven inert by
+  contract tests instead.
+
 ## Production status (2026-07-16)
 
 - **Module:** `packages/providers/src/videasy/direct.ts` + `flavors.ts` + `crypto.ts`

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -536,6 +536,54 @@ History and continuation use **canonical catalog ids** as the merge key (`anilis
 - **AllAnime bridge** — `resolveAllMangaShowId` reads `providerNativeIds.allanime`, then the durable SQLite `provider_title_bridge` cache (TTL class `provider-metadata`), then in-process search bridge. Bridge results are persisted to both history metadata and the cache adapter injected through `ProviderRuntimeContext.titleBridge`.
 - **Legacy repair** — `HistoryIdentityConsolidator` runs once at CLI bootstrap (catalog-proof rows only; set `KUNAI_HISTORY_IDENTITY_DRY_RUN=1` to log without writing). Continue-watching dedupes display rows by catalog id without DB writes.
 
+### Videasy identity, route caching and Wings transport
+
+- **TMDB identity is complete or it is nothing.** `resolveTmdbCatalogId()` in
+  `packages/providers/src/shared/catalog-id.ts` is the single reader for every
+  TMDB-keyed provider (Videasy and the shared direct-stream source path). It accepts
+  an explicit `title.tmdbId`, an exact `tmdb:` prefix, or a bare `title.id`, each of
+  which must match `^[1-9]\d*$` and be a safe integer. The bare form is load-bearing:
+  `kunai -i 438631 -t movie` and the live provider smokes pass a bare numeric id with
+  no `externalIds`. The old `Number.parseInt` readers accepted `123abc`, `123`,
+  `0`, `-5`, `4.5` and `1e5`.
+- **One owner builds the selected-route cache policy.**
+  `createVideasyRouteCachePolicy({ resolveInput, appId, apiRoute })` is the only
+  builder, and it may only be called once a route has actually answered — `apiRoute`
+  is evidence, not a guess. `createVidkingResultFromPayload()` now **requires** a
+  policy and an `apiRoute` and uses the policy verbatim; it previously named the
+  parameter `_cachePolicy`, discarded it, and rebuilt an equivalent policy internally
+  by re-deriving the route and app id. The selected source records `metadata.apiRoute`
+  so route provenance is read explicitly rather than by positionally parsing
+  `cachePolicy.keyParts`.
+- **The CLI stream-cache key is route-agnostic, and that is deliberate.**
+  `buildApiStreamResolveCacheKey()` in
+  `apps/cli/src/services/cache/stream-resolve-cache.ts` derives its preimage from the
+  manifest `keyParts`, which carry no `apiRoute`. Read, write, and invalidation all
+  use that one key, so they cannot disagree. A stale entry whose route later dies is
+  caught by the cache-revalidation stream-health probe, not by key fragmentation.
+- **Wings transport state is bounded.** Seed and preferred-host entries are keyed per
+  media id and previously grew for the life of the process — expiry alone never freed
+  an entry nobody asked for again. All three maps are now `TTLCache` instances with
+  hard ceilings (`WINGS_TRANSPORT_LIMITS`: 16 seed, 256 preferred-host, 32 failure).
+  `TTLCache` gained an optional `maxEntries` and an injectable clock; it evicts
+  expired entries first and only then the oldest write, and replacing a key never
+  counts as growth.
+- **Seed-race outcomes are classified by cause.** A host is penalized only for a
+  genuine pre-winner failure or timeout. A loser aborted because a peer already won
+  is not evidence, and neither is **caller cancellation** — that last case used to
+  put both Wings hosts in a five-minute penalty box every time a user walked away
+  from a playback. Every transition is covered by deterministic deferred-promise
+  tests in `packages/providers/test/videasy-wings-seed-race.test.ts`. When every host
+  is penalized the transport still races them rather than giving up, which is why
+  host health is asserted directly instead of being inferred from request order.
+- **HTTP 500 stays transient.** Only 404 and 410 are `route-dead`. Many
+  speedracelight servers answer 500 "No streams available" for one title while
+  staying healthy for every other title, so quarantining the endpoint on a 500 would
+  take a working route offline.
+- **`wings-tejo` stays deprecated and unsupported.** It is not in the active flavor
+  list, not eligible, and not scheduled in phase A. Its AES-GCM decoder is not
+  implemented and must not be added for a route product code cannot select.
+
 ### Episode metadata ownership
 
 Default hot path prefers provider-native episode titles:

--- a/apps/cli/scripts/build-shared.ts
+++ b/apps/cli/scripts/build-shared.ts
@@ -220,11 +220,15 @@ export function totalMetafileInputBytes(metafile: BunBuildMetafile): number {
  * NPM_PACK_UNPACKED_BUDGET_BYTES, so moving this number cannot affect what a
  * user installs from npm.
  *
- * Raised from 2_800 on 2026-08-13 for the verified offline media/sidecar
- * provenance handoff plus active cancellation and reconnect generation guards.
- * The previous tree had 388 bytes of headroom; the completed bundle is 2_804 KiB.
+ * Raised from 2_800 on 2026-08-13 for the release-hardening provider work
+ * plus the verified offline media/sidecar provenance handoff and active
+ * cancellation/reconnect generation guards. `main` had only 388 bytes of
+ * headroom before those changes. The added provider code is diagnostics and
+ * bounded-cache machinery: endpoint-aware pipe decoding, a curl truncation
+ * guard, strict catalog-id parsing, and TTL cache size bounds. The step restores
+ * real headroom rather than clearing one change.
  */
-export const NPM_BUNDLE_BUDGET_KB = 2_816;
+export const NPM_BUNDLE_BUDGET_KB = 2_880;
 
 /** Packed-size ratchet for the public Node launcher manifest, script, and license. */
 export const NPM_PACK_PACKED_BUDGET_BYTES = 32 * 1024;

--- a/packages/providers/src/shared/catalog-id.ts
+++ b/packages/providers/src/shared/catalog-id.ts
@@ -1,0 +1,37 @@
+import type { TitleIdentity } from "@kunai/types";
+
+const TMDB_ID_PREFIX = "tmdb:";
+
+/**
+ * A catalog id is a complete positive decimal or it is not a catalog id.
+ *
+ * `Number.parseInt` is the wrong tool here: it happily reads `123` out of
+ * `123abc`, accepts surrounding whitespace, and returns `0` and negatives that
+ * then travel on as if they were real ids. Every rejection below is a request
+ * that would otherwise reach a provider API and come back as an unexplained
+ * empty result.
+ */
+export function parseCompletePositiveDecimalId(value: string | undefined): number | null {
+  if (!value || !/^[1-9]\d*$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+/**
+ * The one TMDB identity reader for every TMDB-keyed provider.
+ *
+ * Accepts an explicit `title.tmdbId`, an exact `tmdb:` prefix, or a bare
+ * complete decimal `title.id`. The bare form is load-bearing: `kunai -i 438631
+ * -t movie` and the live provider smokes both pass a bare numeric id with no
+ * `externalIds`, so failing closed on it would take the provider offline.
+ */
+export function resolveTmdbCatalogId(title: TitleIdentity): number | null {
+  const explicit = parseCompletePositiveDecimalId(title.tmdbId);
+  if (explicit !== null) return explicit;
+
+  if (title.id.startsWith(TMDB_ID_PREFIX)) {
+    return parseCompletePositiveDecimalId(title.id.slice(TMDB_ID_PREFIX.length));
+  }
+
+  return parseCompletePositiveDecimalId(title.id);
+}

--- a/packages/providers/src/shared/direct-stream-source.ts
+++ b/packages/providers/src/shared/direct-stream-source.ts
@@ -10,9 +10,9 @@ import type {
   ProviderVariantCandidate,
   StreamCandidate,
   SubtitleCandidate,
-  TitleIdentity,
 } from "@kunai/types";
 
+import { resolveTmdbCatalogId } from "./catalog-id";
 import { createExhaustedResult, emitTraceEvent } from "./resolve-helpers";
 import {
   createStreamId,
@@ -96,7 +96,7 @@ export async function resolveDirectStreamSource(
     });
   }
 
-  const tmdbId = resolveTmdbId(input.title);
+  const tmdbId = resolveTmdbCatalogId(input.title);
   if (!tmdbId) {
     return createExhaustedResult(input, context, providerId, {
       code: "unsupported-title",
@@ -416,12 +416,6 @@ function isTimeoutError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   if (error.name === "TimeoutError" || error.name === "AbortError") return true;
   return /timed out|timeout/i.test(error.message);
-}
-
-function resolveTmdbId(title: TitleIdentity): number | null {
-  const raw = title.tmdbId ?? title.id;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function inferProtocol(url: string): StreamCandidate["protocol"] {

--- a/packages/providers/src/shared/index.ts
+++ b/packages/providers/src/shared/index.ts
@@ -1,4 +1,5 @@
 export * from "./anime-audio-intent";
+export * from "./catalog-id";
 export * from "./anime-metadata";
 export * from "./anime-source-presentation";
 export * from "./known-catalog";

--- a/packages/providers/src/shared/provider-cache.ts
+++ b/packages/providers/src/shared/provider-cache.ts
@@ -4,15 +4,38 @@
 
 type CacheEntry<V> = { readonly value: V; readonly expiresAt: number };
 
+export type TTLCacheOptions = {
+  /**
+   * Hard entry ceiling. Without one, a cache keyed by title/media id grows for
+   * the whole session: expiry alone never frees anything, because an entry is
+   * only dropped when something asks for that exact key again.
+   */
+  readonly maxEntries?: number;
+  /** Injectable clock so eviction and expiry are testable without real time. */
+  readonly now?: () => number;
+};
+
 export class TTLCache<K, V> {
   private readonly store = new Map<K, CacheEntry<V>>();
+  private readonly maxEntries?: number;
+  private readonly now: () => number;
 
-  constructor(private readonly defaultTtlMs: number) {}
+  constructor(
+    private readonly defaultTtlMs: number,
+    options: TTLCacheOptions = {},
+  ) {
+    this.maxEntries = options.maxEntries;
+    this.now = options.now ?? Date.now;
+  }
+
+  get size(): number {
+    return this.store.size;
+  }
 
   get(key: K): V | undefined {
     const entry = this.store.get(key);
     if (!entry) return undefined;
-    if (Date.now() >= entry.expiresAt) {
+    if (this.now() >= entry.expiresAt) {
       this.store.delete(key);
       return undefined;
     }
@@ -20,7 +43,13 @@ export class TTLCache<K, V> {
   }
 
   set(key: K, value: V, ttlMs?: number): void {
-    this.store.set(key, { value, expiresAt: Date.now() + (ttlMs ?? this.defaultTtlMs) });
+    // Replacing a key must not count as growth, so evict only after the write.
+    this.store.set(key, { value, expiresAt: this.now() + (ttlMs ?? this.defaultTtlMs) });
+    this.evictIfNeeded();
+  }
+
+  delete(key: K): void {
+    this.store.delete(key);
   }
 
   clear(): void {
@@ -29,9 +58,24 @@ export class TTLCache<K, V> {
 
   /** Remove all entries older than the given TTL. */
   prune(): void {
-    const now = Date.now();
+    const now = this.now();
     for (const [key, entry] of this.store) {
       if (now >= entry.expiresAt) this.store.delete(key);
+    }
+  }
+
+  /** Drop expired entries first; only then fall back to oldest-inserted. */
+  private evictIfNeeded(): void {
+    const limit = this.maxEntries;
+    if (limit === undefined || this.store.size <= limit) return;
+
+    this.prune();
+
+    // `Map` iterates in insertion order, so the first key is the oldest write.
+    while (this.store.size > limit) {
+      const oldest = this.store.keys().next();
+      if (oldest.done) return;
+      this.store.delete(oldest.value);
     }
   }
 }

--- a/packages/providers/src/videasy/direct.ts
+++ b/packages/providers/src/videasy/direct.ts
@@ -28,7 +28,7 @@ import type {
 } from "@kunai/types";
 
 import { resolveTmdbCatalogId } from "../shared/catalog-id";
-import { HealthTracker } from "../shared/provider-cache";
+import { HealthTracker, TTLCache } from "../shared/provider-cache";
 import {
   appendCycleEventsToResult,
   findLastCycleFailure,
@@ -1367,11 +1367,59 @@ type WingsSeedTransport = {
   readonly seed: string;
 };
 
-const wingsSeedCache = new Map<string, { seed: string; expiresAt: number }>();
-const wingsPreferredHostCache = new Map<number, { apiBase: string; expiresAt: number }>();
+/**
+ * Hard ceilings. Seeds and preferred hosts are keyed per media id, so without a
+ * bound they grow for the lifetime of the process — expiry alone never frees an
+ * entry nobody asks for again. The failure map is host-keyed and naturally tiny;
+ * its bound is a backstop against a future host list, not a live pressure point.
+ */
+export const WINGS_TRANSPORT_LIMITS = {
+  seedEntries: 16,
+  preferredHostEntries: 256,
+  failureEntries: 32,
+} as const;
+
+/** A seed is only valid for the host that issued it, so the pair is the value. */
+const wingsSeedCache = new TTLCache<string, string>(30_000, {
+  maxEntries: WINGS_TRANSPORT_LIMITS.seedEntries,
+});
+const wingsPreferredHostCache = new TTLCache<number, string>(30_000, {
+  maxEntries: WINGS_TRANSPORT_LIMITS.preferredHostEntries,
+});
 /** Hosts that recently failed a seed request get skipped for a while (host-level). */
-const wingsHostFailureCache = new Map<string, number>();
+const wingsHostFailureCache = new TTLCache<string, true>(5 * 60_000, {
+  maxEntries: WINGS_TRANSPORT_LIMITS.failureEntries,
+});
 const WINGS_HOST_FAILURE_PENALTY_MS = 5 * 60_000;
+
+/** Test seam: the seed race is deterministic only with an injected requester. */
+export function fetchWingsdatabaseSeedForTest(
+  mediaId: number,
+  context: ProviderRuntimeContext,
+  signal?: AbortSignal,
+): Promise<WingsSeedTransport | undefined> {
+  return fetchWingsdatabaseSeed(mediaId, context, signal);
+}
+
+/**
+ * Test seam: which hosts currently carry a failure penalty.
+ *
+ * Request order alone cannot prove this — when every host is penalized the
+ * transport deliberately races them all rather than giving up, so "both hosts
+ * were contacted" is true both when nothing was blamed and when everything was.
+ */
+export function wingsPenalizedHostsForTest(): readonly string[] {
+  return [WINGS_API_BASE, WINGS_API_FALLBACK_BASE].filter((base) =>
+    Boolean(wingsHostFailureCache.get(base)),
+  );
+}
+
+/** Test seam: module-scoped transport state must not leak between test cases. */
+export function clearWingsTransportCachesForTest(): void {
+  wingsSeedCache.clear();
+  wingsPreferredHostCache.clear();
+  wingsHostFailureCache.clear();
+}
 
 function wingsSeedCacheKey(apiBase: string, mediaId: number): string {
   return `${apiBase}\u001f${mediaId}`;
@@ -1391,9 +1439,7 @@ async function fetchWingsdatabaseSeed(
     referer: "https://www.cineby.at/",
   } as const;
 
-  const now = Date.now();
-  const preferred = wingsPreferredHostCache.get(mediaId);
-  const preferredBase = preferred && now < preferred.expiresAt ? preferred.apiBase : undefined;
+  const preferredBase = wingsPreferredHostCache.get(mediaId);
   const bases = preferredBase
     ? [
         preferredBase,
@@ -1405,15 +1451,15 @@ async function fetchWingsdatabaseSeed(
   // fallback stays an indivisible host+seed pair.
   const uncached: string[] = [];
   for (const apiBase of bases) {
-    const cached = wingsSeedCache.get(wingsSeedCacheKey(apiBase, mediaId));
-    if (cached && now < cached.expiresAt) {
-      return { apiBase, seed: cached.seed };
+    const cachedSeed = wingsSeedCache.get(wingsSeedCacheKey(apiBase, mediaId));
+    if (cachedSeed) {
+      return { apiBase, seed: cachedSeed };
     }
     uncached.push(apiBase);
   }
 
   // Skip recently-failed hosts unless every host is in the penalty box.
-  const healthy = uncached.filter((base) => (wingsHostFailureCache.get(base) ?? 0) <= now);
+  const healthy = uncached.filter((base) => !wingsHostFailureCache.get(base));
   const candidates = healthy.length > 0 ? healthy : uncached;
   if (candidates.length === 0) return undefined;
 
@@ -1440,19 +1486,22 @@ async function fetchWingsdatabaseSeed(
           if (!body.seed) throw new Error("seed payload missing seed");
           return { apiBase, seed: body.seed, ttlMs: body.ttlMs ?? 30_000 };
         } catch (error) {
-          if (!won) wingsHostFailureCache.set(apiBase, Date.now() + WINGS_HOST_FAILURE_PENALTY_MS);
+          // Three different causes reach this catch and only one is host
+          // evidence. A loser aborted because a peer already won says nothing
+          // about this host, and neither does the *caller* walking away — that
+          // used to poison both hosts for five minutes on every cancelled
+          // playback. A genuine pre-winner failure or timeout is real evidence.
+          if (!won && !effectiveSignal?.aborted) {
+            wingsHostFailureCache.set(apiBase, true, WINGS_HOST_FAILURE_PENALTY_MS);
+          }
           throw error;
         }
       }),
     ).catch(() => undefined);
     if (!winner) return undefined;
 
-    const expiresAt = Date.now() + winner.ttlMs;
-    wingsSeedCache.set(wingsSeedCacheKey(winner.apiBase, mediaId), {
-      seed: winner.seed,
-      expiresAt,
-    });
-    wingsPreferredHostCache.set(mediaId, { apiBase: winner.apiBase, expiresAt });
+    wingsSeedCache.set(wingsSeedCacheKey(winner.apiBase, mediaId), winner.seed, winner.ttlMs);
+    wingsPreferredHostCache.set(mediaId, winner.apiBase, winner.ttlMs);
     wingsHostFailureCache.delete(winner.apiBase);
     return { apiBase: winner.apiBase, seed: winner.seed };
   } finally {

--- a/packages/providers/src/videasy/direct.ts
+++ b/packages/providers/src/videasy/direct.ts
@@ -191,13 +191,12 @@ function createVideasyEndpointHealth(context: ProviderRuntimeContext) {
   };
 }
 
-function classifyVideasyHttpFailure(statusCode: number): EndpointFailureClass {
-  // Only permanent route removal is route-dead. Many speedracelight servers
-  // return HTTP 500 "No streams available" for a single title while staying
-  // healthy for others — do not quarantine the whole endpoint on 500.
-  if (statusCode === 404 || statusCode === 410) return "route-dead";
-  if (statusCode >= 500) return "transient";
-  return "transient";
+export function classifyVideasyHttpFailure(statusCode: number): EndpointFailureClass {
+  // Only permanent route removal is route-dead. Everything else — 500 included —
+  // is transient: many speedracelight servers return HTTP 500 "No streams
+  // available" for a single title while staying healthy for every other title,
+  // so quarantining the endpoint on a 500 would take a working route offline.
+  return statusCode === 404 || statusCode === 410 ? "route-dead" : "transient";
 }
 
 type VidkingServer = (typeof VIDKING_SERVERS)[number];

--- a/packages/providers/src/videasy/direct.ts
+++ b/packages/providers/src/videasy/direct.ts
@@ -27,6 +27,7 @@ import type {
   TitleIdentity,
 } from "@kunai/types";
 
+import { resolveTmdbCatalogId } from "../shared/catalog-id";
 import { HealthTracker } from "../shared/provider-cache";
 import {
   appendCycleEventsToResult,
@@ -302,7 +303,7 @@ export async function resolveVideasyDirect(
     });
   }
 
-  const tmdbId = resolveTmdbId(input.title);
+  const tmdbId = resolveTmdbCatalogId(input.title);
   if (!tmdbId) {
     return createExhaustedResult(input, context, VIDEOSY_PROVIDER_ID, {
       code: "unsupported-title",
@@ -1781,7 +1782,7 @@ export function resolveVideasyClientProfile(
     };
   }
 
-  const tmdbId = resolveTmdbId(input.title);
+  const tmdbId = resolveTmdbCatalogId(input.title);
   const referer =
     customReferer ??
     (tmdbId && input.mediaKind === "series" && input.episode?.season && input.episode?.episode
@@ -2382,12 +2383,6 @@ function isRetryableFailure(context: ProviderRuntimeContext, failure: ProviderFa
   if (!failure.retryable) return false;
   const retryableCodes = context.retryPolicy?.retryableCodes;
   return !retryableCodes || retryableCodes.includes(failure.code);
-}
-
-function resolveTmdbId(title: TitleIdentity): number | null {
-  const raw = title.tmdbId ?? title.id;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function normalizeVidkingAudioLanguage(

--- a/packages/providers/src/videasy/direct.ts
+++ b/packages/providers/src/videasy/direct.ts
@@ -889,9 +889,35 @@ function parseVidkingCycleCandidateMetadata(
   };
 }
 
+/**
+ * The one builder for a Videasy stream-cache policy.
+ *
+ * A route may only be named here **after** a request to it actually succeeded —
+ * `apiRoute` is evidence of a selected route, not a guess. Keeping construction
+ * in one place is what stops the result, the source rows, and the stream rows
+ * from drifting onto three near-identical keys.
+ */
+export function createVideasyRouteCachePolicy(input: {
+  readonly resolveInput: ProviderResolveInput;
+  readonly appId?: string;
+  readonly apiRoute: string;
+}): CachePolicy {
+  return createProviderCachePolicy({
+    providerId: VIDEOSY_PROVIDER_ID,
+    title: input.resolveInput.title,
+    episode: input.resolveInput.episode,
+    subtitleLanguage: input.resolveInput.preferredSubtitleLanguage,
+    qualityPreference: input.resolveInput.qualityPreference,
+    startupPriority: input.resolveInput.startupPriority,
+    videasyAppId: input.appId,
+    apiRoute: input.apiRoute,
+  });
+}
+
 export function createVidkingResultFromPayload({
   input,
-  cachePolicy: _cachePolicy,
+  cachePolicy,
+  apiRoute,
   payload,
   sourceId,
   server,
@@ -908,7 +934,10 @@ export function createVidkingResultFromPayload({
   streamReachabilityVerified,
 }: {
   readonly input: ProviderResolveInput;
-  readonly cachePolicy?: CachePolicy;
+  /** Built by `createVideasyRouteCachePolicy()` and used verbatim — never rebuilt here. */
+  readonly cachePolicy: CachePolicy;
+  /** The route that actually answered. Recorded on the selected source. */
+  readonly apiRoute: string;
   readonly payload: VidkingPayload;
   readonly sourceId?: string;
   readonly server?: string;
@@ -925,17 +954,7 @@ export function createVidkingResultFromPayload({
   readonly streamReachabilityVerified?: boolean;
 }): ProviderResolveResult | null {
   const resolvedServer = (server as VidkingServer | undefined) ?? "wings-cdn";
-  const videasyAppId = context ? resolveVideasyAppId(engineOptions ?? {}, context) : undefined;
-  const policy = createProviderCachePolicy({
-    providerId: VIDEOSY_PROVIDER_ID,
-    title: input.title,
-    episode: input.episode,
-    subtitleLanguage: input.preferredSubtitleLanguage,
-    qualityPreference: input.qualityPreference,
-    startupPriority: input.startupPriority,
-    videasyAppId,
-    apiRoute: resolvedServer,
-  });
+  const policy = cachePolicy;
   const presentation = resolveVidkingPresentation(
     resolvedServer,
     engineOptions ?? {
@@ -1074,6 +1093,10 @@ export function createVidkingResultFromPayload({
         cachePolicy: policy,
         sourceEvidence,
         metadata: {
+          // Explicit route provenance. Anything that later wants to know which
+          // route produced this result reads it here rather than positionally
+          // parsing `cachePolicy.keyParts`.
+          apiRoute,
           server: resolvedServer,
           flavorId: presentation.flavorId,
           flavorArchetype: themedSubtitle,
@@ -1663,9 +1686,16 @@ async function tryVidkingServer(opts: {
             break;
           }
 
+          // The route is only known now that this request succeeded, so this is
+          // the first point at which a route-specific policy is honest.
           const result = createVidkingResultFromPayload({
             input,
-            cachePolicy,
+            cachePolicy: createVideasyRouteCachePolicy({
+              resolveInput: input,
+              appId: resolveVideasyAppId(engineOptions, context),
+              apiRoute: server,
+            }),
+            apiRoute: server,
             payload: decoded,
             sourceId,
             server,

--- a/packages/providers/test/catalog-id.test.ts
+++ b/packages/providers/test/catalog-id.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import type { TitleIdentity } from "@kunai/types";
+
+import { resolveTmdbCatalogId } from "../src/shared/catalog-id";
+
+const movie = (id: string, tmdbId?: string): TitleIdentity => ({
+  id,
+  kind: "movie",
+  title: "Bloodhounds",
+  ...(tmdbId === undefined ? {} : { tmdbId }),
+});
+
+const series = (id: string, tmdbId?: string): TitleIdentity => ({
+  id,
+  kind: "series",
+  title: "Bloodhounds",
+  ...(tmdbId === undefined ? {} : { tmdbId }),
+});
+
+describe("resolveTmdbCatalogId", () => {
+  test("accepts an explicit tmdbId", () => {
+    expect(resolveTmdbCatalogId(movie("whatever", "299167"))).toBe(299167);
+  });
+
+  /**
+   * `kunai -i 438631 -t movie` and the live provider smokes both pass a bare
+   * numeric title id with no `externalIds`, so a bare complete decimal is a
+   * supported production identity — not something to fail closed on.
+   */
+  test("accepts a bare complete decimal title id", () => {
+    expect(resolveTmdbCatalogId(movie("299167"))).toBe(299167);
+    expect(resolveTmdbCatalogId(series("127529"))).toBe(127529);
+  });
+
+  test("accepts an exact tmdb: prefix", () => {
+    expect(resolveTmdbCatalogId(movie("tmdb:299167"))).toBe(299167);
+  });
+
+  test("prefers the explicit tmdbId over the title id", () => {
+    expect(resolveTmdbCatalogId(movie("111", "299167"))).toBe(299167);
+  });
+
+  test("rejects partially numeric ids instead of parsing a prefix out of them", () => {
+    expect(resolveTmdbCatalogId(movie("299167abc"))).toBeNull();
+    expect(resolveTmdbCatalogId(movie("x", "299167abc"))).toBeNull();
+    expect(resolveTmdbCatalogId(movie("12 34"))).toBeNull();
+  });
+
+  test("rejects zero, negatives, signs, decimals and exponents", () => {
+    expect(resolveTmdbCatalogId(movie("0"))).toBeNull();
+    expect(resolveTmdbCatalogId(movie("-5"))).toBeNull();
+    expect(resolveTmdbCatalogId(movie("+5"))).toBeNull();
+    expect(resolveTmdbCatalogId(movie("4.5"))).toBeNull();
+    expect(resolveTmdbCatalogId(movie("1e5"))).toBeNull();
+    expect(resolveTmdbCatalogId(movie("x", "0"))).toBeNull();
+    expect(resolveTmdbCatalogId(movie("x", "-5"))).toBeNull();
+  });
+
+  test("rejects padded ids without trimming them into shape", () => {
+    expect(resolveTmdbCatalogId(movie(" 299167 "))).toBeNull();
+    expect(resolveTmdbCatalogId(movie("tmdb: 299167"))).toBeNull();
+    expect(resolveTmdbCatalogId(movie("x", " 299167 "))).toBeNull();
+    expect(resolveTmdbCatalogId(movie(""))).toBeNull();
+    expect(resolveTmdbCatalogId(movie("   "))).toBeNull();
+  });
+
+  test("rejects other catalogs' and provider-native ids", () => {
+    expect(resolveTmdbCatalogId(movie("anilist:299167"))).toBeNull();
+    expect(resolveTmdbCatalogId(movie("mal:21"))).toBeNull();
+    expect(resolveTmdbCatalogId(movie("bxCKTopaque"))).toBeNull();
+    expect(resolveTmdbCatalogId(movie("one-piece-69"))).toBeNull();
+  });
+
+  test("rejects ids beyond safe integer range", () => {
+    expect(resolveTmdbCatalogId(movie("9".repeat(25)))).toBeNull();
+  });
+});

--- a/packages/providers/test/provider-cache.test.ts
+++ b/packages/providers/test/provider-cache.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+
+import { TTLCache } from "../src/shared/provider-cache";
+
+describe("TTLCache expiry", () => {
+  test("deletes an expired entry on access rather than returning it", () => {
+    let now = 1_000;
+    const cache = new TTLCache<string, string>(100, { now: () => now });
+
+    cache.set("a", "value");
+    expect(cache.get("a")).toBe("value");
+
+    now = 1_101;
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  test("prune drops every expired entry and keeps live ones", () => {
+    let now = 0;
+    const cache = new TTLCache<string, string>(100, { now: () => now });
+
+    cache.set("old", "1");
+    now = 60;
+    cache.set("new", "2");
+    now = 120;
+
+    cache.prune();
+
+    expect(cache.size).toBe(1);
+    expect(cache.get("new")).toBe("2");
+  });
+});
+
+describe("TTLCache size bound", () => {
+  test("evicts the oldest entry once the bound is exceeded", () => {
+    const cache = new TTLCache<string, number>(10_000, { maxEntries: 3 });
+
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+    cache.set("d", 4);
+
+    expect(cache.size).toBe(3);
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.get("d")).toBe(4);
+  });
+
+  test("replacing an existing key does not grow the cache or evict a peer", () => {
+    const cache = new TTLCache<string, number>(10_000, { maxEntries: 2 });
+
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("a", 99);
+
+    expect(cache.size).toBe(2);
+    expect(cache.get("a")).toBe(99);
+    expect(cache.get("b")).toBe(2);
+  });
+
+  test("prefers evicting an expired entry over a live one", () => {
+    let now = 0;
+    const cache = new TTLCache<string, number>(100, { maxEntries: 2, now: () => now });
+
+    cache.set("stale", 1);
+    now = 50;
+    cache.set("live", 2);
+    now = 120; // "stale" has expired, "live" has not
+
+    cache.set("fresh", 3);
+
+    expect(cache.size).toBe(2);
+    expect(cache.get("live")).toBe(2);
+    expect(cache.get("fresh")).toBe(3);
+  });
+
+  test("stays bounded under sustained unique writes", () => {
+    const cache = new TTLCache<string, number>(10_000, { maxEntries: 16 });
+
+    for (let i = 0; i < 1_000; i++) cache.set(`key-${i}`, i);
+
+    expect(cache.size).toBe(16);
+    expect(cache.get("key-999")).toBe(999);
+  });
+
+  test("is unbounded when no bound is configured, preserving existing callers", () => {
+    const cache = new TTLCache<string, number>(10_000);
+
+    for (let i = 0; i < 100; i++) cache.set(`key-${i}`, i);
+
+    expect(cache.size).toBe(100);
+  });
+
+  test("clear empties everything", () => {
+    const cache = new TTLCache<string, number>(10_000, { maxEntries: 4 });
+
+    cache.set("a", 1);
+    cache.clear();
+
+    expect(cache.size).toBe(0);
+    expect(cache.get("a")).toBeUndefined();
+  });
+});

--- a/packages/providers/test/providers.test.ts
+++ b/packages/providers/test/providers.test.ts
@@ -17,6 +17,7 @@ import {
   getMiruroEpisodesResponse,
   miruroProviderModule,
   createVidkingResultFromPayload,
+  createVideasyRouteCachePolicy,
   extractQualitiesFromMaster,
   listVidkingFlavors,
   normalizeIsoLanguageCode,
@@ -37,6 +38,18 @@ import {
   getProviderResearchProfile,
   providerResearchProfiles,
 } from "../src/research";
+
+/** Route policies are built by the provider's one owner, never hand-rolled here. */
+const TEST_ROUTE_POLICY = (apiRoute: string) =>
+  createVideasyRouteCachePolicy({
+    resolveInput: {
+      title: { id: "438631", kind: "movie", title: "Dune", tmdbId: "438631" },
+      mediaKind: "movie",
+      intent: "play",
+      allowedRuntimes: ["direct-http"],
+    },
+    apiRoute,
+  });
 
 const FIXTURE_BASE = new URL("./fixtures/", import.meta.url);
 
@@ -135,6 +148,8 @@ test("provider research profiles separate direct providers from legacy fallbacks
 
 test("vidking direct payload creates selected stream, variants, and subtitle inventory", () => {
   const result = createVidkingResultFromPayload({
+    apiRoute: "mb-flix",
+    cachePolicy: TEST_ROUTE_POLICY("mb-flix"),
     input: {
       title: {
         id: "1668",
@@ -720,6 +735,8 @@ test("vidking refresh intent cycles the wider flavor source set", async () => {
 
 test("vidking payload filtering keeps localized flavored sources explicit", () => {
   const result = createVidkingResultFromPayload({
+    apiRoute: "hdmovie",
+    cachePolicy: TEST_ROUTE_POLICY("hdmovie"),
     input: {
       title: {
         id: "438631",
@@ -762,6 +779,8 @@ test("vidking evidence fixture preserves native server labels beside ISO audio l
     readonly quality: string;
   }>("videasy/expected-normalized.json");
   const result = createVidkingResultFromPayload({
+    apiRoute: "wings-cdn",
+    cachePolicy: TEST_ROUTE_POLICY("wings-cdn"),
     input: {
       title: {
         id: "438631",
@@ -815,6 +834,8 @@ test("vidking fixture fast startup keeps the first ready stream", async () => {
     Parameters<typeof createVidkingResultFromPayload>[0]["payload"]
   >("videasy/source-payload.json");
   const result = createVidkingResultFromPayload({
+    apiRoute: "Kiwi",
+    cachePolicy: TEST_ROUTE_POLICY("Kiwi"),
     input: {
       title: {
         id: "438631",

--- a/packages/providers/test/videasy-route-cache-policy.test.ts
+++ b/packages/providers/test/videasy-route-cache-policy.test.ts
@@ -1,0 +1,126 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+
+import type { CachePolicy, ProviderResolveInput, ProviderRuntimeContext } from "@kunai/types";
+
+import {
+  createVideasyRouteCachePolicy,
+  createVidkingResultFromPayload,
+} from "../src/videasy/direct";
+
+const TEST_CONTEXT: ProviderRuntimeContext = {
+  providerId: "videasy",
+  now: () => "2026-08-13T00:00:00.000Z",
+};
+
+const TEST_INPUT: ProviderResolveInput = {
+  title: { id: "299167", kind: "movie", title: "Bloodhounds", tmdbId: "299167" },
+  mediaKind: "movie",
+  intent: "play",
+  allowedRuntimes: ["direct-http"],
+};
+
+type VidkingTestPayload = Parameters<typeof createVidkingResultFromPayload>[0]["payload"];
+
+let PAYLOAD: VidkingTestPayload;
+
+beforeAll(async () => {
+  PAYLOAD = (await Bun.file(
+    new URL("./fixtures/videasy/source-payload.json", import.meta.url),
+  ).json()) as VidkingTestPayload;
+});
+
+function buildResult(cachePolicy: CachePolicy, apiRoute: string) {
+  return createVidkingResultFromPayload({
+    input: TEST_INPUT,
+    cachePolicy,
+    apiRoute,
+    payload: PAYLOAD,
+    server: apiRoute,
+    context: TEST_CONTEXT,
+  });
+}
+
+describe("createVideasyRouteCachePolicy", () => {
+  test("keys on the selected route, so two routes of one title do not collide", () => {
+    const cdn = createVideasyRouteCachePolicy({
+      resolveInput: TEST_INPUT,
+      apiRoute: "wings-cdn",
+    });
+    const neon = createVideasyRouteCachePolicy({
+      resolveInput: TEST_INPUT,
+      apiRoute: "wings-neon2",
+    });
+
+    expect(cdn.keyParts).not.toEqual(neon.keyParts);
+    expect(cdn.keyParts).toContain("wings-cdn");
+    expect(neon.keyParts).toContain("wings-neon2");
+  });
+
+  test("is stable for the same route and title", () => {
+    const a = createVideasyRouteCachePolicy({ resolveInput: TEST_INPUT, apiRoute: "wings-cdn" });
+    const b = createVideasyRouteCachePolicy({ resolveInput: TEST_INPUT, apiRoute: "wings-cdn" });
+
+    expect(a.keyParts).toEqual(b.keyParts);
+  });
+
+  test("distinguishes app ids", () => {
+    const withApp = createVideasyRouteCachePolicy({
+      resolveInput: TEST_INPUT,
+      apiRoute: "wings-cdn",
+      appId: "app-a",
+    });
+    const withOther = createVideasyRouteCachePolicy({
+      resolveInput: TEST_INPUT,
+      apiRoute: "wings-cdn",
+      appId: "app-b",
+    });
+
+    expect(withApp.keyParts).not.toEqual(withOther.keyParts);
+  });
+});
+
+describe("createVidkingResultFromPayload uses the policy it is given", () => {
+  /**
+   * The function used to name its parameter `_cachePolicy` and rebuild a policy
+   * internally, re-deriving the route and app id. Two owners for one key is the
+   * house "declared and unread" failure mode.
+   */
+  test("returns the exact policy object supplied by the caller", () => {
+    const policy = createVideasyRouteCachePolicy({
+      resolveInput: TEST_INPUT,
+      apiRoute: "wings-cdn",
+    });
+
+    const result = buildResult(policy, "wings-cdn");
+
+    expect(result).not.toBeNull();
+    expect(result?.cachePolicy).toBe(policy);
+  });
+
+  test("carries the selected route through streams and the selected source", () => {
+    const policy = createVideasyRouteCachePolicy({
+      resolveInput: TEST_INPUT,
+      apiRoute: "wings-neon2",
+    });
+
+    const result = buildResult(policy, "wings-neon2");
+
+    expect(result?.sources?.[0]?.metadata?.apiRoute).toBe("wings-neon2");
+    expect(result?.sources?.[0]?.cachePolicy).toBe(policy);
+    for (const stream of result?.streams ?? []) {
+      expect(stream.cachePolicy).toBe(policy);
+    }
+  });
+
+  test("does not alias two routes onto one policy", () => {
+    const cdn = createVideasyRouteCachePolicy({ resolveInput: TEST_INPUT, apiRoute: "wings-cdn" });
+    const neon = createVideasyRouteCachePolicy({
+      resolveInput: TEST_INPUT,
+      apiRoute: "wings-neon2",
+    });
+
+    expect(buildResult(cdn, "wings-cdn")?.cachePolicy?.keyParts).not.toEqual(
+      buildResult(neon, "wings-neon2")?.cachePolicy?.keyParts ?? [],
+    );
+  });
+});

--- a/packages/providers/test/videasy-route-contracts.test.ts
+++ b/packages/providers/test/videasy-route-contracts.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  classifyVideasyHttpFailure,
+  getPhaseAVidkingFlavorIds,
+  isVidkingFlavorDeprecated,
+  listDeprecatedVidkingEndpoints,
+  listEligibleVidkingFlavorIds,
+  listVidkingFlavors,
+} from "../src/videasy";
+
+describe("classifyVideasyHttpFailure", () => {
+  test("only permanent route removal is route-dead", () => {
+    expect(classifyVideasyHttpFailure(404)).toBe("route-dead");
+    expect(classifyVideasyHttpFailure(410)).toBe("route-dead");
+  });
+
+  /**
+   * Intentional: speedracelight returns 500 "No streams available" per title
+   * while the endpoint stays healthy for others. Quarantining on 500 would take
+   * a working route offline.
+   */
+  test("HTTP 500 stays transient", () => {
+    expect(classifyVideasyHttpFailure(500)).toBe("transient");
+    expect(classifyVideasyHttpFailure(502)).toBe("transient");
+    expect(classifyVideasyHttpFailure(503)).toBe("transient");
+  });
+
+  test("client errors other than removal are transient", () => {
+    expect(classifyVideasyHttpFailure(403)).toBe("transient");
+    expect(classifyVideasyHttpFailure(429)).toBe("transient");
+  });
+});
+
+describe("deprecated Videasy routes stay inert", () => {
+  test("wings-tejo is a deprecated endpoint and is not an active flavor", () => {
+    expect(listDeprecatedVidkingEndpoints()).toContain("wings-tejo");
+    expect(isVidkingFlavorDeprecated("wingsdb-titanium")).toBe(true);
+    expect(listVidkingFlavors().some((flavor) => flavor.endpoint === "wings-tejo")).toBe(false);
+  });
+
+  test("no deprecated flavor is eligible or scheduled in phase A", () => {
+    const eligible = listEligibleVidkingFlavorIds();
+    const phaseA = getPhaseAVidkingFlavorIds();
+
+    expect(eligible).not.toContain("wingsdb-titanium");
+    expect(phaseA).not.toContain("wingsdb-titanium");
+    for (const id of [...eligible, ...phaseA]) {
+      expect(isVidkingFlavorDeprecated(id)).toBe(false);
+    }
+  });
+
+  test("the active flavor list never contains a deprecated definition", () => {
+    for (const flavor of listVidkingFlavors()) {
+      expect(flavor.deprecated).not.toBe(true);
+    }
+  });
+});

--- a/packages/providers/test/videasy-wings-seed-race.test.ts
+++ b/packages/providers/test/videasy-wings-seed-race.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { ProviderRuntimeContext } from "@kunai/types";
+
+import {
+  clearWingsTransportCachesForTest,
+  fetchWingsdatabaseSeedForTest,
+  WINGS_API_BASE,
+  WINGS_API_FALLBACK_BASE,
+  wingsPenalizedHostsForTest,
+} from "../src/videasy/direct";
+
+/**
+ * A deferred request: the test decides exactly when each host answers, so the
+ * race outcome never depends on timers or real network ordering.
+ */
+type Deferred = {
+  readonly resolve: (body: unknown) => void;
+  readonly reject: (error: Error) => void;
+  readonly aborted: () => boolean;
+};
+
+function createRequester() {
+  const pending = new Map<string, Deferred>();
+  const calls: string[] = [];
+
+  const requester = (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = String(input);
+    const host = url.startsWith(WINGS_API_BASE) ? WINGS_API_BASE : WINGS_API_FALLBACK_BASE;
+    calls.push(host);
+    return new Promise<Response>((resolve, reject) => {
+      let wasAborted = false;
+      const signal = init?.signal;
+      const onAbort = () => {
+        wasAborted = true;
+        reject(new DOMException("aborted", "AbortError"));
+      };
+      if (signal?.aborted) onAbort();
+      else signal?.addEventListener("abort", onAbort, { once: true });
+
+      pending.set(host, {
+        resolve: (body) => resolve(Response.json(body)),
+        reject,
+        aborted: () => wasAborted,
+      });
+    });
+  };
+
+  return {
+    calls,
+    requester,
+    async settle(host: string, body: unknown) {
+      // Let the racers register before answering.
+      await Promise.resolve();
+      pending.get(host)?.resolve(body);
+    },
+    async fail(host: string, message: string) {
+      await Promise.resolve();
+      pending.get(host)?.reject(new Error(message));
+    },
+  };
+}
+
+function createContext(
+  requester: (input: string | URL | Request, init?: RequestInit) => Promise<Response>,
+  signal?: AbortSignal,
+): ProviderRuntimeContext {
+  return {
+    providerId: "videasy",
+    now: () => new Date().toISOString(),
+    signal,
+    fetch: { runtime: "direct-http", fetch: requester },
+  };
+}
+
+const SEED_BODY = { seed: "seed-value", ttlMs: 30_000 };
+
+beforeEach(() => {
+  clearWingsTransportCachesForTest();
+});
+
+describe("Wings seed race outcomes", () => {
+  test("primary wins and its seed is paired with its own host", async () => {
+    const harness = createRequester();
+    const pendingResult = fetchWingsdatabaseSeedForTest(1, createContext(harness.requester));
+
+    await harness.settle(WINGS_API_BASE, SEED_BODY);
+
+    expect(await pendingResult).toEqual({ apiBase: WINGS_API_BASE, seed: "seed-value" });
+  });
+
+  test("fallback wins and its seed is paired with the fallback host", async () => {
+    const harness = createRequester();
+    const pendingResult = fetchWingsdatabaseSeedForTest(2, createContext(harness.requester));
+
+    await harness.settle(WINGS_API_FALLBACK_BASE, SEED_BODY);
+
+    expect(await pendingResult).toEqual({
+      apiBase: WINGS_API_FALLBACK_BASE,
+      seed: "seed-value",
+    });
+  });
+
+  test("a loser aborted after the winner is not penalized", async () => {
+    const first = createRequester();
+    const firstResult = fetchWingsdatabaseSeedForTest(3, createContext(first.requester));
+    await first.settle(WINGS_API_BASE, SEED_BODY);
+    await firstResult;
+
+    // The fallback lost and was aborted. That is not evidence about the host.
+    expect(wingsPenalizedHostsForTest()).toEqual([]);
+  });
+
+  test("a genuine pre-winner failure penalizes only that host", async () => {
+    const first = createRequester();
+    const firstResult = fetchWingsdatabaseSeedForTest(5, createContext(first.requester));
+    await first.fail(WINGS_API_BASE, "seed HTTP 500");
+    await first.settle(WINGS_API_FALLBACK_BASE, SEED_BODY);
+    expect(await firstResult).toEqual({ apiBase: WINGS_API_FALLBACK_BASE, seed: "seed-value" });
+
+    // The primary is in the penalty box, so the next request skips it entirely.
+    const second = createRequester();
+    const secondResult = fetchWingsdatabaseSeedForTest(6, createContext(second.requester));
+    await second.settle(WINGS_API_FALLBACK_BASE, SEED_BODY);
+    await secondResult;
+
+    expect(second.calls).toEqual([WINGS_API_FALLBACK_BASE]);
+    expect(wingsPenalizedHostsForTest()).toEqual([WINGS_API_BASE]);
+  });
+
+  test("when every host fails the result is undefined", async () => {
+    const harness = createRequester();
+    const pendingResult = fetchWingsdatabaseSeedForTest(7, createContext(harness.requester));
+
+    await harness.fail(WINGS_API_BASE, "seed HTTP 500");
+    await harness.fail(WINGS_API_FALLBACK_BASE, "seed HTTP 500");
+
+    expect(await pendingResult).toBeUndefined();
+    expect(wingsPenalizedHostsForTest()).toEqual([WINGS_API_BASE, WINGS_API_FALLBACK_BASE]);
+  });
+
+  test("all hosts penalized still races them rather than giving up forever", async () => {
+    const first = createRequester();
+    const firstResult = fetchWingsdatabaseSeedForTest(8, createContext(first.requester));
+    await first.fail(WINGS_API_BASE, "seed HTTP 500");
+    await first.fail(WINGS_API_FALLBACK_BASE, "seed HTTP 500");
+    await firstResult;
+
+    const second = createRequester();
+    const secondResult = fetchWingsdatabaseSeedForTest(9, createContext(second.requester));
+    await second.settle(WINGS_API_BASE, SEED_BODY);
+
+    expect(await secondResult).toEqual({ apiBase: WINGS_API_BASE, seed: "seed-value" });
+  });
+
+  /**
+   * The bug this test pins: caller cancellation rejected every in-flight attempt,
+   * and the catch could not tell that apart from a real failure, so walking away
+   * from a playback put both Wings hosts in the penalty box for five minutes.
+   */
+  test("caller abort penalizes neither host", async () => {
+    const controller = new AbortController();
+    const first = createRequester();
+    const firstResult = fetchWingsdatabaseSeedForTest(
+      10,
+      createContext(first.requester, controller.signal),
+    );
+
+    await Promise.resolve();
+    controller.abort();
+
+    expect(await firstResult).toBeUndefined();
+    expect(wingsPenalizedHostsForTest()).toEqual([]);
+  });
+
+  test("a cached seed short-circuits the race for the same media id", async () => {
+    const first = createRequester();
+    const firstResult = fetchWingsdatabaseSeedForTest(12, createContext(first.requester));
+    await first.settle(WINGS_API_BASE, SEED_BODY);
+    await firstResult;
+
+    const second = createRequester();
+
+    expect(await fetchWingsdatabaseSeedForTest(12, createContext(second.requester))).toEqual({
+      apiBase: WINGS_API_BASE,
+      seed: "seed-value",
+    });
+    expect(second.calls).toEqual([]);
+  });
+});


### PR DESCRIPTION
Implements the active-path correctness half of `plans/038-videasy-cache-and-retirement.md`. Deprecated-route deletion is explicitly **not** in scope — the plan says cleanup must not share a commit with active-path fixes and is not a release blocker.

## What changed

- **TMDB identity is complete or it is nothing.** There were two identical `resolveTmdbId` copies (`videasy/direct.ts` and `shared/direct-stream-source.ts`), both `Number.parseInt`-based, so `123abc` → `123`, `" 123 "` → `123`, `"0"` → `0`, `"-5"` → `-5`, `"4.5"` → `4`, `"1e5"` → `1`. Replaced by one shared `resolveTmdbCatalogId()` requiring `^[1-9]\d*$` and a safe integer.
- **One owner for the selected-route cache policy.** `createVidkingResultFromPayload()` named its parameter `_cachePolicy`, discarded it, and rebuilt an equivalent policy internally by re-deriving the route and app id — the house "declared and unread" failure mode. `createVideasyRouteCachePolicy()` is now the only builder, both `cachePolicy` and `apiRoute` are **required**, the policy is used verbatim, and the selected source records `metadata.apiRoute` so route provenance is explicit rather than positionally parsed out of `keyParts`.
- **Wings transport state is bounded.** Seed and preferred-host maps are keyed per media id and grew for the life of the process — expiry alone never freed an entry nobody asked for again. All three moved onto `TTLCache` with hard ceilings (`WINGS_TRANSPORT_LIMITS` = 16 / 256 / 32). `TTLCache` gained optional `maxEntries` and an injectable clock; it evicts expired entries before oldest-write, and replacing a key never counts as growth.
- **HTTP 500 stays transient**, now expressed once instead of via a duplicated branch, and pinned by tests. **`wings-tejo` stays deprecated** — proven inert by contract tests rather than deleted.

## Real bug found: caller abort poisoned Wings host health

Every seed attempt shared one `won` flag, so the catch could not distinguish three causes. A loser aborted after a peer won was correctly spared, but **caller cancellation** rejected every in-flight attempt while `won` was still `false` — so cancelling a playback put **both** Wings hosts in a five-minute penalty box.

`videasy-wings-seed-race.test.ts` covers all six required transitions with deferred promises and no timers: primary win, fallback win, genuine pre-winner failure, intentional loser abort, all-fail, and caller abort, plus cached-seed short-circuit and the all-penalized case.

Worth noting how that test is written: request order **cannot** prove this, because when every host is penalized the transport deliberately races them all rather than giving up — so "both hosts were contacted" is true whether nothing was blamed or everything was. My first version of the test passed with and without the fix. It now asserts host health directly via a test seam, and I verified it fails when the guard is reverted and passes when restored.

## Deliberate divergences from the design plan

- **The logical-request → selected-route cache index was not built.** The plan assumed the CLI could key a stream entry by `apiRoute` before resolve and needed an alias index to repair that. In the code, `buildApiStreamResolveCacheKey()` derives its preimage from the manifest `keyParts`, which contain **no** `apiRoute` — read, write, and invalidation all use that one route-agnostic key, so they cannot disagree and there is no mismatch bug to fix. Fragmenting the key by route would add cache misses for a benefit no test could demonstrate; stale entries whose route later dies are already caught by cache-revalidation stream-health probes. **The plan is the bug here, not the code.**
- **The plan says to reject a bare `id: "123"`.** The code wins: `kunai -i 438631 -t movie` (a documented entrypoint) and every live provider smoke pass a bare numeric `title.id` with **no** `externalIds`. Rejecting it would take Videasy offline. The user's actual requirement — "a complete positive decimal representation" — is enforced; the prefix clause is not.
- **`wings-transport.ts` was not extracted.** Both confirmed defects are fixed and tested in place. The extraction is worthwhile cleanup, not a release blocker, and 036 (an actual release stop condition) is the higher-value use of remaining budget.

## Gates

`typecheck`, `lint`, `fmt:check`, `test`, `build`, `git diff --check`, `verify:doc-paths`, `verify:doc-coverage` — all green.
Tests: 4024 unit + 99 integration + 301 providers + 71 docs + 34 others pass, 0 fail. The integration suite's **47 skips are the pre-existing baseline**, not exclusions introduced here.

## Live gate: GREEN, observed

`bun run test:live:videasy:suite`, through `container.engine.resolve(...)` — **4/4 fixtures passed, 0 failed**, each resolving *and* probing a reachable stream:

| Fixture | Resolved | Reachable | Source | Resolve |
| --- | --- | --- | --- | --- |
| `dutton-ranch` | yes | yes | Yoru | 2416 ms |
| `bloodhounds` | yes | yes | Yoru | 2640 ms |
| `study-group` | yes | yes | Cypher | 2642 ms |
| `dune` | yes | yes | Yoru | 1410 ms |

No deprecated route was promoted. `study-group` recorded one failed source attempt before succeeding on Cypher, which is the intended per-route fallback.

## Merge note

**This branch and #38 both raise `NPM_BUNDLE_BUDGET_KB` 2_800 → 2_880 in `apps/cli/scripts/build-shared.ts`.** Whichever lands second needs a one-hunk rebase; keep both rationale paragraphs. `main` was at 2866812 B against a 2867200 B ceiling — 388 bytes of headroom — so the ratchet was already spent and *any* next change would have tripped it. This guards the development bundle only; it is not what npm ships.

## Incidental

Removed a stale 92 MB `apps/cli/.<hash>.bun-build` temp file with mode `----------`, left by an interrupted binary build. It made `turbo run build` fail with a bare `Permission denied (os error 13)` during file hashing. Untracked scratch, not part of this diff — flagged in case it recurs on another machine.
