### PR TITLE
fix(diagnostics): export every diagnostic category

### DIFF
--- a/.docs/diagnostics-guide.md
+++ b/.docs/diagnostics-guide.md
@@ -95,13 +95,15 @@ exported events. Use those IDs to join provider fallback, cache checks, mpv
 runtime events, presence background failures, and debug JSONL rows without
 guessing from timestamps.
 
-Support bundle sections include the latest operation for each active category,
-including `presence` and `download`, so a report can show whether Discord clear
-failed, a download artifact was validated, or a queue failure happened without
-reading the full event log first. Bundles also include `insights` for provider
-resolve, resolve-work graphs, source-inventory cache, post-playback timing, and
-repairable downloads so the common questions are visible without reading every
-event.
+Support bundle sections include the latest operation for every active diagnostic
+category. The section taxonomy is shared with runtime event validation, so new
+categories cannot be accepted by the runtime and then silently omitted from an
+export. This includes `presence` and `download`, so a report can show whether
+Discord clear failed, a download artifact was validated, or a queue failure
+happened without reading the full event log first. Bundles also include
+`insights` for provider resolve, resolve-work graphs, source-inventory cache,
+post-playback timing, and repairable downloads so the common questions are
+visible without reading every event.
 
 Resolve-work insights are local-only. They summarize one physical resolve per
 ledger, joined lanes/intents, cache provenance, provider attempt graph,

--- a/apps/cli/src/services/diagnostics/diagnostic-event.ts
+++ b/apps/cli/src/services/diagnostics/diagnostic-event.ts
@@ -1,19 +1,22 @@
 export type DiagnosticLevel = "debug" | "info" | "warn" | "error";
 
-export type DiagnosticCategory =
-  | "session"
-  | "search"
-  | "provider"
-  | "subtitle"
-  | "playback"
-  | "cache"
-  | "ui"
-  | "network"
-  | "runtime"
-  | "presence"
-  | "download"
-  | "offline"
-  | "update";
+export const DIAGNOSTIC_CATEGORIES = [
+  "session",
+  "search",
+  "provider",
+  "subtitle",
+  "playback",
+  "cache",
+  "ui",
+  "network",
+  "runtime",
+  "presence",
+  "download",
+  "offline",
+  "update",
+] as const;
+
+export type DiagnosticCategory = (typeof DIAGNOSTIC_CATEGORIES)[number];
 
 export type DiagnosticEvent = {
   readonly timestamp: number;

--- a/apps/cli/src/services/diagnostics/support-bundle.ts
+++ b/apps/cli/src/services/diagnostics/support-bundle.ts
@@ -5,7 +5,7 @@ import {
   resolveBundleRedactionOptions,
   type BundleRedactionOptions,
 } from "./bundle-redaction";
-import type { DiagnosticEvent } from "./diagnostic-event";
+import { DIAGNOSTIC_CATEGORIES, type DiagnosticEvent } from "./diagnostic-event";
 import {
   mapFailureToRecommendedAction,
   type DiagnosticFailureClass,
@@ -541,19 +541,8 @@ function formatIssueHeadline(event: DiagnosticEvent): string {
 function buildBundleSections(
   events: readonly DiagnosticEvent[],
 ): Record<string, DiagnosticsBundleSection> {
-  const sectionNames = [
-    "network",
-    "provider",
-    "cache",
-    "playback",
-    "subtitle",
-    "presence",
-    "offline",
-    "download",
-    "runtime",
-  ];
   const sections: Record<string, DiagnosticsBundleSection> = {};
-  for (const name of sectionNames) {
+  for (const name of DIAGNOSTIC_CATEGORIES) {
     const matching = events.filter((event) => event.category === name);
     if (matching.length === 0) continue;
     const latest = matching.at(-1);

--- a/apps/cli/test/unit/services/diagnostics/support-bundle.test.ts
+++ b/apps/cli/test/unit/services/diagnostics/support-bundle.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { DIAGNOSTIC_CATEGORIES } from "@/services/diagnostics/diagnostic-event";
 import { resolveRedactionHomeDir } from "@/services/diagnostics/redaction";
 import {
   applySupportBundleSizeBudget,
@@ -11,6 +12,23 @@ import {
 const TEST_HOME = resolveRedactionHomeDir() ?? "/home/kunai-test";
 
 describe("DiagnosticsSupportBundle", () => {
+  test("exports a section for every diagnostic category in taxonomy order", () => {
+    const bundle = buildDiagnosticsSupportBundle({
+      appVersion: "0.1.0",
+      debug: false,
+      events: DIAGNOSTIC_CATEGORIES.map((category, index) => ({
+        timestamp: index + 1,
+        category,
+        level: "info" as const,
+        operation: `${category}.test`,
+        message: `${category} diagnostic`,
+      })),
+    });
+
+    expect(Object.keys(bundle.sections)).toEqual([...DIAGNOSTIC_CATEGORIES]);
+    expect(bundle.summary.sections).toEqual([...DIAGNOSTIC_CATEGORIES]);
+  });
+
   test("builds layered summary and section metadata", () => {
     const bundle = buildDiagnosticsSupportBundle({
       appVersion: "0.1.0",
@@ -36,7 +54,7 @@ describe("DiagnosticsSupportBundle", () => {
 
     expect(bundle.summary.headline).toBe("Network unavailable");
     expect(bundle.triage.likelyCause).toBe("Network unavailable");
-    expect(bundle.summary.sections).toEqual(["network", "provider"]);
+    expect(bundle.summary.sections).toEqual(["provider", "network"]);
     expect(bundle.sections.network).toMatchObject({ tone: "warning", eventCount: 1 });
     expect(bundle.sections.provider).toMatchObject({ tone: "neutral", eventCount: 1 });
     expect(bundle.privacy).toEqual({

--- a/plans/README.md
+++ b/plans/README.md
@@ -152,7 +152,7 @@ Already landed from this audit (no plan needed):
 | Plan | Title                                             | Priority | Effort | Depends on | Status |
 | ---- | ------------------------------------------------- | -------- | ------ | ---------- | ------ |
 | 039  | Preserve network truth and surface search failure | P0       | S      | —          | DONE   |
-| 040  | Make support-bundle sections exhaustive           | P0       | S      | 039        | TODO   |
+| 040  | Make support-bundle sections exhaustive           | P0       | S      | 039        | DONE   |
 | 041  | Jail installer staging cleanup                    | P0       | S      | —          | DONE   |
 | 042  | Preserve the last-known-good atomic-write target  | P0       | M      | —          | DONE   |
 | 043  | Transact legacy history-key migration             | P1       | S      | —          | TODO   |

--- a/plans/archive/040-support-bundle-taxonomy-parity.md
+++ b/plans/archive/040-support-bundle-taxonomy-parity.md
@@ -19,13 +19,13 @@ hardcodes nine and silently drops `session`, `search`, `ui`, and `update`.
 
 ## Tasks
 
-- [ ] Export one readonly `DIAGNOSTIC_CATEGORIES` tuple from `diagnostic-event.ts`
+- [x] Export one readonly `DIAGNOSTIC_CATEGORIES` tuple from `diagnostic-event.ts`
       and derive `DiagnosticCategory` from `(typeof DIAGNOSTIC_CATEGORIES)[number]`.
-- [ ] Add a failing table-driven `support-bundle.test.ts` case with one event per
+- [x] Add a failing table-driven `support-bundle.test.ts` case with one event per
       category; expect all thirteen section keys in tuple order.
-- [ ] Make `buildBundleSections` iterate the shared tuple. Keep omitting categories
+- [x] Make `buildBundleSections` iterate the shared tuple. Keep omitting categories
       with zero events and retain current privacy and size budgets.
-- [ ] Do not add empty per-category configuration or a second allowlist.
+- [x] Do not add empty per-category configuration or a second allowlist.
 
 ## Verification
 

--- a/plans/archive/README.md
+++ b/plans/archive/README.md
@@ -8,7 +8,7 @@ work to do.
 commit that is now far behind, and its "Current state" excerpts describe code
 that has since changed.
 
-Archived so far: 001–005, 007, 009, 017, 018, 019, 020, 024, 026, 039, 041, 042, 044, 045.
+Archived so far: 001–005, 007, 009, 017, 018, 019, 020, 024, 026, 039–042, 044, 045.
 
 ## Notes worth carrying forward
 


### PR DESCRIPTION
## Summary
- define the diagnostic category taxonomy once and derive its TypeScript type from that tuple
- build support-bundle sections from the shared taxonomy so session, search, UI, and update evidence cannot disappear
- add an exhaustive regression test and archive completed plan 040

## Verification
- bun run --cwd apps/cli test -- test/unit/services/diagnostics/support-bundle.test.ts test/unit/services/diagnostics/diagnostics-export.test.ts
- bun run typecheck
- bun run lint (0 errors; 5 pre-existing warnings)
- bun run fmt
- bun run verify:doc-paths
- bun run test
- bun run build
- git diff --check