### PR TITLE
fix(search): preserve offline failure truth

### DIFF
--- a/.changeset/network-search-offline-truth.md
+++ b/.changeset/network-search-offline-truth.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Recognize Bun connection failures as offline, keep confirmed offline state until a successful request, and return failed searches with visible retry and offline-library guidance instead of silently replaying them.

--- a/.docs/download-offline-onboarding.md
+++ b/.docs/download-offline-onboarding.md
@@ -128,8 +128,9 @@ was looked up as `tmdb:1339713` and a healthy file reported "Downloaded file una
   "Unable to connect" fetch string) or **limited** (timeouts). Confirmed offline is
   sticky until a later success: a TMDB/proxy fallback that only times out must not
   reclassify the session as flaky. Limited still counts as online for retries.
-  Search while actually offline opens browse with the existing header alert and
-  does not remount the phase in a silent loop.
+  A failed search keeps its query editable, marks search state as failed, and
+  returns to browse with visible retry and `/offline` guidance instead of
+  remounting into a silent automatic-retry loop.
 - `--offline` and `/library` list completed `download_jobs` and validate artifact readability.
 - Local files should validate before playback; corrupt or missing files should offer re-download, not crash.
 - Offline episode rows may show resume percentage or watched state from local history. This is derived from local

--- a/apps/cli/src/app-shell/browse-shell.tsx
+++ b/apps/cli/src/app-shell/browse-shell.tsx
@@ -191,6 +191,7 @@ export function BrowseShell<T>({
   queryDraft,
   initialResults,
   initialResultSubtitle,
+  initialErrorMessage,
   initialWarnings,
   initialSelectedIndex,
   initialCalendarTypeTab,
@@ -220,6 +221,7 @@ export function BrowseShell<T>({
   queryDraft?: BrowseQueryDraft;
   initialResults?: readonly BrowseShellOption<T>[];
   initialResultSubtitle?: string;
+  initialErrorMessage?: string;
   initialWarnings?: readonly string[];
   initialSelectedIndex?: number;
   initialCalendarTypeTab?: CalendarTypeTab;
@@ -293,14 +295,14 @@ export function BrowseShell<T>({
   const [selectedIndex, setSelectedIndex] = useState(initialSelectedIndex ?? 0);
   const [resultSubtitle, setResultSubtitle] = useState(initialResultSubtitle ?? "");
   const [searchState, setSearchState] = useState<"idle" | "loading" | "ready" | "error">(
-    initialResults && initialResults.length > 0 ? "ready" : "idle",
+    initialErrorMessage ? "error" : initialResults && initialResults.length > 0 ? "ready" : "idle",
   );
   const [lastSearchedQuery, setLastSearchedQuery] = useState(
     initialResults && initialResults.length > 0 ? (initialQuery ?? "") : "",
   );
   const [historyIndex, setHistoryIndex] = useState(-1);
   const [draftQuery, setDraftQuery] = useState("");
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(initialErrorMessage ?? null);
   const [emptyMessage, setEmptyMessage] = useState(() => browseIdleHint(mode));
   const [activeIdleContext, setActiveIdleContext] = useState(idleContext);
   const [idleContextStatus, setIdleContextStatus] = useState<"loading" | "ready" | "error">(
@@ -2234,6 +2236,7 @@ export function openBrowseShell<T>({
   queryDraft: sharedQueryDraft,
   initialResults,
   initialResultSubtitle,
+  initialErrorMessage,
   initialWarnings,
   initialSelectedIndex,
   initialCalendarTypeTab,
@@ -2260,6 +2263,7 @@ export function openBrowseShell<T>({
   queryDraft?: BrowseQueryDraft;
   initialResults?: readonly BrowseShellOption<T>[];
   initialResultSubtitle?: string;
+  initialErrorMessage?: string;
   initialWarnings?: readonly string[];
   initialSelectedIndex?: number;
   initialCalendarTypeTab?: CalendarTypeTab;
@@ -2298,6 +2302,7 @@ export function openBrowseShell<T>({
         queryDraft={queryDraft}
         initialResults={initialResults}
         initialResultSubtitle={initialResultSubtitle}
+        initialErrorMessage={initialErrorMessage}
         initialWarnings={initialWarnings}
         initialSelectedIndex={initialSelectedIndex}
         initialCalendarTypeTab={initialCalendarTypeTab}

--- a/apps/cli/src/app/search/SearchPhase.ts
+++ b/apps/cli/src/app/search/SearchPhase.ts
@@ -40,7 +40,10 @@ import { launchCalendarContinue } from "@/app/search/calendar-continue-launch";
 import { isCalendarSearchResult, loadCalendarResults } from "@/app/search/calendar-results";
 import { playTrailer } from "@/app/search/details-trailer";
 import { enrichSelectedTitleIdentity } from "@/app/search/enrich-selected-title";
-import { shouldRunBootstrapSearch } from "@/app/search/search-failure-policy";
+import {
+  buildSearchFailureNote,
+  shouldRunBootstrapSearch,
+} from "@/app/search/search-failure-policy";
 import { buildSearchFilterChipOptions } from "@/app/search/search-filter-chips";
 import { applySearchSelectionSessionRouting } from "@/app/search/search-selection-routing";
 import {
@@ -190,6 +193,34 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
     const { container } = context;
     const { searchRegistry, providerRegistry, stateManager, logger, diagnosticsService } =
       container;
+    const containSearchFailure = (error: unknown, operation: string) => {
+      const failure = kitsuneErrorFromUnknown(error, {
+        code: "NETWORK_ERROR",
+        message: "Search failed",
+        service: searchRegistry.getDefault()?.metadata.id,
+        retryable: true,
+      });
+      const snapshot = container.connectivity.getSnapshot();
+      stateManager.dispatch({ type: "SET_SEARCH_STATE", state: "error" });
+      logger.error("Search phase error", { error: String(error), operation });
+      diagnosticsService.record(
+        buildSearchDiagnosticEvent({
+          operation,
+          status: "failed",
+          severity: "recoverable",
+          failureClass:
+            snapshot.status === "offline"
+              ? "offline"
+              : snapshot.status === "limited"
+                ? "timeout"
+                : "unknown",
+          recommendedAction: "retry",
+          message: "Search phase error",
+          context: { error: String(error) },
+        }),
+      );
+      return { failure, note: buildSearchFailureNote(failure, snapshot) };
+    };
 
     try {
       const preserveExistingSearch =
@@ -252,6 +283,7 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
       // go through the same honest local-filter pipeline as interactive Enter.
       let pendingSearchEvidence: SearchFilterEvidence | undefined;
       let pendingSearchWarnings: readonly string[] = [];
+      let initialSearchError: string | undefined;
 
       while (true) {
         const currentState = stateManager.getState();
@@ -305,18 +337,26 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
           const searchIntent = createSearchIntentEngine().fromText(currentState.searchQuery, {
             currentMode: currentState.mode,
           });
-          const search = await observeOnline(container, "search-error", () =>
-            searchTitles(searchIntent.intent, {
-              mode: stateManager.getState().mode,
-              providerId: currentState.provider,
-              animeLanguageProfile: container.config.animeLanguageProfile,
-              youtubeLanguageProfile: container.config.youtubeLanguageProfile,
-              signal: context.signal,
-              searchRegistry,
-              providerRegistry,
-              enrichAnimeMetadata: true,
-            }),
-          );
+          let search: Awaited<ReturnType<typeof searchTitles>>;
+          try {
+            search = await observeOnline(container, "search-error", () =>
+              searchTitles(searchIntent.intent, {
+                mode: stateManager.getState().mode,
+                providerId: currentState.provider,
+                animeLanguageProfile: container.config.animeLanguageProfile,
+                youtubeLanguageProfile: container.config.youtubeLanguageProfile,
+                signal: context.signal,
+                searchRegistry,
+                providerRegistry,
+                enrichAnimeMetadata: true,
+              }),
+            );
+          } catch (error) {
+            if (context.signal.aborted) throw error;
+            initialSearchError = containSearchFailure(error, "search.bootstrap.failed").note;
+            continue;
+          }
+          initialSearchError = undefined;
           const results = search.results;
           pendingSearchEvidence = search.evidence;
           pendingSearchWarnings = searchIntent.warnings;
@@ -473,6 +513,7 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
           settings: container.config.getRaw(),
           initialCalendarTypeTab,
           initialCalendarRoute: openedCalendarRoute,
+          initialErrorMessage: initialSearchError,
           onLoadCalendar: async (signal) => {
             const bundle = await loadCalendarResults(container, signal);
             signal.throwIfAborted();
@@ -626,18 +667,26 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
             stateManager.dispatch({ type: "SET_SEARCH_QUERY", query });
             stateManager.dispatch({ type: "SET_SEARCH_STATE", state: "loading" });
 
-            const search = await observeOnline(container, "search-error", () =>
-              searchTitles(searchIntent.intent, {
-                mode: stateManager.getState().mode,
-                providerId: stateManager.getState().provider,
-                animeLanguageProfile: container.config.animeLanguageProfile,
-                youtubeLanguageProfile: container.config.youtubeLanguageProfile,
-                signal: context.signal,
-                searchRegistry,
-                providerRegistry,
-                enrichAnimeMetadata: true,
-              }),
-            );
+            let search: Awaited<ReturnType<typeof searchTitles>>;
+            try {
+              search = await observeOnline(container, "search-error", () =>
+                searchTitles(searchIntent.intent, {
+                  mode: stateManager.getState().mode,
+                  providerId: stateManager.getState().provider,
+                  animeLanguageProfile: container.config.animeLanguageProfile,
+                  youtubeLanguageProfile: container.config.youtubeLanguageProfile,
+                  signal: context.signal,
+                  searchRegistry,
+                  providerRegistry,
+                  enrichAnimeMetadata: true,
+                }),
+              );
+            } catch (error) {
+              if (context.signal.aborted) throw error;
+              const failure = containSearchFailure(error, "search.query.failed");
+              throw new Error(failure.note, { cause: error });
+            }
+            initialSearchError = undefined;
             const results = search.results;
 
             logger.info("Search complete", {
@@ -667,6 +716,7 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
             );
 
             stateManager.dispatch({ type: "SET_SEARCH_RESULTS", results });
+            stateManager.dispatch({ type: "SET_SEARCH_STATE", state: "ready" });
 
             const freshBrowseContext = await loadBrowseDisplayContext(container, results);
             return {
@@ -1065,26 +1115,10 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
       if (context.signal.aborted) {
         return { status: "cancelled" };
       }
-      stateManager.dispatch({ type: "SET_SEARCH_STATE", state: "error" });
-      logger.error("Search phase error", { error: String(e) });
-      diagnosticsService.record(
-        buildSearchDiagnosticEvent({
-          operation: "search.phase.failed",
-          status: "failed",
-          severity: "recoverable",
-          failureClass: "unknown",
-          message: "Search phase error",
-          context: { error: String(e) },
-        }),
-      );
+      const failure = containSearchFailure(e, "search.phase.failed");
       return {
         status: "error",
-        error: kitsuneErrorFromUnknown(e, {
-          code: "NETWORK_ERROR",
-          message: "Search failed",
-          service: searchRegistry.getDefault()?.metadata.id,
-          retryable: true,
-        }),
+        error: failure.failure,
       };
     }
   }

--- a/apps/cli/src/app/search/SearchPhase.ts
+++ b/apps/cli/src/app/search/SearchPhase.ts
@@ -40,6 +40,7 @@ import { launchCalendarContinue } from "@/app/search/calendar-continue-launch";
 import { isCalendarSearchResult, loadCalendarResults } from "@/app/search/calendar-results";
 import { playTrailer } from "@/app/search/details-trailer";
 import { enrichSelectedTitleIdentity } from "@/app/search/enrich-selected-title";
+import { shouldRunBootstrapSearch } from "@/app/search/search-failure-policy";
 import { buildSearchFilterChipOptions } from "@/app/search/search-filter-chips";
 import { applySearchSelectionSessionRouting } from "@/app/search/search-selection-routing";
 import {
@@ -296,7 +297,7 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
           continue;
         }
 
-        if (currentState.searchQuery.trim().length > 0 && currentState.searchResults.length === 0) {
+        if (shouldRunBootstrapSearch(currentState)) {
           // A real text search supersedes any route subtitle (calendar/trending/etc).
           routeSubtitle = undefined;
           stateManager.dispatch({ type: "SET_SEARCH_STATE", state: "loading" });
@@ -1064,6 +1065,7 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
       if (context.signal.aborted) {
         return { status: "cancelled" };
       }
+      stateManager.dispatch({ type: "SET_SEARCH_STATE", state: "error" });
       logger.error("Search phase error", { error: String(e) });
       diagnosticsService.record(
         buildSearchDiagnosticEvent({

--- a/apps/cli/src/app/search/SearchPhase.ts
+++ b/apps/cli/src/app/search/SearchPhase.ts
@@ -124,10 +124,26 @@ export function searchResultsHaveCachedTitleAliases(
 
 export { describeSearchResultAvailability };
 
+type SearchPhaseDependencies = {
+  readonly searchTitles: typeof searchTitles;
+  readonly openBrowseShell: (
+    input: Parameters<typeof openBrowseShell<SearchResult>>[0],
+  ) => ReturnType<typeof openBrowseShell<SearchResult>>;
+};
+
+const DEFAULT_SEARCH_PHASE_DEPENDENCIES: SearchPhaseDependencies = {
+  searchTitles,
+  openBrowseShell,
+};
+
 export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
   name = "search";
   private hasQueuedStartupReleaseReconciliation = false;
   private hasHealedHistoryMetadata = false;
+
+  constructor(
+    private readonly dependencies: SearchPhaseDependencies = DEFAULT_SEARCH_PHASE_DEPENDENCIES,
+  ) {}
 
   private readLocalBrowseHistory(context: PhaseContext): Record<string, HistoryProgress> {
     const { container } = context;
@@ -340,7 +356,7 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
           let search: Awaited<ReturnType<typeof searchTitles>>;
           try {
             search = await observeOnline(container, "search-error", () =>
-              searchTitles(searchIntent.intent, {
+              this.dependencies.searchTitles(searchIntent.intent, {
                 mode: stateManager.getState().mode,
                 providerId: currentState.provider,
                 animeLanguageProfile: container.config.animeLanguageProfile,
@@ -507,7 +523,7 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
         pendingSearchEvidence = undefined;
         pendingSearchWarnings = [];
 
-        const outcomePromise = openBrowseShell({
+        const outcomePromise = this.dependencies.openBrowseShell({
           mode: syncedState.mode,
           provider: syncedState.provider,
           settings: container.config.getRaw(),
@@ -670,7 +686,7 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
             let search: Awaited<ReturnType<typeof searchTitles>>;
             try {
               search = await observeOnline(container, "search-error", () =>
-                searchTitles(searchIntent.intent, {
+                this.dependencies.searchTitles(searchIntent.intent, {
                   mode: stateManager.getState().mode,
                   providerId: stateManager.getState().provider,
                   animeLanguageProfile: container.config.animeLanguageProfile,

--- a/apps/cli/src/app/search/search-failure-policy.ts
+++ b/apps/cli/src/app/search/search-failure-policy.ts
@@ -1,5 +1,5 @@
 import type { KitsuneError } from "@/domain/errors";
-import type { SearchStatus, StateTransition } from "@/domain/session/SessionState";
+import type { SearchStatus } from "@/domain/session/SessionState";
 import type { NetworkSnapshot } from "@/services/network/NetworkStatus";
 
 export type BootstrapSearchState = {
@@ -25,20 +25,4 @@ export function buildSearchFailureNote(error: KitsuneError, snapshot: NetworkSna
     return `Search failed: ${error.message} · retry`;
   }
   return `Search failed: ${error.message} · open /diagnostics`;
-}
-
-type SearchFailurePresenter = {
-  readonly connectivity: { getSnapshot(): NetworkSnapshot };
-  readonly stateManager: {
-    dispatch(
-      transition: Extract<StateTransition, { readonly type: "SET_PLAYBACK_FEEDBACK" }>,
-    ): void;
-  };
-};
-
-export function presentSearchFailure(target: SearchFailurePresenter, error: KitsuneError): void {
-  target.stateManager.dispatch({
-    type: "SET_PLAYBACK_FEEDBACK",
-    note: buildSearchFailureNote(error, target.connectivity.getSnapshot()),
-  });
 }

--- a/apps/cli/src/app/search/search-failure-policy.ts
+++ b/apps/cli/src/app/search/search-failure-policy.ts
@@ -1,0 +1,44 @@
+import type { KitsuneError } from "@/domain/errors";
+import type { SearchStatus, StateTransition } from "@/domain/session/SessionState";
+import type { NetworkSnapshot } from "@/services/network/NetworkStatus";
+
+export type BootstrapSearchState = {
+  readonly searchQuery: string;
+  readonly searchResults: readonly unknown[];
+  readonly searchState: SearchStatus;
+};
+
+/** A failed bootstrap stays interactive until the user explicitly retries. */
+export function shouldRunBootstrapSearch(state: BootstrapSearchState): boolean {
+  return (
+    state.searchState !== "error" &&
+    state.searchQuery.trim().length > 0 &&
+    state.searchResults.length === 0
+  );
+}
+
+export function buildSearchFailureNote(error: KitsuneError, snapshot: NetworkSnapshot): string {
+  if (snapshot.status === "offline") {
+    return `Search failed: ${error.message} · retry or open /offline`;
+  }
+  if (error.retryable) {
+    return `Search failed: ${error.message} · retry`;
+  }
+  return `Search failed: ${error.message} · open /diagnostics`;
+}
+
+type SearchFailurePresenter = {
+  readonly connectivity: { getSnapshot(): NetworkSnapshot };
+  readonly stateManager: {
+    dispatch(
+      transition: Extract<StateTransition, { readonly type: "SET_PLAYBACK_FEEDBACK" }>,
+    ): void;
+  };
+};
+
+export function presentSearchFailure(target: SearchFailurePresenter, error: KitsuneError): void {
+  target.stateManager.dispatch({
+    type: "SET_PLAYBACK_FEEDBACK",
+    note: buildSearchFailureNote(error, target.connectivity.getSnapshot()),
+  });
+}

--- a/apps/cli/src/app/session/SessionController.ts
+++ b/apps/cli/src/app/session/SessionController.ts
@@ -6,7 +6,6 @@
 // =============================================================================
 
 import { primeShareBootstrapStartSeconds } from "@/app/bootstrap/share-bootstrap-start";
-import { presentSearchFailure } from "@/app/search/search-failure-policy";
 import type { SearchPhaseInput } from "@/app/search/SearchPhase";
 import type { Phase, PhaseResult, PhaseContext } from "@/app/session/Phase";
 import { abortOrphanDownloadResolve, type Container } from "@/container";
@@ -132,7 +131,6 @@ export class SessionController {
             if (searchResult.status === "cancelled") continue;
             if (searchResult.status === "error") {
               logger.error("Search phase failed", { error: searchResult.error });
-              presentSearchFailure(this.container, searchResult.error);
               continue;
             }
 

--- a/apps/cli/src/app/session/SessionController.ts
+++ b/apps/cli/src/app/session/SessionController.ts
@@ -6,6 +6,7 @@
 // =============================================================================
 
 import { primeShareBootstrapStartSeconds } from "@/app/bootstrap/share-bootstrap-start";
+import { presentSearchFailure } from "@/app/search/search-failure-policy";
 import type { SearchPhaseInput } from "@/app/search/SearchPhase";
 import type { Phase, PhaseResult, PhaseContext } from "@/app/session/Phase";
 import { abortOrphanDownloadResolve, type Container } from "@/container";
@@ -130,8 +131,8 @@ export class SessionController {
             if (searchResult.status === "quit") break;
             if (searchResult.status === "cancelled") continue;
             if (searchResult.status === "error") {
-              // Log error and continue to next iteration
               logger.error("Search phase failed", { error: searchResult.error });
+              presentSearchFailure(this.container, searchResult.error);
               continue;
             }
 

--- a/apps/cli/src/services/catalog/tmdb-proxy.ts
+++ b/apps/cli/src/services/catalog/tmdb-proxy.ts
@@ -1,5 +1,6 @@
 import { withTimeoutSignal } from "@/infra/abort/timeout-signal";
 import { observeOnlineIfBound } from "@/services/network/network-observation";
+import { classifyNetworkFailure } from "@/services/network/NetworkStatus";
 import { VIDEASY_DB_BASE } from "@kunai/providers";
 
 export { VIDEASY_DB_BASE as TMDB_PROXY_BASE };
@@ -101,14 +102,8 @@ export function isTmdbNetworkError(error: unknown): boolean {
   return (
     name.includes("failedtoopensocket") ||
     name.includes("aborterror") ||
-    message.includes("failedtoopensocket") ||
-    message.includes("unable to connect") ||
-    message.includes("econnrefused") ||
     message.includes("network") ||
-    message.includes("unreachable") ||
-    message.includes("timed out") ||
-    message.includes("timeout") ||
-    message.includes("was there a typo in the url or port")
+    classifyNetworkFailure(message) !== "unknown"
   );
 }
 

--- a/apps/cli/src/services/catalog/tmdb-proxy.ts
+++ b/apps/cli/src/services/catalog/tmdb-proxy.ts
@@ -102,6 +102,7 @@ export function isTmdbNetworkError(error: unknown): boolean {
     name.includes("failedtoopensocket") ||
     name.includes("aborterror") ||
     message.includes("failedtoopensocket") ||
+    message.includes("unable to connect") ||
     message.includes("econnrefused") ||
     message.includes("network") ||
     message.includes("unreachable") ||

--- a/apps/cli/src/services/network/Connectivity.ts
+++ b/apps/cli/src/services/network/Connectivity.ts
@@ -53,9 +53,10 @@ export class Connectivity {
 
   recordFailure(message: string, evidence: NetworkEvidence): void {
     if (this.getOfflineMode()) return;
-    const status = classifyNetworkFailure(message);
+    const classified = classifyNetworkFailure(message);
+    const observedStatus = classified === "unknown" ? "limited" : classified;
     this.snapshot = {
-      status: status === "unknown" ? "limited" : status,
+      status: this.snapshot.status === "offline" ? "offline" : observedStatus,
       checkedAt: Date.now(),
       evidence,
       message,

--- a/apps/cli/src/services/network/NetworkStatus.ts
+++ b/apps/cli/src/services/network/NetworkStatus.ts
@@ -30,6 +30,9 @@ const NETWORK_ERROR_PATTERNS = [
   "network is unreachable",
   "err_internet_disconnected",
   "err_name_not_resolved",
+  "unable to connect",
+  "failedtoopensocket",
+  "was there a typo in the url or port",
   "dns",
 ];
 

--- a/apps/cli/test/unit/app-shell/browse-search-failure.useinput.test.tsx
+++ b/apps/cli/test/unit/app-shell/browse-search-failure.useinput.test.tsx
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test";
+
+import { BrowseShell } from "@/app-shell/browse-shell";
+import React, { act } from "react";
+
+import { render } from "../../harness/render-capture";
+
+test("failed bootstrap search keeps its query and offline recovery visible", async () => {
+  const queries: string[] = [];
+  const handle = render(
+    <BrowseShell
+      mode="series"
+      provider="videasy"
+      initialQuery="Bojack Horseman"
+      initialErrorMessage="Search failed: Search service unreachable · retry or open /offline"
+      placeholder="Search"
+      commands={[]}
+      onSearch={async (query) => {
+        queries.push(query);
+        return { options: [], subtitle: "0 results" };
+      }}
+      onResolve={() => {}}
+      onSubmit={() => {}}
+      onCancel={() => {}}
+    />,
+    { columns: 100, rows: 32 },
+  );
+
+  try {
+    expect(handle.lastFrame()).toContain("Bojack Horseman");
+    expect(handle.lastFrame()).toContain("Search failed");
+    expect(handle.lastFrame()).toContain("retry or open /offline");
+
+    await act(async () => {
+      handle.stdin.enqueue(["\r"]);
+      await Promise.resolve();
+    });
+
+    expect(queries).toEqual(["Bojack Horseman"]);
+  } finally {
+    handle.unmount();
+  }
+});

--- a/apps/cli/test/unit/app/search/search-failure-policy.test.ts
+++ b/apps/cli/test/unit/app/search/search-failure-policy.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildSearchFailureNote,
+  presentSearchFailure,
+  shouldRunBootstrapSearch,
+} from "@/app/search/search-failure-policy";
+
+describe("search failure policy", () => {
+  test("an error state suppresses automatic bootstrap replay but a fresh idle query runs", () => {
+    expect(
+      shouldRunBootstrapSearch({
+        searchQuery: "Bojack Horseman",
+        searchResults: [],
+        searchState: "error",
+      }),
+    ).toBe(false);
+    expect(
+      shouldRunBootstrapSearch({
+        searchQuery: "Bojack Horseman",
+        searchResults: [],
+        searchState: "idle",
+      }),
+    ).toBe(true);
+    expect(
+      shouldRunBootstrapSearch({
+        searchQuery: "",
+        searchResults: [],
+        searchState: "idle",
+      }),
+    ).toBe(false);
+  });
+
+  test("offline search failure offers retry and the offline library", () => {
+    const note = buildSearchFailureNote(
+      {
+        code: "NETWORK_ERROR",
+        message: "Search service unreachable",
+        retryable: true,
+      },
+      {
+        status: "offline",
+        checkedAt: 1,
+        evidence: "search-error",
+        message: "Unable to connect. Is the computer able to access the url?",
+      },
+    );
+
+    expect(note).toBe("Search failed: Search service unreachable · retry or open /offline");
+  });
+
+  test("limited failures offer retry without falsely declaring full offline mode", () => {
+    const note = buildSearchFailureNote(
+      {
+        code: "NETWORK_ERROR",
+        message: "Search service timed out",
+        retryable: true,
+      },
+      {
+        status: "limited",
+        checkedAt: 1,
+        evidence: "search-error",
+        message: "request timed out",
+      },
+    );
+
+    expect(note).toBe("Search failed: Search service timed out · retry");
+  });
+
+  test("presenting a failure dispatches the actionable note to the shell", () => {
+    const actions: unknown[] = [];
+    presentSearchFailure(
+      {
+        connectivity: {
+          getSnapshot: () => ({
+            status: "offline",
+            checkedAt: 1,
+            evidence: "search-error",
+          }),
+        },
+        stateManager: {
+          dispatch: (action) => actions.push(action),
+        },
+      },
+      {
+        code: "NETWORK_ERROR",
+        message: "Search service unreachable",
+        retryable: true,
+      },
+    );
+
+    expect(actions).toEqual([
+      {
+        type: "SET_PLAYBACK_FEEDBACK",
+        note: "Search failed: Search service unreachable · retry or open /offline",
+      },
+    ]);
+  });
+});

--- a/apps/cli/test/unit/app/search/search-failure-policy.test.ts
+++ b/apps/cli/test/unit/app/search/search-failure-policy.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 
 import {
   buildSearchFailureNote,
-  presentSearchFailure,
   shouldRunBootstrapSearch,
 } from "@/app/search/search-failure-policy";
 
@@ -65,35 +64,5 @@ describe("search failure policy", () => {
     );
 
     expect(note).toBe("Search failed: Search service timed out · retry");
-  });
-
-  test("presenting a failure dispatches the actionable note to the shell", () => {
-    const actions: unknown[] = [];
-    presentSearchFailure(
-      {
-        connectivity: {
-          getSnapshot: () => ({
-            status: "offline",
-            checkedAt: 1,
-            evidence: "search-error",
-          }),
-        },
-        stateManager: {
-          dispatch: (action) => actions.push(action),
-        },
-      },
-      {
-        code: "NETWORK_ERROR",
-        message: "Search service unreachable",
-        retryable: true,
-      },
-    );
-
-    expect(actions).toEqual([
-      {
-        type: "SET_PLAYBACK_FEEDBACK",
-        note: "Search failed: Search service unreachable · retry or open /offline",
-      },
-    ]);
   });
 });

--- a/apps/cli/test/unit/app/search/search-phase-offline-bootstrap.test.ts
+++ b/apps/cli/test/unit/app/search/search-phase-offline-bootstrap.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "bun:test";
+
+import type { openBrowseShell } from "@/app-shell/browse-shell";
+import { SearchPhase } from "@/app/search/SearchPhase";
+import type { Container } from "@/container";
+import { SessionStateManagerImpl } from "@/domain/session/SessionStateManager";
+import type { SearchResult } from "@/domain/types";
+import type { Logger } from "@/infra/logger/Logger";
+import { Connectivity } from "@/services/network/Connectivity";
+import type { searchTitles } from "@/services/search/SearchRoutingService";
+
+const logger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+  child: () => logger,
+};
+
+test("bootstrap network failure opens browse once with retained query and recovery", async () => {
+  const stateManager = new SessionStateManagerImpl({ logger });
+  const connectivity = new Connectivity(() => false);
+  const diagnostics: unknown[] = [];
+  let searchCalls = 0;
+  let browseInput: Parameters<typeof openBrowseShell<SearchResult>>[0] | undefined;
+
+  const phase = new SearchPhase({
+    searchTitles: (async () => {
+      searchCalls += 1;
+      throw new Error("Unable to connect. Is the computer able to access the url?");
+    }) as typeof searchTitles,
+    openBrowseShell: async (input) => {
+      browseInput = input;
+      return { type: "cancelled" };
+    },
+  });
+
+  const provider = {
+    metadata: { id: "videasy", isAnimeProvider: false, isYoutubeProvider: false },
+  };
+  const container = {
+    stateManager,
+    connectivity,
+    logger,
+    diagnosticsService: { record: (event: unknown) => diagnostics.push(event) },
+    config: {
+      offlineMode: false,
+      animeLanguageProfile: { audio: "original", subtitle: "en" },
+      youtubeLanguageProfile: { audio: "original", subtitle: "none" },
+      animeTitlePreference: "provider",
+      getRaw: () => ({}),
+    },
+    searchRegistry: { getDefault: () => ({ metadata: { id: "tmdb" } }) },
+    providerRegistry: {
+      get: () => provider,
+      getDefaultForMode: () => provider,
+    },
+    queueService: { peekNext: () => null },
+    releaseProgressCache: {
+      summarizeActive: () => ({ episodeCount: 0, titleCount: 0 }),
+      getByTitleIds: () => new Map(),
+    },
+    offlineAssetService: { listNextReadyByTitleCursors: () => [] },
+  } as unknown as Container;
+
+  const result = await phase.execute(
+    { initialQuery: "Bojack Horseman" },
+    { container, signal: new AbortController().signal },
+  );
+
+  expect(result).toEqual({ status: "cancelled" });
+  expect(searchCalls).toBe(1);
+  expect(stateManager.getState()).toMatchObject({
+    searchQuery: "Bojack Horseman",
+    searchState: "error",
+  });
+  expect(browseInput?.initialQuery).toBe("Bojack Horseman");
+  expect(browseInput?.initialErrorMessage).toBe(
+    "Search failed: Unable to connect. Is the computer able to access the url? · retry or open /offline",
+  );
+  const failures = diagnostics.filter(
+    (event) =>
+      typeof event === "object" &&
+      event !== null &&
+      "operation" in event &&
+      event.operation === "search.bootstrap.failed",
+  );
+  expect(failures).toHaveLength(1);
+  expect(failures[0]).toMatchObject({
+    category: "search",
+    context: {
+      error: "Error: Unable to connect. Is the computer able to access the url?",
+      failureClass: "offline",
+      recommendedAction: "retry",
+    },
+  });
+});

--- a/apps/cli/test/unit/services/catalog/tmdb-proxy.test.ts
+++ b/apps/cli/test/unit/services/catalog/tmdb-proxy.test.ts
@@ -15,6 +15,12 @@ describe("tmdb proxy search errors", () => {
     expect(formatTmdbSearchError(error).message).toBe("Search service unreachable");
   });
 
+  test("maps Bun unable-to-connect failures to a friendly search message", () => {
+    const error = new Error("Unable to connect. Is the computer able to access the url?");
+    expect(isTmdbNetworkError(error)).toBe(true);
+    expect(formatTmdbSearchError(error).message).toBe("Search service unreachable");
+  });
+
   test("preserves non-network errors", () => {
     const error = new Error("Search failed: 500");
     expect(formatTmdbSearchError(error).message).toBe("Search failed: 500");

--- a/apps/cli/test/unit/services/network/connectivity.test.ts
+++ b/apps/cli/test/unit/services/network/connectivity.test.ts
@@ -20,6 +20,23 @@ describe("Connectivity", () => {
     expect(connectivity.isOnline()).toBe(true);
   });
 
+  test("offline evidence stays sticky until an online operation succeeds", () => {
+    const connectivity = new Connectivity(() => false);
+
+    connectivity.recordFailure("ENETUNREACH", "search-error");
+    connectivity.recordFailure("request timed out", "provider-error");
+
+    expect(connectivity.getSnapshot()).toMatchObject({
+      status: "offline",
+      evidence: "provider-error",
+      message: "request timed out",
+    });
+    expect(connectivity.isOnline()).toBe(false);
+
+    connectivity.recordSuccess("search-error");
+    expect(connectivity.getSnapshot().status).toBe("online");
+  });
+
   test("subscribe fires when network reality changes", () => {
     const connectivity = new Connectivity(() => false);
     let calls = 0;

--- a/apps/cli/test/unit/services/network/network-status.test.ts
+++ b/apps/cli/test/unit/services/network/network-status.test.ts
@@ -13,6 +13,14 @@ describe("NetworkStatus", () => {
     expect(classifyNetworkFailure("Network is unreachable")).toBe("offline");
   });
 
+  test("classifies Bun unable-to-connect failures as offline", () => {
+    expect(
+      classifyNetworkFailure("Unable to connect. Is the computer able to access the url?"),
+    ).toBe("offline");
+    expect(classifyNetworkFailure("FailedToOpenSocket")).toBe("offline");
+    expect(classifyNetworkFailure("Was there a typo in the url or port?")).toBe("offline");
+  });
+
   test("classifies single timeouts as limited instead of offline", () => {
     expect(classifyNetworkFailure("provider timed out")).toBe("limited");
   });

--- a/plans/039-network-search-offline-truth.md
+++ b/plans/039-network-search-offline-truth.md
@@ -1,0 +1,64 @@
+# Plan 039: Preserve network truth and surface search failure
+
+> **Drift check:** `git diff --stat 207ef937..HEAD -- apps/cli/src/services/network apps/cli/src/services/catalog/tmdb-proxy.ts apps/cli/src/app/search apps/cli/src/app/session apps/cli/test/unit/services/network apps/cli/test/unit/services/catalog apps/cli/test/unit/app`
+
+**Goal:** Treat Bun connection failures as offline evidence, keep that evidence
+sticky until a successful online operation, and return failed searches to an
+actionable search screen instead of silently retrying or appearing to redirect
+home.
+
+## Status
+
+- **Priority:** P0
+- **Effort:** S
+- **Risk:** LOW
+- **Planned at:** `207ef937`, 2026-08-14
+- **Evidence:** GitHub issue #20 reports Bun's `Unable to connect. Is the computer able to access the url?` during search.
+
+## Invariants
+
+- Persisted `offlineMode` remains user intent; runtime failures must not write config.
+- An offline observation cannot be downgraded by a later timeout. Only a confirmed
+  online success restores `online`.
+- HTTP/provider failures such as 404 remain provider evidence, not network evidence.
+- A failed bootstrap search keeps the query editable, marks search state `error`, and
+  does not automatically replay on the next search-phase mount.
+- The visible message offers retry and `/offline`; diagnostics keep the original error.
+
+## Tasks
+
+### Task 1: Characterize Bun connection failures and sticky state
+
+- [ ] Add the exact issue #20 Bun message to `network-status.test.ts` and
+      `tmdb-proxy.test.ts`; expect offline classification and `Search service unreachable`.
+- [ ] Add a `connectivity.test.ts` case proving `offline -> timeout` stays offline and
+      a confirmed search success restores online.
+- [ ] Run those assertions before implementation and confirm they fail for the
+      missing behavior.
+- [ ] Expand the shared classifiers in `NetworkStatus.ts` and `tmdb-proxy.ts`, then
+      make `Connectivity.recordFailure` preserve an existing offline status.
+
+### Task 2: Stop automatic replay and produce actionable feedback
+
+- [ ] Add `apps/cli/src/app/search/search-failure-policy.ts` with pure functions that
+      decide whether bootstrap search may run and format the failure note from a
+      `KitsuneError` plus `NetworkSnapshot`.
+- [ ] Add `search-failure-policy.test.ts` first. Prove `searchState: "error"`
+      suppresses bootstrap replay, idle/loading queries behave intentionally, and an
+      offline note contains both `retry` and `/offline`.
+- [ ] Use the policy in `SearchPhase.ts`; dispatch `SET_SEARCH_STATE: "error"` in
+      the outer failure path.
+- [ ] In `SessionController.ts`, dispatch the policy note when SearchPhase returns an
+      error before continuing to the next interactive search mount.
+- [ ] Keep the existing structured `search.phase.failed` event and raw logged error.
+
+## Verification
+
+```sh
+bun run --cwd apps/cli test -- test/unit/services/network/network-status.test.ts test/unit/services/network/connectivity.test.ts test/unit/services/catalog/tmdb-proxy.test.ts test/unit/app/search/search-failure-policy.test.ts
+bun run typecheck
+bun run lint
+bun run fmt
+bun run test
+bun run build
+```

--- a/plans/039-network-search-offline-truth.md
+++ b/plans/039-network-search-offline-truth.md
@@ -46,10 +46,12 @@ home.
 - [ ] Add `search-failure-policy.test.ts` first. Prove `searchState: "error"`
       suppresses bootstrap replay, idle/loading queries behave intentionally, and an
       offline note contains both `retry` and `/offline`.
-- [ ] Use the policy in `SearchPhase.ts`; dispatch `SET_SEARCH_STATE: "error"` in
-      the outer failure path.
-- [ ] In `SessionController.ts`, dispatch the policy note when SearchPhase returns an
-      error before continuing to the next interactive search mount.
+- [ ] Contain bootstrap failure inside `SearchPhase.ts`, keep the query/state in that
+      phase, and pass the failure into BrowseShell's initial error surface.
+- [ ] Add a render regression that shows the retained query, retry copy, and
+      `/offline`, then retries the same query on Enter.
+- [ ] Convert interactive search rejections into the same actionable BrowseShell
+      error while retaining the original failure in structured diagnostics.
 - [ ] Keep the existing structured `search.phase.failed` event and raw logged error.
 
 ## Verification

--- a/plans/040-support-bundle-taxonomy-parity.md
+++ b/plans/040-support-bundle-taxonomy-parity.md
@@ -1,0 +1,38 @@
+# Plan 040: Make support-bundle sections exhaustive
+
+> **Drift check:** `git diff --stat 207ef937..HEAD -- apps/cli/src/services/diagnostics/diagnostic-event.ts apps/cli/src/services/diagnostics/support-bundle.ts apps/cli/test/unit/services/diagnostics`
+
+**Goal:** Ensure every diagnostic category accepted by the runtime can appear in
+an exported support bundle without maintaining a second, drifting category list.
+
+## Status
+
+- **Priority:** P0
+- **Effort:** S
+- **Risk:** LOW
+- **Planned at:** `207ef937`, 2026-08-14
+
+## Current defect
+
+`DiagnosticCategory` contains thirteen categories, while `buildBundleSections`
+hardcodes nine and silently drops `session`, `search`, `ui`, and `update`.
+
+## Tasks
+
+- [ ] Export one readonly `DIAGNOSTIC_CATEGORIES` tuple from `diagnostic-event.ts`
+      and derive `DiagnosticCategory` from `(typeof DIAGNOSTIC_CATEGORIES)[number]`.
+- [ ] Add a failing table-driven `support-bundle.test.ts` case with one event per
+      category; expect all thirteen section keys in tuple order.
+- [ ] Make `buildBundleSections` iterate the shared tuple. Keep omitting categories
+      with zero events and retain current privacy and size budgets.
+- [ ] Do not add empty per-category configuration or a second allowlist.
+
+## Verification
+
+```sh
+bun run --cwd apps/cli test -- test/unit/services/diagnostics/support-bundle.test.ts test/unit/services/diagnostics/diagnostics-export.test.ts
+bun run typecheck
+bun run lint
+bun run fmt
+bun run test
+```

--- a/plans/041-installer-staging-containment.md
+++ b/plans/041-installer-staging-containment.md
@@ -1,0 +1,42 @@
+# Plan 041: Jail installer staging cleanup
+
+> **Drift check:** `git diff --stat 207ef937..HEAD -- apps/cli/src/services/update/native-installer/install-layout.ts apps/cli/src/services/update/native-installer/transaction.ts apps/cli/test/unit/services/update/native-installer`
+
+**Goal:** Make every recursive installer cleanup prove structural containment
+inside Kunai's staging root before deleting anything.
+
+## Status
+
+- **Priority:** P0
+- **Effort:** S
+- **Risk:** MED
+- **Planned at:** `207ef937`, 2026-08-14
+
+## Current defect
+
+`isInsideStagingRoot` normalizes slashes but does not resolve `.` or `..`. A
+persisted abandoned transaction can pass the lexical prefix check while resolving
+outside `stagingRoot`, after which cleanup performs recursive `rm`.
+
+## Tasks
+
+- [ ] Add table-driven `install-layout.test.ts` cases for POSIX and Windows:
+      direct children pass; root, sibling-prefix, and traversal paths fail.
+- [ ] Compare fully resolved paths with `node:path`/`node:path.win32`; never use
+      unresolved `startsWith` as the containment decision.
+- [ ] Make `removeStagingAndPruneParents` fail closed before its first `rm` when the
+      candidate is outside the staging root.
+- [ ] Add a dead-PID transaction cleanup test with a traversal path and an external
+      sentinel; prove cleanup cannot remove the sentinel.
+- [ ] Keep ordinary version/root pruning behavior on valid staging paths.
+
+## Verification
+
+```sh
+bun run --cwd apps/cli test -- test/unit/services/update/native-installer/install-layout.test.ts test/unit/services/update/native-installer/transaction.test.ts
+bun run typecheck
+bun run lint
+bun run fmt
+bun run test
+bun run build
+```

--- a/plans/042-atomic-json-last-known-good.md
+++ b/plans/042-atomic-json-last-known-good.md
@@ -1,0 +1,42 @@
+# Plan 042: Preserve the last-known-good atomic-write target
+
+> **Drift check:** `git diff --stat 207ef937..HEAD -- apps/cli/src/infra/fs/atomic-write.ts apps/cli/test/unit/infra/fs`
+
+**Goal:** Make Windows replacement failures preserve the previous valid config,
+token, metadata, or support-bundle file.
+
+## Status
+
+- **Priority:** P0
+- **Effort:** M
+- **Risk:** MED
+- **Planned at:** `207ef937`, 2026-08-14
+
+## Current defect
+
+On Windows `EPERM`, `EEXIST`, or `ENOTEMPTY`, `atomicMove` unlinks the target and
+then retries the rename. If that rename fails, the old target is already gone.
+
+## Tasks
+
+- [ ] Refactor filesystem operations behind a package-private injected adapter so
+      failure ordering is testable without replacing `process.platform`.
+- [ ] Add `apps/cli/test/unit/infra/fs/atomic-write.test.ts` covering normal replace
+      and the Windows fallback.
+- [ ] Prove a failed replacement leaves the original bytes readable and cleans temp
+      files.
+- [ ] Replace through a same-directory backup; remove it only after success and
+      restore it if installing the temp file fails.
+- [ ] If restoration fails, retain the backup and throw both failure contexts.
+- [ ] Preserve pre-rename `0o600` on POSIX secret writers and all public APIs.
+
+## Verification
+
+```sh
+bun run --cwd apps/cli test -- test/unit/infra/fs/atomic-write.test.ts test/unit/infra/storage/FileStorage.test.ts
+bun run typecheck
+bun run lint
+bun run fmt
+bun run test
+bun run build
+```

--- a/plans/043-history-key-migration-transaction.md
+++ b/plans/043-history-key-migration-transaction.md
@@ -1,0 +1,39 @@
+# Plan 043: Transact legacy history-key migration
+
+> **Drift check:** `git diff --stat 207ef937..HEAD -- packages/storage/src/repositories/history.ts packages/storage/test/history-youtube-key.test.ts packages/storage/src/repositories/history-title-aliases.ts`
+
+**Goal:** Make legacy movie-to-video history-key migration all-or-nothing so a
+failed canonical upsert cannot erase resume history.
+
+## Status
+
+- **Priority:** P1
+- **Effort:** S
+- **Risk:** LOW
+- **Planned at:** `207ef937`, 2026-08-14
+
+## Current defect
+
+`HistoryRepository.upsertProgress` deletes a YouTube row under its legacy `movie`
+key before inserting/updating the canonical `video` key. Those writes and the alias
+update are not transactional.
+
+## Tasks
+
+- [ ] Extend `history-youtube-key.test.ts` with failure injection at canonical
+      insert; assert the legacy row remains and no canonical row or alias commits.
+- [ ] Add a success assertion for exactly one canonical row with accumulated fields
+      and aliases preserved.
+- [ ] Run the read, legacy delete, canonical UPSERT, and alias update inside one
+      `this.db.transaction` callback invoked by `upsertProgress`.
+- [ ] Do not add a schema migration; this is write-path atomicity only.
+
+## Verification
+
+```sh
+bun run --cwd packages/storage test test/history-youtube-key.test.ts test/history-title-aliases.test.ts
+bun run typecheck
+bun run lint
+bun run fmt
+bun run test
+```

--- a/plans/README.md
+++ b/plans/README.md
@@ -149,13 +149,13 @@ Already landed from this audit (no plan needed):
 
 ### Wave 9 — Audit remediation: truth, containment, durability
 
-| Plan | Title                                             | Priority | Effort | Depends on | Status      |
-| ---- | ------------------------------------------------- | -------- | ------ | ---------- | ----------- |
-| 039  | Preserve network truth and surface search failure | P0       | S      | —          | IN PROGRESS |
-| 040  | Make support-bundle sections exhaustive           | P0       | S      | 039        | TODO        |
-| 041  | Jail installer staging cleanup                    | P0       | S      | —          | TODO        |
-| 042  | Preserve the last-known-good atomic-write target  | P0       | M      | —          | TODO        |
-| 043  | Transact legacy history-key migration             | P1       | S      | —          | TODO        |
+| Plan | Title                                             | Priority | Effort | Depends on | Status |
+| ---- | ------------------------------------------------- | -------- | ------ | ---------- | ------ |
+| 039  | Preserve network truth and surface search failure | P0       | S      | —          | DONE   |
+| 040  | Make support-bundle sections exhaustive           | P0       | S      | 039        | TODO   |
+| 041  | Jail installer staging cleanup                    | P0       | S      | —          | TODO   |
+| 042  | Preserve the last-known-good atomic-write target  | P0       | M      | —          | TODO   |
+| 043  | Transact legacy history-key migration             | P1       | S      | —          | TODO   |
 
 Plans 039 and 040 are sequenced because the first fixes the user-visible search
 failure and the second guarantees its search/session diagnostics survive export.

--- a/plans/README.md
+++ b/plans/README.md
@@ -111,8 +111,8 @@ Execute 031 and 032 before calling the release stable. Plans 033 and 034 are the
 highest-value interaction work. The remaining provider plans are independent,
 except that 035 should land before expanding the AniDB release fixture beyond S1.
 
-| Plan | Title                                                   | Priority | Effort | Depends on | Status |
-| ---- | ------------------------------------------------------- | -------- | ------ | ---------- | ------ |
+| Plan | Title                                                    | Priority | Effort | Depends on | Status |
+| ---- | -------------------------------------------------------- | -------- | ------ | ---------- | ------ |
 | 031  | Make the default AniDB route searchable and signoff-real | P0       | M      | —          | TODO   |
 | 032  | Make sync identity-safe and describe real capabilities   | P0       | M      | —          | TODO   |
 | 033  | Restore truthful playback state after buffering/stalls   | P1       | S      | —          | TODO   |
@@ -146,6 +146,20 @@ Already landed from this audit (no plan needed):
   fail when a declaration has no reader. This is the ratchet the whole wave hangs off:
   each plan below deletes its baseline entries as it lands. Verified by mutation.
 - **History YouTube facet** — YouTube rows were filed under Movies.
+
+### Wave 9 — Audit remediation: truth, containment, durability
+
+| Plan | Title                                             | Priority | Effort | Depends on | Status      |
+| ---- | ------------------------------------------------- | -------- | ------ | ---------- | ----------- |
+| 039  | Preserve network truth and surface search failure | P0       | S      | —          | IN PROGRESS |
+| 040  | Make support-bundle sections exhaustive           | P0       | S      | 039        | TODO        |
+| 041  | Jail installer staging cleanup                    | P0       | S      | —          | TODO        |
+| 042  | Preserve the last-known-good atomic-write target  | P0       | M      | —          | TODO        |
+| 043  | Transact legacy history-key migration             | P1       | S      | —          | TODO        |
+
+Plans 039 and 040 are sequenced because the first fixes the user-visible search
+failure and the second guarantees its search/session diagnostics survive export.
+Plans 041–043 are independent and should remain separate implementation PRs.
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (one-line reason) | REJECTED (one-line rationale)
 

--- a/plans/archive/039-network-search-offline-truth.md
+++ b/plans/archive/039-network-search-offline-truth.md
@@ -13,6 +13,7 @@ home.
 - **Effort:** S
 - **Risk:** LOW
 - **Planned at:** `207ef937`, 2026-08-14
+- **Completed at:** `2472f2cf`, 2026-08-14
 - **Evidence:** GitHub issue #20 reports Bun's `Unable to connect. Is the computer able to access the url?` during search.
 
 ## Invariants
@@ -29,38 +30,44 @@ home.
 
 ### Task 1: Characterize Bun connection failures and sticky state
 
-- [ ] Add the exact issue #20 Bun message to `network-status.test.ts` and
+- [x] Add the exact issue #20 Bun message to `network-status.test.ts` and
       `tmdb-proxy.test.ts`; expect offline classification and `Search service unreachable`.
-- [ ] Add a `connectivity.test.ts` case proving `offline -> timeout` stays offline and
+- [x] Add a `connectivity.test.ts` case proving `offline -> timeout` stays offline and
       a confirmed search success restores online.
-- [ ] Run those assertions before implementation and confirm they fail for the
+- [x] Run those assertions before implementation and confirm they fail for the
       missing behavior.
-- [ ] Expand the shared classifiers in `NetworkStatus.ts` and `tmdb-proxy.ts`, then
+- [x] Expand the shared classifiers in `NetworkStatus.ts` and `tmdb-proxy.ts`, then
       make `Connectivity.recordFailure` preserve an existing offline status.
 
 ### Task 2: Stop automatic replay and produce actionable feedback
 
-- [ ] Add `apps/cli/src/app/search/search-failure-policy.ts` with pure functions that
+- [x] Add `apps/cli/src/app/search/search-failure-policy.ts` with pure functions that
       decide whether bootstrap search may run and format the failure note from a
       `KitsuneError` plus `NetworkSnapshot`.
-- [ ] Add `search-failure-policy.test.ts` first. Prove `searchState: "error"`
+- [x] Add `search-failure-policy.test.ts` first. Prove `searchState: "error"`
       suppresses bootstrap replay, idle/loading queries behave intentionally, and an
       offline note contains both `retry` and `/offline`.
-- [ ] Contain bootstrap failure inside `SearchPhase.ts`, keep the query/state in that
+- [x] Contain bootstrap failure inside `SearchPhase.ts`, keep the query/state in that
       phase, and pass the failure into BrowseShell's initial error surface.
-- [ ] Add a render regression that shows the retained query, retry copy, and
+- [x] Add a render regression that shows the retained query, retry copy, and
       `/offline`, then retries the same query on Enter.
-- [ ] Convert interactive search rejections into the same actionable BrowseShell
+- [x] Convert interactive search rejections into the same actionable BrowseShell
       error while retaining the original failure in structured diagnostics.
-- [ ] Keep the existing structured `search.phase.failed` event and raw logged error.
+- [x] Keep structured failure diagnostics and the raw logged error.
 
 ## Verification
 
 ```sh
-bun run --cwd apps/cli test -- test/unit/services/network/network-status.test.ts test/unit/services/network/connectivity.test.ts test/unit/services/catalog/tmdb-proxy.test.ts test/unit/app/search/search-failure-policy.test.ts
+bun run --cwd apps/cli test:file test/unit/services/network/network-status.test.ts
+bun run --cwd apps/cli test:file test/unit/services/network/connectivity.test.ts
+bun run --cwd apps/cli test:file test/unit/services/catalog/tmdb-proxy.test.ts
+bun run --cwd apps/cli test:file test/unit/app/search/search-failure-policy.test.ts
+bun run --cwd apps/cli test:file test/unit/app-shell/browse-search-failure.useinput.test.tsx
+bun run --cwd apps/cli test:file test/unit/app/search/search-phase-offline-bootstrap.test.ts
 bun run typecheck
 bun run lint
-bun run fmt
+bun run fmt:check
+bun run verify:doc-paths
 bun run test
 bun run build
 ```

--- a/plans/archive/README.md
+++ b/plans/archive/README.md
@@ -8,7 +8,7 @@ work to do.
 commit that is now far behind, and its "Current state" excerpts describe code
 that has since changed.
 
-Archived so far: 001–005, 007, 009, 017, 018, 019, 020, 024, 026.
+Archived so far: 001–005, 007, 009, 017, 018, 019, 020, 024, 026, 039.
 
 ## Notes worth carrying forward
 


### PR DESCRIPTION
## Summary

- recognize Bun's connection-open failure as offline evidence and keep offline state sticky until a confirmed online operation
- contain failed bootstrap searches inside Browse, retain the editable query, and show retry plus `/offline` recovery instead of falling back to Home
- route interactive failures through the same visible error state while preserving the raw failure in structured diagnostics
- add render-level and SearchPhase-level regressions, update the owning offline documentation, and record the remaining audit work as plans 040-043

## Verification

- `bun run test` — 14/14 tasks; CLI unit suite 4,053 passed, 0 failed
- `bun run build` — application bundle and 93.2 MiB Linux host binary succeeded
- `bun run typecheck`
- `bun run lint` — 0 errors; 5 pre-existing warnings in files inherited from PR #41
- `bun run fmt:check`
- `bun run verify:doc-paths`
- independent standards review: READY
- independent spec review: READY

Closes #20
