### PR TITLE
fix(ci): provision verified Windows mpv

### DIFF
--- a/.docs/repo-infrastructure.md
+++ b/.docs/repo-infrastructure.md
@@ -138,6 +138,15 @@ Windows SQLite teardown), provisions native mpv so the real named-pipe IPC
 contract is mandatory, and runs the compiled Windows binary through the plain
 Node npm launcher with Bun absent from the child PATH.
 
+Native mpv provisioning is owned by
+`.github/scripts/provision-windows-mpv.ps1`. CI downloads a pinned official mpv
+Windows archive directly, retries transient transfer failures, verifies its
+checked-in SHA-256 before extraction, then executes `mpv --version`. Do not
+replace this with an unpinned Chocolatey or Scoop install: package-manager feed
+availability is not part of Kunai's Windows parity contract. When upgrading mpv,
+update the version, release URL, and digest together and keep the provisioning
+contract test green.
+
 Closed: the parity leg now builds a Windows host binary and smoke-tests
 `--version` / `--help` through the same Node launcher npm users execute. That
 gap had shipped a `kunai.exe` which exited 0

--- a/.github/scripts/provision-windows-mpv.ps1
+++ b/.github/scripts/provision-windows-mpv.ps1
@@ -1,0 +1,103 @@
+[CmdletBinding()]
+param(
+  [ValidateRange(1, 10)]
+  [int]$MaxAttempts = 3,
+
+  [string]$InstallRoot = ""
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+# Keep the URL and digest immutable together. This is the official mpv Windows
+# archive also referenced by Scoop's mpv manifest, without making CI depend on
+# a mutable package-manager feed or on bootstrapping another package manager.
+$mpvVersion = "0.41.0"
+$archiveName = "mpv-v$mpvVersion-x86_64-pc-windows-msvc.zip"
+$archiveUri = "https://github.com/mpv-player/mpv/releases/download/v0.41.0/mpv-v0.41.0-x86_64-pc-windows-msvc.zip"
+$expectedSha256 = "4e197f729f5071c6772f35fffd96e0f36e3e8a044bd9479b136bb09b7c6a80ff"
+
+if ([string]::IsNullOrWhiteSpace($InstallRoot)) {
+  $tempRoot = if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) { $env:TEMP } else { $env:RUNNER_TEMP }
+  $InstallRoot = Join-Path $tempRoot "kunai-mpv-$mpvVersion"
+}
+
+$archivePath = Join-Path $InstallRoot $archiveName
+$extractRoot = Join-Path $InstallRoot "expanded"
+New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
+
+function Get-VerifiedArchive {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Uri,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Destination,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedSha256,
+
+    [Parameter(Mandatory = $true)]
+    [int]$Attempts
+  )
+
+  for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+    try {
+      Remove-Item -LiteralPath $Destination -Force -ErrorAction SilentlyContinue
+      Write-Host "Downloading mpv $mpvVersion (attempt $attempt/$Attempts)"
+      Invoke-WebRequest -Uri $Uri -OutFile $Destination -MaximumRetryCount 2 -RetryIntervalSec 2
+
+      $actualSha256 = (Get-FileHash -LiteralPath $Destination -Algorithm SHA256).Hash.ToLowerInvariant()
+      if ($actualSha256 -ne $ExpectedSha256) {
+        throw "mpv archive checksum mismatch: expected $ExpectedSha256, got $actualSha256"
+      }
+
+      return
+    }
+    catch {
+      Remove-Item -LiteralPath $Destination -Force -ErrorAction SilentlyContinue
+      if ($attempt -eq $Attempts) {
+        throw "Unable to download a verified mpv archive after $Attempts attempts: $($_.Exception.Message)"
+      }
+
+      $delaySeconds = [Math]::Min(2 * $attempt, 6)
+      Write-Warning "mpv download attempt $attempt failed: $($_.Exception.Message). Retrying in $delaySeconds seconds."
+      Start-Sleep -Seconds $delaySeconds
+    }
+  }
+}
+
+Get-VerifiedArchive `
+  -Uri $archiveUri `
+  -Destination $archivePath `
+  -ExpectedSha256 $expectedSha256 `
+  -Attempts $MaxAttempts
+
+Remove-Item -LiteralPath $extractRoot -Recurse -Force -ErrorAction SilentlyContinue
+Expand-Archive -LiteralPath $archivePath -DestinationPath $extractRoot
+
+$mpvCandidates = @(Get-ChildItem -LiteralPath $extractRoot -Filter "mpv.exe" -File -Recurse)
+if ($mpvCandidates.Count -ne 1) {
+  throw "Expected exactly one mpv.exe in the verified archive, found $($mpvCandidates.Count)"
+}
+
+$mpvPath = $mpvCandidates[0].FullName
+$mpvDirectory = $mpvCandidates[0].Directory.FullName
+$env:PATH = "$mpvDirectory$([IO.Path]::PathSeparator)$env:PATH"
+
+if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_PATH)) {
+  Add-Content -LiteralPath $env:GITHUB_PATH -Value $mpvDirectory
+}
+
+$mpvProcess = Start-Process `
+  -FilePath $mpvPath `
+  -ArgumentList "--version" `
+  -NoNewWindow `
+  -Wait `
+  -PassThru
+if ($mpvProcess.ExitCode -ne 0) {
+  throw "mpv --version exited $($mpvProcess.ExitCode)"
+}
+
+Write-Host "Provisioned mpv $mpvVersion from verified archive"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
               - 'README.md'
               - 'packages/**'
               - 'package.json'
+              - '.github/scripts/provision-windows-mpv.ps1'
               - '.github/workflows/ci.yml'
               - '.github/workflows/release.yml'
               - '.github/workflows/installer-matrix.yml'
@@ -228,11 +229,7 @@ jobs:
       - name: Provision native mpv
         shell: pwsh
         timeout-minutes: 8
-        run: |
-          choco install mpvio --yes --no-progress
-          $mpv = (Get-Command mpv.exe -ErrorAction Stop).Source
-          & $mpv --version
-          if ($LASTEXITCODE -ne 0) { throw "mpv --version exited $LASTEXITCODE" }
+        run: ./.github/scripts/provision-windows-mpv.ps1
 
       - name: Typecheck workspaces
         run: bun run typecheck

--- a/apps/cli/test/unit/scripts/windows-mpv-provision-contract.test.ts
+++ b/apps/cli/test/unit/scripts/windows-mpv-provision-contract.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "../../../../..");
+const SCRIPT_PATH = join(REPO_ROOT, ".github/scripts/provision-windows-mpv.ps1");
+const WORKFLOW_PATH = join(REPO_ROOT, ".github/workflows/ci.yml");
+
+describe("Windows mpv CI provisioning contract", () => {
+  const script = readFileSync(SCRIPT_PATH, "utf8");
+  const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+
+  test("uses the checked-in provisioner instead of a mutable package-manager feed", () => {
+    const provisionerReferences = workflow.match(/.github\/scripts\/provision-windows-mpv\.ps1/g);
+    expect(provisionerReferences).toHaveLength(2);
+    expect(workflow).not.toMatch(/choco(?:latey)?\s+install\s+mpv/i);
+    expect(workflow).not.toMatch(/scoop\s+install\s+mpv/i);
+  });
+
+  test("pins the official archive and verifies its SHA-256 before extraction", () => {
+    expect(script).toContain(
+      "https://github.com/mpv-player/mpv/releases/download/v0.41.0/mpv-v0.41.0-x86_64-pc-windows-msvc.zip",
+    );
+    expect(script).toContain("4e197f729f5071c6772f35fffd96e0f36e3e8a044bd9479b136bb09b7c6a80ff");
+    expect(script).toContain("Get-FileHash");
+    expect(script.indexOf("Get-FileHash")).toBeLessThan(script.indexOf("Expand-Archive"));
+  });
+
+  test("retries bounded downloads and makes the verified executable available", () => {
+    expect(script).toMatch(/\[ValidateRange\(1, 10\)\]\s*\[int\]\$MaxAttempts = 3/);
+    expect(script).toContain("Invoke-WebRequest");
+    expect(script).toContain("$env:GITHUB_PATH");
+    expect(script).toContain("Start-Process");
+    expect(script).toContain(".ExitCode");
+    expect(script).toContain('ArgumentList "--version"');
+    expect(script).not.toContain("$LASTEXITCODE");
+  });
+});


### PR DESCRIPTION
## Summary
- replace the flaky Chocolatey mpvio feed dependency with mpv's pinned official Windows release archive
- retry transient downloads, verify SHA-256 before extraction, and probe the installed executable
- add a regression contract and document the Windows parity ownership contract

## Why
Windows parity failed repeatedly before Kunai code ran because Chocolatey's V2 community feed returned invalid XML for mpvio. A direct immutable artifact keeps the blocking job meaningful without bootstrapping Scoop or trusting a mutable package feed.

## Verification
- pinned archive downloaded and independently matched SHA-256 4e197f729f5071c6772f35fffd96e0f36e3e8a044bd9479b136bb09b7c6a80ff
- archive contains exactly one mpv.exe
- bun run typecheck
- bun run lint (0 errors; 5 existing warnings)
- bun run fmt
- bun run verify:doc-paths
- bun run test (4077 unit + 100 integration passed)
- bun run build
- bun run scripts/ci-bootstrap-contract.ts

The Windows CLI parity job is the final native PowerShell execution proof.