### PR TITLE
fix(installer): contain recursive staging cleanup

### DIFF
--- a/apps/cli/src/services/update/native-installer/install-layout.ts
+++ b/apps/cli/src/services/update/native-installer/install-layout.ts
@@ -1,6 +1,6 @@
 import { rm, rmdir } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, posix, win32 } from "node:path";
 
 import { getKunaiPaths, joinerForNodePlatform, type StoragePlatform } from "@kunai/storage";
 
@@ -142,20 +142,25 @@ export async function removeStagingAndPruneParents(
   stagingPath: string,
   stagingRoot: string,
 ): Promise<void> {
+  if (!isInsideStagingRoot(stagingPath, stagingRoot)) {
+    throw new Error("Refusing to remove path outside the staging root");
+  }
   await rm(stagingPath, { recursive: true, force: true }).catch(() => {});
   await pruneEmptyStagingParents(stagingPath, stagingRoot);
 }
 
-/** Normalized for prefix comparison: forward slashes, no trailing separator. */
-function normalizeDirPath(path: string): string {
-  return path.replaceAll("\\", "/").replace(/\/+$/, "");
-}
-
-/** True when `path` sits inside `root` (and is not `root` itself). */
-export function isInsideStagingRoot(path: string, root: string): boolean {
-  const normalizedRoot = normalizeDirPath(root);
-  const normalizedPath = normalizeDirPath(path);
-  return normalizedPath.startsWith(`${normalizedRoot}/`);
+/** True when `candidate` resolves inside `root` (and is not `root` itself). */
+export function isInsideStagingRoot(candidate: string, root: string): boolean {
+  const pathApi = /^[A-Za-z]:[\\/]/.test(root) || root.startsWith("\\\\") ? win32 : posix;
+  const resolvedRoot = pathApi.resolve(root);
+  const resolvedCandidate = pathApi.resolve(candidate);
+  const relative = pathApi.relative(resolvedRoot, resolvedCandidate);
+  return (
+    relative.length > 0 &&
+    relative !== ".." &&
+    !relative.startsWith(`..${pathApi.sep}`) &&
+    !pathApi.isAbsolute(relative)
+  );
 }
 
 /**

--- a/apps/cli/test/unit/services/update/native-installer/install-layout.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/install-layout.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 
 import {
   getInstallLayoutPaths,
+  isInsideStagingRoot,
   lockFilePath,
   parseVersionFromExecPath,
   removeStagingAndPruneParents,
@@ -13,6 +14,63 @@ import {
 import type { CanonicalVersion } from "@/services/update/version";
 
 describe("install layout paths", () => {
+  const containmentCases = [
+    {
+      label: "POSIX direct child",
+      path: "/cache/kunai/staging/1.2.3",
+      root: "/cache/kunai/staging",
+      expected: true,
+    },
+    {
+      label: "POSIX root",
+      path: "/cache/kunai/staging",
+      root: "/cache/kunai/staging",
+      expected: false,
+    },
+    {
+      label: "POSIX sibling prefix",
+      path: "/cache/kunai/staging-old/1.2.3",
+      root: "/cache/kunai/staging",
+      expected: false,
+    },
+    {
+      label: "POSIX traversal",
+      path: "/cache/kunai/staging/1.2.3/../../../sentinel",
+      root: "/cache/kunai/staging",
+      expected: false,
+    },
+    {
+      label: "Windows direct child",
+      path: String.raw`C:\cache\kunai\staging\1.2.3`,
+      root: String.raw`C:\cache\kunai\staging`,
+      expected: true,
+    },
+    {
+      label: "Windows root",
+      path: String.raw`C:\cache\kunai\staging`,
+      root: String.raw`C:\cache\kunai\staging`,
+      expected: false,
+    },
+    {
+      label: "Windows sibling prefix",
+      path: String.raw`C:\cache\kunai\staging-old\1.2.3`,
+      root: String.raw`C:\cache\kunai\staging`,
+      expected: false,
+    },
+    {
+      label: "Windows traversal",
+      path: String.raw`C:\cache\kunai\staging\1.2.3\..\..\..\sentinel`,
+      root: String.raw`C:\cache\kunai\staging`,
+      expected: false,
+    },
+  ] as const;
+
+  for (const { label, path, root, expected } of containmentCases) {
+    test(`classifies ${label} structurally`, () => {
+      expect(isInsideStagingRoot(path, root)).toBe(expected);
+    });
+  }
+
   test("derives versioned paths from data dir", () => {
     const layout = getInstallLayoutPaths({
       dataDir: "/data/kunai",
@@ -67,5 +125,20 @@ describe("install layout paths", () => {
     await removeStagingAndPruneParents(staging, stagingRoot);
 
     expect(await readdir(cacheDir)).toEqual([]);
+  });
+
+  test("removeStagingAndPruneParents refuses traversal before recursive removal", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai-staging-containment-"));
+    const stagingRoot = join(root, "cache", "staging");
+    const external = join(root, "sentinel");
+    await mkdir(join(stagingRoot, "1.2.3"), { recursive: true });
+    await mkdir(external, { recursive: true });
+    await writeFile(join(external, "keep.txt"), "keep");
+
+    await expect(
+      removeStagingAndPruneParents(`${stagingRoot}/1.2.3/../../../sentinel`, stagingRoot),
+    ).rejects.toThrow("outside the staging root");
+
+    expect(await readdir(external)).toEqual(["keep.txt"]);
   });
 });

--- a/apps/cli/test/unit/services/update/native-installer/transaction.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/transaction.test.ts
@@ -7,6 +7,7 @@ import { join } from "node:path";
 import { getInstallLayoutPaths } from "@/services/update/native-installer/install-layout";
 import {
   beginInstallTransaction,
+  cleanupAbandonedTransactions,
   finishInstallTransaction,
   inspectInstallTransaction,
   listInstallTransactions,
@@ -76,6 +77,28 @@ describe("install transaction records", () => {
     const inspection = await inspectInstallTransaction(layout, record.id);
     expect(inspection.status).toBe("present");
     expect(await readdir(layout.transactionsDir)).toEqual(before);
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("abandoned traversal records cannot remove an external sentinel", async () => {
+    const { root, layout } = await makeLayout();
+    const external = join(root, "external");
+    const sentinel = join(external, "keep.txt");
+    await mkdir(join(layout.stagingRoot, "1.2.3"), { recursive: true });
+    await mkdir(external, { recursive: true });
+    await Bun.write(sentinel, "keep");
+    const record = await beginInstallTransaction(layout, {
+      kind: "upgrade",
+      version: "1.2.3",
+      pid: 2_147_483_646,
+      stagingDir: `${layout.stagingRoot}/1.2.3/../../../external`,
+      startedAt: "2020-01-01T00:00:00.000Z",
+    });
+
+    expect(await cleanupAbandonedTransactions(layout)).toBe(1);
+    expect(existsSync(sentinel)).toBe(true);
+    expect(await inspectInstallTransaction(layout, record.id)).toEqual({ status: "missing" });
 
     await rm(root, { recursive: true, force: true });
   });

--- a/plans/README.md
+++ b/plans/README.md
@@ -153,7 +153,7 @@ Already landed from this audit (no plan needed):
 | ---- | ------------------------------------------------- | -------- | ------ | ---------- | ------ |
 | 039  | Preserve network truth and surface search failure | P0       | S      | —          | DONE   |
 | 040  | Make support-bundle sections exhaustive           | P0       | S      | 039        | TODO   |
-| 041  | Jail installer staging cleanup                    | P0       | S      | —          | TODO   |
+| 041  | Jail installer staging cleanup                    | P0       | S      | —          | DONE   |
 | 042  | Preserve the last-known-good atomic-write target  | P0       | M      | —          | TODO   |
 | 043  | Transact legacy history-key migration             | P1       | S      | —          | TODO   |
 

--- a/plans/archive/041-installer-staging-containment.md
+++ b/plans/archive/041-installer-staging-containment.md
@@ -11,6 +11,7 @@ inside Kunai's staging root before deleting anything.
 - **Effort:** S
 - **Risk:** MED
 - **Planned at:** `207ef937`, 2026-08-14
+- **Completed at:** `a13e991d`, 2026-08-14
 
 ## Current defect
 
@@ -20,15 +21,15 @@ outside `stagingRoot`, after which cleanup performs recursive `rm`.
 
 ## Tasks
 
-- [ ] Add table-driven `install-layout.test.ts` cases for POSIX and Windows:
+- [x] Add table-driven `install-layout.test.ts` cases for POSIX and Windows:
       direct children pass; root, sibling-prefix, and traversal paths fail.
-- [ ] Compare fully resolved paths with `node:path`/`node:path.win32`; never use
+- [x] Compare fully resolved paths with `node:path`/`node:path.win32`; never use
       unresolved `startsWith` as the containment decision.
-- [ ] Make `removeStagingAndPruneParents` fail closed before its first `rm` when the
+- [x] Make `removeStagingAndPruneParents` fail closed before its first `rm` when the
       candidate is outside the staging root.
-- [ ] Add a dead-PID transaction cleanup test with a traversal path and an external
+- [x] Add a dead-PID transaction cleanup test with a traversal path and an external
       sentinel; prove cleanup cannot remove the sentinel.
-- [ ] Keep ordinary version/root pruning behavior on valid staging paths.
+- [x] Keep ordinary version/root pruning behavior on valid staging paths.
 
 ## Verification
 

--- a/plans/archive/README.md
+++ b/plans/archive/README.md
@@ -8,7 +8,7 @@ work to do.
 commit that is now far behind, and its "Current state" excerpts describe code
 that has since changed.
 
-Archived so far: 001–005, 007, 009, 017, 018, 019, 020, 024, 026, 039.
+Archived so far: 001–005, 007, 009, 017, 018, 019, 020, 024, 026, 039, 041.
 
 ## Notes worth carrying forward
 


### PR DESCRIPTION
## Summary

- replace lexical staging-prefix checks with resolved POSIX/Windows structural containment
- reject unsafe direct cleanup before the first recursive removal
- prove abandoned traversal records cannot delete an external sentinel
- mark plan 041 complete and archive it with the implementation

## Root cause

`isInsideStagingRoot` normalized separators but did not resolve `..`. A persisted abandoned transaction could therefore pass the prefix check while resolving outside the staging root, after which cleanup performed recursive `rm`.

## Verification

- focused containment and transaction tests: 16 passed
- native installer unit suite: 84 passed
- full repository suite: 4,065 passed, 0 failed
- `bun run build`
- `bun run typecheck`
- `bun run lint` (0 errors; 5 pre-existing warnings)
- `bun run fmt`
- `bun run verify:doc-paths`
- pre-push full suite: 4,065 passed, 0 failed