### PR TITLE
fix: route provider episodes by season identity

### DIFF
--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -530,6 +530,10 @@ Provider manifests expose `catalogIdentity` (`provider-native` | `anilist` | `tm
   results are remapped to opaque AllAnime show ids before resolve; `externalIds.anilistId` is
   preserved on merge. An AllAnime lookup may populate only `providerNativeIds.allanime`.
 - **Miruro** — `anilist`. Discovery ids stay numeric AniList ids; no AllManga Tier-1 remapping runs.
+- **AllAnime and Miruro episode numbering** — when a request carries both a
+  season-relative `episode` and `absoluteEpisode`, their APIs receive the
+  season-relative value. Absolute numbering is used only for an absolute-only
+  request. AniDB keeps its separate catalog-proven routing policy below.
 
 A catalog's own id space is numeric, so a non-numeric id is never accepted into the `anilistId` or
 `tmdbId` slot even when the active provider declares that catalog identity.

--- a/packages/providers/src/allmanga/direct.ts
+++ b/packages/providers/src/allmanga/direct.ts
@@ -30,6 +30,7 @@ import {
   findLastCycleFailure,
   providerFailureCodeFromCycleFailure,
 } from "../shared/provider-cycle";
+import { selectProviderEpisodeNumber } from "../shared/provider-episode-number";
 import { createExhaustedResult, emitTraceEvent } from "../shared/resolve-helpers";
 import {
   normalizeProviderDisplayLabel,
@@ -264,7 +265,7 @@ export const allmangaProviderModule: CoreProviderModule = {
 
     try {
       const mode = resolveAnimeAudioIntent(input.preferredAudioLanguage ?? "original").catalogMode;
-      const episodeNum = input.episode?.absoluteEpisode ?? input.episode?.episode ?? 1;
+      const episodeNum = selectProviderEpisodeNumber(input.episode);
 
       // Same GQL catalog as listEpisodes (showCatalogCache, 45s TTL in api-client).
       const detail = await loadAvailableEpisodesDetail(

--- a/packages/providers/src/miruro/direct.ts
+++ b/packages/providers/src/miruro/direct.ts
@@ -49,6 +49,7 @@ import {
   findLastCycleFailure,
   providerFailureCodeFromCycleFailure,
 } from "../shared/provider-cycle";
+import { selectProviderEpisodeNumber } from "../shared/provider-episode-number";
 import { createExhaustedResult, emitTraceEvent } from "../shared/resolve-helpers";
 import { finalizeCycleSourceInventory } from "../shared/source-inventory";
 import { selectReadyStream } from "../shared/startup-selection";
@@ -1671,7 +1672,7 @@ export const miruroProviderModule: CoreProviderModule = {
       });
     }
 
-    const episodeNum = input.episode?.absoluteEpisode ?? input.episode?.episode ?? 1;
+    const episodeNum = selectProviderEpisodeNumber(input.episode);
     const startedAt = context.now();
     const events: ProviderTraceEvent[] = [];
     const failures: ProviderFailure[] = [];

--- a/packages/providers/src/shared/index.ts
+++ b/packages/providers/src/shared/index.ts
@@ -7,6 +7,7 @@ export * from "./hls-manifest";
 export * from "./hls-ladder";
 export * from "./direct-stream-source";
 export * from "./provider-cycle";
+export * from "./provider-episode-number";
 export * from "./resolve-helpers";
 export * from "./resolve-inventory-anomaly";
 export * from "./stream-reachability";

--- a/packages/providers/src/shared/provider-episode-number.ts
+++ b/packages/providers/src/shared/provider-episode-number.ts
@@ -1,0 +1,9 @@
+import type { EpisodeIdentity } from "@kunai/types";
+
+/**
+ * Provider requests follow the proven season-relative identity when it exists.
+ * Absolute numbering is reserved for inputs that carry no relative episode.
+ */
+export function selectProviderEpisodeNumber(episode: EpisodeIdentity | undefined): number {
+  return episode?.episode ?? episode?.absoluteEpisode ?? 1;
+}

--- a/packages/providers/test/provider-episode-number.test.ts
+++ b/packages/providers/test/provider-episode-number.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+
+import { selectProviderEpisodeNumber } from "../src/shared/provider-episode-number";
+
+describe("provider episode-number routing", () => {
+  test("prefers a proven season-relative episode over absolute numbering", () => {
+    expect(selectProviderEpisodeNumber({ season: 2, episode: 1, absoluteEpisode: 13 })).toBe(1);
+  });
+
+  test("uses absolute numbering for an absolute-only request", () => {
+    expect(selectProviderEpisodeNumber({ absoluteEpisode: 13 })).toBe(13);
+  });
+
+  test("keeps the existing episode-one default when identity is missing", () => {
+    expect(selectProviderEpisodeNumber(undefined)).toBe(1);
+    expect(selectProviderEpisodeNumber({})).toBe(1);
+  });
+});

--- a/plans/README.md
+++ b/plans/README.md
@@ -27,7 +27,6 @@ the behavior source of truth; a stale plan is a documentation bug.
 | 030  | Distribution documentation truth                            | TODO after release behavior settles                 |
 | 032  | Sync identity and capability truth                          | TODO; execute after the reliability train           |
 | 043  | Transactional legacy history-key migration                  | TODO; independent data-migration PR                 |
-| 046  | Provider episode routing truth                              | TODO; K-17                                          |
 
 Status values: TODO · PARTIAL · BLOCKED (with reason) · IN PROGRESS.
 
@@ -55,16 +54,15 @@ table replaces its status claims.
 | K-14    | FIXED          | PR #37 gives slow installer suites an explicit reachable timeout budget.                                                                                               |
 | K-15    | FIXED          | PR #44 structurally contains recursive staging cleanup.                                                                                                                |
 | K-16    | OPEN           | Global help still promises `--dry-run` changes nothing while the reader only guards protocol install/rollback; plan 023.                                               |
-| K-17    | OPEN           | AllManga and Miruro still prefer `absoluteEpisode`; plan 046.                                                                                                          |
+| K-17    | FIXED          | AllAnime and Miruro now prefer a proven season-relative episode; absolute-only inputs retain absolute routing.                                                         |
 
-Current count after plan 047: **13 fixed, 4 open**.
+Current count after plan 046: **14 fixed, 3 open**.
 
 ## Release-focused train
 
 1. The docs/truth reconciliation and plan 047 lifecycle slice are complete.
-2. Execute the release-truth slices together only if the diff stays reviewable:
-   plan 021 K-04/K-08 removal, plan 023 K-16 narrowing, and plan 046 K-17
-   routing. Keep separate commits so any provider change can be reverted alone.
+2. Provider routing plan 046 is complete. Execute plan 021 K-04/K-08 removal
+   and plan 023 K-16 narrowing together only if the diff stays reviewable.
 3. Execute plan 043 as its own migration PR.
 4. Rebase and re-audit the existing `fix/tracker-sync-correctness` worktree,
    then execute plan 032. Do not merge that stale branch as-is.

--- a/plans/archive/046-provider-episode-routing-truth.md
+++ b/plans/archive/046-provider-episode-routing-truth.md
@@ -57,4 +57,15 @@ the routing rule to make a live smoke green.
 - A proposed fix touches `packages/providers/src/allmanga/api-client.ts` crypto,
   attestation, or decoder constants.
 
-Status: TODO
+## Result
+
+- `selectProviderEpisodeNumber()` now owns the shared season-relative-first
+  policy used by both AllAnime and Miruro.
+- Provider-package regression tests cover S2E1 with absolute 13, absolute-only
+  requests, and the missing-identity default.
+- The AllAnime live smoke reached its current episode catalog but stream
+  resolution was captcha-gated from the test network. The Miruro live smoke was
+  blocked by Cloudflare WAF on both mirrors. These are classified provider
+  availability failures, not reasons to restore unsafe episode routing.
+
+Status: COMPLETE

--- a/plans/archive/README.md
+++ b/plans/archive/README.md
@@ -9,7 +9,7 @@ commit that is now far behind, and its "Current state" excerpts describe code
 that has since changed.
 
 Archived so far: 001–005, 007, 009, 016–020, 024–029, 031, 033–042,
-044–045, 047, plus the old 2026-07-22 handoff.
+044–047, plus the old 2026-07-22 handoff.
 
 ## Notes worth carrying forward
 


### PR DESCRIPTION
## Summary

- route AllAnime and Miruro with a proven season-relative episode before `absoluteEpisode`
- retain absolute numbering for absolute-only requests and episode 1 as the missing-identity fallback
- centralize the provider-side policy with deterministic regression coverage
- document the numbering contract, archive completed plan 046, and mark K-17 fixed

## Verification

- `bun run --cwd packages/providers test` — 339 passed
- `bun run test` — all workspace tasks passed; 4,195 CLI unit tests passed
- `bun run typecheck`
- `bun run lint` — 0 errors; 5 pre-existing CLI warnings in untouched files
- `bun run fmt`
- `bun run verify:doc-paths`
- `bun run build`
- `git diff --check`

## Live provider evidence

- AllAnime: catalog and episode metadata loaded, then stream resolution was captcha-gated from the test network
- Miruro: request reached the live pipe path, then both mirrors were blocked by Cloudflare WAF

These are classified availability failures. The deterministic routing contract remains enforced.
