### PR TITLE
fix(installer): preserve the Windows launcher on activation failure

### DIFF
--- a/apps/cli/src/services/update/native-installer/launcher.ts
+++ b/apps/cli/src/services/update/native-installer/launcher.ts
@@ -13,16 +13,91 @@ import {
 } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 
+interface LauncherFileOps {
+  chmod(path: string, mode: number): Promise<void>;
+  copyFile(from: string, to: string): Promise<void>;
+  rename(from: string, to: string): Promise<void>;
+  rm(path: string, options: { force: true }): Promise<void>;
+}
+
+const nodeLauncherFileOps: LauncherFileOps = { chmod, copyFile, rename, rm };
+
 /** Retry rename to absorb transient AV/Defender locks (mainly Windows). */
-async function renameWithRetry(from: string, to: string, attempts = 5): Promise<void> {
+async function renameWithRetry(
+  from: string,
+  to: string,
+  options: {
+    readonly attempts?: number;
+    readonly fs?: LauncherFileOps;
+    readonly sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<void> {
+  const attempts = options.attempts ?? 5;
+  const fs = options.fs ?? nodeLauncherFileOps;
+  const sleep = options.sleep ?? Bun.sleep;
   for (let i = 0; i < attempts; i++) {
     try {
-      await rename(from, to);
+      await fs.rename(from, to);
       return;
     } catch (err) {
       if (i === attempts - 1) throw err;
-      await Bun.sleep(150 * (i + 1));
+      await sleep(150 * (i + 1));
     }
+  }
+}
+
+interface WindowsLauncherOptions {
+  readonly asidePath?: string;
+  readonly attempts?: number;
+  readonly candidatePath?: string;
+  readonly fs?: LauncherFileOps;
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+async function updateWindowsLauncher(
+  input: { readonly launcherPath: string; readonly versionPath: string },
+  options: WindowsLauncherOptions = {},
+): Promise<void> {
+  const fs = options.fs ?? nodeLauncherFileOps;
+  const suffix = `${process.pid}.${Date.now()}`;
+  const candidate = options.candidatePath ?? `${input.launcherPath}.new.${suffix}`;
+  const aside = options.asidePath ?? `${input.launcherPath}.old.${Date.now()}`;
+  const renameOptions = {
+    attempts: options.attempts,
+    fs,
+    sleep: options.sleep,
+  };
+
+  await fs.rm(candidate, { force: true }).catch(() => {});
+  try {
+    // Finish staging the replacement before moving the last-known-good launcher.
+    await fs.copyFile(input.versionPath, candidate);
+    await fs.chmod(candidate, 0o755).catch(() => {});
+
+    if (!existsSync(input.launcherPath)) {
+      await renameWithRetry(candidate, input.launcherPath, renameOptions);
+      return;
+    }
+
+    await fs.rm(aside, { force: true }).catch(() => {});
+    await renameWithRetry(input.launcherPath, aside, renameOptions);
+    try {
+      await renameWithRetry(candidate, input.launcherPath, renameOptions);
+    } catch (installError) {
+      try {
+        await renameWithRetry(aside, input.launcherPath, renameOptions);
+      } catch (restoreError) {
+        const failure = new AggregateError(
+          [installError, restoreError],
+          `Launcher activation and restoration failed; previous launcher retained at ${aside}`,
+          { cause: restoreError },
+        );
+        throw failure;
+      }
+      throw installError;
+    }
+  } finally {
+    await fs.rm(candidate, { force: true }).catch(() => {});
   }
 }
 
@@ -65,15 +140,7 @@ export async function updateLauncher(input: {
   await mkdir(dirname(input.launcherPath), { recursive: true });
 
   if (platform === "win32") {
-    if (existsSync(input.launcherPath)) {
-      const aside = `${input.launcherPath}.old.${Date.now()}`;
-      await rm(aside, { force: true }).catch(() => {});
-      await renameWithRetry(input.launcherPath, aside).catch(async () => {
-        await rm(input.launcherPath, { force: true });
-      });
-    }
-    await copyFile(input.versionPath, input.launcherPath);
-    await chmod(input.launcherPath, 0o755).catch(() => {});
+    await updateWindowsLauncher(input);
     return;
   }
 
@@ -171,3 +238,5 @@ export async function removeLauncherIfVersioned(input: {
   await rm(input.launcherPath, { force: true });
   return true;
 }
+
+export const __testing = { updateWindowsLauncher };

--- a/apps/cli/test/unit/services/update/native-installer/launcher.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/launcher.test.ts
@@ -1,11 +1,22 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readdir, readlink, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readlink,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  __testing,
   atomicInstallBinaryFromFile,
   atomicWriteBinary,
   inspectLauncherOwnership,
@@ -78,6 +89,151 @@ describe("launcher", () => {
     expect(removed.length).toBeGreaterThan(0);
     expect(await readdir(join(root, "bin"))).toEqual(["kunai.exe"]);
     expect(await Bun.file(launcherPath).text()).toBe("V2-BINARY");
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("Windows activation preserves the working launcher when staging the replacement fails", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai-launcher-win-stage-failure-"));
+    const launcherPath = join(root, "bin", "kunai.exe");
+    const missingVersionPath = join(root, "versions", "2.0.0", "kunai.exe");
+    await mkdir(join(root, "bin"), { recursive: true });
+    await writeFile(launcherPath, "WORKING-BINARY");
+
+    await expect(
+      updateLauncher({
+        launcherPath,
+        versionPath: missingVersionPath,
+        platform: "win32",
+      }),
+    ).rejects.toThrow();
+
+    expect(await Bun.file(launcherPath).text()).toBe("WORKING-BINARY");
+    expect(await readdir(join(root, "bin"))).toEqual(["kunai.exe"]);
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("Windows activation restores the working launcher when installing the candidate fails", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai-launcher-win-activate-failure-"));
+    const launcherPath = join(root, "bin", "kunai.exe");
+    const versionPath = join(root, "versions", "2.0.0", "kunai.exe");
+    const candidatePath = `${launcherPath}.candidate`;
+    const asidePath = `${launcherPath}.old.test`;
+    await mkdir(join(root, "bin"), { recursive: true });
+    await mkdir(join(root, "versions", "2.0.0"), { recursive: true });
+    await writeFile(launcherPath, "WORKING-BINARY");
+    await writeFile(versionPath, "NEW-BINARY");
+
+    let renameAttempt = 0;
+    const result = __testing.updateWindowsLauncher(
+      { launcherPath, versionPath },
+      {
+        asidePath,
+        attempts: 1,
+        candidatePath,
+        fs: {
+          chmod,
+          copyFile,
+          rename: async (from, to) => {
+            renameAttempt += 1;
+            if (renameAttempt === 2)
+              throw Object.assign(new Error("activate failed"), { code: "EIO" });
+            await rename(from, to);
+          },
+          rm: (path, options) => rm(path, options),
+        },
+        sleep: async () => {},
+      },
+    );
+
+    await expect(result).rejects.toThrow("activate failed");
+    expect(await Bun.file(launcherPath).text()).toBe("WORKING-BINARY");
+    expect(existsSync(candidatePath)).toBe(false);
+    expect(existsSync(asidePath)).toBe(false);
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("Windows activation never deletes the working launcher when it cannot move it aside", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai-launcher-win-aside-failure-"));
+    const launcherPath = join(root, "bin", "kunai.exe");
+    const versionPath = join(root, "versions", "2.0.0", "kunai.exe");
+    const candidatePath = `${launcherPath}.candidate`;
+    const asidePath = `${launcherPath}.old.test`;
+    await mkdir(join(root, "bin"), { recursive: true });
+    await mkdir(join(root, "versions", "2.0.0"), { recursive: true });
+    await writeFile(launcherPath, "WORKING-BINARY");
+    await writeFile(versionPath, "NEW-BINARY");
+
+    const result = __testing.updateWindowsLauncher(
+      { launcherPath, versionPath },
+      {
+        asidePath,
+        attempts: 1,
+        candidatePath,
+        fs: {
+          chmod,
+          copyFile,
+          rename: async () => {
+            throw new Error("aside failed");
+          },
+          rm: (path, options) => rm(path, options),
+        },
+        sleep: async () => {},
+      },
+    );
+
+    await expect(result).rejects.toThrow("aside failed");
+    expect(await Bun.file(launcherPath).text()).toBe("WORKING-BINARY");
+    expect(existsSync(candidatePath)).toBe(false);
+    expect(existsSync(asidePath)).toBe(false);
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("Windows activation retains the last-known-good aside when restoration fails", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai-launcher-win-restore-failure-"));
+    const launcherPath = join(root, "bin", "kunai.exe");
+    const versionPath = join(root, "versions", "2.0.0", "kunai.exe");
+    const candidatePath = `${launcherPath}.candidate`;
+    const asidePath = `${launcherPath}.old.test`;
+    await mkdir(join(root, "bin"), { recursive: true });
+    await mkdir(join(root, "versions", "2.0.0"), { recursive: true });
+    await writeFile(launcherPath, "WORKING-BINARY");
+    await writeFile(versionPath, "NEW-BINARY");
+
+    let renameAttempt = 0;
+    const result = __testing.updateWindowsLauncher(
+      { launcherPath, versionPath },
+      {
+        asidePath,
+        attempts: 1,
+        candidatePath,
+        fs: {
+          chmod,
+          copyFile,
+          rename: async (from, to) => {
+            renameAttempt += 1;
+            if (renameAttempt === 2) throw new Error("activate failed");
+            if (renameAttempt === 3) throw new Error("restore failed");
+            await rename(from, to);
+          },
+          rm: (path, options) => rm(path, options),
+        },
+        sleep: async () => {},
+      },
+    );
+
+    const error = await result.catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors.map(String)).toEqual([
+      "Error: activate failed",
+      "Error: restore failed",
+    ]);
+    expect(existsSync(launcherPath)).toBe(false);
+    expect(existsSync(candidatePath)).toBe(false);
+    expect(await Bun.file(asidePath).text()).toBe("WORKING-BINARY");
 
     await rm(root, { recursive: true, force: true });
   });

--- a/plans/README.md
+++ b/plans/README.md
@@ -156,10 +156,11 @@ Already landed from this audit (no plan needed):
 | 041  | Jail installer staging cleanup                    | P0       | S      | —          | DONE   |
 | 042  | Preserve the last-known-good atomic-write target  | P0       | M      | —          | DONE   |
 | 043  | Transact legacy history-key migration             | P1       | S      | —          | TODO   |
+| 044  | Preserve the working Windows launcher             | P0       | S      | —          | DONE   |
 
 Plans 039 and 040 are sequenced because the first fixes the user-visible search
 failure and the second guarantees its search/session diagnostics survive export.
-Plans 041–043 are independent and should remain separate implementation PRs.
+Plans 041–044 are independent and should remain separate implementation PRs.
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (one-line reason) | REJECTED (one-line rationale)
 

--- a/plans/archive/044-windows-launcher-last-known-good.md
+++ b/plans/archive/044-windows-launcher-last-known-good.md
@@ -1,0 +1,44 @@
+# Plan 044: Preserve the working Windows launcher
+
+> **Drift check:** `git diff --stat 1abbb481..HEAD -- apps/cli/src/services/update/native-installer/launcher.ts apps/cli/test/unit/services/update/native-installer/launcher.test.ts`
+
+**Goal:** A failed Windows launcher upgrade must leave either the previous launcher
+at its public path or an explicit recoverable same-directory copy-aside.
+
+## Status
+
+- **Priority:** P0
+- **Effort:** S
+- **Risk:** MED
+- **Planned at:** `1abbb481`, 2026-08-14
+- **Completed at:** `22c09d96`, 2026-08-14
+
+## Defect
+
+Windows activation moved the working launcher aside before copying the new binary.
+If staging failed, the public launcher disappeared. If moving the launcher aside
+failed, the fallback deleted it before attempting the replacement, creating a
+second last-known-good loss window.
+
+## Completed tasks
+
+- [x] Stage and chmod the replacement beside the launcher before touching the live
+      executable.
+- [x] Remove the destructive delete-on-rename-failure fallback.
+- [x] Restore the previous launcher if candidate activation fails.
+- [x] Retain the copy-aside and report both errors if restoration also fails.
+- [x] Cover staging, activation, and restoration failure ordering with deterministic
+      unit tests.
+- [x] Preserve the existing Unix symlink path and Windows ownership contract.
+
+## Verification
+
+```sh
+bun run --cwd apps/cli test -- test/unit/services/update/native-installer/launcher.test.ts
+bun run --cwd apps/cli test -- test/unit/services/update/native-installer
+bun run typecheck
+bun run lint
+bun run fmt
+bun run test
+bun run build
+```

--- a/plans/archive/README.md
+++ b/plans/archive/README.md
@@ -8,7 +8,7 @@ work to do.
 commit that is now far behind, and its "Current state" excerpts describe code
 that has since changed.
 
-Archived so far: 001–005, 007, 009, 017, 018, 019, 020, 024, 026, 039, 041, 042.
+Archived so far: 001–005, 007, 009, 017, 018, 019, 020, 024, 026, 039, 041, 042, 044.
 
 ## Notes worth carrying forward
 


### PR DESCRIPTION
## Summary

- stage the Windows replacement executable before touching the live launcher
- remove the destructive delete-on-rename-failure fallback
- restore the prior launcher when candidate activation fails
- retain a recoverable copy-aside and report both errors when restoration fails
- record K-05 as completed in archived plan 044

## Root cause

Windows activation moved or deleted the working launcher before proving that the replacement could be staged and installed. Failures in either window could leave the public `kunai.exe` path missing.

## Verification

- focused launcher tests: 14 passed
- native installer unit suite: 87 passed
- full repository suite: 4,074 passed, 0 failed
- pre-push full suite: 4,074 passed, 0 failed
- `bun run build`
- `bun run typecheck`
- `bun run lint` (0 errors; 5 pre-existing warnings)
- `bun run fmt`
- `bun run verify:doc-paths`