### PR TITLE
docs: rescue the active analytics plan from the archive

### DIFF
--- a/.plans/roadmap.md
+++ b/.plans/roadmap.md
@@ -61,6 +61,12 @@ archive and put only the residue here.
 | Boundary + downloads         | Reviewed adaptive-download design, not started           | [boundary-hardening-and-adaptive-downloads.md](./boundary-hardening-and-adaptive-downloads.md)   |
 | Poster release smokes        | Real-terminal Kitty, iTerm2, Sixel, and multiplexer pass | [poster-protocol-release-smokes.md](./poster-protocol-release-smokes.md)                         |
 
+### Analytics
+
+| Track                    | Remaining                                                                                                           | Plan                                                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Usage analytics redesign | Spec and plan written, not executed. Replaces the never-shipped opt-in ping with an opt-out subsystem over Postgres | [usage-analytics-redesign.md](./usage-analytics-redesign.md) · [design](./usage-analytics-redesign-design.md) |
+
 ### Structure
 
 | Track                        | Remaining                                                                                                                                                                                                          | Plan                                                                         |

--- a/.plans/usage-analytics-redesign-design.md
+++ b/.plans/usage-analytics-redesign-design.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-14
 Status: approved design, not yet implemented
-Supersedes: `docs/superpowers/archive/specs/2026-07-25-telemetry-privacy-and-observability-design.md`
+Supersedes: `.archive/superpowers/archive/specs/2026-07-25-telemetry-privacy-and-observability-design.md`
 
 ## Why
 

--- a/.plans/usage-analytics-redesign.md
+++ b/.plans/usage-analytics-redesign.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Bun, TypeScript, Ink (terminal UI), Vercel functions, Neon Postgres (`@neondatabase/serverless`), Next.js (docs site), `bun:test`.
 
-**Spec:** [`docs/superpowers/specs/2026-08-14-usage-analytics-redesign-design.md`](../specs/2026-08-14-usage-analytics-redesign-design.md)
+**Spec:** [`.plans/usage-analytics-redesign-design.md`](./usage-analytics-redesign-design.md)
 
 ## Global Constraints
 
@@ -3232,7 +3232,7 @@ test so the contract and the user-facing page cannot diverge from code."
 
 ## Execution Handoff
 
-Plan complete and saved to `docs/superpowers/plans/2026-08-14-usage-analytics-redesign.md`. Two execution options:
+Plan complete and saved to `.plans/usage-analytics-redesign.md`. Two execution options:
 
 **1. Subagent-Driven (recommended)** — a fresh subagent per task, review between tasks, fast iteration.
 


### PR DESCRIPTION
## What changed

#54 moved `docs/superpowers/` wholesale into `.archive/`. That was right for the closed SDD wave, but it swept up the one plan still in flight — the **usage analytics redesign**, whose checkboxes are unticked and whose config rename is in progress in the working tree.

`.archive/README.md` states its contents carry **no authority**, so leaving an unfinished plan there hides live work from exactly the agents meant to execute it. This is the doc rot the consolidation exists to prevent, caused by the consolidation itself.

- `.archive/superpowers/plans/2026-08-14-usage-analytics-redesign.md` → `.plans/usage-analytics-redesign.md`
- `.archive/superpowers/specs/2026-08-14-usage-analytics-redesign-design.md` → `.plans/usage-analytics-redesign-design.md`
- Indexed on `.plans/roadmap.md` under a new **Analytics** track — an unindexed plan does not exist under the roadmap's own rule 2.

Also repoints three links the move had broken: the plan's spec reference, the spec's superseded-by note, and a self-reference in the plan footer.

## Checklist

- [x] Changeset — **N/A**, docs only
- [x] `bun run guard` — N/A
- [x] `bun run fmt && bun run lint && bun run test && bun run typecheck` — `bun run ci` green, 51/51
- [x] `bun run build` — N/A, no packaging-sensitive change
- [x] Live smokes skipped intentionally — no runtime change