### PR TITLE
fix(offline): hand library playback back to session

### DIFF
--- a/apps/cli/src/app-shell/download-manager-shell.tsx
+++ b/apps/cli/src/app-shell/download-manager-shell.tsx
@@ -15,6 +15,7 @@ import { computeQueueRowLayout } from "@/app-shell/primitives/list-row-layout";
 import { MediaListShell } from "@/app-shell/primitives/MediaListShell";
 import { ProgressBar } from "@/app-shell/primitives/ProgressBar";
 import { StateBlock } from "@/app-shell/primitives/StateBlock";
+import { resolveRootLibraryPlaybackLaunch } from "@/app-shell/root-library-playback-bridge";
 import { ResizeBlocker } from "@/app-shell/shell-primitives";
 import { truncateLine } from "@/app-shell/shell-text";
 import { getWindowStart } from "@/app-shell/shell-text";
@@ -342,7 +343,10 @@ export function DownloadManagerContent({
             job.status === "repairable")
         ) {
           void import("@/app/offline/offline-playback-launch").then(
-            ({ requestUnifiedOfflinePlayback }) => requestUnifiedOfflinePlayback(container, job.id),
+            ({ requestUnifiedOfflinePlayback }) =>
+              requestUnifiedOfflinePlayback(container, job.id, {
+                onDirectLaunch: resolveRootLibraryPlaybackLaunch,
+              }),
           );
           return;
         }

--- a/apps/cli/src/app-shell/library-title-detail.tsx
+++ b/apps/cli/src/app-shell/library-title-detail.tsx
@@ -12,6 +12,7 @@ import {
   type PreviewRailModel,
 } from "@/app-shell/primitives/PreviewRail.model";
 import { SectionGroup } from "@/app-shell/primitives/SectionGroup";
+import { resolveRootLibraryPlaybackLaunch } from "@/app-shell/root-library-playback-bridge";
 import { getWindowStart, truncateLine } from "@/app-shell/shell-text";
 import { palette } from "@/app-shell/shell-theme";
 import { useDebouncedViewportPolicy } from "@/app-shell/use-viewport-policy";
@@ -213,7 +214,9 @@ export function LibraryTitleDetail({
               });
               return;
             }
-            await requestUnifiedOfflinePlayback(container, job.id);
+            await requestUnifiedOfflinePlayback(container, job.id, {
+              onDirectLaunch: resolveRootLibraryPlaybackLaunch,
+            });
             return;
           }
 

--- a/apps/cli/src/app-shell/root-library-playback-bridge.ts
+++ b/apps/cli/src/app-shell/root-library-playback-bridge.ts
@@ -1,0 +1,27 @@
+import type { OfflinePlaybackLaunch } from "@/app/offline/offline-playback-launch";
+
+type LibraryPlaybackResolver = (launch: OfflinePlaybackLaunch | null) => void;
+
+let pendingResolver: LibraryPlaybackResolver | null = null;
+
+/** Wait for the active root-owned Library overlay to select a playable artifact. */
+export function waitForRootLibraryPlaybackLaunch(): Promise<OfflinePlaybackLaunch | null> {
+  pendingResolver?.(null);
+  return new Promise((resolve) => {
+    pendingResolver = resolve;
+  });
+}
+
+/** Deliver directly to the workflow that opened Library; no launch is retained afterward. */
+export function resolveRootLibraryPlaybackLaunch(launch: OfflinePlaybackLaunch): void {
+  const resolve = pendingResolver;
+  pendingResolver = null;
+  resolve?.(launch);
+}
+
+/** Settle a Library workflow that closed without selecting playback. */
+export function cancelRootLibraryPlaybackLaunch(): void {
+  const resolve = pendingResolver;
+  pendingResolver = null;
+  resolve?.(null);
+}

--- a/apps/cli/src/app-shell/workflows/shell-workflows.ts
+++ b/apps/cli/src/app-shell/workflows/shell-workflows.ts
@@ -17,6 +17,11 @@ import {
   noteForExternalOpenFailure,
 } from "@/app-shell/external-open-fallback";
 import { openSessionProviderPicker } from "@/app-shell/provider-picker-overlay";
+import {
+  cancelRootLibraryPlaybackLaunch,
+  resolveRootLibraryPlaybackLaunch,
+  waitForRootLibraryPlaybackLaunch,
+} from "@/app-shell/root-library-playback-bridge";
 import { openDiagnosticsOverlay, openRootOwnedOverlay } from "@/app-shell/root-overlay-bridge";
 import { resolveShareTarget } from "@/app/bootstrap/resolve-share-target";
 import { buildShareRefFromTitleContext } from "@/app/bootstrap/share-ref-from-context";
@@ -527,7 +532,9 @@ export async function openOfflineLibraryGroupPicker(
         );
         continue;
       }
-      await requestUnifiedOfflinePlayback(container, job.id);
+      await requestUnifiedOfflinePlayback(container, job.id, {
+        onDirectLaunch: resolveRootLibraryPlaybackLaunch,
+      });
       return;
     }
     if (action === "reveal") {
@@ -926,11 +933,19 @@ async function handleContinue(container: Container): Promise<"handled"> {
 async function handleLibraryOverlay(
   container: Container,
   view: "library" | "queue",
-): Promise<"handled"> {
+): Promise<ShellWorkflowResult> {
   const { stateManager } = container;
+  const playbackLaunch = waitForRootLibraryPlaybackLaunch();
   stateManager.dispatch({ type: "OPEN_OVERLAY", overlay: { type: "library", view } });
   await waitForOverlayClose(stateManager, "library");
-  return "handled";
+  cancelRootLibraryPlaybackLaunch();
+  const launch = await playbackLaunch;
+  if (!launch) return "handled";
+  return {
+    type: "history-entry",
+    title: launch.title,
+    ...(launch.episode ? { episode: launch.episode } : {}),
+  };
 }
 
 async function handleStaticOverlay(

--- a/apps/cli/src/app/offline/offline-playback-launch.ts
+++ b/apps/cli/src/app/offline/offline-playback-launch.ts
@@ -13,6 +13,11 @@ export type OfflinePlaybackRequestResult =
   | { readonly status: "browse-handoff"; readonly launch: OfflinePlaybackLaunch }
   | { readonly status: "direct"; readonly launch: OfflinePlaybackLaunch };
 
+export type OfflinePlaybackRequestOptions = {
+  /** Called synchronously before overlay close when no retained browse session owns the launch. */
+  readonly onDirectLaunch?: (launch: OfflinePlaybackLaunch) => void;
+};
+
 export function titleInfoFromDownloadJob(job: DownloadJobRecord): TitleInfo {
   return {
     id: job.titleId,
@@ -92,16 +97,21 @@ export async function prepareOfflinePlaybackLaunch(
 export async function requestUnifiedOfflinePlayback(
   container: Container,
   jobId: string,
+  options: OfflinePlaybackRequestOptions = {},
 ): Promise<OfflinePlaybackRequestResult | null> {
   const launch = await prepareOfflinePlaybackLaunch(container, jobId);
   if (!launch) return null;
-
-  container.stateManager.dispatch({ type: "CLOSE_TOP_OVERLAY" });
 
   const closedBrowse = forceCloseRootContent<BrowseShellResult<SearchResult>>({
     type: "launch-playback",
     launch,
   });
+
+  if (!closedBrowse) {
+    options.onDirectLaunch?.(launch);
+  }
+
+  container.stateManager.dispatch({ type: "CLOSE_TOP_OVERLAY" });
 
   if (closedBrowse) {
     return { status: "browse-handoff", launch };

--- a/apps/cli/test/unit/app-shell/library-playback-handoff.test.tsx
+++ b/apps/cli/test/unit/app-shell/library-playback-handoff.test.tsx
@@ -1,0 +1,125 @@
+import { expect, test } from "bun:test";
+
+import { LibraryShell } from "@/app-shell/library-shell";
+import { handleShellAction } from "@/app-shell/workflows";
+import type { Container } from "@/container";
+import type { OfflineLibraryEntry } from "@/services/offline/offline-library";
+import type { DownloadJobRecord } from "@kunai/storage";
+import React, { act } from "react";
+
+import { render } from "../../harness/render-capture";
+import { createContainerFixture } from "../../support/container-fixture";
+
+const JOB = {
+  id: "job-1",
+  titleId: "title-1",
+  titleName: "Dune: Prophecy",
+  mediaKind: "series",
+  mode: "series",
+  season: 1,
+  episode: 2,
+  outputPath: "/tmp/dune-prophecy-s01e02.mp4",
+  tempPath: "/tmp/dune-prophecy-s01e02.part",
+  streamUrl: "https://example.invalid/dune-prophecy",
+  headers: {},
+  status: "completed",
+  progressPercent: 100,
+  fileSize: 1024 * 1024,
+  retryCount: 0,
+  attempt: 1,
+  maxAttempts: 3,
+  createdAt: "2026-08-14T00:00:00.000Z",
+  updatedAt: "2026-08-14T00:00:00.000Z",
+  completedAt: "2026-08-14T00:00:00.000Z",
+  providerId: "vidking",
+} as DownloadJobRecord;
+
+const ENTRY: OfflineLibraryEntry = { job: JOB, status: "ready" };
+
+async function waitForFrame(
+  handle: { lastFrame: () => string | undefined },
+  needle: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    if (handle.lastFrame()?.includes(needle)) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+  }
+  throw new Error(`frame never contained ${JSON.stringify(needle)}\n${handle.lastFrame() ?? ""}`);
+}
+
+test("/library returns the selected offline episode to the session workflow", async () => {
+  const { container: overlayContainer } = createContainerFixture();
+  const container = {
+    ...overlayContainer,
+    config: {
+      zenMode: false,
+      downloadsEnabled: true,
+      protectedDownloadJobIds: [] as string[],
+      update: async () => undefined,
+      save: async () => undefined,
+    },
+    downloadService: {
+      listActive: () => [],
+      listCompleted: () => [],
+      listFailed: () => [],
+      onEvent: () => () => undefined,
+      deleteJob: () => undefined,
+      abort: async () => undefined,
+      retry: async () => undefined,
+      processQueue: async () => undefined,
+      repairRepairableSidecars: async () => ({
+        checked: 0,
+        repaired: 0,
+        stillRepairable: 0,
+        failed: 0,
+      }),
+    },
+    offlineLibraryService: {
+      listCompletedEntries: async () => [ENTRY],
+      getPlayableSource: async () => ({ status: "ready" as const, job: JOB }),
+    },
+    historyRepository: {
+      listLatestByTitle: () => [],
+      listByTitle: () => [],
+    },
+    connectivity: {
+      isOnline: () => false,
+      subscribe: () => () => undefined,
+    },
+  } as unknown as Container;
+
+  const workflowResult = handleShellAction({ action: "library", container });
+  await Promise.resolve();
+
+  const handle = render(<LibraryShell container={container} onClose={() => {}} />, {
+    columns: 100,
+    rows: 40,
+  });
+  try {
+    await waitForFrame(handle, "Dune: Prophecy");
+    handle.stdin.enqueue("\r");
+    await waitForFrame(handle, "Continue this title online");
+    handle.stdin.enqueue("\r");
+
+    let result: Awaited<typeof workflowResult> | undefined;
+    await act(async () => {
+      result = await workflowResult;
+      await Promise.resolve();
+    });
+    expect(result).toEqual({
+      type: "history-entry",
+      title: {
+        id: "title-1",
+        type: "series",
+        name: "Dune: Prophecy",
+        isAnime: false,
+        launchSource: "offline-library",
+      },
+      episode: { season: 1, episode: 2 },
+    });
+  } finally {
+    handle.unmount();
+  }
+});

--- a/apps/cli/test/unit/app-shell/root-library-playback-bridge.test.ts
+++ b/apps/cli/test/unit/app-shell/root-library-playback-bridge.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+
+import {
+  cancelRootLibraryPlaybackLaunch,
+  resolveRootLibraryPlaybackLaunch,
+  waitForRootLibraryPlaybackLaunch,
+} from "@/app-shell/root-library-playback-bridge";
+
+test("closing Library settles the active playback waiter without leaving a stale launch", async () => {
+  const cancelled = waitForRootLibraryPlaybackLaunch();
+  cancelRootLibraryPlaybackLaunch();
+  await expect(cancelled).resolves.toBeNull();
+
+  const next = waitForRootLibraryPlaybackLaunch();
+  resolveRootLibraryPlaybackLaunch({
+    title: {
+      id: "title-2",
+      type: "movie",
+      name: "Fresh selection",
+      launchSource: "offline-library",
+    },
+  });
+
+  await expect(next).resolves.toEqual({
+    title: {
+      id: "title-2",
+      type: "movie",
+      name: "Fresh selection",
+      launchSource: "offline-library",
+    },
+  });
+});


### PR DESCRIPTION
## Summary

- return a selected offline movie or episode from the root Library overlay to the active session workflow
- deliver direct local launches before closing the overlay, without retaining a stale launch mailbox
- cover both Library and completed Downloads entry points

## Root cause

The root Library workflow always returned handled after its overlay closed. When no retained Browse root owned the launch, requestUnifiedOfflinePlayback returned a direct launch to a component caller that could not propagate it, so SearchPhase returned to Home instead of entering playback.

## Verification

- exact /library title and episode Enter sequence regression test
- stale/cancelled bridge regression test
- offline local playback resolution integration suite, including Obsession
- full bun run test: 4,055 pass, 0 fail
- bun run build
- bun run typecheck
- bun run lint: 0 errors; 5 pre-existing warnings in untouched files
- bun run fmt
- React Doctor changed scope: no issues found