### PR TITLE
fix: make playback lifecycle ownership truthful

### DIFF
--- a/.docs/architecture.md
+++ b/.docs/architecture.md
@@ -160,12 +160,14 @@ Production resolution is browserless by default:
 
 `apps/cli/src/mpv.ts`:
 
-- launches `mpv` detached
-- binds the active one-shot control to the playback abort signal, so shutdown
-  stops the current player instead of waiting for the process-exit backstop
-- writes playback position through a Lua helper
-- polls the position file after exit
-- has a deadline to avoid hanging forever if `mpv` dies badly
+- launches and registers the owned `mpv` child for shutdown backstop cleanup
+- binds the active one-shot control to a playback generation and abort signal,
+  so shutdown stops the current player without clearing a replacement's control
+- connects Bun IPC and derives readiness, progress, EOF, tracks, and playback
+  start from observed player events
+- treats IPC bootstrap failure as an ownership failure: terminate and reap the
+  exact spawned child before provider fallback can create another player
+- keeps socket cleanup and final telemetry bounded after process exit
 
 This is part of the repo's reliability contract. Changes are fine, but recovery under kill signals, EOF, or expired stream URLs needs to remain solid.
 

--- a/apps/cli/src/app/playback/PlaybackPhase.ts
+++ b/apps/cli/src/app/playback/PlaybackPhase.ts
@@ -14,6 +14,7 @@ import {
 import { episodeInfoFromSelection } from "@/app/bootstrap/episode-info-from-catalog";
 import { consumeShareBootstrapStartSeconds } from "@/app/bootstrap/share-bootstrap-start";
 import { resolveTitleHistoryLookupId } from "@/app/bootstrap/title-info";
+import { confirmPlaybackStart } from "@/app/playback/confirmed-playback-start";
 import { resolveLocalEpisodePlayback } from "@/app/playback/episode-playback-source";
 import {
   adoptEpisodePrefetchBundle,
@@ -2331,18 +2332,6 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
             }
           };
 
-          run.playbackSession = this.transitionPlaybackSession(
-            context,
-            run.playbackSession,
-            "playback-started",
-            {
-              titleId: title.id,
-              season: currentEpisode.season,
-              episode: currentEpisode.episode,
-              provider: resolvedProviderId,
-            },
-          );
-
           if (context.signal.aborted) {
             stateManager.dispatch({ type: "SET_PLAYBACK_STATUS", status: "idle" });
             this.releasePlaybackLedgerWithoutPersist();
@@ -2369,7 +2358,17 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
               providerHandoff.successfulProviderId,
               playbackIterationAbort.signal,
               () => {
-                queueAttempt?.acknowledgeStarted();
+                run.playbackSession = confirmPlaybackStart({
+                  session: run.playbackSession,
+                  transition: (session, event) =>
+                    this.transitionPlaybackSession(context, session, event, {
+                      titleId: title.id,
+                      season: currentEpisode.season,
+                      episode: currentEpisode.episode,
+                      provider: resolvedProviderId,
+                    }),
+                  acknowledgeQueue: () => queueAttempt?.acknowledgeStarted(),
+                });
               },
               run.localPlaybackSource ?? undefined,
             );
@@ -3157,10 +3156,15 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
             autoplaySessionPaused: stateManager.getState().autoplaySessionPaused,
             signalAborted: context.signal.aborted,
           });
+          // One decision owns one exact queue head. Re-reading after the
+          // catalog path would let a reordered row bypass or replace the
+          // interrupting play-next intent that prevented episode countdown.
+          const autoAdvanceQueueHead = container.queueService.peekNext();
           const { nextEpisode, catalogAutoNext, catalogAutoplayEndBanner, blockedBy } =
             await planCatalogAutoAdvance({
               autoplayAdvanceArgs,
               guards: readAutoAdvanceGuards(),
+              queueHead: autoAdvanceQueueHead,
               seriesDone: !episodeAvailability.nextEpisode,
               autoplayRecommendations: container.config.autoplayRecommendations,
               isAnime: stateManager.getState().mode === "anime",
@@ -3297,7 +3301,7 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
             autoplayPaused: run.playbackSession.autoplayPaused,
             autoplaySessionPaused: stateManager.getState().autoplaySessionPaused,
             aborted: context.signal.aborted,
-            hasQueuedNext: Boolean(container.queueService.peekNext()),
+            hasQueuedNext: Boolean(autoAdvanceQueueHead),
             autoplayRecommendationsEnabled: container.config.autoplayRecommendations,
           });
           const recommendationRailItems = await recommendationRail.resolveRailItems({
@@ -3318,7 +3322,7 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
           const playlistAutoNext = planPlaylistAutoAdvance({
             catalogNextEpisode: nextEpisode,
             guards: readAutoAdvanceGuards(),
-            queueHead: container.queueService.peekNext(),
+            queueHead: autoAdvanceQueueHead,
             seriesHasNextEpisode: Boolean(episodeAvailability.nextEpisode),
             autoplayRecommendations: container.config.autoplayRecommendations,
             topRecommendation,

--- a/apps/cli/src/app/playback/confirmed-playback-start.ts
+++ b/apps/cli/src/app/playback/confirmed-playback-start.ts
@@ -1,0 +1,21 @@
+import type {
+  PlaybackSessionPhaseEvent,
+  PlaybackSessionState,
+} from "@/app/playback/playback-session-controller";
+
+/**
+ * Commits the two state changes that share the confirmed-playback boundary.
+ * Process spawn, IPC connection, and player-ready must never call this helper.
+ */
+export function confirmPlaybackStart(input: {
+  readonly session: PlaybackSessionState;
+  readonly transition: (
+    session: PlaybackSessionState,
+    event: Extract<PlaybackSessionPhaseEvent, "playback-started">,
+  ) => PlaybackSessionState;
+  readonly acknowledgeQueue?: () => void;
+}): PlaybackSessionState {
+  const session = input.transition(input.session, "playback-started");
+  input.acknowledgeQueue?.();
+  return session;
+}

--- a/apps/cli/src/app/playback/playback-catalog-autoadvance.ts
+++ b/apps/cli/src/app/playback/playback-catalog-autoadvance.ts
@@ -10,6 +10,7 @@ import { formatCaughtUpReleaseBanner } from "@/app/post-play/caught-up-banner";
 import type { NextUp } from "@/domain/playback/resolve-next-up";
 import type { EpisodeInfo } from "@/domain/types";
 import type { CatalogScheduleService } from "@/services/catalog/CatalogScheduleService";
+import type { QueueEntry } from "@kunai/storage";
 
 export type CatalogAutoAdvancePlan = {
   readonly nextEpisode: EpisodeInfo | null;
@@ -25,6 +26,7 @@ export type CatalogAutoAdvancePlan = {
 export async function planCatalogAutoAdvance(input: {
   readonly autoplayAdvanceArgs: AutoAdvanceArgs;
   readonly guards: AutoAdvanceGuards;
+  readonly queueHead: QueueEntry | undefined;
   readonly seriesDone: boolean;
   readonly autoplayRecommendations: boolean;
   readonly isAnime: boolean;
@@ -36,7 +38,7 @@ export async function planCatalogAutoAdvance(input: {
   const catalogAutoNext = evaluateAutoAdvanceNextUp({
     guards: input.guards,
     nextEpisode,
-    queueHead: undefined,
+    queueHead: input.queueHead,
     topRecommendation: null,
     seriesDone: input.seriesDone,
     autoplayRecommendations: input.autoplayRecommendations,

--- a/apps/cli/src/infra/player/PlayerServiceImpl.ts
+++ b/apps/cli/src/infra/player/PlayerServiceImpl.ts
@@ -476,9 +476,16 @@ export class PlayerServiceImpl implements PlayerService {
     generation: PlaybackGeneration,
     control: Parameters<PlayerControlService["setActive"]>[0],
   ): void {
+    if (!control) {
+      // Completion can arrive after stop/cancellation retired the generation.
+      // Clear the control only when that retired generation still owns it;
+      // never let a late null erase a replacement player's controls.
+      this.clearActiveControlFor(generation);
+      return;
+    }
     if (!this.isCurrentGeneration(generation)) return;
-    this.activeControlGeneration = control ? generation : null;
-    this.deps.playerControl.setActive(control ? this.guardControlGenerations(control) : null);
+    this.activeControlGeneration = generation;
+    this.deps.playerControl.setActive(this.guardControlGenerations(control));
   }
 
   /**

--- a/apps/cli/src/mpv.ts
+++ b/apps/cli/src/mpv.ts
@@ -8,6 +8,7 @@ import { openMpvIpcSession, waitForMpvIpcEndpoint } from "@/infra/player/mpv-ipc
 import {
   createMpvIpcEndpoint,
   ipcServerCliArg,
+  mpvIpcBootstrapDiagnosticsHintSuffix,
   mpvIpcTransportTag,
   newMpvIpcSessionId,
   shouldUnlinkUnixSocket,
@@ -18,7 +19,12 @@ import {
 } from "@/infra/player/mpv-playback-kernel";
 import { isLocalHlsManifestPlaybackUrl } from "@/infra/player/mpv-playback-url";
 import { isAllowedMpvUrl, type MpvUrlKind } from "@/infra/player/mpv-playback-url";
-import { registerMpvProcess } from "@/infra/player/mpv-process-registry";
+import {
+  registerMpvProcess,
+  terminateMpvProcess,
+  type MpvChildProcess,
+  type MpvTerminationResult,
+} from "@/infra/player/mpv-process-registry";
 import type { MpvRuntimeOptions } from "@/infra/player/mpv-runtime-options";
 import { shouldApplyStartAtSeek } from "@/infra/player/mpv-start-seek";
 import { LOCAL_HLS_DEMUXER_LAVF_OPTIONS } from "@/infra/player/mpv-stream-http-headers";
@@ -294,10 +300,10 @@ async function launchMpvInner(
   const ipcBootstrap = (async () => {
     const ipcBootstrapStarted = Date.now();
     const ready = await waitForMpvIpcEndpoint(ipcEndpoint, 5_000);
-    if (!ready) {
-      notifyPlayerReady();
-      return;
-    }
+    assertOneShotMpvIpcEndpointReady(
+      ready,
+      `IPC endpoint was not ready after ${Date.now() - ipcBootstrapStarted}ms at ${ipcServerCliArg(ipcEndpoint)}.${mpvIpcBootstrapDiagnosticsHintSuffix()}`,
+    );
 
     ipcSession = await openMpvIpcSession({
       endpoint: ipcEndpoint,
@@ -352,7 +358,7 @@ async function launchMpvInner(
       emitPlaybackEvent({ type: "subtitle-inventory-ready", trackCount });
       emitPlaybackEvent({ type: "subtitle-attached", trackCount });
     }
-  })().catch((err) => {
+  })().catch(async (err) => {
     dbg("mpv-ipc", "ipc-bootstrap-failed", {
       endpoint: ipcServerCliArg(ipcEndpoint),
       error: String(err),
@@ -362,6 +368,17 @@ async function launchMpvInner(
       type: "ipc-command-failed",
       command: "bootstrap",
       error: String(err),
+    });
+    await settleOneShotMpvIpcBootstrapFailure({
+      process: mpv,
+      clearOwnedControl: () => opts.onControlReady?.(null),
+      reportTerminationFailure: () => {
+        emitPlaybackEvent({
+          type: "ipc-command-failed",
+          command: "terminate",
+          error: "mpv did not exit after forced bootstrap teardown",
+        });
+      },
     });
   });
 
@@ -421,6 +438,31 @@ export function shouldAbortLaunchForDefinitivePreflight(
   ipcConnected: boolean,
 ): result is Extract<StreamPreflightResult, { status: "unreachable" }> {
   return shouldAbortPlaybackForPreflight(result, ipcConnected);
+}
+
+export function assertOneShotMpvIpcEndpointReady(ready: boolean, detail: string): asserts ready {
+  if (!ready) throw new Error(detail);
+}
+
+/**
+ * A one-shot IPC failure still owns the child it spawned. Do not release the
+ * generation or allow provider fallback until that exact child is reaped.
+ */
+export async function settleOneShotMpvIpcBootstrapFailure(options: {
+  readonly process: MpvChildProcess;
+  readonly terminate?: (process: MpvChildProcess) => Promise<MpvTerminationResult>;
+  readonly clearOwnedControl: () => void;
+  readonly reportTerminationFailure: () => void;
+}): Promise<MpvTerminationResult> {
+  const result = await (options.terminate ?? terminateMpvProcess)(options.process);
+  if (result.exited) {
+    options.clearOwnedControl();
+  } else {
+    // Keep the control/process registry ownership intact. Returning to fallback
+    // here would knowingly stack a second mpv over a still-live first one.
+    options.reportTerminationFailure();
+  }
+  return result;
 }
 
 export async function cleanupAbortedMpvLaunch(options: {

--- a/apps/cli/test/unit/app/playback/confirmed-playback-start.test.ts
+++ b/apps/cli/test/unit/app/playback/confirmed-playback-start.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+import { confirmPlaybackStart } from "@/app/playback/confirmed-playback-start";
+import {
+  createPlaybackSessionState,
+  transitionPlaybackSessionPhase,
+} from "@/app/playback/playback-session-controller";
+
+describe("confirmed playback start boundary", () => {
+  test("keeps the session ready until confirmation, then transitions and acknowledges once", () => {
+    const ready = transitionPlaybackSessionPhase(
+      createPlaybackSessionState({ autoNextEnabled: true }),
+      "stream-ready",
+    );
+    const events: string[] = [];
+
+    expect(ready.phase).toBe("ready");
+
+    const playing = confirmPlaybackStart({
+      session: ready,
+      transition: (session, event) => {
+        events.push(event);
+        return transitionPlaybackSessionPhase(session, event);
+      },
+      acknowledgeQueue: () => events.push("queue-acknowledged"),
+    });
+
+    expect(playing.phase).toBe("playing");
+    expect(events).toEqual(["playback-started", "queue-acknowledged"]);
+  });
+});

--- a/apps/cli/test/unit/app/playback/playback-catalog-autoadvance.test.ts
+++ b/apps/cli/test/unit/app/playback/playback-catalog-autoadvance.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+
+import { planCatalogAutoAdvance } from "@/app/playback/playback-catalog-autoadvance";
+import { createPlaybackSessionState } from "@/app/playback/playback-session-controller";
+import type { EpisodeAvailability } from "@/domain/playback/playback-policy";
+import { planMediaQueuePlacement } from "@/domain/queue/QueuePlanner";
+import type { PlaybackResult } from "@/domain/types";
+import type { QueueEntry } from "@kunai/storage";
+
+const result: PlaybackResult = {
+  endReason: "eof",
+  watchedSeconds: 1_400,
+  duration: 1_400,
+  lastNonZeroPositionSeconds: 1_400,
+  lastNonZeroDurationSeconds: 1_400,
+  playerExitCode: 0,
+  playerExitSignal: null,
+};
+const availability: EpisodeAvailability = {
+  nextEpisode: { season: 1, episode: 2 },
+  previousEpisode: null,
+  nextSeasonEpisode: null,
+  upcomingNext: null,
+  animeNextReleaseUnknown: false,
+  tmdbUnavailable: false,
+};
+
+function queueHead(priority: number): QueueEntry {
+  return {
+    id: "queue-next",
+    title: "Interrupting title",
+    titleId: "tmdb:99",
+    mediaKind: "series",
+    priority,
+  } as QueueEntry;
+}
+
+async function plan(head: QueueEntry) {
+  return await planCatalogAutoAdvance({
+    autoplayAdvanceArgs: {
+      result,
+      title: { id: "tmdb:1", name: "Current", type: "series" },
+      currentEpisode: { season: 1, episode: 1 },
+      session: createPlaybackSessionState({ autoNextEnabled: true }),
+      availability,
+    },
+    guards: {
+      endReason: "eof",
+      autoplayPaused: false,
+      autoplaySessionPaused: false,
+      signalAborted: false,
+    },
+    queueHead: head,
+    seriesDone: false,
+    autoplayRecommendations: false,
+    isAnime: false,
+  });
+}
+
+describe("catalog auto-advance queue precedence", () => {
+  test("an explicit play-next head prevents the catalog episode countdown", async () => {
+    const head = queueHead(planMediaQueuePlacement("next").priority);
+
+    const planned = await plan(head);
+
+    expect(planned.nextEpisode).toEqual({ season: 1, episode: 2 });
+    expect(planned.catalogAutoNext).toEqual({ kind: "queue", entry: head });
+  });
+
+  test("an ordinary queue head stays behind the catalog episode chain", async () => {
+    const head = queueHead(planMediaQueuePlacement("end").priority);
+
+    const planned = await plan(head);
+
+    expect(planned.catalogAutoNext).toEqual({
+      kind: "episode",
+      episode: { season: 1, episode: 2 },
+    });
+  });
+});

--- a/apps/cli/test/unit/infra/player/PlayerServiceImpl.test.ts
+++ b/apps/cli/test/unit/infra/player/PlayerServiceImpl.test.ts
@@ -18,6 +18,8 @@ import type { DiagnosticEventInput } from "@/services/diagnostics/diagnostic-eve
 /** Reaches the generation seams the service owns privately. */
 type GenerationInternals = {
   readonly currentGeneration: PlaybackGeneration;
+  activateGeneration(persistent: boolean): PlaybackGeneration;
+  setActiveControlFor(generation: PlaybackGeneration, control: ActivePlayerControl | null): void;
   wrapPlaybackEventHandler(
     generation: PlaybackGeneration,
     handler: ((input: PlayerPlaybackEventEnvelope) => void) | undefined,
@@ -350,6 +352,50 @@ describe("PlayerServiceImpl diagnostics", () => {
 });
 
 describe("PlayerServiceImpl playback generations", () => {
+  test("a retired generation clears only the control it owns", () => {
+    const events: DiagnosticEventInput[] = [];
+    const active: Array<string | null> = [];
+    const { service } = createService(events, {
+      playerControl: {
+        setActive: (control) => active.push(control?.id ?? null),
+      },
+    });
+    const generationOne = internals(service).activateGeneration(false);
+    internals(service).setActiveControlFor(generationOne, {
+      id: "generation-one",
+      stop: async () => {},
+    });
+    internals(service).activateGeneration(false);
+
+    internals(service).setActiveControlFor(generationOne, null);
+
+    expect(active).toEqual(["generation-one", null]);
+  });
+
+  test("a retired generation cannot clear a replacement control", () => {
+    const events: DiagnosticEventInput[] = [];
+    const active: Array<string | null> = [];
+    const { service } = createService(events, {
+      playerControl: {
+        setActive: (control) => active.push(control?.id ?? null),
+      },
+    });
+    const generationOne = internals(service).activateGeneration(false);
+    internals(service).setActiveControlFor(generationOne, {
+      id: "generation-one",
+      stop: async () => {},
+    });
+    const generationTwo = internals(service).activateGeneration(false);
+    internals(service).setActiveControlFor(generationTwo, {
+      id: "generation-two",
+      stop: async () => {},
+    });
+
+    internals(service).setActiveControlFor(generationOne, null);
+
+    expect(active).toEqual(["generation-one", "generation-two"]);
+  });
+
   test("play activates a generation synchronously, before the first await", async () => {
     const events: DiagnosticEventInput[] = [];
     const { service } = createService(events, {

--- a/apps/cli/test/unit/infra/player/one-shot-mpv-bootstrap.test.ts
+++ b/apps/cli/test/unit/infra/player/one-shot-mpv-bootstrap.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+import type { MpvChildProcess, MpvTerminationResult } from "@/infra/player/mpv-process-registry";
+import { assertOneShotMpvIpcEndpointReady, settleOneShotMpvIpcBootstrapFailure } from "@/mpv";
+
+const child = {
+  exited: Promise.resolve(0),
+  exitCode: 0,
+  kill: () => {},
+} satisfies MpvChildProcess;
+
+describe("one-shot mpv IPC bootstrap ownership", () => {
+  test("an endpoint timeout is a bootstrap failure, not player readiness", () => {
+    expect(() => assertOneShotMpvIpcEndpointReady(false, "endpoint timed out")).toThrow(
+      "endpoint timed out",
+    );
+    expect(() => assertOneShotMpvIpcEndpointReady(true, "unused")).not.toThrow();
+  });
+
+  test("waits for owned-child termination before clearing its control", async () => {
+    let releaseTermination!: () => void;
+    const terminationGate = new Promise<void>((resolve) => {
+      releaseTermination = resolve;
+    });
+    const events: string[] = [];
+
+    const settlement = settleOneShotMpvIpcBootstrapFailure({
+      process: child,
+      terminate: async (target): Promise<MpvTerminationResult> => {
+        expect(target).toBe(child);
+        events.push("terminate-started");
+        await terminationGate;
+        events.push("terminated");
+        return { exited: true, exitCode: 0, signal: "SIGTERM" };
+      },
+      clearOwnedControl: () => events.push("control-cleared"),
+      reportTerminationFailure: () => events.push("termination-failed"),
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(["terminate-started"]);
+
+    releaseTermination();
+    await expect(settlement).resolves.toEqual({ exited: true, exitCode: 0, signal: "SIGTERM" });
+    expect(events).toEqual(["terminate-started", "terminated", "control-cleared"]);
+  });
+
+  test("keeps ownership when the child cannot be reaped", async () => {
+    const events: string[] = [];
+
+    await expect(
+      settleOneShotMpvIpcBootstrapFailure({
+        process: child,
+        terminate: async () => ({ exited: false, exitCode: null, signal: "SIGKILL" }),
+        clearOwnedControl: () => events.push("control-cleared"),
+        reportTerminationFailure: () => events.push("termination-failed"),
+      }),
+    ).resolves.toEqual({ exited: false, exitCode: null, signal: "SIGKILL" });
+
+    expect(events).toEqual(["termination-failed"]);
+  });
+});

--- a/plans/README.md
+++ b/plans/README.md
@@ -28,7 +28,6 @@ the behavior source of truth; a stale plan is a documentation bug.
 | 032  | Sync identity and capability truth                          | TODO; execute after the reliability train           |
 | 043  | Transactional legacy history-key migration                  | TODO; independent data-migration PR                 |
 | 046  | Provider episode routing truth                              | TODO; K-17                                          |
-| 047  | Playback/session/queue/one-shot lifecycle                   | TODO; K-06/K-11/K-13                                |
 
 Status values: TODO · PARTIAL · BLOCKED (with reason) · IN PROGRESS.
 
@@ -45,32 +44,31 @@ table replaces its status claims.
 | K-03    | FIXED          | PR #42 preserves sticky offline truth and search failure copy.                                                                                                         |
 | K-04    | OPEN           | `providerRelay.videoFallback` persists, but `rewriteStreamUrlForRelay` has no production reader. Remove the unused promise in plan 021; do not add shared video relay. |
 | K-05    | FIXED          | PR #46 preserves the working Windows launcher across activation failure.                                                                                               |
-| K-06    | OPEN           | `PlaybackPhase` still marks the session playing before `playStream()`; plan 047.                                                                                       |
+| K-06    | FIXED          | Session phase moves from ready to playing only inside the confirmed `playback-started` callback.                                                                       |
 | K-07    | FIXED          | PR #27 restores playing after progress resumes and rejects stale mpv work.                                                                                             |
 | K-08    | OPEN           | Contract conformance still baselines two known orphaned relay contracts; plan 021 with K-04.                                                                           |
 | K-09    | FIXED          | PR #45 preserves the last-known-good atomic JSON target on Windows.                                                                                                    |
 | K-10    | FIXED          | This reconciliation removes stale top-level TODO/checklist authorities, archives landed plans, and corrects provider/poster docs.                                      |
-| K-11    | OPEN           | Catalog auto-next still runs before the real interrupting queue head is consulted; plan 047.                                                                           |
+| K-11    | FIXED          | Auto-advance reads one exact queue head before catalog planning, so play-next interrupts before countdown while ordinary rows wait.                                    |
 | K-12    | FIXED          | PR #47 adds download claim CAS, state-safe publication, and crash recovery.                                                                                            |
-| K-13    | OPEN           | One-shot IPC bootstrap ownership still needs a child-termination regression; plan 047.                                                                                 |
+| K-13    | FIXED          | One-shot IPC bootstrap failure terminates and reaps its owned child; generation tests prevent clearing a replacement control.                                          |
 | K-14    | FIXED          | PR #37 gives slow installer suites an explicit reachable timeout budget.                                                                                               |
 | K-15    | FIXED          | PR #44 structurally contains recursive staging cleanup.                                                                                                                |
 | K-16    | OPEN           | Global help still promises `--dry-run` changes nothing while the reader only guards protocol install/rollback; plan 023.                                               |
 | K-17    | OPEN           | AllManga and Miruro still prefer `absoluteEpisode`; plan 046.                                                                                                          |
 
-Current count after this reconciliation: **10 fixed, 7 open**.
+Current count after plan 047: **13 fixed, 4 open**.
 
 ## Release-focused train
 
-1. Merge this docs/truth PR after docs, format, and path gates pass.
-2. Execute plan 047 as one playback-lifecycle PR (K-06/K-11/K-13).
-3. Execute the release-truth slices together only if the diff stays reviewable:
+1. The docs/truth reconciliation and plan 047 lifecycle slice are complete.
+2. Execute the release-truth slices together only if the diff stays reviewable:
    plan 021 K-04/K-08 removal, plan 023 K-16 narrowing, and plan 046 K-17
    routing. Keep separate commits so any provider change can be reverted alone.
-4. Execute plan 043 as its own migration PR.
-5. Rebase and re-audit the existing `fix/tracker-sync-correctness` worktree,
+3. Execute plan 043 as its own migration PR.
+4. Rebase and re-audit the existing `fix/tracker-sync-correctness` worktree,
    then execute plan 032. Do not merge that stale branch as-is.
-6. Run the deterministic release gate, provider signoff, real mpv playback,
+5. Run the deterministic release gate, provider signoff, real mpv playback,
    and poster-protocol smokes. Only then merge version PR #31.
 
 The release PR is intentionally last: Changesets will keep updating it while

--- a/plans/archive/047-playback-lifecycle-audit-remediation.md
+++ b/plans/archive/047-playback-lifecycle-audit-remediation.md
@@ -1,5 +1,16 @@
 # Plan 047: Make playback, queue interruption, and one-shot ownership truthful
 
+Status: **COMPLETE** on 2026-08-14.
+
+Completion evidence:
+
+- confirmed-start phase and queue acknowledgement share one callback boundary;
+- catalog and playlist planning consume the same exact queue head;
+- one-shot IPC bootstrap failure waits for owned-child termination and uses
+  generation-safe control cleanup;
+- focused playback, queue lifecycle, process registry, and generation tests
+  cover the regressions.
+
 > **For executors:** use test-driven development and verification before
 > completion. Work against current `PlaybackPhase.ts`; do not import unrelated
 > local playback/prefetch edits from another worktree.
@@ -79,5 +90,3 @@ plan because process and IPC behavior differs by platform.
   connection rather than confirmed progress.
 - Cleanup cannot prove which generation owns the child.
 - The queue fix would require reviving deprecated `QueueService.advance()`.
-
-Status: TODO

--- a/plans/archive/README.md
+++ b/plans/archive/README.md
@@ -9,7 +9,7 @@ commit that is now far behind, and its "Current state" excerpts describe code
 that has since changed.
 
 Archived so far: 001–005, 007, 009, 016–020, 024–029, 031, 033–042,
-044–045, plus the old 2026-07-22 handoff.
+044–045, 047, plus the old 2026-07-22 handoff.
 
 ## Notes worth carrying forward
 


### PR DESCRIPTION
## Summary

- move the session's `playback-started` transition and queue acknowledgement behind confirmed mpv playback
- make catalog auto-advance, recommendations, and playlist planning consume the same exact queue head
- terminate and reap the owned one-shot mpv child when IPC bootstrap fails, with generation-safe control cleanup
- archive completed plan 047 and update the K-01–K-17 truth ledger

Closes K-06, K-11, and K-13 from the production-readiness audit.

## Verification

- `bun run test` — 4,195 CLI unit tests, all workspace test tasks passed
- `bun run typecheck`
- `bun run lint` — 0 errors; 5 pre-existing warnings in untouched files
- `bun run fmt`
- `bun run fmt:check`
- `bun run verify:doc-paths`
- `bun run build`
- `git diff --check`
