### PR TITLE
fix(storage): preserve atomic write targets on Windows

### DIFF
--- a/apps/cli/src/infra/fs/atomic-write.ts
+++ b/apps/cli/src/infra/fs/atomic-write.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, rename, unlink } from "node:fs/promises";
+import { chmod, lstat, mkdir, rename, unlink } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 
 function tempPath(targetPath: string): string {
@@ -7,21 +7,98 @@ function tempPath(targetPath: string): string {
   return join(dir, `.${base}.${process.pid}-${Math.random().toString(36).slice(2, 10)}.tmp`);
 }
 
-async function atomicMove(tmp: string, targetPath: string): Promise<void> {
+function backupPath(targetPath: string): string {
+  const dir = dirname(targetPath);
+  const base = basename(targetPath);
+  return join(dir, `.${base}.${process.pid}-${Math.random().toString(36).slice(2, 10)}.bak`);
+}
+
+interface AtomicFileOps {
+  lstat(path: string): Promise<{ isDirectory(): boolean }>;
+  rename(from: string, to: string): Promise<void>;
+  unlink(path: string): Promise<void>;
+}
+
+interface AtomicMoveOptions {
+  backupPath?: string;
+  fs?: AtomicFileOps;
+  platform?: NodeJS.Platform;
+}
+
+const nodeAtomicFileOps: AtomicFileOps = { lstat, rename, unlink };
+
+function isWindowsReplaceConflict(error: unknown, platform: NodeJS.Platform): boolean {
+  const code = (error as NodeJS.ErrnoException)?.code;
+  return platform === "win32" && (code === "EPERM" || code === "EEXIST" || code === "ENOTEMPTY");
+}
+
+async function removeIfPresent(path: string, fs: AtomicFileOps): Promise<void> {
+  await fs.unlink(path).catch(() => {});
+}
+
+async function atomicMove(
+  tmp: string,
+  targetPath: string,
+  options: AtomicMoveOptions = {},
+): Promise<void> {
+  const fs = options.fs ?? nodeAtomicFileOps;
+  const platform = options.platform ?? process.platform;
+
   try {
-    await rename(tmp, targetPath);
+    await fs.rename(tmp, targetPath);
   } catch (err) {
-    const code = (err as NodeJS.ErrnoException)?.code;
-    if (
-      process.platform === "win32" &&
-      (code === "EPERM" || code === "EEXIST" || code === "ENOTEMPTY")
-    ) {
-      await unlink(targetPath).catch(() => {});
-      await rename(tmp, targetPath);
-    } else {
-      await unlink(tmp).catch(() => {});
+    if (!isWindowsReplaceConflict(err, platform)) {
+      await removeIfPresent(tmp, fs);
       throw err;
     }
+
+    const targetStats = await fs.lstat(targetPath).catch(async (statError) => {
+      await removeIfPresent(tmp, fs);
+      const failure = new AggregateError(
+        [err, statError],
+        "Atomic replacement failed while inspecting the previous target",
+        { cause: statError },
+      );
+      throw failure;
+    });
+    if (targetStats.isDirectory()) {
+      await removeIfPresent(tmp, fs);
+      throw err;
+    }
+
+    const backup = options.backupPath ?? backupPath(targetPath);
+    try {
+      await fs.rename(targetPath, backup);
+    } catch (backupError) {
+      await removeIfPresent(tmp, fs);
+      const failure = new AggregateError(
+        [err, backupError],
+        "Atomic replacement failed before the previous target could be preserved",
+        { cause: backupError },
+      );
+      throw failure;
+    }
+
+    try {
+      await fs.rename(tmp, targetPath);
+    } catch (installError) {
+      try {
+        await fs.rename(backup, targetPath);
+      } catch (restoreError) {
+        await removeIfPresent(tmp, fs);
+        const failure = new AggregateError(
+          [installError, restoreError],
+          `Atomic replacement and restoration failed; previous target retained at ${backup}`,
+          { cause: restoreError },
+        );
+        throw failure;
+      }
+
+      await removeIfPresent(tmp, fs);
+      throw installError;
+    }
+
+    await fs.unlink(backup);
   }
 }
 
@@ -85,3 +162,5 @@ export async function writeAtomicSecretText(targetPath: string, contents: string
 export async function writeAtomicSecretJson(targetPath: string, value: unknown): Promise<void> {
   await writeAtomicSecretText(targetPath, JSON.stringify(value, null, 2));
 }
+
+export const __testing = { atomicMove };

--- a/apps/cli/test/unit/infra/fs/atomic-write.test.ts
+++ b/apps/cli/test/unit/infra/fs/atomic-write.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { lstat, mkdir, mkdtemp, readFile, rename, rm, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { __testing } from "@/infra/fs/atomic-write";
+
+const roots: string[] = [];
+
+async function makeFiles(): Promise<{
+  backup: string;
+  root: string;
+  target: string;
+  tmp: string;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "kunai-atomic-write-"));
+  roots.push(root);
+  const target = join(root, "config.json");
+  const tmp = join(root, ".config.json.tmp");
+  const backup = join(root, ".config.json.backup");
+  await writeFile(target, "old");
+  await writeFile(tmp, "new");
+  return { backup, root, target, tmp };
+}
+
+function fsError(code: string, message: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), { code });
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("atomicMove", () => {
+  test("normally replaces the target without leaving temporary files", async () => {
+    const { backup, target, tmp } = await makeFiles();
+
+    await __testing.atomicMove(tmp, target, {
+      backupPath: backup,
+      fs: { lstat, rename, unlink },
+      platform: "linux",
+    });
+
+    expect(await readFile(target, "utf8")).toBe("new");
+    expect(existsSync(tmp)).toBe(false);
+    expect(existsSync(backup)).toBe(false);
+  });
+
+  test("uses a same-directory backup for the Windows replacement fallback", async () => {
+    const { target, tmp } = await makeFiles();
+    const operations: string[] = [];
+    let generatedBackup: string | undefined;
+    let renameAttempt = 0;
+
+    await __testing.atomicMove(tmp, target, {
+      fs: {
+        lstat,
+        rename: async (from, to) => {
+          operations.push(`rename:${from}->${to}`);
+          renameAttempt += 1;
+          if (renameAttempt === 1) throw fsError("EPERM", "replace blocked");
+          if (renameAttempt === 2) generatedBackup = to;
+          await rename(from, to);
+        },
+        unlink: async (path) => {
+          operations.push(`unlink:${path}`);
+          await unlink(path);
+        },
+      },
+      platform: "win32",
+    });
+
+    expect(await readFile(target, "utf8")).toBe("new");
+    expect(existsSync(tmp)).toBe(false);
+    expect(generatedBackup).toBeDefined();
+    expect(dirname(generatedBackup!)).toBe(dirname(target));
+    expect(existsSync(generatedBackup!)).toBe(false);
+    expect(operations).toEqual([
+      `rename:${tmp}->${target}`,
+      `rename:${target}->${generatedBackup}`,
+      `rename:${tmp}->${target}`,
+      `unlink:${generatedBackup}`,
+    ]);
+  });
+
+  test("does not treat a directory as a replaceable Windows file target", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai-atomic-write-directory-"));
+    roots.push(root);
+    const target = join(root, "config.json");
+    const tmp = join(root, ".config.json.tmp");
+    await mkdir(target);
+    await writeFile(tmp, "new");
+
+    const result = __testing.atomicMove(tmp, target, {
+      fs: {
+        lstat,
+        rename: async () => {
+          throw fsError("EEXIST", "replace blocked");
+        },
+        unlink,
+      },
+      platform: "win32",
+    });
+
+    await expect(result).rejects.toThrow("replace blocked");
+    expect((await lstat(target)).isDirectory()).toBe(true);
+    expect(existsSync(tmp)).toBe(false);
+  });
+
+  test("restores the original target and cleans the temp file when installation fails", async () => {
+    const { backup, target, tmp } = await makeFiles();
+    let renameAttempt = 0;
+
+    const result = __testing.atomicMove(tmp, target, {
+      backupPath: backup,
+      fs: {
+        lstat,
+        rename: async (from, to) => {
+          renameAttempt += 1;
+          if (renameAttempt === 1) throw fsError("EPERM", "replace blocked");
+          if (renameAttempt === 3) throw fsError("EIO", "install failed");
+          await rename(from, to);
+        },
+        unlink,
+      },
+      platform: "win32",
+    });
+
+    await expect(result).rejects.toThrow("install failed");
+    expect(await readFile(target, "utf8")).toBe("old");
+    expect(existsSync(tmp)).toBe(false);
+    expect(existsSync(backup)).toBe(false);
+  });
+
+  test("retains the backup and reports both errors when restoration also fails", async () => {
+    const { backup, target, tmp } = await makeFiles();
+    let renameAttempt = 0;
+
+    const result = __testing.atomicMove(tmp, target, {
+      backupPath: backup,
+      fs: {
+        lstat,
+        rename: async (from, to) => {
+          renameAttempt += 1;
+          if (renameAttempt === 1) throw fsError("EPERM", "replace blocked");
+          if (renameAttempt === 3) throw fsError("EIO", "install failed");
+          if (renameAttempt === 4) throw fsError("EACCES", "restore failed");
+          await rename(from, to);
+        },
+        unlink,
+      },
+      platform: "win32",
+    });
+
+    const error = await result.catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors.map(String)).toEqual([
+      "Error: install failed",
+      "Error: restore failed",
+    ]);
+    expect(existsSync(target)).toBe(false);
+    expect(existsSync(tmp)).toBe(false);
+    expect(await readFile(backup, "utf8")).toBe("old");
+  });
+});

--- a/plans/README.md
+++ b/plans/README.md
@@ -154,7 +154,7 @@ Already landed from this audit (no plan needed):
 | 039  | Preserve network truth and surface search failure | P0       | S      | —          | DONE   |
 | 040  | Make support-bundle sections exhaustive           | P0       | S      | 039        | TODO   |
 | 041  | Jail installer staging cleanup                    | P0       | S      | —          | DONE   |
-| 042  | Preserve the last-known-good atomic-write target  | P0       | M      | —          | TODO   |
+| 042  | Preserve the last-known-good atomic-write target  | P0       | M      | —          | DONE   |
 | 043  | Transact legacy history-key migration             | P1       | S      | —          | TODO   |
 
 Plans 039 and 040 are sequenced because the first fixes the user-visible search

--- a/plans/archive/042-atomic-json-last-known-good.md
+++ b/plans/archive/042-atomic-json-last-known-good.md
@@ -11,6 +11,7 @@ token, metadata, or support-bundle file.
 - **Effort:** M
 - **Risk:** MED
 - **Planned at:** `207ef937`, 2026-08-14
+- **Completed at:** `fd6f1458`, 2026-08-14
 
 ## Current defect
 
@@ -19,16 +20,16 @@ then retries the rename. If that rename fails, the old target is already gone.
 
 ## Tasks
 
-- [ ] Refactor filesystem operations behind a package-private injected adapter so
+- [x] Refactor filesystem operations behind a package-private injected adapter so
       failure ordering is testable without replacing `process.platform`.
-- [ ] Add `apps/cli/test/unit/infra/fs/atomic-write.test.ts` covering normal replace
+- [x] Add `apps/cli/test/unit/infra/fs/atomic-write.test.ts` covering normal replace
       and the Windows fallback.
-- [ ] Prove a failed replacement leaves the original bytes readable and cleans temp
+- [x] Prove a failed replacement leaves the original bytes readable and cleans temp
       files.
-- [ ] Replace through a same-directory backup; remove it only after success and
+- [x] Replace through a same-directory backup; remove it only after success and
       restore it if installing the temp file fails.
-- [ ] If restoration fails, retain the backup and throw both failure contexts.
-- [ ] Preserve pre-rename `0o600` on POSIX secret writers and all public APIs.
+- [x] If restoration fails, retain the backup and throw both failure contexts.
+- [x] Preserve pre-rename `0o600` on POSIX secret writers and all public APIs.
 
 ## Verification
 

--- a/plans/archive/README.md
+++ b/plans/archive/README.md
@@ -8,7 +8,7 @@ work to do.
 commit that is now far behind, and its "Current state" excerpts describe code
 that has since changed.
 
-Archived so far: 001–005, 007, 009, 017, 018, 019, 020, 024, 026, 039, 041.
+Archived so far: 001–005, 007, 009, 017, 018, 019, 020, 024, 026, 039, 041, 042.
 
 ## Notes worth carrying forward
 


### PR DESCRIPTION
## Summary

- replace the destructive Windows unlink fallback with a same-directory backup transaction
- restore the previous target if installing the temp file fails
- retain the backup and report both failure contexts if restoration also fails
- preserve existing public writers and pre-rename `0o600` handling
- mark plan 042 complete and archive it

## Root cause

On Windows replacement errors (`EPERM`, `EEXIST`, or `ENOTEMPTY`), the fallback deleted the valid target before retrying the rename. If that second rename failed, config, token, metadata, or support-bundle contents were lost.

## Verification

- focused atomic-write and FileStorage tests: 8 passed
- full repository suite: 4,069 passed, 0 failed
- pre-push full suite: 4,069 passed, 0 failed
- `bun run build`
- `bun run typecheck`
- `bun run lint` (0 errors; 5 pre-existing warnings)
- `bun run fmt`
- `bun run verify:doc-paths`