### PR TITLE
fix(allmanga): diagnose the NEED_CAPTCHA gate and demote AllAnime from the automatic lane

### DIFF
--- a/.changeset/allmanga-captcha-truth.md
+++ b/.changeset/allmanga-captcha-truth.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+AllAnime now reports a captcha-gated stream request as a blocked, non-retryable failure naming the relay workaround, instead of silently returning no streams next to a full episode list. It is also demoted out of the automatic anime fallback lane while staying manually selectable.

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -430,7 +430,55 @@ If the provider has native search or episode listing, export standalone function
   - source-name inventory and ranking (`Default`, `Yt-mp4`, `S-mp4`, `Mp4`/mp4upload, `Luf-Mp4`, `Ak`; Filemoon removed upstream)
   - downstream link extraction from decoded source URLs — `Mp4` scrapes the embed HTML for `src: "…"` and plays with `Referer: https://www.mp4upload.com` plus mpv `--tls-verify=no`
 
-Note: ani-cli v5 (2026-08-01) left AllAnime/mkissa for **anidb.app**. Kunai keeps AllManga as a secondary anime source and adds `anidb` as the default anime provider. See [.docs/research/anidb-provider-dossier.md](./research/anidb-provider-dossier.md).
+### AllAnime NEED_CAPTCHA (2026-08-13)
+
+The "valid episode catalog, zero extracted streams" symptom is **not** a crypto or
+parity defect. Measured against the production constants (`api.mkissa.net` +
+`https://mkissa.to` referer + build id 81):
+
+- Bootstrap succeeds, `keyHex` and `queryHash` are both 64 chars, the `aaReq`
+  attestation is accepted, and **no** `AA_CRYPTO_*` error is returned.
+- The episode **catalog** query resolves normally (11 episodes for the
+  Demon Slayer fixture, titles and all).
+- The episode **sources** query returns `NEED_CAPTCHA` on every valid host/referer
+  pair — `api.mkissa.net` ← `mkissa.to` and `api.allanime.day` ← `allmanga.to` both
+  return it; `api.allanime.day` ← `allanime.to` is a flat HTTP 403.
+
+That asymmetry — catalog ungated, sources gated — is exactly what produced a full
+episode list next to zero streams.
+
+`NEED_CAPTCHA` was previously unhandled anywhere in the codebase: it fell through
+the retry loop, `rawSources` stayed empty, and the user saw
+`No streams extracted from AllManga for episode N`. It is now
+`AllMangaCaptchaError`, classified as **`blocked` and non-retryable** (a captcha is
+not a network fault and retrying or re-bootstrapping cannot clear it), with a
+message naming the one thing that does help — a user-owned relay in an ungated
+region. It is checked _before_ the crypto-staleness and rate-limit branches so it
+cannot be mistaken for either.
+
+A relay running on the same machine as the client does **not** clear the gate,
+because the egress IP is unchanged; a relay deployed to an ungated region is the
+untested variable. Consequently `allanime` was dropped from the automatic anime
+lane on 2026-08-13 while staying a registered, manually selectable production
+module.
+
+**Do not "fix" this by changing crypto.** Build id 81, the bootstrap, HMAC
+`x-aa-boot`, and AES-256-GCM are all working and verified. The historical
+epoch/partB query construction and AES-CTR decryption must not be restored.
+
+**wixmp referer: current behaviour retained.** Plan 036 proposed attaching the
+mkissa site referer for `repackager.wixmp.com`, gated on a fixture proving the
+current final-stream fallback insufficient. No such fixture can be built from this
+network: the pipeline never reaches source extraction, so there is no live wixmp
+row to characterize. Per that gate, `resolveDirectStreamReferer()` is unchanged.
+mp4upload keeps its dedicated referer and scoped `--tls-verify=no`; TLS
+verification is not broadened to any other host.
+
+Note: ani-cli v5 (2026-08-01) left AllAnime/mkissa for **anidb.app** and deleted its AllAnime code
+entirely, so **there is no upstream parity reference left** for this provider — the "compare against
+ani-cli" step above applies to AniDB only. For mkissa crypto the live JS chunk is the sole source of
+truth. Kunai keeps AllManga as a manually selectable secondary anime source with `anidb` as the
+default anime provider. See [.docs/research/anidb-provider-dossier.md](./research/anidb-provider-dossier.md).
 
 Parity tip: for AniDB compare against local ani-cli `master`. For mkissa crypto, the live JS chunk is the source of truth when ani-cli no longer tracks it. The API rate-limits bursts (~3s), so stale-material recovery re-bootstraps keys instead of retry-storming.
 
@@ -455,9 +503,11 @@ Active providers are registered in `apps/cli/src/container/bootstrap-providers.t
 `loadProductionProviderModules()`. A module existing under `packages/providers/src/` does not make
 it live, and release signoff derives its cases from that list plus the configured lane defaults.
 
-`anidb` is the **default** provider-native anime catalog (`animeProvider: "anidb"`); `allanime` is
-the **fallback** (`animeProviderPriority: ["anidb", "allanime"]`); `miruro` stays manually
-selectable.
+`anidb` is the **default** provider-native anime catalog and, as of 2026-08-13, the **only**
+provider in the automatic anime lane (`animeProvider: "anidb"`,
+`animeProviderPriority: ["anidb"]`). `allanime` and `miruro` both stay registered production
+modules and remain manually selectable; neither runs as an automatic fallback. See
+"AllAnime NEED_CAPTCHA" below and the Miruro pipe contract for why each was demoted.
 
 | ID           | Content Types | Runtime     | Module Location                               |
 | ------------ | ------------- | ----------- | --------------------------------------------- |

--- a/apps/cli/scripts/build-shared.ts
+++ b/apps/cli/scripts/build-shared.ts
@@ -225,8 +225,9 @@ export function totalMetafileInputBytes(metafile: BunBuildMetafile): number {
  * cancellation/reconnect generation guards. `main` had only 388 bytes of
  * headroom before those changes. The added provider code is diagnostics and
  * bounded-cache machinery: endpoint-aware pipe decoding, a curl truncation
- * guard, strict catalog-id parsing, and TTL cache size bounds. The step restores
- * real headroom rather than clearing one change.
+ * guard, strict catalog-id parsing, captcha classification that replaces a
+ * silent empty result, and TTL cache size bounds. The step restores real
+ * headroom rather than clearing one change.
  */
 export const NPM_BUNDLE_BUDGET_KB = 2_880;
 

--- a/packages/config/src/defaults.ts
+++ b/packages/config/src/defaults.ts
@@ -8,12 +8,18 @@ export const DEFAULT_CONFIG: KitsuneConfig = {
   defaultMode: "series",
   // Series automatic lane (2026-07-16): Videasy first (fast seed+neon path), then Rivestream, VidLink.
   provider: "videasy",
-  // AniDB is ani-cli v5's primary source; AllManga stays as fallback while mkissa CF churn settles.
+  // AniDB is ani-cli v5's primary source, and the only anime provider in the
+  // automatic lane. AllAnime and Miruro stay registered and manually selectable.
   animeProvider: "anidb",
   youtubeProvider: "youtube",
   providerPriority: ["rivestream", "vidlink"],
-  // Miruro remains manually selectable until its pipe mirrors pass the live release gate.
-  animeProviderPriority: ["anidb", "allanime"],
+  // AllAnime is demoted out of the automatic fallback (2026-08-13): its stream
+  // sources endpoint answers NEED_CAPTCHA on bot/geo-gated networks while its
+  // episode catalog still loads, so automatic fallback can only spend resolve
+  // budget and then fail. It stays registered and manually selectable, and works
+  // where the gate does not apply or behind a user-owned relay in an ungated
+  // region. Miruro is demoted for the same class of reason (Cloudflare WAF).
+  animeProviderPriority: ["anidb"],
   youtubeProviderPriority: ["youtube"],
   youtubeLanguageProfile: { audio: "original", subtitle: "en", quality: "1080p" },
   youtubeMetadata: {},

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -58,9 +58,17 @@ describe("@kunai/config parse boundary", () => {
     expect(DEFAULT_CONFIG.providerPriority).not.toContain("videasy");
   });
 
-  test("defaults keep Miruro out of the automatic anime fallback lane", () => {
+  /**
+   * Both AllAnime and Miruro stay registered production modules and remain
+   * manually selectable; neither is in the automatic lane. AllAnime's stream
+   * sources endpoint answers NEED_CAPTCHA on bot/geo-gated networks while its
+   * episode catalog still loads, so as an automatic fallback it can only burn
+   * resolve budget before failing.
+   */
+  test("defaults keep captcha-gated providers out of the automatic anime lane", () => {
     expect(DEFAULT_CONFIG.animeProvider).toBe("anidb");
-    expect(DEFAULT_CONFIG.animeProviderPriority).toEqual(["anidb", "allanime"]);
+    expect(DEFAULT_CONFIG.animeProviderPriority).toEqual(["anidb"]);
+    expect(DEFAULT_CONFIG.animeProviderPriority).not.toContain("allanime");
     expect(DEFAULT_CONFIG.animeProviderPriority).not.toContain("miruro");
   });
 });

--- a/packages/providers/src/allmanga/api-client.ts
+++ b/packages/providers/src/allmanga/api-client.ts
@@ -639,6 +639,35 @@ export async function gqlRaw(
   }
 }
 
+/**
+ * The AllAnime/mkissa API answers the episode-sources query with `NEED_CAPTCHA`
+ * when the caller's network is bot- or geo-gated. The episode *catalog* query is
+ * not gated, so the symptom is a full episode list next to zero streams.
+ *
+ * This is not a crypto fault: build id, bootstrap material, `aaReq`, and the
+ * persisted query hash are all accepted when it happens. Re-bootstrapping or
+ * retrying the identical request cannot clear it, so it must fail loudly and
+ * point at the one thing that does help — a user-owned relay in an ungated
+ * region (`providerRelay.baseUrl`, see `.docs/providers.md`).
+ */
+export class AllMangaCaptchaError extends Error {
+  readonly code = "allmanga-captcha-required" as const;
+
+  constructor() {
+    super(
+      "AllAnime requires a captcha for stream sources from this network. " +
+        "The episode catalog still loads, which is why the episode list looks healthy. " +
+        "Configure a user-owned provider relay (providerRelay.baseUrl) in an ungated region.",
+    );
+    this.name = "AllMangaCaptchaError";
+  }
+}
+
+/** Distinguishes the captcha gate from crypto staleness and rate limiting. */
+export function isAllMangaCaptchaResponse(rawText: string): boolean {
+  return rawText.includes("NEED_CAPTCHA");
+}
+
 export async function resolveEpisodeSources(opts: {
   readonly context: ProviderRuntimeContext;
   readonly apiUrl: string;
@@ -696,6 +725,12 @@ export async function resolveEpisodeSources(opts: {
 
     if (!rawText) return [];
     if (rawText.includes('"tobeparsed"')) break;
+
+    // Check before the crypto/rate-limit branches: a captcha gate is neither,
+    // and retrying or re-bootstrapping against it only wastes the budget.
+    if (isAllMangaCaptchaResponse(rawText)) {
+      throw new AllMangaCaptchaError();
+    }
 
     if (rawText.includes("Too many requests")) {
       rateLimitRetries += 1;

--- a/packages/providers/src/allmanga/direct.ts
+++ b/packages/providers/src/allmanga/direct.ts
@@ -39,6 +39,7 @@ import { selectReadyStream } from "../shared/startup-selection";
 import { normalizeIsoLanguageCode, subtitleLanguageDisplayName } from "../shared/subtitle-helpers";
 import {
   type StreamLink,
+  AllMangaCaptchaError,
   loadAvailableEpisodesDetail,
   resolveAnimeEpisodeString,
   resolveEpisodeSources,
@@ -707,11 +708,15 @@ export const allmangaProviderModule: CoreProviderModule = {
         });
       }
 
+      // A captcha gate is not a network fault and retrying cannot clear it —
+      // reporting it as retryable network noise is what made this look like an
+      // empty episode rather than a blocked request.
+      const captchaBlocked = error instanceof AllMangaCaptchaError;
       const failure: ProviderFailure = {
         providerId: ALLANIME_PROVIDER_ID,
-        code: "network-error",
+        code: captchaBlocked ? "blocked" : "network-error",
         message: error instanceof Error ? error.message : "AllManga API failed",
-        retryable: true,
+        retryable: !captchaBlocked,
         at: context.now(),
       };
       failures.push(failure);

--- a/packages/providers/test/allmanga.test.ts
+++ b/packages/providers/test/allmanga.test.ts
@@ -24,6 +24,7 @@ import {
   ALLMANGA_QUERY_HASH,
   BUNDLED_ALLMANGA_CRYPTO,
   buildStreamHeaders,
+  AllMangaCaptchaError,
   clearAllMangaProviderCachesForTest,
   decodeTobeparsed,
   decryptTobeparsedPlaintext,
@@ -383,6 +384,52 @@ describe("AllManga crypto material (mkissa bootstrap)", () => {
       // Initial derive + exactly one stale re-bootstrap.
       expect(site.bootstrapFetchCount).toBe(2);
       expect(sleeps).toEqual([400]);
+    } finally {
+      clearAllMangaProviderCachesForTest();
+    }
+  });
+
+  /**
+   * `NEED_CAPTCHA` is what a geo/bot-gated region actually gets back from the
+   * episode-sources query while the episode *catalog* still resolves — the exact
+   * "valid catalog, zero streams" shape. It used to fall through the retry loop
+   * and return an empty list, so the user saw "No streams extracted" with no way
+   * to know the request was gated rather than the episode empty.
+   */
+  test("surfaces NEED_CAPTCHA as a distinct, actionable failure", async () => {
+    using site = mockCryptoSiteFetch({
+      apiResponses: ['{"errors":[{"message":"NEED_CAPTCHA"}],"data":{"episode":null}}'],
+    });
+
+    let thrown: unknown;
+    try {
+      await resolveWithSiteSources();
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(AllMangaCaptchaError);
+    expect((thrown as Error).message).toContain("captcha");
+    // A captcha is not a crypto problem: it must not trigger re-bootstrapping,
+    // and it must not burn the retry budget on identical requests.
+    expect(site.apiCallCount).toBe(1);
+    expect(site.bootstrapFetchCount).toBe(1);
+  });
+
+  test("does not mistake NEED_CAPTCHA for a stale key or a rate limit", async () => {
+    using site = mockCryptoSiteFetch({
+      apiResponses: ['{"errors":[{"message":"NEED_CAPTCHA"}]}', PLAIN_SOURCE_JSON],
+    });
+    const sleeps: number[] = [];
+    setAllMangaRetrySleepForTest((ms) => {
+      sleeps.push(ms);
+      return Promise.resolve();
+    });
+
+    try {
+      await expect(resolveWithSiteSources()).rejects.toBeInstanceOf(AllMangaCaptchaError);
+      expect(sleeps).toEqual([]);
+      expect(site.apiCallCount).toBe(1);
     } finally {
       clearAllMangaProviderCachesForTest();
     }


### PR DESCRIPTION
Addresses `plans/036-allmanga-parity-cleanup.md` and the "valid episode catalog, zero extracted streams" release stop condition.

## The bug is not what the plan assumed

The plan and the handoff treat this as a source-admission / wixmp-referer / parity problem. It is neither. Measured against the exact production constants (`api.mkissa.net` + `https://mkissa.to` referer + build id 81):

- Bootstrap succeeds. `keyHex` and `queryHash` are both 64 chars. The `aaReq` attestation is **accepted** — **no `AA_CRYPTO_*` error of any kind**.
- The episode **catalog** query resolves normally — 11 episodes with titles for the Demon Slayer fixture.
- The episode **sources** query returns **`NEED_CAPTCHA`**.

Every valid host/referer pair returns it:

| API | Referer | Result |
| --- | --- | --- |
| `api.mkissa.net` | `https://mkissa.to` | 200 `NEED_CAPTCHA` |
| `api.allanime.day` | `https://allmanga.to` | 200 `NEED_CAPTCHA` |
| `api.allanime.day` | `https://allanime.to` | HTTP 403 |

Catalog ungated + sources gated **is** the "full episode list, zero streams" symptom. This is the documented `NEED_CAPTCHA` condition that the user-owned relay exists for, not a crypto or parity defect.

## What changed

**1. The captcha was a silent no-op.** `NEED_CAPTCHA` appeared **nowhere** in the codebase. It fell through the retry loop, `rawSources` stayed empty, and the user got `No streams extracted from AllManga for episode N` — indistinguishable from an empty episode.

It is now `AllMangaCaptchaError`, checked **before** the crypto-staleness and rate-limit branches so it cannot be mistaken for either, and classified as **`blocked` / non-retryable** (a captcha is not a network fault; retrying and re-bootstrapping cannot clear it). The message names the one thing that helps — a user-owned relay in an ungated region. Two tests pin it, including that it neither re-bootstraps nor burns the retry budget.

**2. AllAnime demoted out of the automatic anime lane** — `animeProviderPriority: ["anidb", "allanime"]` → `["anidb"]`. It stays a registered production module in `loadProductionProviderModules()` and remains manually selectable. This is the same treatment Miruro already has, and it is the option you chose over full deprecation: on a gated network AllAnime as an automatic fallback can only spend resolve budget and then fail, but it is not code-broken and should keep working where the gate does not apply or behind a relay in an ungated region.

## Constraints honoured

- **Build id 81, the bootstrap, HMAC `x-aa-boot` and AES-256-GCM are untouched** — they are verified working, so there was nothing to fix. The historical epoch/partB construction and AES-CTR decryption were not restored.
- **TLS verification stays disabled only for mp4upload.** Not broadened.
- **wixmp referer behaviour is unchanged**, per the gate you set. The plan allows a referer change only after a fixture proves the current final-stream fallback insufficient. No such fixture can be built from this network: the pipeline never reaches source extraction, so there is no live wixmp row to characterize. The gate says "if the fixture passes, keep current behaviour" — so `resolveDirectStreamReferer()` is untouched.
- **`Luf-Mp4` admission was left alone.** It is a dead-source cleanup with no observable effect while every request is captcha-gated, and it is not the stop condition. Flagged as residue rather than done blind.

## No upstream parity reference

ani-cli v5 deleted AllAnime entirely (`a6ac602`), so there is no reference implementation left to compare against. `.docs/providers.md` now says this explicitly — the "compare against ani-cli" step in the parity policy applies to AniDB only, and for mkissa crypto the live JS chunk is the sole source of truth.

## Gates

`typecheck`, `lint`, `fmt:check`, `test`, `build`, `git diff --check`, `verify:doc-paths`, `verify:doc-coverage` — all green.
Tests: 4024 unit + 99 integration + 266 providers + 71 docs + 34 others pass, 0 fail. The integration suite's **47 skips are the pre-existing baseline**, not exclusions introduced here.

## Live evidence

- `bun run test:live:allanime` — **red, and correctly red.** Catalog resolves 11 episodes; the failure is now the actionable captcha message instead of `No streams extracted`.
- `bun run test:live:relay-allanime` against a local relay — **also captcha'd**, as expected: a relay on the same machine does not change the egress IP. A relay deployed to an ungated region is the one variable I could not test, and I am not claiming it as verified.
- `bun run test:live:anidb` — **green**, `streamResolved: true`, host `hls.anidb.app`. This is the check that matters for the demotion: the default anime lane still resolves a real stream without AllAnime behind it.

## Merge note

**All three provider branches (#38, #39, this) raise `NPM_BUNDLE_BUDGET_KB` 2_800 → 2_880 in `apps/cli/scripts/build-shared.ts`.** Whichever lands after the first needs a one-hunk rebase; keep the rationale. `main` was at 2866812 B against a 2867200 B ceiling — 388 bytes of headroom — so the ratchet was already spent and any next change would have tripped it. This guards the development bundle only; it is not what npm ships.
