### PR TITLE
fix(offline): preserve trusted local playback

### DIFF
--- a/.changeset/offline-local-playback-trust.md
+++ b/.changeset/offline-local-playback-trust.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Keep verified offline downloads on their trusted local media and subtitle paths, without provider recovery or remote playback metadata requests, and harden cancellation and reconnect handling around the mpv handoff.

--- a/.docs/architecture.md
+++ b/.docs/architecture.md
@@ -161,6 +161,8 @@ Production resolution is browserless by default:
 `apps/cli/src/mpv.ts`:
 
 - launches `mpv` detached
+- binds the active one-shot control to the playback abort signal, so shutdown
+  stops the current player instead of waiting for the process-exit backstop
 - writes playback position through a Lua helper
 - polls the position file after exit
 - has a deadline to avoid hanging forever if `mpv` dies badly

--- a/.docs/download-offline-onboarding.md
+++ b/.docs/download-offline-onboarding.md
@@ -124,6 +124,12 @@ was looked up as `tmdb:1339713` and a healthy file reported "Downloaded file una
 
 - No aggressive startup network probe.
 - Offline prompt appears only after a real network failure.
+- Runtime network status is **offline** (connect/DNS/unreachable — including Bun's
+  "Unable to connect" fetch string) or **limited** (timeouts). Confirmed offline is
+  sticky until a later success: a TMDB/proxy fallback that only times out must not
+  reclassify the session as flaky. Limited still counts as online for retries.
+  Search while actually offline opens browse with the existing header alert and
+  does not remount the phase in a silent loop.
 - `--offline` and `/library` list completed `download_jobs` and validate artifact readability.
 - Local files should validate before playback; corrupt or missing files should offer re-download, not crash.
 - Offline episode rows may show resume percentage or watched state from local history. This is derived from local
@@ -151,6 +157,13 @@ was looked up as `tmdb:1339713` and a healthy file reported "Downloaded file una
 - An offline-library launch keeps its explicit local-only origin through episode selection and
   playback. The validated local source is handed to the local mpv path, including local subtitle
   sidecars, rather than being represented as a remote stream URL.
+- The full player-options path preserves that verified origin by exact media/sidecar path match, so
+  resume, autoplay, timing, track preferences, and cancellation remain available without weakening
+  mpv URL safety. A local launch failure is a local player problem: it never invalidates provider
+  caches or enters source/provider failover.
+- Offline playback does not start remote subtitle or timing-metadata lookup, provider prefetch, or
+  recommendation warming. Local next-episode readiness, cached timing, and local subtitle sidecars
+  remain available.
 - Offline asset lookup uses the same canonical title identity as download enqueue. This covers
   provider-native anime ids, canonical AniList/TMDB ids, and YouTube ids across download, library,
   and normal playback surfaces.

--- a/.docs/mpv-in-process-reconnect.md
+++ b/.docs/mpv-in-process-reconnect.md
@@ -56,6 +56,11 @@ increments the generation **before** cleanup, so a late IPC event from the
 previous cycle cannot revive a session the user already replaced or stopped.
 Reconnect budgets and backoff above are unchanged by this.
 
+Reconnect backoff and post-`file-loaded` completion carry the initiating
+generation explicitly. They re-check it after every awaited seek, unpause, and
+subtitle operation; a replacement during any one of those waits prevents every
+remaining command and state mutation from the retired cycle.
+
 ## Status recovery contract
 
 One authoritative transition policy owns current playback status

--- a/.plans/offline-provider-independent-playback.md
+++ b/.plans/offline-provider-independent-playback.md
@@ -1,0 +1,334 @@
+# Offline Provider-Independent Playback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+Status: **planned** — implement before retiring a production provider, or promote during a broader offline-durability pass.
+
+**Goal:** Keep a verified downloaded artifact playable even when the provider recorded on its download job is no longer registered.
+
+**Architecture:** Resolve playback source authority before requiring a provider module. Represent local and provider acquisition as a discriminated union, keep provider-only orchestration behind the provider arm, and send both arms through the existing unified player lifecycle. Do not model the local library as a fake provider.
+
+**Tech Stack:** Bun, TypeScript, SQLite-backed offline repositories, the existing `PlaybackPhase` and `PlayerService` seams.
+
+**Spec:** [.docs/download-offline-onboarding.md](../.docs/download-offline-onboarding.md)
+
+## Global Constraints
+
+- A readable, validated local artifact is authoritative for an offline-library launch.
+- Missing provider registration must not block verified local playback.
+- Provider lookup remains mandatory before any online resolution, cache invalidation, health mutation, or provider fallback.
+- Preserve the exact-path local trust contract; never weaken mpv URL validation.
+- Preserve the unified `player.play()` lifecycle, including resume, autoplay, tracks, timing, cancellation, and generation ownership.
+- Do not introduce a synthetic or fake provider module for local media.
+- Additional provider subtitle tracks remain remote; only a verified local sidecar receives local trust.
+- Episode numbers remain 1-based at the UI seam.
+
+---
+
+## Problem and trigger
+
+`applyDownloadJobSessionRouting()` currently restores `job.providerId` into session state. `PlaybackPhase` then calls `providerRegistry.get()` and returns `PROVIDER_UNAVAILABLE` before `resolveLocalEpisodePlayback()` can inspect the validated artifact. A download therefore becomes stranded if its recorded provider is removed without an alias.
+
+This does not block current downloads while their provider remains registered. Treat either of these events as the trigger to schedule the plan:
+
+- removal or renaming of a production provider without a complete alias;
+- a beta/release milestone that promises downloads survive provider retirement.
+
+## Non-goals
+
+- Do not make online playback work without a compatible provider.
+- Do not rewrite provider fallback, source inventory, or title identity.
+- Do not split the entire `PlaybackPhase` in the same change.
+- Do not migrate old download rows merely to satisfy playback; the runtime must tolerate their recorded provider ID.
+
+## Acceptance criteria
+
+1. An offline-library job with `providerId: "retired-provider"` launches its verified local media and sidecar.
+2. The retired provider is never resolved, health-scored, invalidated, or selected as fallback.
+3. Local playback retains resume, timing, track selection, active cancellation, and persistent-session generation behavior.
+4. If the local artifact is missing or invalid, the user receives `offline-file-unavailable`; Kunai does not attempt online fallback under `--offline`.
+5. If an online launch has no local source and its selected provider is absent, behavior remains `PROVIDER_UNAVAILABLE`.
+6. Local next-episode continuation uses only the offline episode index; it does not require provider metadata.
+
+---
+
+### Task 1: Introduce source authority before provider lookup
+
+**Files:**
+
+- Create: `apps/cli/src/app/playback/playback-source-authority.ts`
+- Create: `apps/cli/test/unit/app/playback/playback-source-authority.test.ts`
+- Reuse: `apps/cli/src/app/playback/episode-playback-source.ts`
+
+**Interfaces:**
+
+- Consumes: `LocalEpisodePlaybackResolution`, `ProviderRegistry`, `TitleInfo`, and `EpisodeInfo`.
+- Produces: `PlaybackSourceAuthority` and `resolvePlaybackSourceAuthority()`.
+
+- [ ] **Step 1: Write the failing authority tests**
+
+```ts
+test("verified offline media wins before a retired provider lookup", async () => {
+  let providerReads = 0;
+  const local = readyLocalResolution({ providerId: "retired-provider" });
+
+  const result = await resolvePlaybackSourceAuthority({
+    configuredProviderId: "retired-provider",
+    offlineOnly: true,
+    resolveLocal: async () => local,
+    getProvider: () => {
+      providerReads += 1;
+      return undefined;
+    },
+  });
+
+  expect(result).toEqual({ kind: "local", resolution: local });
+  expect(providerReads).toBe(0);
+});
+
+test("online acquisition still fails closed without local media or a provider", async () => {
+  const result = await resolvePlaybackSourceAuthority({
+    configuredProviderId: "retired-provider",
+    offlineOnly: false,
+    resolveLocal: async () => null,
+    getProvider: () => undefined,
+  });
+
+  expect(result).toEqual({
+    kind: "provider-unavailable",
+    providerId: "retired-provider",
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```sh
+bun run --cwd apps/cli test test/unit/app/playback/playback-source-authority.test.ts
+```
+
+Expected: failure because `playback-source-authority.ts` does not exist.
+
+- [ ] **Step 3: Implement the acquisition interface**
+
+```ts
+import type { LocalEpisodePlaybackResolution } from "@/app/playback/episode-playback-source";
+import type { Provider } from "@/services/providers/Provider";
+
+export type PlaybackSourceAuthority =
+  | { readonly kind: "local"; readonly resolution: LocalEpisodePlaybackResolution }
+  | { readonly kind: "provider"; readonly provider: Provider }
+  | { readonly kind: "offline-unavailable" }
+  | { readonly kind: "provider-unavailable"; readonly providerId: string };
+
+export async function resolvePlaybackSourceAuthority(input: {
+  readonly configuredProviderId: string;
+  readonly offlineOnly: boolean;
+  readonly resolveLocal: () => Promise<LocalEpisodePlaybackResolution | null>;
+  readonly getProvider: (providerId: string) => Provider | undefined;
+}): Promise<PlaybackSourceAuthority> {
+  const local = await input.resolveLocal();
+  if (local) return { kind: "local", resolution: local };
+  if (input.offlineOnly) return { kind: "offline-unavailable" };
+  const provider = input.getProvider(input.configuredProviderId);
+  return provider
+    ? { kind: "provider", provider }
+    : { kind: "provider-unavailable", providerId: input.configuredProviderId };
+}
+```
+
+Keep source-preference policy inside the injected `resolveLocal()` call so online search and Continue retain their existing preference semantics.
+
+- [ ] **Step 4: Run the authority tests and verify GREEN**
+
+Run the command from Step 2. Expected: all tests pass.
+
+- [ ] **Step 5: Commit the authority module**
+
+```sh
+git add apps/cli/src/app/playback/playback-source-authority.ts \
+  apps/cli/test/unit/app/playback/playback-source-authority.test.ts
+git commit -m "refactor(playback): resolve source authority before providers"
+```
+
+---
+
+### Task 2: Make `PlaybackPhase` consume the authority union
+
+**Files:**
+
+- Modify: `apps/cli/src/app/playback/PlaybackPhase.ts`
+- Modify: `apps/cli/test/unit/app/playback/playback-phase-outer-loop.test.ts`
+- Test: `apps/cli/test/integration/offline-local-playback-resolution.test.ts`
+
+**Interfaces:**
+
+- Consumes: `resolvePlaybackSourceAuthority()` from Task 1.
+- Produces: a provider-independent local route through the existing `runMpvPlaybackSession()` and `PlayerServiceImpl` handoff.
+
+- [ ] **Step 1: Add the retired-provider phase regression**
+
+Build a `PlaybackPhase.execute()` harness whose offline library returns a ready local source, whose `providerRegistry.get()` returns `undefined`, and whose player captures `PlayerOptions.localPlaybackSource`.
+
+```ts
+expect(result.status).toBe("success");
+expect(capturedOptions?.localPlaybackSource?.filePath).toBe(localMediaPath);
+expect(providerResolveCalls).toBe(0);
+expect(providerHealthWrites).toBe(0);
+expect(cacheInvalidations).toBe(0);
+```
+
+Also retain an online control case:
+
+```ts
+expect(onlineResult).toMatchObject({
+  status: "error",
+  error: { code: "PROVIDER_UNAVAILABLE" },
+});
+```
+
+- [ ] **Step 2: Run the phase regression and verify RED**
+
+```sh
+bun run --cwd apps/cli test \
+  test/unit/app/playback/playback-phase-outer-loop.test.ts \
+  test/integration/offline-local-playback-resolution.test.ts
+```
+
+Expected: the offline case returns `PROVIDER_UNAVAILABLE` before reaching the player.
+
+- [ ] **Step 3: Integrate source authority without nullable-provider leakage**
+
+At the start of the episode iteration:
+
+```ts
+const sourceAuthority = await resolvePlaybackSourceAuthority({
+  configuredProviderId: run.sessionSoftProviderId ?? configuredProviderId,
+  offlineOnly: isOfflineLaunch,
+  resolveLocal: () =>
+    resolveLocalEpisodePlayback(container, title, currentEpisode, {
+      entrypoint: isOfflineLaunch
+        ? "offline-library"
+        : title.launchSource === "continue"
+          ? "continue"
+          : "online-search",
+      forceOnline: run.episodePlaybackSourceOverride === "online",
+      forceLocal: isOfflineLaunch || run.episodePlaybackSourceOverride === "local",
+    }),
+  getProvider: (providerId) => providerRegistry.get(providerId),
+});
+```
+
+Handle every union arm explicitly:
+
+- `local`: populate `stream`, `run.localEpisodeTiming`, `run.localPlaybackJobId`, and `run.localPlaybackSource`; use `"local"` only as diagnostic source identity.
+- `provider`: enter the existing provider trace/cache/resolve path with `sourceAuthority.provider`.
+- `offline-unavailable`: dispatch `buildOfflineFileUnavailableProblem()` and return to results.
+- `provider-unavailable`: return the existing `PROVIDER_UNAVAILABLE` error.
+
+Do not create `const currentProvider: Provider | undefined` and thread it through the method. Provider-only operations—including recent remote-stream reuse, source selection, resolve tracing, provider handoff, cache invalidation, health mutation, and provider prefetch—must live inside the `provider` arm. Local episode availability continues through the offline index.
+
+- [ ] **Step 4: Run the focused phase and player suites**
+
+```sh
+bun run --cwd apps/cli test \
+  test/unit/app/playback/playback-phase-outer-loop.test.ts \
+  test/integration/offline-local-playback-resolution.test.ts \
+  test/unit/app/playback/run-mpv-playback-session.test.ts \
+  test/unit/infra/player/PlayerServiceImpl.test.ts
+```
+
+Expected: all tests pass, including the online control case.
+
+- [ ] **Step 5: Commit phase integration**
+
+```sh
+git add apps/cli/src/app/playback/PlaybackPhase.ts \
+  apps/cli/test/unit/app/playback/playback-phase-outer-loop.test.ts \
+  apps/cli/test/integration/offline-local-playback-resolution.test.ts
+git commit -m "fix(offline): play downloads after provider retirement"
+```
+
+---
+
+### Task 3: Pin offline continuation and update product truth
+
+**Files:**
+
+- Modify: `apps/cli/test/unit/app/offline-playback-launch.test.ts`
+- Modify: `.docs/download-offline-onboarding.md`
+- Modify: `.plans/roadmap.md`
+- Move on completion: `.plans/offline-provider-independent-playback.md` to `.plans/archive/offline-provider-independent-playback.md`
+
+**Interfaces:**
+
+- Consumes: the source-authority behavior from Tasks 1–2.
+- Produces: durable offline-launch and documentation contracts.
+
+- [ ] **Step 1: Add launch and local-next-episode assertions**
+
+```ts
+test("offline launch preserves a retired provider id as metadata only", async () => {
+  const job = readyJob({ providerId: "retired-provider" });
+  const launch = await prepareOfflinePlaybackLaunch(containerFor(job), job.id);
+
+  expect(launch?.title.launchSource).toBe("offline-library");
+  expect(dispatchedMode.provider).toBe("retired-provider");
+  expect(providerRegistryReads).toBe(0);
+});
+```
+
+Extend the phase regression to move from S01E01 to an offline-ready S01E02 with the provider still absent. Assert no remote prefetch or provider lookup occurs.
+
+- [ ] **Step 2: Run offline launch, episode-index, and source-selection tests**
+
+```sh
+bun run --cwd apps/cli test \
+  test/unit/app/offline-playback-launch.test.ts \
+  test/unit/services/offline/offline-episode-index.test.ts \
+  test/unit/domain/playback-source/source-selection-engine.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Update current behavior documentation**
+
+Add this invariant to `.docs/download-offline-onboarding.md` after implementation:
+
+```md
+- A validated local artifact remains playable when its recorded provider is no longer registered.
+  Provider identity is metadata for local playback and becomes mandatory only when online resolution starts.
+```
+
+Move this plan to `.plans/archive/`, remove its active roadmap row, and describe it as historical implementation evidence.
+
+- [ ] **Step 4: Run complete verification**
+
+```sh
+bun run test
+bun run typecheck
+bun run lint
+bun run fmt:check
+bun run verify:doc-paths
+bun run build
+git diff --check
+```
+
+Expected: every command exits zero. Existing warning-only lint output is acceptable only if no new warning points at files changed by this plan.
+
+- [ ] **Step 5: Commit documentation and plan closure**
+
+```sh
+git add .docs/download-offline-onboarding.md .plans/roadmap.md \
+  .plans/archive/offline-provider-independent-playback.md \
+  apps/cli/test/unit/app/offline-playback-launch.test.ts
+git commit -m "docs(offline): record provider-independent playback"
+```
+
+## Self-review record
+
+- Spec coverage: all six acceptance criteria map to Tasks 1–3.
+- Placeholder scan: no unfinished marker, generic error-handling instruction, or unnamed test obligation remains.
+- Type consistency: Task 2 consumes the exact `PlaybackSourceAuthority` and `resolvePlaybackSourceAuthority()` interface defined in Task 1.

--- a/.plans/roadmap.md
+++ b/.plans/roadmap.md
@@ -1,6 +1,6 @@
 # Kunai — Roadmap
 
-Last updated: 2026-07-29
+Last updated: 2026-08-13
 
 This is the **only index of active work**. Everything in `.plans/` is unfinished
 by construction; everything finished lives in [`archive/`](./archive/README.md).
@@ -71,6 +71,7 @@ lands; leftover polish becomes a row here, not a surviving plan file.
 | Release schedules               | TV weekly/season projection                               | [catalog-release-schedule-service.md](./catalog-release-schedule-service.md)                                 |
 | Upcoming-episode UX             | `upcomingNext` vs released `nextEpisode` mutual exclusion | [series-catalog-end-state-and-upcoming-episode-ux.md](./series-catalog-end-state-and-upcoming-episode-ux.md) |
 | Download / offline / onboarding | Download slices, offline library, setup wizard            | [download-offline-onboarding.md](./download-offline-onboarding.md)                                           |
+| Provider-independent offline    | Keep downloads playable after provider retirement         | [offline-provider-independent-playback.md](./offline-provider-independent-playback.md)                       |
 | Offline artwork cache           | Library previews                                          | [offline-artwork-cache-and-library-previews.md](./offline-artwork-cache-and-library-previews.md)             |
 | Network status                  | Offline suggestion surface                                | [network-status-and-offline-suggestion.md](./network-status-and-offline-suggestion.md)                       |
 | Recovery policy engine          | Policy modes                                              | [recovery-policy-engine.md](./recovery-policy-engine.md)                                                     |

--- a/apps/cli/scripts/build-shared.ts
+++ b/apps/cli/scripts/build-shared.ts
@@ -219,8 +219,12 @@ export function totalMetafileInputBytes(metafile: BunBuildMetafile): number {
  * ~9 KiB) and is ratcheted separately by NPM_PACK_PACKED_BUDGET_BYTES /
  * NPM_PACK_UNPACKED_BUDGET_BYTES, so moving this number cannot affect what a
  * user installs from npm.
+ *
+ * Raised from 2_800 on 2026-08-13 for the verified offline media/sidecar
+ * provenance handoff plus active cancellation and reconnect generation guards.
+ * The previous tree had 388 bytes of headroom; the completed bundle is 2_804 KiB.
  */
-export const NPM_BUNDLE_BUDGET_KB = 2_800;
+export const NPM_BUNDLE_BUDGET_KB = 2_816;
 
 /** Packed-size ratchet for the public Node launcher manifest, script, and license. */
 export const NPM_PACK_PACKED_BUDGET_BYTES = 32 * 1024;

--- a/apps/cli/src/app/playback/PlaybackPhase.ts
+++ b/apps/cli/src/app/playback/PlaybackPhase.ts
@@ -131,6 +131,7 @@ import { createQueuePlaybackAttempt } from "@/app/playback/queue-playback-attemp
 import {
   recentPlaybackStreamKey,
   recentPlaybackStreamMatchesProvider,
+  restoreRecentPlaybackStream,
   type RecentPlaybackStreamProvenance,
   type RecentPlaybackStreamRecord,
 } from "@/app/playback/recent-playback-stream";
@@ -1316,6 +1317,7 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
                 title,
                 currentEpisode,
                 isAnime: isAnimePlayback,
+                networkAllowed: playbackNetworkAllowed,
                 animeEpisodeCount: knownEpisodeCount,
                 animeEpisodes: currentAnimeEpisodes,
                 watchedEntries,
@@ -1544,9 +1546,11 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
               recentPlaybackStreamMatchesProvider(recent, currentProvider.metadata.id) &&
               recentStreamMatchesPreferred(recent, currentProvider.metadata.id, currentEpisode)
             ) {
-              stream = recent.stream;
-              resolvedProviderId = recent.resolvedProviderId;
-              streamProvenance = recent.provenance;
+              const restored = restoreRecentPlaybackStream(recent);
+              stream = restored.stream;
+              resolvedProviderId = restored.resolvedProviderId;
+              streamProvenance = restored.provenance;
+              run.localPlaybackSource = restored.localPlaybackSource;
               diagnosticsService.record({
                 ...playbackCorrelation,
                 category: "cache",
@@ -2144,12 +2148,24 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
           stateManager.dispatch({ type: "SET_STREAM", stream: preparedStream });
 
           const episodeKey = `${title.id}:${currentEpisode.season}:${currentEpisode.episode}`;
-          recentEpisodeStreams.set(episodeKey, {
-            stream: preparedStream,
-            selectedProviderId: currentProvider.metadata.id,
-            resolvedProviderId,
-            provenance: streamProvenance,
-          });
+          if (streamProvenance === "local") {
+            if (run.localPlaybackSource) {
+              recentEpisodeStreams.set(episodeKey, {
+                stream: preparedStream,
+                selectedProviderId: currentProvider.metadata.id,
+                resolvedProviderId,
+                provenance: "local",
+                localPlaybackSource: run.localPlaybackSource,
+              });
+            }
+          } else {
+            recentEpisodeStreams.set(episodeKey, {
+              stream: preparedStream,
+              selectedProviderId: currentProvider.metadata.id,
+              resolvedProviderId,
+              provenance: streamProvenance,
+            });
+          }
           if (recentEpisodeStreams.size > 5) {
             const first = recentEpisodeStreams.keys().next().value;
             if (first !== undefined) recentEpisodeStreams.delete(first);

--- a/apps/cli/src/app/playback/PlaybackPhase.ts
+++ b/apps/cli/src/app/playback/PlaybackPhase.ts
@@ -98,6 +98,7 @@ import { invalidateEpisodePlaybackCaches } from "@/app/playback/playback-source-
 import {
   listOrderedPlaybackSourceIds,
   planStartupFailover,
+  shouldUseProviderPlaybackRecovery,
   STARTUP_STALL_TIMEOUT_MS,
 } from "@/app/playback/playback-source-failover";
 import {
@@ -112,6 +113,7 @@ import {
   type PlaybackStatusSignal,
   type PlaybackStatusSnapshot,
 } from "@/app/playback/playback-status-policy";
+import { shouldFetchPlaybackTiming } from "@/app/playback/playback-timing-fetch-policy";
 import {
   applyPlaybackControlTrackSelection,
   buildTrackOverrideDiagnosticContext,
@@ -166,6 +168,7 @@ import {
   toEpisodeNavigationState,
 } from "@/domain/playback/playback-policy";
 import {
+  buildLocalPlaybackFailureProblem,
   buildOfflineFileUnavailableProblem,
   buildPlayerFailureProblem,
   buildProviderResolveProblem,
@@ -1209,6 +1212,7 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
             }
           };
           recordStartupMark("episode-bootstrap-started");
+          const playbackNetworkAllowed = !isOfflineLaunch && container.connectivity.isOnline();
 
           // Warm the catalog-detail cache early so the playback/post-play panels
           // can read it. On resolve we dispatch SET_TITLE_DETAIL so the UI reacts
@@ -1237,9 +1241,11 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
           // on the successful provider when they differ.
           recordStartupMark("timing-fetch-started");
           const configuredTimingProviderId = currentProvider?.metadata.id;
-          const timingFetch = isOfflineLaunch
-            ? Promise.resolve(null)
-            : this.getPlaybackTimingMetadata(
+          const timingFetch = shouldFetchPlaybackTiming({
+            networkAllowed: playbackNetworkAllowed,
+            hasTiming: false,
+          })
+            ? this.getPlaybackTimingMetadata(
                 title,
                 currentEpisode,
                 playbackTimingByEpisode,
@@ -1247,7 +1253,8 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
                 stateManager.getState().mode === "anime",
                 configuredTimingProviderId,
                 container.diagnosticsService,
-              );
+              )
+            : Promise.resolve(null);
 
           const watchedEntries = historyRepository.listByTitleIdentity(historyTitleLookup);
           const playbackMode = stateManager.getState().mode;
@@ -2068,15 +2075,20 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
             run.localEpisodeTiming ??
             (successfulTimingProviderId === configuredTimingProviderId
               ? await timingFetch
-              : await this.getPlaybackTimingMetadata(
-                  title,
-                  currentEpisode,
-                  playbackTimingByEpisode,
-                  resolveController.signal,
-                  stateManager.getState().mode === "anime",
-                  successfulTimingProviderId,
-                  container.diagnosticsService,
-                ));
+              : shouldFetchPlaybackTiming({
+                    networkAllowed: playbackNetworkAllowed,
+                    hasTiming: false,
+                  })
+                ? await this.getPlaybackTimingMetadata(
+                    title,
+                    currentEpisode,
+                    playbackTimingByEpisode,
+                    resolveController.signal,
+                    stateManager.getState().mode === "anime",
+                    successfulTimingProviderId,
+                    container.diagnosticsService,
+                  )
+                : null);
           run.localEpisodeTiming = null;
           recordStartupMark("timing-ready", stream);
           const playbackTiming = mergeTimingMetadata(
@@ -2095,7 +2107,12 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
           // if the background retry resolves while the episode is playing, so all
           // post-playback decisions (history, autoNext, result classification) use it.
           const effectiveTiming = { current: playbackTiming };
-          if (!playbackTiming) {
+          if (
+            shouldFetchPlaybackTiming({
+              networkAllowed: playbackNetworkAllowed,
+              hasTiming: playbackTiming !== null,
+            })
+          ) {
             runBackgroundTask({
               task: "playback.retryTiming",
               category: "playback",
@@ -2258,6 +2275,7 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
                 stopAfterCurrent: run.playbackSession.stopAfterCurrent,
                 sessionMode: run.playbackSession.mode,
                 autoplayPaused: run.playbackSession.autoplayPaused,
+                networkAllowed: !isOfflineLaunch && container.connectivity.isOnline(),
               })
             ) {
               return;
@@ -2521,10 +2539,12 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
             });
           }
 
+          const providerRecoveryAllowed = shouldUseProviderPlaybackRecovery(streamProvenance);
           const shouldInvalidateStreamCache =
-            result.endReason === "error" ||
-            result.suspectedDeadStream === true ||
-            didPlaybackFailToStart(result);
+            providerRecoveryAllowed &&
+            (result.endReason === "error" ||
+              result.suspectedDeadStream === true ||
+              didPlaybackFailToStart(result));
           if (shouldInvalidateStreamCache) {
             const invalidateProviderId = providerHandoff.successfulProviderId;
             const selectedResolveStream = preparedStream.providerResolveResult?.streams.find(
@@ -2612,8 +2632,51 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
           // pushed into shell state: doing so rendered "autoplay paused" as if the
           // user's session preference had changed just because they closed mpv.
           // Only an explicit toggle changes the visible autoplay setting.
-          let shouldAutoFallbackProvider = playbackDecision.shouldFallbackProvider;
-          if (playbackDecision.shouldRefreshSource) {
+          let shouldAutoFallbackProvider =
+            playbackDecision.shouldFallbackProvider && !isOfflineLaunch;
+          if (!providerRecoveryAllowed && playbackDecision.shouldRefreshSource) {
+            const isExplicitLocalRelaunch =
+              playbackControlAction === "refresh" || playbackControlAction === "recover";
+            if (isExplicitLocalRelaunch) {
+              run.pendingStart = startAtResumePoint(
+                toHistoryTimestamp(result, effectiveTiming.current, quitThresholdMode),
+                { suppressResumePrompt: true },
+              );
+              run.episodePlaybackSourceOverride = "local";
+              continue;
+            }
+
+            const localProblem = buildLocalPlaybackFailureProblem();
+            stateManager.dispatch({
+              type: "SET_PLAYBACK_PROBLEM",
+              problem: localProblem,
+            });
+            diagnosticsService.record({
+              ...playbackCorrelation,
+              category: "playback",
+              operation: "playback.source.local.failed",
+              level: "error",
+              message: localProblem.userMessage,
+              titleId: title.id,
+              season: currentEpisode.season,
+              episode: currentEpisode.episode,
+              context: {
+                cause: localProblem.cause,
+                endReason: result.endReason,
+                playerExitCode: result.playerExitCode,
+              },
+            });
+            await releasePersistentMpvForTerminalFailure({
+              player,
+              playerControl,
+              userMessage: localProblem.userMessage,
+              reason: `local-playback:${classifyPlaybackFailureFromResult(result)}`,
+              diagnostics: diagnosticsService,
+            });
+            return { status: "success", value: "back_to_results" };
+          }
+
+          if (providerRecoveryAllowed && playbackDecision.shouldRefreshSource) {
             const isExplicitSourceRefresh =
               playbackControlAction === "refresh" || playbackControlAction === "recover";
             const isAutoSourceRecover =
@@ -4010,10 +4073,13 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
       stream,
       requestedSubLang,
       hasTmdbId: provenTmdbId !== null,
+      networkAvailable:
+        title.launchSource !== "offline-library" && context.container.connectivity.isOnline(),
     });
     if (!lookupDecision.attempt) {
       if (
         lookupDecision.reason !== "disabled" &&
+        lookupDecision.reason !== "offline" &&
         lookupDecision.reason !== "attached" &&
         lookupDecision.reason !== "hardsub-satisfied"
       ) {

--- a/apps/cli/src/app/playback/episode-prefetch.ts
+++ b/apps/cli/src/app/playback/episode-prefetch.ts
@@ -99,7 +99,9 @@ export function isEpisodePrefetchEligible(input: {
   readonly stopAfterCurrent: boolean;
   readonly sessionMode: "manual" | "autoplay-chain";
   readonly autoplayPaused: boolean;
+  readonly networkAllowed?: boolean;
 }): boolean {
+  if (input.networkAllowed === false) return false;
   if (input.titleType !== "series" || !input.hasNextEpisode) return false;
   if (input.stopAfterCurrent) return false;
   if (input.sessionMode === "autoplay-chain" && input.autoplayPaused) return false;

--- a/apps/cli/src/app/playback/playback-episode-picker.ts
+++ b/apps/cli/src/app/playback/playback-episode-picker.ts
@@ -38,6 +38,8 @@ export type PlaybackEpisodePickerInput = {
   watchedEntries?: readonly HistoryProgress[];
   releaseBadges?: ReadonlyMap<string, string>;
   downloadedEpisodes?: ReadonlySet<string>;
+  /** False for offline-library launches; the picker then reads only the local index. */
+  networkAllowed?: boolean;
   loadEpisodes?: typeof fetchEpisodes;
 };
 
@@ -56,6 +58,7 @@ export async function buildPlaybackEpisodePickerOptions({
   watchedEntries = [],
   releaseBadges,
   downloadedEpisodes,
+  networkAllowed = true,
   loadEpisodes = fetchEpisodes,
 }: PlaybackEpisodePickerInput): Promise<PlaybackEpisodePickerOptions> {
   const watchedByEpisode = new Map(
@@ -70,6 +73,34 @@ export async function buildPlaybackEpisodePickerOptions({
       options: [],
       subtitle: "Episode picker is only available for episodic playback",
       initialIndex: 0,
+    };
+  }
+
+  if (!networkAllowed) {
+    const prefix = `${currentEpisode.season}:`;
+    const episodes = [...(downloadedEpisodes ?? [])]
+      .filter((key) => key.startsWith(prefix))
+      .map((key) => Number(key.slice(prefix.length)))
+      .filter((episode) => Number.isInteger(episode) && episode > 0)
+      .sort((left, right) => left - right);
+    const options = episodes.map((episode) =>
+      buildEpisodePickerOption({
+        season: currentEpisode.season,
+        episode,
+        label: `Episode ${episode}`,
+        offlineDownloaded: true,
+        current: episode === currentEpisode.episode,
+        history: watchedByEpisode.get(`${currentEpisode.season}:${episode}`),
+      }),
+    );
+    return {
+      subtitle: formatEpisodePickerSubtitle({
+        seriesName: title.name,
+        season: currentEpisode.season,
+        options,
+      }),
+      options,
+      initialIndex: getInitialIndex(options, `${currentEpisode.season}:${currentEpisode.episode}`),
     };
   }
 

--- a/apps/cli/src/app/playback/playback-source-failover.ts
+++ b/apps/cli/src/app/playback/playback-source-failover.ts
@@ -1,5 +1,7 @@
 import type { ProviderResolveResult } from "@kunai/types";
 
+import type { RecentPlaybackStreamProvenance } from "./recent-playback-stream";
+
 /** ~3 catalog sources + 1 provider hop before surfacing post-play recovery. */
 export const MAX_STARTUP_FAILOVER_ATTEMPTS = 4;
 
@@ -10,6 +12,13 @@ export type StartupFailoverPlan =
   | { readonly kind: "advance-source"; readonly sourceId: string }
   | { readonly kind: "fallback-provider" }
   | { readonly kind: "give-up" };
+
+/** Local artifacts have no provider source to refresh, invalidate, or fail over from. */
+export function shouldUseProviderPlaybackRecovery(
+  provenance: RecentPlaybackStreamProvenance,
+): boolean {
+  return provenance !== "local";
+}
 
 /** Ordered source ids from a resolve result (catalog / inventory order). */
 export function listOrderedPlaybackSourceIds(

--- a/apps/cli/src/app/playback/playback-timing-fetch-policy.ts
+++ b/apps/cli/src/app/playback/playback-timing-fetch-policy.ts
@@ -1,0 +1,6 @@
+export function shouldFetchPlaybackTiming(input: {
+  readonly networkAllowed: boolean;
+  readonly hasTiming: boolean;
+}): boolean {
+  return input.networkAllowed && !input.hasTiming;
+}

--- a/apps/cli/src/app/playback/recent-playback-stream.ts
+++ b/apps/cli/src/app/playback/recent-playback-stream.ts
@@ -1,13 +1,37 @@
 import type { EpisodeInfo, StreamInfo } from "@/domain/types";
+import type { LocalPlaybackSource } from "@/services/offline/local-playback-source";
 
 export type RecentPlaybackStreamProvenance = "fresh" | "cache" | "prefetch" | "fallback" | "local";
 
-export type RecentPlaybackStreamRecord = {
+type RecentPlaybackStreamBase = {
   readonly stream: StreamInfo;
   readonly selectedProviderId: string;
   readonly resolvedProviderId: string;
-  readonly provenance: RecentPlaybackStreamProvenance;
 };
+
+export type RecentPlaybackStreamRecord =
+  | (RecentPlaybackStreamBase & {
+      readonly provenance: "local";
+      readonly localPlaybackSource: LocalPlaybackSource;
+    })
+  | (RecentPlaybackStreamBase & {
+      readonly provenance: Exclude<RecentPlaybackStreamProvenance, "local">;
+      readonly localPlaybackSource?: never;
+    });
+
+export function restoreRecentPlaybackStream(recent: RecentPlaybackStreamRecord): {
+  readonly stream: StreamInfo;
+  readonly resolvedProviderId: string;
+  readonly provenance: RecentPlaybackStreamProvenance;
+  readonly localPlaybackSource: LocalPlaybackSource | null;
+} {
+  return {
+    stream: recent.stream,
+    resolvedProviderId: recent.resolvedProviderId,
+    provenance: recent.provenance,
+    localPlaybackSource: recent.provenance === "local" ? recent.localPlaybackSource : null,
+  };
+}
 
 export function recentPlaybackStreamKey(titleId: string, episode: EpisodeInfo): string {
   return `${titleId}:${episode.season}:${episode.episode}`;

--- a/apps/cli/src/app/playback/run-mpv-playback-session.ts
+++ b/apps/cli/src/app/playback/run-mpv-playback-session.ts
@@ -194,6 +194,7 @@ export async function runMpvPlaybackSession(
       startAt: input.startAt,
       timing: input.timing,
       correlation: input.correlation,
+      localPlaybackSource: input.localPlaybackSource,
       shareLinkContext: {
         ...input.shareLinkContext,
         onCopied: hooks.onShareCopied,

--- a/apps/cli/src/app/playback/subtitle-selection.ts
+++ b/apps/cli/src/app/playback/subtitle-selection.ts
@@ -21,6 +21,7 @@ export type LateSubtitleLookupDecision = {
   attempt: boolean;
   reason:
     | "disabled"
+    | "offline"
     | "tmdb-id-missing"
     | "attached"
     | "inventory-satisfied"
@@ -33,14 +34,19 @@ export function shouldAttemptLateSubtitleLookup({
   stream,
   requestedSubLang,
   hasTmdbId,
+  networkAvailable = true,
 }: {
   stream: StreamInfo;
   requestedSubLang: string;
   hasTmdbId: boolean;
+  networkAvailable?: boolean;
 }): LateSubtitleLookupDecision {
   const availableTracks = stream.subtitleList?.length ?? 0;
   if (isSubtitlePreferenceDisabled(requestedSubLang)) {
     return { attempt: false, reason: "disabled", availableTracks };
+  }
+  if (!networkAvailable) {
+    return { attempt: false, reason: "offline", availableTracks };
   }
   if (!hasTmdbId) {
     return { attempt: false, reason: "tmdb-id-missing", availableTracks };

--- a/apps/cli/src/domain/playback/playback-problem.ts
+++ b/apps/cli/src/domain/playback/playback-problem.ts
@@ -72,6 +72,19 @@ export function buildOfflineFileUnavailableProblem(): PlaybackProblem {
   };
 }
 
+/** A verified artifact reached mpv, but the local player handoff itself failed. */
+export function buildLocalPlaybackFailureProblem(): PlaybackProblem {
+  return {
+    stage: "mpv",
+    severity: "blocking",
+    cause: "local-playback-failed",
+    userMessage:
+      "The downloaded file was found, but mpv could not open it. Open Diagnostics for the exact player error.",
+    recommendedAction: "diagnostics",
+    secondaryActions: ["relaunch"],
+  };
+}
+
 export function buildProviderResolveProblem({
   attempts,
 }: {
@@ -315,6 +328,7 @@ export function toErrorScenario(
     // shell rendered the bare `⚠ issue · offline-file-unavailable` slug instead
     // of the error surface every other blocking failure gets.
     case "offline-file-unavailable":
+    case "local-playback-failed":
       return {
         kind: "title-unavailable",
         title: context.title ?? extractUnavailableTitle(problem.userMessage),

--- a/apps/cli/src/infra/player/PersistentMpvSession.ts
+++ b/apps/cli/src/infra/player/PersistentMpvSession.ts
@@ -973,12 +973,14 @@ export class PersistentMpvSession {
     primarySubtitle: string | null,
     subtitleTracks?: readonly SubtitleTrack[],
     onAttached?: (trackCount: number) => void,
+    primarySubtitleUrlKind?: MpvUrlKind,
   ): Promise<void> {
     await this.subtitleManager.replaceSubtitleInventory(
       this.ipcSession,
       primarySubtitle,
       subtitleTracks,
       onAttached,
+      primarySubtitleUrlKind,
     );
   }
 
@@ -1510,6 +1512,7 @@ export class PersistentMpvSession {
 
     const now = Date.now();
     if (now < this.reconnectBackoffUntilMs) return false;
+    const reconnectGeneration = this.cycleGeneration;
 
     const nextAttempt = this.reconnectTryCount + 1;
     const backoffBefore =
@@ -1518,6 +1521,7 @@ export class PersistentMpvSession {
         : 0;
     if (backoffBefore > 0) {
       await Bun.sleep(backoffBefore);
+      if (!this.isGenerationCurrent(reconnectGeneration)) return false;
     }
 
     this.reconnectInFlight = true;
@@ -1545,7 +1549,6 @@ export class PersistentMpvSession {
       active.telemetry.lastReliableProgressSeconds = savedLastReliable;
       // Reconnect reloads the same cycle: keep its generation, but retire the
       // previous pending owner so two load owners never coexist.
-      const reconnectGeneration = this.cycleGeneration;
       this.pendingInProcessReconnect = {
         seekSeconds,
         shouldSeek,
@@ -1603,7 +1606,10 @@ export class PersistentMpvSession {
     seekSeconds: number;
     shouldSeek: boolean;
     trigger: InProcessReconnectTrigger;
+    generation: PlaybackGeneration;
   }): Promise<void> {
+    const isCurrent = () => this.isGenerationCurrent(spec.generation);
+    if (!isCurrent()) return;
     const opts = this.currentCycleOptions();
     try {
       if (spec.shouldSeek && this.ipcSession) {
@@ -1611,11 +1617,13 @@ export class PersistentMpvSession {
           ["seek", spec.seekSeconds, "absolute"],
           3_000,
         );
+        if (!isCurrent()) return;
         if (seekResult.ok) {
           this.currentPositionSeconds = spec.seekSeconds;
         }
       }
       await this.ipcSession?.send(["set_property", "pause", false], 500);
+      if (!isCurrent()) return;
 
       await this.replaceSubtitleInventory(
         opts.primarySubtitle,
@@ -1624,7 +1632,9 @@ export class PersistentMpvSession {
           opts.onPlaybackEvent?.({ type: "subtitle-inventory-ready", trackCount });
           opts.onPlaybackEvent?.({ type: "subtitle-attached", trackCount });
         },
+        opts.subtitleUrlKind,
       );
+      if (!isCurrent()) return;
 
       opts.onPlaybackEvent?.({
         type: "mpv-in-process-reconnect",
@@ -1633,6 +1643,7 @@ export class PersistentMpvSession {
         detail: spec.trigger,
       });
     } catch (error) {
+      if (!isCurrent()) return;
       const message = error instanceof Error ? error.message : String(error);
       opts.onPlaybackEvent?.({
         type: "mpv-in-process-reconnect",
@@ -1641,9 +1652,11 @@ export class PersistentMpvSession {
         detail: `${spec.trigger}: ${message}`,
       });
     } finally {
-      this.reconnectInFlight = false;
-      this.nearEofFired = false;
-      await this.handleSegmentSkipProgress(opts);
+      if (isCurrent()) {
+        this.reconnectInFlight = false;
+        this.nearEofFired = false;
+        await this.handleSegmentSkipProgress(opts);
+      }
     }
   }
 }

--- a/apps/cli/src/infra/player/PersistentMpvSession.ts
+++ b/apps/cli/src/infra/player/PersistentMpvSession.ts
@@ -974,6 +974,7 @@ export class PersistentMpvSession {
     subtitleTracks?: readonly SubtitleTrack[],
     onAttached?: (trackCount: number) => void,
     primarySubtitleUrlKind?: MpvUrlKind,
+    isCurrent?: () => boolean,
   ): Promise<void> {
     await this.subtitleManager.replaceSubtitleInventory(
       this.ipcSession,
@@ -981,6 +982,7 @@ export class PersistentMpvSession {
       subtitleTracks,
       onAttached,
       primarySubtitleUrlKind,
+      isCurrent,
     );
   }
 
@@ -1633,6 +1635,7 @@ export class PersistentMpvSession {
           opts.onPlaybackEvent?.({ type: "subtitle-attached", trackCount });
         },
         opts.subtitleUrlKind,
+        isCurrent,
       );
       if (!isCurrent()) return;
 

--- a/apps/cli/src/infra/player/PlayerService.ts
+++ b/apps/cli/src/infra/player/PlayerService.ts
@@ -118,8 +118,14 @@ export interface PlayerOptions {
   onPlaybackEvent?: (input: PlayerPlaybackEventEnvelope) => void;
   /** Called once when playback enters the last ~30 s (autoplay-chain mode only). */
   onNearEof?: () => void;
-  /** When aborted, `play()` rejects before spawning mpv. */
+  /** Rejects before spawn; while one-shot playback is active, stops its mpv control. */
   abortSignal?: AbortSignal;
+  /**
+   * Verified offline source that authorized local filesystem targets for this
+   * play. The player matches paths exactly before opting into local URL rules;
+   * provider-controlled streams remain remote-only.
+   */
+  localPlaybackSource?: LocalPlaybackSource;
   shareLinkContext?: {
     readonly mode: ShellMode;
     readonly title: Pick<TitleInfo, "id" | "type" | "name" | "externalIds" | "isAnime">;

--- a/apps/cli/src/infra/player/PlayerServiceImpl.ts
+++ b/apps/cli/src/infra/player/PlayerServiceImpl.ts
@@ -298,13 +298,22 @@ export class PlayerServiceImpl implements PlayerService {
     );
 
     try {
-      const urlKind = materialized.kind === "none" ? "remote" : "local";
+      const verifiedLocalSource = options.localPlaybackSource;
+      const urlKind =
+        verifiedLocalSource?.filePath === playbackStream.url || materialized.kind !== "none"
+          ? "local"
+          : "remote";
+      const subtitleUrlKind =
+        playbackStream.subtitle && verifiedLocalSource?.subtitlePath === playbackStream.subtitle
+          ? "local"
+          : "remote";
       const result =
         options.playbackMode === "autoplay-chain"
           ? await this.playAutoplayChainStream(
               playbackStream,
               options,
               urlKind,
+              subtitleUrlKind,
               publish,
               retiredGeneration,
             )
@@ -312,6 +321,7 @@ export class PlayerServiceImpl implements PlayerService {
               playbackStream,
               options,
               urlKind,
+              subtitleUrlKind,
               publish,
               retiredGeneration,
             );
@@ -646,46 +656,63 @@ export class PlayerServiceImpl implements PlayerService {
     stream: StreamInfo,
     options: PlayerOptions,
     urlKind: "remote" | "local",
+    subtitleUrlKind: "remote" | "local",
     publish: (event: PlayerPlaybackEvent) => void,
     retiredGeneration: PlaybackGeneration | null,
   ): Promise<PlaybackResult> {
     const generation = this.currentGeneration;
     await this.retirePersistentSession(retiredGeneration);
-    return await (this.deps.launchMpv ?? launchMpv)({
-      url: stream.url,
-      urlKind,
-      headers: stream.headers ?? {},
-      subtitle: stream.subtitle ?? null,
-      subtitleUrlKind: "remote",
-      audioPreference: options.audioPreference,
-      subtitlePreference: options.subtitlePreference,
-      subtitleTracks: stream.subtitleList,
-      displayTitle: options.displayTitle,
-      startAt: options.startAt,
-      requiresYtdl: stream.requiresYtdl,
-      ytdlFormat: stream.ytdlFormat,
-      ytdlRawOptions: stream.ytdlRawOptions,
-      attach: options.attach,
-      timing: options.timing,
-      autoSkipEnabled: options.autoSkipEnabled,
-      skipRecap: options.skipRecap,
-      skipIntro: options.skipIntro,
-      skipPreview: options.skipPreview,
-      skipCredits: options.skipCredits,
-      onControlReady: (control) => this.setActiveControlFor(generation, control),
-      onPlayerReady: options.onPlayerReady,
-      onPlaybackEvent: publish,
-      mpv: {
-        ...this.deps.mpv,
-        startupPriority: this.deps.config.startupPriority,
-      },
-    });
+    const stopOnAbort = () => {
+      const active = this.deps.playerControl.getActive?.();
+      if (!active) return;
+      void active.stop("playback-aborted").catch(() => {
+        // Session shutdown retains the process-registry SIGKILL backstop.
+      });
+    };
+    options.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
+    try {
+      return await (this.deps.launchMpv ?? launchMpv)({
+        url: stream.url,
+        urlKind,
+        headers: stream.headers ?? {},
+        subtitle: stream.subtitle ?? null,
+        subtitleUrlKind,
+        audioPreference: options.audioPreference,
+        subtitlePreference: options.subtitlePreference,
+        subtitleTracks: stream.subtitleList,
+        displayTitle: options.displayTitle,
+        startAt: options.startAt,
+        requiresYtdl: stream.requiresYtdl,
+        ytdlFormat: stream.ytdlFormat,
+        ytdlRawOptions: stream.ytdlRawOptions,
+        attach: options.attach,
+        timing: options.timing,
+        autoSkipEnabled: options.autoSkipEnabled,
+        skipRecap: options.skipRecap,
+        skipIntro: options.skipIntro,
+        skipPreview: options.skipPreview,
+        skipCredits: options.skipCredits,
+        onControlReady: (control) => {
+          this.setActiveControlFor(generation, control);
+          if (control && options.abortSignal?.aborted) stopOnAbort();
+        },
+        onPlayerReady: options.onPlayerReady,
+        onPlaybackEvent: publish,
+        mpv: {
+          ...this.deps.mpv,
+          startupPriority: this.deps.config.startupPriority,
+        },
+      });
+    } finally {
+      options.abortSignal?.removeEventListener("abort", stopOnAbort);
+    }
   }
 
   private async playAutoplayChainStream(
     stream: StreamInfo,
     options: PlayerOptions,
     urlKind: "remote" | "local",
+    subtitleUrlKind: "remote" | "local",
     publish: (event: PlayerPlaybackEvent) => void,
     retiredGeneration: PlaybackGeneration | null,
   ): Promise<PlaybackResult> {
@@ -701,7 +728,7 @@ export class PlayerServiceImpl implements PlayerService {
     const sharedOptions = {
       displayTitle: options.displayTitle,
       urlKind,
-      subtitleUrlKind: "remote" as const,
+      subtitleUrlKind,
       audioPreference: options.audioPreference,
       subtitlePreference: options.subtitlePreference,
       primarySubtitle: stream.subtitle ?? null,

--- a/apps/cli/src/infra/player/PlayerServiceImpl.ts
+++ b/apps/cli/src/infra/player/PlayerServiceImpl.ts
@@ -34,6 +34,7 @@ import {
   type HlsRelayStopReason,
 } from "./hls-relay";
 import { resolveLocalPlaybackPolicy, type LocalPlaybackPolicyInput } from "./local-playback-policy";
+import { classifyMpvLaunchError } from "./mpv-launch-error";
 import { killActiveMpvProcessesSync as killRegisteredMpvProcesses } from "./mpv-process-registry";
 import type { MpvRuntimeOptions } from "./mpv-runtime-options";
 import { PersistentMpvSession } from "./PersistentMpvSession";
@@ -368,20 +369,19 @@ export class PlayerServiceImpl implements PlayerService {
 
       return result;
     } catch (e) {
+      if (e instanceof PlaybackAbortedError) throw e;
       const errorMessage = e instanceof Error ? e.message : String(e);
-      const actionableHint = errorMessage.toLowerCase().includes("mpv")
-        ? "mpv is required for playback. Install mpv and retry."
-        : "Run / export-diagnostics and / report-issue if this keeps failing.";
+      const launchFailure = classifyMpvLaunchError(e);
       this.deps.logger.error("MPV playback failed", { error: String(e) });
       this.deps.diagnostics.record(
         buildPlaybackDiagnosticEvent({
           operation: "mpv.playback.failed",
           status: "failed",
           severity: "blocked",
-          failureClass: "dependency",
+          failureClass: launchFailure.failureClass,
           message: "MPV playback failed",
           correlation: options.correlation,
-          context: { error: errorMessage, hint: actionableHint },
+          context: { error: errorMessage, hint: launchFailure.hint },
         }),
       );
       return {
@@ -661,7 +661,6 @@ export class PlayerServiceImpl implements PlayerService {
     retiredGeneration: PlaybackGeneration | null,
   ): Promise<PlaybackResult> {
     const generation = this.currentGeneration;
-    await this.retirePersistentSession(retiredGeneration);
     const stopOnAbort = () => {
       const active = this.deps.playerControl.getActive?.();
       if (!active) return;
@@ -671,6 +670,10 @@ export class PlayerServiceImpl implements PlayerService {
     };
     options.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
     try {
+      await this.retirePersistentSession(retiredGeneration);
+      if (options.abortSignal?.aborted) {
+        throw new PlaybackAbortedError("playback aborted before mpv launch");
+      }
       return await (this.deps.launchMpv ?? launchMpv)({
         url: stream.url,
         urlKind,
@@ -693,8 +696,14 @@ export class PlayerServiceImpl implements PlayerService {
         skipPreview: options.skipPreview,
         skipCredits: options.skipCredits,
         onControlReady: (control) => {
+          if (control && options.abortSignal?.aborted) {
+            if (this.isCurrentGeneration(generation)) this.invalidateProcessGeneration();
+            void control.stop("playback-aborted").catch(() => {
+              // Session shutdown retains the process-registry SIGKILL backstop.
+            });
+            return;
+          }
           this.setActiveControlFor(generation, control);
-          if (control && options.abortSignal?.aborted) stopOnAbort();
         },
         onPlayerReady: options.onPlayerReady,
         onPlaybackEvent: publish,

--- a/apps/cli/src/infra/player/mpv-launch-error.ts
+++ b/apps/cli/src/infra/player/mpv-launch-error.ts
@@ -1,0 +1,35 @@
+export type MpvLaunchErrorKind = "dependency" | "unsafe-target";
+
+/** Typed failures raised before mpv owns playback, so diagnostics keep the real remediation. */
+export class MpvLaunchError extends Error {
+  override readonly name = "MpvLaunchError";
+
+  constructor(
+    readonly kind: MpvLaunchErrorKind,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export function classifyMpvLaunchError(error: unknown): {
+  readonly failureClass: "dependency" | "cancelled" | "unknown";
+  readonly hint: string;
+} {
+  if (error instanceof MpvLaunchError && error.kind === "dependency") {
+    return {
+      failureClass: "dependency",
+      hint: "mpv is required for playback. Install mpv and retry.",
+    };
+  }
+  if (error instanceof MpvLaunchError && error.kind === "unsafe-target") {
+    return {
+      failureClass: "unknown",
+      hint: "Kunai rejected an unsafe playback target. Export Diagnostics and report the issue.",
+    };
+  }
+  return {
+    failureClass: "unknown",
+    hint: "Run / export-diagnostics and / report-issue if this keeps failing.",
+  };
+}

--- a/apps/cli/src/infra/player/persistent-ready-work-executor.ts
+++ b/apps/cli/src/infra/player/persistent-ready-work-executor.ts
@@ -1,5 +1,6 @@
 import type { PlaybackGeneration } from "@/domain/playback/playback-generation";
 import type { PlaybackTimingMetadata, SubtitleTrack } from "@/domain/types";
+import type { MpvUrlKind } from "@/infra/player/mpv-playback-url";
 import { collectAdditionalSubtitleTracks, shouldApplyStartAtSeek } from "@/mpv";
 
 import type { MpvIpcSession } from "./mpv-ipc";
@@ -14,6 +15,7 @@ import type { PlayerPlaybackEvent } from "./PlayerService";
 export type PersistentReadyWorkOptions = {
   displayTitle: string;
   primarySubtitle: string | null;
+  subtitleUrlKind?: MpvUrlKind;
   subtitleTracks?: readonly SubtitleTrack[];
   startAt?: number;
   resumePromptAt?: number;
@@ -154,6 +156,7 @@ export class PersistentReadyWorkExecutor {
           options.onPlaybackEvent?.({ type: "subtitle-inventory-ready", trackCount });
           options.onPlaybackEvent?.({ type: "subtitle-attached", trackCount });
         },
+        options.subtitleUrlKind,
       );
     }
     if (!isCurrent()) return;

--- a/apps/cli/src/infra/player/persistent-ready-work-executor.ts
+++ b/apps/cli/src/infra/player/persistent-ready-work-executor.ts
@@ -157,6 +157,7 @@ export class PersistentReadyWorkExecutor {
           options.onPlaybackEvent?.({ type: "subtitle-attached", trackCount });
         },
         options.subtitleUrlKind,
+        isCurrent,
       );
     }
     if (!isCurrent()) return;

--- a/apps/cli/src/infra/player/persistent-subtitle-manager.ts
+++ b/apps/cli/src/infra/player/persistent-subtitle-manager.ts
@@ -39,13 +39,19 @@ export class PersistentSubtitleManager {
     return [...this.externalSubtitleIds];
   }
 
-  async removeExternalSubtitles(ipcSession: MpvIpcSession | null): Promise<void> {
-    if (!ipcSession) return;
-    if (this.externalSubtitleIds.length === 0) return;
+  async removeExternalSubtitles(
+    ipcSession: MpvIpcSession | null,
+    isCurrent: () => boolean = () => true,
+  ): Promise<boolean> {
+    if (!ipcSession || !isCurrent()) return false;
+    if (this.externalSubtitleIds.length === 0) return true;
 
     for (const trackId of this.externalSubtitleIds) {
+      if (!isCurrent()) return false;
       await ipcSession.send(["sub-remove", trackId], 1_000);
+      if (!isCurrent()) return false;
     }
+    return true;
   }
 
   async replaceSubtitleInventory(
@@ -54,10 +60,11 @@ export class PersistentSubtitleManager {
     subtitleTracks?: readonly SubtitleTrack[],
     onAttached?: (trackCount: number) => void,
     primarySubtitleKind: MpvUrlKind = "remote",
+    isCurrent: () => boolean = () => true,
   ): Promise<void> {
-    if (!ipcSession) return;
+    if (!ipcSession || !isCurrent()) return;
 
-    await this.removeExternalSubtitles(ipcSession);
+    if (!(await this.removeExternalSubtitles(ipcSession, isCurrent))) return;
 
     const safePrimary =
       primarySubtitle && isAllowedMpvUrl(primarySubtitle, primarySubtitleKind)
@@ -69,22 +76,23 @@ export class PersistentSubtitleManager {
         ["sub-add", safePrimary, "select", primary.title, primary.language],
         MPV_SUBTITLE_ATTACH_TIMEOUT_MS,
       );
-      if (!result.ok) return;
+      if (!result.ok || !isCurrent()) return;
     }
 
     const additionalTracks = collectAdditionalSubtitleTracks(safePrimary, subtitleTracks).filter(
       (track) => isAllowedMpvUrl(track.url, "remote"),
     );
     for (const track of additionalTracks) {
+      if (!isCurrent()) return;
       const result = await ipcSession.send(
         ["sub-add", track.url, "auto", track.display ?? "", track.language ?? ""],
         MPV_SUBTITLE_ATTACH_TIMEOUT_MS,
       );
-      if (!result.ok) return;
+      if (!result.ok || !isCurrent()) return;
     }
 
     const attachedCount = (safePrimary ? 1 : 0) + additionalTracks.length;
-    if (attachedCount > 0) {
+    if (attachedCount > 0 && isCurrent()) {
       onAttached?.(attachedCount);
     }
   }

--- a/apps/cli/src/infra/player/persistent-subtitle-manager.ts
+++ b/apps/cli/src/infra/player/persistent-subtitle-manager.ts
@@ -1,5 +1,5 @@
 import type { SubtitleTrack } from "@/domain/types";
-import { isAllowedMpvUrl } from "@/infra/player/mpv-playback-url";
+import { isAllowedMpvUrl, type MpvUrlKind } from "@/infra/player/mpv-playback-url";
 import { collectAdditionalSubtitleTracks, describeSubtitleTrackForMpv } from "@/mpv";
 
 import type { MpvIpcSession } from "./mpv-ipc";
@@ -53,13 +53,16 @@ export class PersistentSubtitleManager {
     primarySubtitle: string | null,
     subtitleTracks?: readonly SubtitleTrack[],
     onAttached?: (trackCount: number) => void,
+    primarySubtitleKind: MpvUrlKind = "remote",
   ): Promise<void> {
     if (!ipcSession) return;
 
     await this.removeExternalSubtitles(ipcSession);
 
     const safePrimary =
-      primarySubtitle && isAllowedMpvUrl(primarySubtitle, "remote") ? primarySubtitle : null;
+      primarySubtitle && isAllowedMpvUrl(primarySubtitle, primarySubtitleKind)
+        ? primarySubtitle
+        : null;
     if (safePrimary) {
       const primary = describeSubtitleTrackForMpv(safePrimary, subtitleTracks);
       const result = await ipcSession.send(

--- a/apps/cli/src/mpv.ts
+++ b/apps/cli/src/mpv.ts
@@ -36,6 +36,7 @@ import {
 export { shouldApplyStartAtSeek };
 export { isLocalHlsManifestPlaybackUrl } from "@/infra/player/mpv-playback-url";
 export { isAllowedMpvUrl, type MpvUrlKind } from "@/infra/player/mpv-playback-url";
+import { MpvLaunchError } from "@/infra/player/mpv-launch-error";
 import {
   applyEndFileEvent,
   applyObservedPropertySample,
@@ -105,7 +106,7 @@ export async function launchMpv(opts: {
   };
 
   if (!Bun.which("mpv")) {
-    throw new Error("mpv is not installed or not found on PATH");
+    throw new MpvLaunchError("dependency", "mpv is not installed or not found on PATH");
   }
 
   const stdio = opts.attach ? ("inherit" as const) : ("ignore" as const);
@@ -483,7 +484,10 @@ export function buildMpvArgs(
   },
 ): string[] {
   if (!isAllowedMpvUrl(opts.url, opts.urlKind ?? "remote")) {
-    throw new Error("Refusing to launch mpv with unsafe stream URL scheme");
+    throw new MpvLaunchError(
+      "unsafe-target",
+      "Refusing to launch mpv with unsafe stream URL scheme",
+    );
   }
 
   const args: string[] = [];

--- a/apps/cli/test/integration/offline-local-playback-resolution.test.ts
+++ b/apps/cli/test/integration/offline-local-playback-resolution.test.ts
@@ -4,8 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { resolveLocalEpisodePlayback } from "@/app/playback/episode-playback-source";
+import { runMpvPlaybackSession } from "@/app/playback/run-mpv-playback-session";
 import type { Container } from "@/container";
 import type { TitleInfo } from "@/domain/types";
+import { PlayerServiceImpl } from "@/infra/player/PlayerServiceImpl";
+import type { launchMpv } from "@/mpv";
 import type { ContinueSourcePreference } from "@/services/continuation/continuation-source";
 import { OfflineTitleIdentityService } from "@/services/offline/offline-title-identity";
 import { OfflineAssetService } from "@/services/offline/OfflineAssetService";
@@ -139,6 +142,85 @@ const movieTitle: TitleInfo = {
 };
 
 describe("offline local playback resolution", () => {
+  test("resolved local artifact crosses the full player handoff as a trusted file", async () => {
+    const harness = createHarness({
+      titleId: "1339713",
+      mediaKind: "movie",
+      season: 1,
+      episode: 1,
+    });
+    const resolution = await resolveLocalEpisodePlayback(
+      containerFor(harness),
+      movieTitle,
+      { season: 1, episode: 1 },
+      { entrypoint: "offline-library", forceLocal: true },
+    );
+    expect(resolution).not.toBeNull();
+    if (!resolution) throw new Error("expected local playback resolution");
+
+    let launchedWith: Parameters<typeof launchMpv>[0] | null = null;
+    const player = new PlayerServiceImpl({
+      logger: {
+        child: () => {
+          throw new Error("not used");
+        },
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        fatal: () => {},
+      },
+      tracer: {
+        span: async <T>(_name: string, run: () => Promise<T>) => await run(),
+        getCurrentTrace: () => null,
+        getCurrentSpan: () => null,
+      },
+      diagnostics: { record: () => {} },
+      playerControl: { setActive: () => {} },
+      config: { getRaw: () => ({}) },
+      launchMpv: (async (options) => {
+        launchedWith = options;
+        return {
+          watchedSeconds: 1,
+          duration: 1,
+          endReason: "eof",
+          playerExitCode: 0,
+          playerExitSignal: null,
+          lastNonZeroPositionSeconds: 1,
+          lastNonZeroDurationSeconds: 1,
+        };
+      }) as typeof launchMpv,
+    } as never);
+    const hooks = new Proxy(
+      {},
+      {
+        get: (_target, property) =>
+          property === "applyPlaybackStatusSignal" ? () => ({ accepted: true }) : () => undefined,
+      },
+    ) as Parameters<typeof runMpvPlaybackSession>[0]["hooks"];
+
+    await runMpvPlaybackSession({
+      stream: resolution.stream,
+      title: movieTitle,
+      episode: { season: 1, episode: 1 },
+      player,
+      playOptions: {},
+      subtitleStatus: "local",
+      startAt: 0,
+      hooks,
+      sessionAborted: false,
+      iterationAborted: false,
+      shareLinkContext: { mode: "series", title: movieTitle },
+      timing: resolution.timing,
+      localPlaybackSource: resolution.source,
+    });
+
+    expect(launchedWith).toMatchObject({
+      url: harness.filePath,
+      urlKind: "local",
+    });
+  });
+
   test("a downloaded movie resolves to its local file", async () => {
     // The reported bug. `applyDownloadJobSessionRouting` routes a movie whose
     // job carries mode "series" into series mode, so the session mode and the

--- a/apps/cli/test/unit/app/episode-prefetch.test.ts
+++ b/apps/cli/test/unit/app/episode-prefetch.test.ts
@@ -1,12 +1,29 @@
 import { expect, test } from "bun:test";
 
-import { EpisodePrefetchHandle, type EpisodePrefetchBundle } from "@/app/playback/episode-prefetch";
+import {
+  EpisodePrefetchHandle,
+  isEpisodePrefetchEligible,
+  type EpisodePrefetchBundle,
+} from "@/app/playback/episode-prefetch";
 
 const target = {
   titleId: "tmdb:1",
   episode: { season: 1, episode: 2 },
   providerId: "videasy",
 };
+
+test("offline playback is never eligible for provider prefetch", () => {
+  expect(
+    isEpisodePrefetchEligible({
+      titleType: "series",
+      hasNextEpisode: true,
+      stopAfterCurrent: false,
+      sessionMode: "autoplay-chain",
+      autoplayPaused: false,
+      networkAllowed: false,
+    }),
+  ).toBe(false);
+});
 
 test("suspend keeps in-flight resolve and ready bundle", async () => {
   const handle = new EpisodePrefetchHandle();

--- a/apps/cli/test/unit/app/playback-episode-picker.test.ts
+++ b/apps/cli/test/unit/app/playback-episode-picker.test.ts
@@ -143,6 +143,27 @@ describe("buildEpisodePickerOption", () => {
 });
 
 describe("buildPlaybackEpisodePickerOptions", () => {
+  test("offline picker derives series episodes only from the downloaded index", async () => {
+    let loadCalls = 0;
+    const result = await buildPlaybackEpisodePickerOptions({
+      title: seriesTitle,
+      currentEpisode: { season: 2, episode: 5 },
+      isAnime: false,
+      networkAllowed: false,
+      downloadedEpisodes: new Set(["1:9", "2:7", "2:5", "2:6"]),
+      watchedEntries: WATCHED_ENTRIES,
+      loadEpisodes: async () => {
+        loadCalls += 1;
+        return [];
+      },
+    });
+
+    expect(loadCalls).toBe(0);
+    expect(result.options.map((option) => option.value)).toEqual(["2:5", "2:6", "2:7"]);
+    expect(result.options[0]).toMatchObject({ badge: "✓", tone: "success" });
+    expect(result.initialIndex).toBe(0);
+  });
+
   test("anime path prefers animeEpisodes labels over numbered stubs", async () => {
     const options = await buildPlaybackEpisodePickerOptions({
       title: seriesTitle,

--- a/apps/cli/test/unit/app/playback-problem.test.ts
+++ b/apps/cli/test/unit/app/playback-problem.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildLocalPlaybackFailureProblem,
   buildMpvMissingProblem,
   buildOfflineFileUnavailableProblem,
   buildPlayerFailureProblem,
@@ -9,6 +10,23 @@ import {
 } from "@/domain/playback/playback-problem";
 
 describe("playback problem model", () => {
+  test("reports a local player launch failure without suggesting provider recovery", () => {
+    const problem = buildLocalPlaybackFailureProblem();
+
+    expect(problem).toMatchObject({
+      stage: "mpv",
+      severity: "blocking",
+      cause: "local-playback-failed",
+      recommendedAction: "diagnostics",
+      secondaryActions: ["relaunch"],
+    });
+    expect(problem.userMessage).toContain("downloaded file");
+    expect(toErrorScenario(problem, { title: "Obsession" })).toEqual({
+      kind: "title-unavailable",
+      title: "Obsession",
+    });
+  });
+
   test("maps an unplayable downloaded file to a blocking problem that names the remedy", () => {
     const problem = buildOfflineFileUnavailableProblem();
 

--- a/apps/cli/test/unit/app/playback-timing-fetch-policy.test.ts
+++ b/apps/cli/test/unit/app/playback-timing-fetch-policy.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+
+import { shouldFetchPlaybackTiming } from "@/app/playback/playback-timing-fetch-policy";
+
+test("offline playback never fetches remote timing metadata", () => {
+  expect(
+    shouldFetchPlaybackTiming({
+      networkAllowed: false,
+      hasTiming: false,
+    }),
+  ).toBe(false);
+});
+
+test("online playback retries when timing metadata is absent", () => {
+  expect(
+    shouldFetchPlaybackTiming({
+      networkAllowed: true,
+      hasTiming: false,
+    }),
+  ).toBe(true);
+});
+
+test("existing timing metadata suppresses a remote retry", () => {
+  expect(
+    shouldFetchPlaybackTiming({
+      networkAllowed: true,
+      hasTiming: true,
+    }),
+  ).toBe(false);
+});

--- a/apps/cli/test/unit/app/playback/playback-source-failover.test.ts
+++ b/apps/cli/test/unit/app/playback/playback-source-failover.test.ts
@@ -4,11 +4,18 @@ import {
   listOrderedPlaybackSourceIds,
   pickNextCatalogSourceId,
   planStartupFailover,
+  shouldUseProviderPlaybackRecovery,
   STARTUP_STALL_TIMEOUT_MS,
 } from "@/app/playback/playback-source-failover";
 import type { ProviderResolveResult } from "@kunai/types";
 
 describe("playback-source-failover", () => {
+  test("verified local playback never enters provider stream recovery", () => {
+    expect(shouldUseProviderPlaybackRecovery("local")).toBe(false);
+    expect(shouldUseProviderPlaybackRecovery("fresh")).toBe(true);
+    expect(shouldUseProviderPlaybackRecovery("cache")).toBe(true);
+  });
+
   test("STARTUP_STALL_TIMEOUT_MS leaves headroom past 20s for slow CDNs", () => {
     expect(STARTUP_STALL_TIMEOUT_MS).toBeGreaterThanOrEqual(45_000);
   });

--- a/apps/cli/test/unit/app/playback/run-mpv-playback-session.test.ts
+++ b/apps/cli/test/unit/app/playback/run-mpv-playback-session.test.ts
@@ -418,5 +418,9 @@ describe("runMpvPlaybackSession completion", () => {
     expect(calls).toEqual(["remote"]);
     expect(seenOptions[0]?.startAt).toBe(42);
     expect(seenOptions[0]?.shareLinkContext).toBeDefined();
+    expect(
+      (seenOptions[0] as PlayerOptions & { localPlaybackSource?: LocalPlaybackSource })
+        ?.localPlaybackSource,
+    ).toEqual(LOCAL_SOURCE);
   });
 });

--- a/apps/cli/test/unit/app/recent-playback-stream.test.ts
+++ b/apps/cli/test/unit/app/recent-playback-stream.test.ts
@@ -3,12 +3,41 @@ import { describe, expect, test } from "bun:test";
 import {
   recentPlaybackStreamKey,
   recentPlaybackStreamMatchesProvider,
+  restoreRecentPlaybackStream,
   type RecentPlaybackStreamRecord,
 } from "@/app/playback/recent-playback-stream";
 
 const stream = { url: "https://example.test/stream.m3u8" } as never;
 
 describe("recent playback stream", () => {
+  test("restores verified local provenance with its exact trust source", () => {
+    const localPlaybackSource = {
+      kind: "local" as const,
+      jobId: "job-1",
+      titleId: "title-1",
+      titleName: "Offline episode",
+      mediaKind: "series" as const,
+      providerId: "vidking",
+      season: 1,
+      episode: 2,
+      filePath: "/media/episode-2.mkv",
+    };
+    const recent: RecentPlaybackStreamRecord = {
+      stream,
+      selectedProviderId: "vidking",
+      resolvedProviderId: "vidking",
+      provenance: "local",
+      localPlaybackSource,
+    };
+
+    expect(restoreRecentPlaybackStream(recent)).toEqual({
+      stream,
+      resolvedProviderId: "vidking",
+      provenance: "local",
+      localPlaybackSource,
+    });
+  });
+
   test("keys streams by title and 1-based episode identity", () => {
     expect(recentPlaybackStreamKey("tmdb:1396", { season: 2, episode: 7 })).toBe("tmdb:1396:2:7");
   });

--- a/apps/cli/test/unit/app/subtitle-selection.test.ts
+++ b/apps/cli/test/unit/app/subtitle-selection.test.ts
@@ -204,6 +204,21 @@ describe("choosePlaybackSubtitle", () => {
 });
 
 describe("shouldAttemptLateSubtitleLookup", () => {
+  test("never starts a remote subtitle lookup while offline", () => {
+    const decision = shouldAttemptLateSubtitleLookup({
+      stream: {
+        ...BASE_STREAM,
+        subtitle: undefined,
+        subtitleList: undefined,
+      },
+      requestedSubLang: "en",
+      hasTmdbId: true,
+      networkAvailable: false,
+    });
+
+    expect(decision).toMatchObject({ attempt: false, reason: "offline" });
+  });
+
   test("tries Wyzie when provider inventory exists but has no matching configured subtitle", () => {
     expect(
       shouldAttemptLateSubtitleLookup({

--- a/apps/cli/test/unit/infra/player/PlayerServiceImpl.test.ts
+++ b/apps/cli/test/unit/infra/player/PlayerServiceImpl.test.ts
@@ -69,7 +69,10 @@ function createService(
   events: DiagnosticEventInput[],
   overrides: {
     presentation?: { isInteractiveShellMounted: () => boolean };
-    playerControl?: { setActive: (control: unknown) => void };
+    playerControl?: {
+      setActive: (control: ActivePlayerControl | null) => void;
+      getActive?: () => ActivePlayerControl | null;
+    };
     launchMpv?: typeof launchMpv;
   } = {},
 ) {
@@ -104,6 +107,41 @@ function createService(
 }
 
 describe("PlayerServiceImpl diagnostics", () => {
+  test("full play marks a verified local file and sidecar as trusted local targets", async () => {
+    const events: DiagnosticEventInput[] = [];
+    let launchedWith: Parameters<typeof launchMpv>[0] | null = null;
+    const localSource = {
+      ...LOCAL_SOURCE,
+      subtitlePath: "/media/episode-2.en.srt",
+    };
+    const { service } = createService(events, {
+      launchMpv: (async (options) => {
+        launchedWith = options;
+        return createPlaybackResult();
+      }) as typeof launchMpv,
+    });
+
+    await service.play(
+      createStream({
+        url: localSource.filePath,
+        headers: {},
+        subtitle: localSource.subtitlePath,
+      }),
+      {
+        url: localSource.filePath,
+        displayTitle: "Offline episode",
+        localPlaybackSource: localSource,
+      } as PlayerOptions,
+    );
+
+    expect(launchedWith).toMatchObject({
+      url: localSource.filePath,
+      urlKind: "local",
+      subtitle: localSource.subtitlePath,
+      subtitleUrlKind: "local",
+    });
+  });
+
   test("rejects a terminal HLS response before spawning MPV", async () => {
     const events: DiagnosticEventInput[] = [];
     let launches = 0;
@@ -512,6 +550,48 @@ describe("PlayerServiceImpl playback generations", () => {
 });
 
 describe("PlayerServiceImpl shutdown", () => {
+  test("aborting an active one-shot play stops its mpv control", async () => {
+    const events: DiagnosticEventInput[] = [];
+    let activeControl: ActivePlayerControl | null = null;
+    let stopReason: string | undefined;
+    let finishPlayback!: (result: PlaybackResult) => void;
+    const playbackResult = new Promise<PlaybackResult>((resolve) => {
+      finishPlayback = resolve;
+    });
+    const { service } = createService(events, {
+      playerControl: {
+        setActive: (control) => {
+          activeControl = control;
+        },
+        getActive: () => activeControl,
+      },
+      launchMpv: (async (options) => {
+        options.onControlReady?.({
+          id: "one-shot",
+          stop: async (reason) => {
+            stopReason = reason;
+          },
+        });
+        return await playbackResult;
+      }) as typeof launchMpv,
+    });
+    const abortController = new AbortController();
+
+    const playing = service.play(createStream(), {
+      url: "https://cdn.example/show/episode.mp4",
+      displayTitle: "Episode 1",
+      abortSignal: abortController.signal,
+    });
+    await Bun.sleep(0);
+    abortController.abort("session-shutdown");
+    await Bun.sleep(0);
+    const observedStopReason = stopReason;
+    finishPlayback(createPlaybackResult());
+    await playing;
+
+    expect(observedStopReason).toBe("playback-aborted");
+  });
+
   test("local playback retires a persistent player and owns the active controls", async () => {
     const events: DiagnosticEventInput[] = [];
     const lifecycle: string[] = [];

--- a/apps/cli/test/unit/infra/player/PlayerServiceImpl.test.ts
+++ b/apps/cli/test/unit/infra/player/PlayerServiceImpl.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { PlaybackGeneration } from "@/domain/playback/playback-generation";
 import type { PlaybackResult, StreamInfo } from "@/domain/types";
+import { MpvLaunchError } from "@/infra/player/mpv-launch-error";
 import { registerMpvProcess } from "@/infra/player/mpv-process-registry";
 import { PlaybackAbortedError } from "@/infra/player/playback-aborted";
 import type { ActivePlayerControl } from "@/infra/player/PlayerControlService";
@@ -107,6 +108,39 @@ function createService(
 }
 
 describe("PlayerServiceImpl diagnostics", () => {
+  test("classifies only typed missing-mpv failures as dependency problems", async () => {
+    const dependencyEvents: DiagnosticEventInput[] = [];
+    const genericEvents: DiagnosticEventInput[] = [];
+    const { service: dependencyService } = createService(dependencyEvents, {
+      launchMpv: (async () => {
+        throw new MpvLaunchError("dependency", "mpv is not installed or not found on PATH");
+      }) as typeof launchMpv,
+    });
+    const { service: genericService } = createService(genericEvents, {
+      launchMpv: (async () => {
+        throw new Error("mpv socket refused the launch");
+      }) as typeof launchMpv,
+    });
+
+    await dependencyService.play(createStream(), {
+      url: "https://cdn.example/show/episode.mp4",
+      displayTitle: "Episode 1",
+    });
+    await genericService.play(createStream(), {
+      url: "https://cdn.example/show/episode.mp4",
+      displayTitle: "Episode 1",
+    });
+
+    const dependencyFailure = dependencyEvents.find(
+      (event) => event.operation === "mpv.playback.failed",
+    );
+    const genericFailure = genericEvents.find((event) => event.operation === "mpv.playback.failed");
+    expect(dependencyFailure?.context?.failureClass).toBe("dependency");
+    expect(dependencyFailure?.context?.hint).toContain("Install mpv");
+    expect(genericFailure?.context?.failureClass).toBe("unknown");
+    expect(genericFailure?.context?.hint).not.toContain("Install mpv");
+  });
+
   test("full play marks a verified local file and sidecar as trusted local targets", async () => {
     const events: DiagnosticEventInput[] = [];
     let launchedWith: Parameters<typeof launchMpv>[0] | null = null;
@@ -550,6 +584,93 @@ describe("PlayerServiceImpl playback generations", () => {
 });
 
 describe("PlayerServiceImpl shutdown", () => {
+  test("an abort during persistent retirement prevents the one-shot spawn", async () => {
+    const events: DiagnosticEventInput[] = [];
+    let releaseClose!: () => void;
+    let closeStarted!: () => void;
+    let launchCalls = 0;
+    const closeReached = new Promise<void>((resolve) => {
+      closeStarted = resolve;
+    });
+    const closeGate = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+    const { service } = createService(events, {
+      launchMpv: (async () => {
+        launchCalls += 1;
+        return createPlaybackResult();
+      }) as typeof launchMpv,
+    });
+    (
+      service as unknown as { persistentSession: { isAlive(): boolean; close(): Promise<void> } }
+    ).persistentSession = {
+      isAlive: () => true,
+      async close() {
+        closeStarted();
+        await closeGate;
+      },
+    };
+    const abortController = new AbortController();
+
+    const playing = service.play(createStream(), {
+      url: "https://cdn.example/show/episode.mp4",
+      displayTitle: "Episode 1",
+      abortSignal: abortController.signal,
+    });
+    await closeReached;
+    abortController.abort("session-shutdown");
+    releaseClose();
+
+    await expect(playing).rejects.toBeInstanceOf(PlaybackAbortedError);
+    expect(launchCalls).toBe(0);
+  });
+
+  test("an abort before one-shot control publication stops the supplied control directly", async () => {
+    const events: DiagnosticEventInput[] = [];
+    let publishControl!: () => void;
+    let stopReason: string | undefined;
+    let finishPlayback!: (result: PlaybackResult) => void;
+    const controlGate = new Promise<void>((resolve) => {
+      publishControl = resolve;
+    });
+    const playbackResult = new Promise<PlaybackResult>((resolve) => {
+      finishPlayback = resolve;
+    });
+    const { service } = createService(events, {
+      playerControl: {
+        setActive: () => {},
+        getActive: () => null,
+      },
+      launchMpv: (async (options) => {
+        await controlGate;
+        options.onControlReady?.({
+          id: "late-one-shot",
+          stop: async (reason) => {
+            stopReason = reason;
+          },
+        });
+        return await playbackResult;
+      }) as typeof launchMpv,
+    });
+    const abortController = new AbortController();
+
+    const playing = service.play(createStream(), {
+      url: "https://cdn.example/show/episode.mp4",
+      displayTitle: "Episode 1",
+      abortSignal: abortController.signal,
+    });
+    await Bun.sleep(0);
+    abortController.abort("session-shutdown");
+    service.beginShutdown();
+    publishControl();
+    await Bun.sleep(0);
+    const observedStopReason = stopReason;
+    finishPlayback(createPlaybackResult());
+    await playing;
+
+    expect(observedStopReason).toBe("playback-aborted");
+  });
+
   test("aborting an active one-shot play stops its mpv control", async () => {
     const events: DiagnosticEventInput[] = [];
     let activeControl: ActivePlayerControl | null = null;

--- a/apps/cli/test/unit/infra/player/persistent-mpv-session-harness.test.ts
+++ b/apps/cli/test/unit/infra/player/persistent-mpv-session-harness.test.ts
@@ -872,6 +872,71 @@ describe("PersistentMpvSession fake IPC lifecycle harness", () => {
     expect(harness.commands.slice(replacementCommandCount)).toEqual([]);
   });
 
+  test("a replacement during reconnect subtitle cleanup blocks stale subtitle attachment", async () => {
+    let releaseRemoval!: () => void;
+    let removalStarted!: () => void;
+    const removalReached = new Promise<void>((resolve) => {
+      removalStarted = resolve;
+    });
+    const removalGate = new Promise<void>((resolve) => {
+      releaseRemoval = resolve;
+    });
+    const events: unknown[] = [];
+    const harness = createHarness({
+      beforeSend: async (command) => {
+        if (command[0] !== "sub-remove") return;
+        removalStarted();
+        await removalGate;
+      },
+    });
+    const session = await PersistentMpvSession.create({
+      stream: createStream({ url: "https://video.example/reconnect-subtitle-race.m3u8" }),
+      options: {
+        displayTitle: "Episode 1",
+        primarySubtitle: "https://subs.example/episode-1.vtt",
+        onPlaybackEvent: (event) => events.push(event),
+      },
+      kitsuneConfig: {
+        mpvInProcessStreamReconnect: true,
+        mpvInProcessStreamReconnectMaxAttempts: 1,
+        mpvKunaiScriptOpts: "",
+      } as never,
+      onControlReady: () => {},
+      runtime: harness.runtime,
+    });
+    harness.callbacks().onFileLoaded?.({ observedAt: 1 });
+    await flushAsyncWork();
+    harness.callbacks().onPropertyUpdate({
+      name: "track-list",
+      value: [{ id: 9, type: "sub", external: true }],
+      observedAt: 2,
+    });
+    harness.callbacks().onPropertyUpdate({ name: "duration", value: 600, observedAt: 3 });
+    harness.callbacks().onPropertyUpdate({ name: "time-pos", value: 100, observedAt: 4 });
+    harness
+      .callbacks()
+      .onPropertyUpdate({ name: "demuxer-via-network", value: true, observedAt: 5 });
+    harness.callbacks().onPropertyUpdate({
+      name: "demuxer-cache-state",
+      value: { "fw-bytes": 0 },
+      observedAt: 6,
+    });
+    harness.callbacks().onEndFile({ reason: "error", observedAt: 7 });
+    await flushAsyncWork();
+    harness.callbacks().onFileLoaded?.({ observedAt: 8 });
+    await removalReached;
+
+    (session as unknown as { advanceCycleGeneration(): unknown }).advanceCycleGeneration();
+    const commandCountAtReplacement = harness.commands.length;
+    releaseRemoval();
+    await flushAsyncWork();
+
+    expect(harness.commands.slice(commandCountAtReplacement)).toEqual([]);
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "mpv-in-process-reconnect", phase: "complete" }),
+    );
+  });
+
   test("a replacement during reconnect backoff prevents the stale reload", async () => {
     const harness = createHarness();
     const events: unknown[] = [];

--- a/apps/cli/test/unit/infra/player/persistent-mpv-session-harness.test.ts
+++ b/apps/cli/test/unit/infra/player/persistent-mpv-session-harness.test.ts
@@ -34,7 +34,11 @@ function createFakeProcess() {
   return { handle, endProcess: (code = 0) => resolveExit(code) };
 }
 
-function createHarness() {
+function createHarness(
+  harnessOptions: {
+    readonly beforeSend?: (command: readonly unknown[]) => Promise<void> | void;
+  } = {},
+) {
   let callbacks!: CapturedCallbacks;
   let resolveExit!: (code: number) => void;
   const commands: unknown[][] = [];
@@ -53,6 +57,7 @@ function createHarness() {
   const ipc: MpvIpcSession = {
     async send(command) {
       commands.push([...command]);
+      await harnessOptions.beforeSend?.(command);
       return {
         ok: true,
         command,
@@ -808,6 +813,121 @@ describe("PersistentMpvSession fake IPC lifecycle harness", () => {
     const playbackResult = session.waitForCurrentPlayback();
     harness.callbacks().onEndFile({ reason: "quit", observedAt: 18_200 });
     await playbackResult;
+  });
+
+  test("a replacement during reconnect seek blocks every stale completion command", async () => {
+    let releaseSeek!: () => void;
+    let seekStarted!: () => void;
+    const seekReached = new Promise<void>((resolve) => {
+      seekStarted = resolve;
+    });
+    const seekGate = new Promise<void>((resolve) => {
+      releaseSeek = resolve;
+    });
+    const harness = createHarness({
+      beforeSend: async (command) => {
+        if (command[0] !== "seek") return;
+        seekStarted();
+        await seekGate;
+      },
+    });
+    const session = await PersistentMpvSession.create({
+      stream: createStream({ url: "https://video.example/reconnect-race.m3u8" }),
+      options: {
+        displayTitle: "Episode 1",
+        primarySubtitle: "https://subs.example/episode-1.vtt",
+      },
+      kitsuneConfig: {
+        mpvInProcessStreamReconnect: true,
+        mpvInProcessStreamReconnectMaxAttempts: 1,
+        mpvKunaiScriptOpts: "",
+      } as never,
+      onControlReady: () => {},
+      runtime: harness.runtime,
+    });
+    harness.callbacks().onFileLoaded?.({ observedAt: 1 });
+    harness.callbacks().onPropertyUpdate({ name: "duration", value: 600, observedAt: 2 });
+    harness.callbacks().onPropertyUpdate({ name: "time-pos", value: 100, observedAt: 3 });
+    harness
+      .callbacks()
+      .onPropertyUpdate({ name: "demuxer-via-network", value: true, observedAt: 4 });
+    harness.callbacks().onPropertyUpdate({
+      name: "demuxer-cache-state",
+      value: { "fw-bytes": 0 },
+      observedAt: 5,
+    });
+    harness.callbacks().onEndFile({ reason: "error", observedAt: 6 });
+    await flushAsyncWork();
+    harness.callbacks().onFileLoaded?.({ observedAt: 7 });
+    await seekReached;
+
+    // A stop/replacement retires the reconnect's generation before its IPC
+    // command resolves. Drive that private seam directly so the test controls
+    // the exact await boundary instead of needing a second active cycle.
+    (session as unknown as { advanceCycleGeneration(): unknown }).advanceCycleGeneration();
+    const replacementCommandCount = harness.commands.length;
+    releaseSeek();
+    await flushAsyncWork();
+
+    expect(harness.commands.slice(replacementCommandCount)).toEqual([]);
+  });
+
+  test("a replacement during reconnect backoff prevents the stale reload", async () => {
+    const harness = createHarness();
+    const events: unknown[] = [];
+    const session = await PersistentMpvSession.create({
+      stream: createStream({ url: "https://video.example/backoff-race.m3u8" }),
+      options: {
+        displayTitle: "Episode 1",
+        primarySubtitle: null,
+        onPlaybackEvent: (event) => events.push(event),
+      },
+      kitsuneConfig: {
+        mpvInProcessStreamReconnect: true,
+        mpvInProcessStreamReconnectMaxAttempts: 2,
+        mpvKunaiScriptOpts: "",
+        tuningOverrides: { mpvReconnectBaseBackoffMs: 100, mpvReconnectMaxBackoffMs: 100 },
+      } as never,
+      onControlReady: () => {},
+      runtime: harness.runtime,
+    });
+    const markNetworkable = (base: number) => {
+      harness.callbacks().onPropertyUpdate({ name: "duration", value: 600, observedAt: base });
+      harness.callbacks().onPropertyUpdate({ name: "time-pos", value: 100, observedAt: base + 1 });
+      harness
+        .callbacks()
+        .onPropertyUpdate({ name: "demuxer-via-network", value: true, observedAt: base + 2 });
+      harness.callbacks().onPropertyUpdate({
+        name: "demuxer-cache-state",
+        value: { "fw-bytes": 0 },
+        observedAt: base + 3,
+      });
+    };
+
+    harness.callbacks().onFileLoaded?.({ observedAt: 1 });
+    markNetworkable(2);
+    harness.callbacks().onEndFile({ reason: "error", observedAt: 6 });
+    await flushAsyncWork();
+    markNetworkable(7);
+    harness.callbacks().onEndFile({ reason: "error", observedAt: 12 });
+    await Bun.sleep(10);
+    (session as unknown as { advanceCycleGeneration(): unknown }).advanceCycleGeneration();
+    const commandCountAtReplacement = harness.commands.length;
+    await Bun.sleep(150);
+    await flushAsyncWork();
+
+    expect(
+      harness.commands
+        .slice(commandCountAtReplacement)
+        .some((command) => command[0] === "loadfile"),
+    ).toBe(false);
+    expect(
+      events.filter(
+        (event) =>
+          (event as { type?: string }).type === "mpv-in-process-reconnect" &&
+          (event as { phase?: string }).phase === "started",
+      ),
+    ).toHaveLength(1);
   });
 
   test("reconnect that dies before file-loaded does not block a retry within budget", async () => {

--- a/apps/cli/test/unit/infra/player/persistent-subtitle-manager.test.ts
+++ b/apps/cli/test/unit/infra/player/persistent-subtitle-manager.test.ts
@@ -38,6 +38,23 @@ function createFakeIpc(failCommand?: string): {
 }
 
 describe("PersistentSubtitleManager", () => {
+  test("accepts a verified local primary subtitle during persistent replacement", async () => {
+    const { ipc, commands } = createFakeIpc();
+    const manager = new PersistentSubtitleManager();
+
+    await (
+      manager.replaceSubtitleInventory as unknown as (
+        ipc: MpvIpcSession,
+        primarySubtitle: string,
+        subtitleTracks: undefined,
+        onAttached: undefined,
+        primarySubtitleKind: "local",
+      ) => Promise<void>
+    )(ipc, "/media/episode-2.en.srt", undefined, undefined, "local");
+
+    expect(commands).toEqual([["sub-add", "/media/episode-2.en.srt", "select", "", ""]]);
+  });
+
   test("skips local subtitle targets on remote persistent playback", async () => {
     const { ipc, commands } = createFakeIpc();
     const manager = new PersistentSubtitleManager();

--- a/apps/cli/test/unit/infra/player/persistent-subtitle-manager.test.ts
+++ b/apps/cli/test/unit/infra/player/persistent-subtitle-manager.test.ts
@@ -125,6 +125,33 @@ describe("PersistentSubtitleManager", () => {
     expect(attachedCounts).toEqual([2]);
   });
 
+  test("stops replacement when its generation retires during subtitle removal", async () => {
+    let current = true;
+    const commands: unknown[][] = [];
+    const ipc: MpvIpcSession = {
+      async send(command) {
+        commands.push([...command]);
+        if (command[0] === "sub-remove") current = false;
+        return { ok: true, command, requestId: commands.length, response: {} };
+      },
+      sendUnchecked() {},
+      async close() {},
+    };
+    const manager = new PersistentSubtitleManager();
+    manager.updateTrackList([{ id: 7, type: "sub", external: true }]);
+
+    await manager.replaceSubtitleInventory(
+      ipc,
+      "https://subs.example/main.vtt",
+      [{ url: "https://subs.example/alt.vtt", language: "es" }],
+      undefined,
+      "remote",
+      () => current,
+    );
+
+    expect(commands).toEqual([["sub-remove", 7]]);
+  });
+
   test("uses a longer mpv deadline for remote subtitle attachment", async () => {
     const { ipc, timeouts } = createFakeIpc();
     const manager = new PersistentSubtitleManager();


### PR DESCRIPTION
## What changed

Preserve verified local download provenance through the final mpv handoff so offline playback stays local, while hardening adjacent cancellation and reconnect behavior.

## Why

The earlier offline identity repair made downloaded entries resolvable, but the final playback boundary still flattened a verified local acquisition into the same shape as a provider stream. That allowed local files to enter provider recovery and remote enrichment paths, producing `offline-file-unavailable`/home-screen failures even when the media existed.

## Details

- carry trusted local media and subtitle paths through the full playback/player boundary
- keep local failures out of provider failover and provider cache invalidation
- suppress remote subtitle, timing, and next-episode prefetch work for offline acquisitions
- keep verified local trust attached across recent-episode replay and build offline pickers only from downloaded assets
- make one-shot cancellation terminal across pre-launch races and reject stale persistent-mpv reconnect work between every IPC await
- classify missing-mpv, unsafe-target, and generic launch failures without misleading dependency advice
- add regression coverage for the Obsession-style downloaded-series path and adjacent playback lifecycle edges
- record the larger provider-independent offline-library design in `.plans/offline-provider-independent-playback.md`

## Verification

- reproduced the downloaded Obsession entry through the isolated `--offline` harness: the handoff contains the exact local MP4 and local VTT, with no VidLink/provider hop, `offline-file-unavailable`, unsafe-path rejection, or IntroDB request (the fake mpv process exits after recording the handoff)
- `bun run test` — 14/14 tasks; CLI suite 4043 passed, 0 failed
- `bun run typecheck` — 14/14 tasks
- `bun run lint` — passed; five pre-existing warnings only
- `bun run fmt:check` — 26/26 tasks
- `bun run verify:doc-paths` — 45 documents passed
- `bun run guard` — passed
- `bun run build` — 10/10 tasks, including host binary
- `git diff --check a28d8180..HEAD` — passed

Live provider/Discord smokes were intentionally skipped: this path must not contact a provider, and the isolated offline reproduction covers its runtime contract.

## Checklist

- [x] Changeset added (`bun run changeset`) — required for user-facing CLI changes; N/A for docs-only or non-release infra
- [x] `bun run guard` passes when `apps/cli/package.json`, changelogs, or `.changeset/**` changed
- [x] `bun run fmt && bun run lint && bun run test && bun run typecheck` passes locally
- [x] `bun run build` passes for feature, playback, provider, release, or packaging-sensitive changes
- [x] Live provider or Discord smokes were skipped intentionally, or run manually with results noted
