### PR TITLE
feat(providers): AniDB→AniSkip MAL propagation, Miruro WAF hint, relay hardening

### DIFF
--- a/.changeset/provider-routes-and-relay-truth.md
+++ b/.changeset/provider-routes-and-relay-truth.md
@@ -1,0 +1,10 @@
+---
+"@kitsunekode/kunai": minor
+---
+
+Keep the anime auto-skip and provider-relay paths working after upstream rotations.
+
+- AniSkip now resolves a MAL id for AniDB titles, so opening and ending skips work on the default anime provider instead of silently never firing. The lookup shares the provider package's Cloudflare-aware transport and overlaps stream resolution, so it adds no serial request to playback start.
+- AllAnime tracks the upstream `mkissa` rotation to build 119 and 7-day epochs; the previous constants failed every stream request with `AA_CRYPTO_MISSING_BUILD`.
+- A relay no longer strips the provider-auth headers (`x-build-id`, `x-aa-boot`, `x-obfuscated`, `x-session-token`) that AllAnime bootstrap and Miruro decoding depend on, which previously made every bootstrap through a relay fail with `invalid_boot_token`.
+- A Miruro request blocked by Cloudflare now names the user-owned relay workaround rather than reporting an unexplained failure.

--- a/.docs/playback-timing-and-aniskip.md
+++ b/.docs/playback-timing-and-aniskip.md
@@ -57,6 +57,17 @@ Reference ecosystem: [synacktraa/ani-skip](https://github.com/synacktraa/ani-ski
 | Numeric                          | AniList, TMDB TV, or other     | Try ARM `anilist` → MAL; if missing, try ARM **TMDB → MAL** list (first entry; split cours caveat).                                                                   |
 | Opaque + non-AllAnime provider   | Unknown catalog                | Fall back: AniList **title search** (optional `seasonYear` from `title.year`) → ARM AniList → MAL.                                                                    |
 
+**AniDB stamps MAL at resolve time.** The AniDB module's `resolve()` calls
+`fetchAnidbMalId()` (in `packages/providers/src/anidb/client.ts`, TTL 1 h cache,
+scrapes `myanimelist.net/anime/{id}` from the anidb.app anime page) when the input
+title carries no `malId`, and stamps the value into the resolve result's
+`externalIds.malId`. AniSkip's direct `externalIds.malId` short-circuit
+(`resolveMalIdForAniSkip`) then wins, so AniDB-sourced titles skip the fuzzy
+AniList title-search fallback entirely. Input `malId` is always preferred over the
+scrape; the scrape is best-effort (undefined on failure), runs **in parallel** with
+stream resolution so it never adds a serial request to the resolve hot path, and
+never blocks resolve.
+
 **Important:** `PlaybackTimingFetchContext.providerId` must match the **manifest provider id** (e.g. `allanime` from `@kunai/core`), because branching keys off that string.
 
 ## `PlaybackTimingFetchContext` (extension seam)

--- a/.docs/provider-dossiers/allmanga.md
+++ b/.docs/provider-dossiers/allmanga.md
@@ -1,6 +1,6 @@
 ---
 status: current
-lastReviewed: "2026-07-19"
+lastReviewed: "2026-08-17"
 ---
 
 # Provider: AllManga / AllAnime
@@ -10,7 +10,7 @@ lastReviewed: "2026-07-19"
 ## Summary
 
 - **Runtime class:** Direct HTTP GraphQL + decoded source APIs. No browser should be needed on the hot path.
-- **Reference implementation:** Local ani-cli checkout at `~/Projects/osc/ani-cli`.
+- **Reference implementation:** Local ani-cli checkout at `~/Projects/osc/ani-cli` — historical only: ani-cli v5 (2026-08-01) moved to anidb.app and deleted its AllAnime code, so the live mkissa JS chunk is the sole source of truth now.
 - **Production module:** `packages/providers/src/allmanga/*`.
 - **Current status (2026-07-18):** Episode resolve requires ani-cli `aaReq` AES-GCM attestation + rotated hex decrypt key (`origin/fix`). Without it the API returns `AA_CRYPTO_MISSING`. Search/episode catalog POST paths still work without `aaReq`.
 
@@ -29,7 +29,7 @@ The source flow matches ani-cli:
 
 ```text
 episode GraphQL persisted GET + aaReq + x-build-id
-  -> "tobeparsed" AES-CTR payload (hex key)
+  -> "tobeparsed" AES-256-GCM payload (rotated hex key, build id 81)
   -> decoded source names + encoded API paths (or direct https embeds)
   -> per-source API fetch on allanime.day
   -> mp4 / HLS / DASH-shaped candidates
@@ -37,14 +37,14 @@ episode GraphQL persisted GET + aaReq + x-build-id
 
 ani-cli currently generates links for these source families:
 
-| Source family       | ani-cli behavior                          | Kunai behavior today            |
-| ------------------- | ----------------------------------------- | ------------------------------- |
-| `Default`           | WIXMP/repackager or master HLS extraction | Supported                       |
-| `Yt-mp4`            | direct tools/fast4speed URL               | Supported                       |
-| `S-mp4`             | API JSON with direct mp4 when present     | Supported when link exists      |
-| `Mp4`               | mp4upload page scrape                     | Not a current production target |
-| `Fm-mp4` / Filemoon | AES/decrypt path                          | Partially supported             |
-| `Ak`                | Not in the older ani-cli provider list    | **Current drift gap**           |
+| Source family       | ani-cli behavior                          | Kunai behavior today                                                                      |
+| ------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `Default`           | WIXMP/repackager or master HLS extraction | Supported                                                                                 |
+| `Yt-mp4`            | direct tools/fast4speed URL               | Supported                                                                                 |
+| `S-mp4`             | API JSON with direct mp4 when present     | Supported when link exists                                                                |
+| `Mp4`               | mp4upload page scrape                     | Supported (embed scrape + `Referer: https://www.mp4upload.com`, scoped `--tls-verify=no`) |
+| `Fm-mp4` / Filemoon | AES/decrypt path                          | Removed upstream (b8032b7); no Kunai code path remains                                    |
+| `Ak`                | Not in the older ani-cli provider list    | **Current drift gap**                                                                     |
 
 ### Solo Leveling S01E01 drift
 
@@ -94,7 +94,7 @@ The experiment generated a temporary MPD from one selected video representation 
 ## Known
 
 - GraphQL search/catalog is working with `youtu-chan.com` referer.
-- The AES-CTR `tobeparsed` decode constants still match ani-cli parity.
+- The AES-256-GCM `tobeparsed` decode path and build id 81 crypto bootstrap are verified working; AES-CTR must not be restored (see `.docs/providers.md`).
 - Source APIs can return valid data that is not a single HLS/mp4 URL.
 - Returning only the `Ak` video URL would be wrong because audio is separate.
 - The provider contract already allows `protocol: "dash"` and `container: "mpd"`, but there is no implemented AllManga MPD/EDL handoff for `rawUrls`.

--- a/.docs/provider-dossiers/allmanga.md
+++ b/.docs/provider-dossiers/allmanga.md
@@ -29,7 +29,7 @@ The source flow matches ani-cli:
 
 ```text
 episode GraphQL persisted GET + aaReq + x-build-id
-  -> "tobeparsed" AES-256-GCM payload (rotated hex key, build id 81)
+  -> "tobeparsed" AES-256-GCM payload (rotated hex key, build id 119, 7-day epochs)
   -> decoded source names + encoded API paths (or direct https embeds)
   -> per-source API fetch on allanime.day
   -> mp4 / HLS / DASH-shaped candidates
@@ -94,7 +94,7 @@ The experiment generated a temporary MPD from one selected video representation 
 ## Known
 
 - GraphQL search/catalog is working with `youtu-chan.com` referer.
-- The AES-256-GCM `tobeparsed` decode path and build id 81 crypto bootstrap are verified working; AES-CTR must not be restored (see `.docs/providers.md`).
+- The AES-256-GCM `tobeparsed` decode path and build id 119 crypto bootstrap are verified working (re-derived 2026-08-17 after the 81→119 build rotation; episodes resolve through a user relay); AES-CTR must not be restored (see `.docs/providers.md`).
 - Source APIs can return valid data that is not a single HLS/mp4 URL.
 - Returning only the `Ak` video URL would be wrong because audio is separate.
 - The provider contract already allows `protocol: "dash"` and `container: "mpd"`, but there is no implemented AllManga MPD/EDL handoff for `rawUrls`.

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -473,6 +473,32 @@ module.
 `x-aa-boot`, and AES-256-GCM are all working and verified. The historical
 epoch/partB query construction and AES-CTR decryption must not be restored.
 
+### AllAnime via user relay (2026-08-17)
+
+With a user-owned relay in place, the picture changes:
+
+- The relay egress (Vercel `iad1` in the reference deployment) reaches
+  `api.mkissa.net` and `cdn.mkissa.net` without a Cloudflare challenge —
+  `GET https://api.mkissa.net/` answers with a plain upstream 404, not CF HTML.
+- Bootstrap, search, and the episode **catalog** all succeed through the relay.
+- The episode **sources** query now answers `AA_CRYPTO_MISSING_BUILD` — upstream
+  rotated the build id/string-table material out from under build 81. The
+  bootstrap endpoint still serves build-81 material (queryHash
+  `f4662f4b7510b26795dd53ef824a0bf1740fbbc5d1273fab18222ac831bca8d0`), which the
+  API no longer accepts. Both the dynamic and bundled material fail identically,
+  so this is a fresh crypto-intake task: re-derive the current build id, mask
+  fragments, and query hash from the live chunks on
+  `cdn.mkissa.net/all/mk/_app/immutable/` (the string-table rotator lives in the
+  crypto chunk, e.g. `CA0Qy_FU.js`). Until then AllAnime stays catalog-only even
+  through a relay.
+
+- **Deployed relays go stale with provider manifests.** The relay server builds
+  its host registry from `@kunai/providers` manifests at deploy time. A relay
+  deployed before the mkissa migration rejects `api.mkissa.net` with
+  `host-not-allowed`. After any change to a provider's `relayProfile.upstreamHosts`,
+  redeploy the relay. `apps/relay-server` also pins `typescript@5.9.3` because
+  Vercel's `@vercel/node` builder crashes on the repo-wide TypeScript 7.
+
 **wixmp referer: current behaviour retained.** Plan 036 proposed attaching the
 mkissa site referer for `repackager.wixmp.com`, gated on a fixture proving the
 current final-stream fallback insufficient. No such fixture can be built from this
@@ -701,6 +727,10 @@ Miruro resolves entirely through `GET /api/secure/pipe?e=…` on `www.miruro.bz`
   escape hatch that exists — a user-owned relay (`providerRelay.baseUrl`) in an
   ungated region; as of 2026-08-17 the `curl --http2` fallback is itself CF-403'd
   from some networks, so the hint is the actionable part of the failure.
+  Verified live the same day: a relay deployed on Vercel `iad1` receives the
+  "Just a moment" challenge on the pipe too, so that region does **not** count
+  as ungated for Miruro — only a relay on an egress Miruro's WAF tolerates
+  (unproven region, likely non-US cloud IPs) would clear the gate.
 - **Live evidence is the smoke's job.** `bun run test:live:miruro` resolves through
   `container.engine.resolve(...)`, probes the selected stream itself, and reports
   `streamReachable` and `resolverAttestedReachable` separately. It passes on measured

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -697,7 +697,10 @@ Miruro resolves entirely through `GET /api/secure/pipe?e=…` on `www.miruro.bz`
 - **The WAF fail-fast threshold of 2 is deliberate, not a defect.** It equals the real
   mirror count (`www.miruro.bz` + `www.miruro.ru`); when both return Cloudflare HTML
   the block is region-wide and further candidates fail identically. Changing it needs
-  a reproducible failure sequence, not a guess.
+  a reproducible failure sequence, not a guess. The block message names the one
+  escape hatch that exists — a user-owned relay (`providerRelay.baseUrl`) in an
+  ungated region; as of 2026-08-17 the `curl --http2` fallback is itself CF-403'd
+  from some networks, so the hint is the actionable part of the failure.
 - **Live evidence is the smoke's job.** `bun run test:live:miruro` resolves through
   `container.engine.resolve(...)`, probes the selected stream itself, and reports
   `streamReachable` and `resolverAttestedReachable` separately. It passes on measured

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -431,7 +431,7 @@ If the provider has native search or episode listing, export standalone function
   - search GraphQL query shape
   - episode list query shape
   - episode source GET with persisted query + `aaReq` AES-256-GCM attestation — without this the API returns `AA_CRYPTO_MISSING`; a rotated key/epoch/build returns `AA_CRYPTO_STALE`/`AA_CRYPTO_INVALID`/`AA_CRYPTO_MISSING_BUILD`
-  - dynamic key derivation (`getAllMangaCryptoMaterial`): bootstrap `GET /client-crypto/v1/bootstrap?buildId=81&k=k7` with HMAC `x-aa-boot`, then `key = deriveMaskKey(buildId) XOR partB` (see `packages/providers/src/allmanga/crypto.ts`). Bundled material is fallback only
+  - dynamic key derivation (`getAllMangaCryptoMaterial`): bootstrap `GET /client-crypto/v1/bootstrap?buildId=119&k=k7` with HMAC `x-aa-boot`, then `key = deriveMaskKey(buildId) XOR partB` (see `packages/providers/src/allmanga/crypto.ts`). Bundled material is fallback only
   - `aaReq` AES-256-GCM over `{v,ts,epoch,buildId,qh,k}` with IV `SHA-256(epoch:buildId:qh:ts:k)[0:12]`; send `x-build-id` on API GETs
   - `tobeparsed` AES-256-GCM decoding: base64(0x01 || iv12 || ct || tag16)
   - source-name inventory and ranking (`Default`, `Yt-mp4`, `S-mp4`, `Mp4`/mp4upload, `Luf-Mp4`, `Ak`; Filemoon removed upstream)
@@ -475,23 +475,34 @@ epoch/partB query construction and AES-CTR decryption must not be restored.
 
 ### AllAnime via user relay (2026-08-17)
 
-With a user-owned relay in place, the picture changes:
+With a user-owned relay in place, AllAnime works end-to-end. `bun run
+test:live:relay-allanime` passes with real streams (e.g. `video.wixstatic.com`
+1080p mp4 via the `Default` source).
 
 - The relay egress (Vercel `iad1` in the reference deployment) reaches
-  `api.mkissa.net` and `cdn.mkissa.net` without a Cloudflare challenge —
-  `GET https://api.mkissa.net/` answers with a plain upstream 404, not CF HTML.
-- Bootstrap, search, and the episode **catalog** all succeed through the relay.
-- The episode **sources** query now answers `AA_CRYPTO_MISSING_BUILD` — upstream
-  rotated the build id/string-table material out from under build 81. The
-  bootstrap endpoint still serves build-81 material (queryHash
-  `f4662f4b7510b26795dd53ef824a0bf1740fbbc5d1273fab18222ac831bca8d0`), which the
-  API no longer accepts. Both the dynamic and bundled material fail identically,
-  so this is a fresh crypto-intake task: re-derive the current build id, mask
-  fragments, and query hash from the live chunks on
-  `cdn.mkissa.net/all/mk/_app/immutable/` (the string-table rotator lives in the
-  crypto chunk, e.g. `CA0Qy_FU.js`). Until then AllAnime stays catalog-only even
-  through a relay.
+  `api.mkissa.net` and `cdn.mkissa.net` without a Cloudflare challenge and is
+  **not** captcha-gated for the episode sources query.
+- On 2026-08-17 the upstream build rotated **81 → 119** and the epoch scale
+  moved from 3-day to **7-day** (`epochMs: 604800000`, 1-day grace, plus a
+  `switchAt` boundary). The old material answered `AA_CRYPTO_MISSING_BUILD`.
+  The new constants (build id `119`, mask fragments, epoch scale, and the
+  episode persisted-query hash `ca735f…`) were re-derived from the live site:
+  string table + rotation from the crypto chunk (`CA0Qy_FU.js`, 144-entry
+  table, rotation verified by recomputing the browser's `x-aa-boot` HMAC) and
+  the episode hash from the `_9` GraphQL template in the same chunk, then
+  confirmed against a real browser session's network traffic. The same
+  procedure applies on the next rotation.
+- The episode sources request now also carries `k: "k7"` in `extensions`
+  (alongside `persistedQuery` + `aaReq`), matching the live site.
 
+**Relay gaps found and fixed the same day:**
+
+- **The relay metadata allowlist was dropping provider-auth headers.**
+  `x-build-id`, `x-aa-boot`, `x-obfuscated`, and `x-session-token` were not in
+  `METADATA_HEADER_ALLOWLIST`, so every bootstrap through a relay failed with
+  `invalid_boot_token` even when the client material was correct. They are now
+  forwarded (header-text validation still applies); `x-obfuscated` is also
+  passed through on relay responses for Miruro pipe decoding.
 - **Deployed relays go stale with provider manifests.** The relay server builds
   its host registry from `@kunai/providers` manifests at deploy time. A relay
   deployed before the mkissa migration rejects `api.mkissa.net` with

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -742,6 +742,20 @@ Miruro resolves entirely through `GET /api/secure/pipe?e=…` on `www.miruro.bz`
   "Just a moment" challenge on the pipe too, so that region does **not** count
   as ungated for Miruro — only a relay on an egress Miruro's WAF tolerates
   (unproven region, likely non-US cloud IPs) would clear the gate.
+- **The pipe itself is fingerprint-gated, not dead.** From a real browser the
+  envelope (`?e=base64url({path,method,query,body,version})`, e.g.
+  `{"path":"episodes","query":{"anilistId":"21"},"version":"0.2.0"}`) answers
+  200 with `x-obfuscated: 2` while plain curl gets CF HTML — intermittent by
+  network. The curl fallback now reuses the AniDB curl-impersonate candidate
+  list (`shared/curl-impersonate.ts`): with `curl_chrome136`/`curl_firefox135`
+  installed, the pipe request carries a browser TLS fingerprint and clears the
+  gate. Without an impersonate build, a WAF 403 is expected behavior, not a bug.
+- **Per-server failures are not provider failures.** Miruro's site marks single
+  servers under maintenance ("Some servers are under maintenance. Please switch
+  servers if needed.") while others keep working. Kunai mirrors that: after the
+  pipe resolves, each server is attempted as its own source candidate
+  (`source:miruro:pipe:<server>:<audio>`), and a failed candidate moves to the
+  next server in `MIRURO_SERVER_TRY_ORDER` instead of exhausting the provider.
 - **Live evidence is the smoke's job.** `bun run test:live:miruro` resolves through
   `container.engine.resolve(...)`, probes the selected stream itself, and reports
   `streamReachable` and `resolverAttestedReachable` separately. It passes on measured

--- a/apps/cli/src/aniskip.ts
+++ b/apps/cli/src/aniskip.ts
@@ -5,6 +5,7 @@ import {
   type PlaybackTimingSourceFetchResult,
 } from "@/infra/timing/PlaybackTimingSource";
 import { fetchArmIdGraph } from "@/services/catalog/arm-client";
+import { fetchAnidbMalId } from "@kunai/providers";
 import type { ProviderExternalIds } from "@kunai/types";
 
 const ANISKIP_API = "https://api.aniskip.com/v1/skip-times";
@@ -84,40 +85,19 @@ async function fetchMalIdFromAllAnimeShow(
   }
 }
 
-const ANIDB_MAL_LOOKUP_UA =
-  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
-const malIdFromAnidbShowCache = new Map<string, number | null>();
-
 /**
  * Resolve MAL numeric id from an AniDB catalog show id, matching ani-cli `anidb_desc`.
+ *
+ * Delegates to the provider package rather than scraping here: AniDB sits behind
+ * Cloudflare, and `fetchAnidbMalId` goes through the shared curl transport that
+ * gets past it. A plain `fetch` from this side would be served the interstitial,
+ * find no MAL link in it, and cache that as "this show has no MAL id".
  */
 async function fetchMalIdFromAnidbShow(
   showId: string,
   signal?: AbortSignal,
 ): Promise<number | null> {
-  if (malIdFromAnidbShowCache.has(showId)) return malIdFromAnidbShowCache.get(showId) ?? null;
-
-  try {
-    const res = await fetch(`https://anidb.app/anime/${encodeURIComponent(showId)}`, {
-      headers: {
-        "User-Agent": ANIDB_MAL_LOOKUP_UA,
-        Referer: "https://anidb.app/",
-      },
-      signal: signal ?? AbortSignal.timeout(5_000),
-    });
-    if (!res.ok) {
-      malIdFromAnidbShowCache.set(showId, null);
-      return null;
-    }
-    const page = await res.text();
-    const match = /https:\/\/myanimelist\.net\/anime\/(\d+)/.exec(page);
-    const parsed = match?.[1] ? Number.parseInt(match[1], 10) : null;
-    malIdFromAnidbShowCache.set(showId, parsed);
-    return parsed;
-  } catch {
-    malIdFromAnidbShowCache.set(showId, null);
-    return null;
-  }
+  return (await fetchAnidbMalId(showId, signal)) ?? null;
 }
 
 async function resolveMalIdForAniSkip(opts: {

--- a/apps/cli/src/aniskip.ts
+++ b/apps/cli/src/aniskip.ts
@@ -84,6 +84,42 @@ async function fetchMalIdFromAllAnimeShow(
   }
 }
 
+const ANIDB_MAL_LOOKUP_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+const malIdFromAnidbShowCache = new Map<string, number | null>();
+
+/**
+ * Resolve MAL numeric id from an AniDB catalog show id, matching ani-cli `anidb_desc`.
+ */
+async function fetchMalIdFromAnidbShow(
+  showId: string,
+  signal?: AbortSignal,
+): Promise<number | null> {
+  if (malIdFromAnidbShowCache.has(showId)) return malIdFromAnidbShowCache.get(showId) ?? null;
+
+  try {
+    const res = await fetch(`https://anidb.app/anime/${encodeURIComponent(showId)}`, {
+      headers: {
+        "User-Agent": ANIDB_MAL_LOOKUP_UA,
+        Referer: "https://anidb.app/",
+      },
+      signal: signal ?? AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) {
+      malIdFromAnidbShowCache.set(showId, null);
+      return null;
+    }
+    const page = await res.text();
+    const match = /https:\/\/myanimelist\.net\/anime\/(\d+)/.exec(page);
+    const parsed = match?.[1] ? Number.parseInt(match[1], 10) : null;
+    malIdFromAnidbShowCache.set(showId, parsed);
+    return parsed;
+  } catch {
+    malIdFromAnidbShowCache.set(showId, null);
+    return null;
+  }
+}
+
 async function resolveMalIdForAniSkip(opts: {
   catalogTitleId: string;
   externalIds?: ProviderExternalIds;
@@ -106,6 +142,11 @@ async function resolveMalIdForAniSkip(opts: {
   if (providerId === "allanime" && catalogTitleId && !isNumericAniListId(catalogTitleId)) {
     const fromAllAnime = await fetchMalIdFromAllAnimeShow(catalogTitleId, signal);
     if (fromAllAnime !== null) return fromAllAnime;
+  }
+
+  if (providerId === "anidb" && catalogTitleId && !isNumericAniListId(catalogTitleId)) {
+    const fromAnidb = await fetchMalIdFromAnidbShow(catalogTitleId, signal);
+    if (fromAnidb !== null) return fromAnidb;
   }
 
   const nativeAniListId = normalizeNumericId(externalIds?.anilistId);

--- a/apps/cli/test/unit/aniskip.test.ts
+++ b/apps/cli/test/unit/aniskip.test.ts
@@ -50,3 +50,38 @@ test("fetchAniSkipTimingMetadata uses provider-native MAL id before lookup fallb
     false,
   );
 });
+
+test("fetchAniSkipTimingMetadata resolves MAL id from AniDB show page for opaque anidb catalog ids", async () => {
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    calls.push(url);
+    if (url.includes("anidb.app/anime/onigiri-3942")) {
+      return new Response(
+        '<html><body><a href="https://myanimelist.net/anime/32606/Onigiri">MAL</a></body></html>',
+        { status: 200, headers: { "content-type": "text/html" } },
+      );
+    }
+    if (url.includes("api.aniskip.com")) {
+      return new Response(
+        JSON.stringify({
+          found: true,
+          results: [{ skipType: "op", interval: { startTime: 0, endTime: 30 } }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response("Not Found", { status: 404 });
+  }) as typeof fetch;
+
+  const timing = await fetchAniSkipTimingMetadata({
+    anilistId: "onigiri-3942",
+    titleName: "Onigiri",
+    providerId: "anidb",
+    episode: 1,
+  });
+
+  expect(timing?.intro).toEqual([{ startMs: 0, endMs: 30000 }]);
+  expect(calls.some((url) => url.includes("anidb.app/anime/onigiri-3942"))).toBe(true);
+  expect(calls.some((url) => url.includes("/32606/1?"))).toBe(true);
+});

--- a/apps/cli/test/unit/aniskip.test.ts
+++ b/apps/cli/test/unit/aniskip.test.ts
@@ -56,13 +56,20 @@ test("fetchAniSkipTimingMetadata resolves MAL id from AniDB show page for opaque
   globalThis.fetch = (async (input: string | URL | Request) => {
     const url = String(input);
     calls.push(url);
-    if (url.includes("anidb.app/anime/onigiri-3942")) {
+    const parsed = (() => {
+      try {
+        return new URL(url);
+      } catch {
+        return null;
+      }
+    })();
+    if (parsed?.hostname === "anidb.app" && parsed.pathname === "/anime/onigiri-3942") {
       return new Response(
         '<html><body><a href="https://myanimelist.net/anime/32606/Onigiri">MAL</a></body></html>',
         { status: 200, headers: { "content-type": "text/html" } },
       );
     }
-    if (url.includes("api.aniskip.com")) {
+    if (parsed?.hostname === "api.aniskip.com") {
       return new Response(
         JSON.stringify({
           found: true,
@@ -82,6 +89,14 @@ test("fetchAniSkipTimingMetadata resolves MAL id from AniDB show page for opaque
   });
 
   expect(timing?.intro).toEqual([{ startMs: 0, endMs: 30000 }]);
-  expect(calls.some((url) => url.includes("anidb.app/anime/onigiri-3942"))).toBe(true);
+  const anidbShowCall = calls.find((url) => {
+    try {
+      const parsed = new URL(url);
+      return parsed.hostname === "anidb.app" && parsed.pathname === "/anime/onigiri-3942";
+    } catch {
+      return false;
+    }
+  });
+  expect(anidbShowCall).toBeDefined();
   expect(calls.some((url) => url.includes("/32606/1?"))).toBe(true);
 });

--- a/apps/cli/test/unit/aniskip.test.ts
+++ b/apps/cli/test/unit/aniskip.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, expect, test } from "bun:test";
 
 import { fetchAniSkipTimingMetadata, mapAniSkipTypeToTimingField } from "@/aniskip";
+import { clearAnidbCachesForTest } from "@kunai/providers";
 
 const originalFetch = globalThis.fetch;
+const originalWhich = Bun.which;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  Bun.which = originalWhich;
+  // The AniDB MAL cache lives in the provider package and outlives a test file.
+  clearAnidbCachesForTest();
 });
 
 test("mapAniSkipTypeToTimingField only accepts playback skip categories we intentionally support", () => {
@@ -52,6 +57,10 @@ test("fetchAniSkipTimingMetadata uses provider-native MAL id before lookup fallb
 });
 
 test("fetchAniSkipTimingMetadata resolves MAL id from AniDB show page for opaque anidb catalog ids", async () => {
+  // The AniDB scrape goes through the provider package's curl transport, which
+  // only falls back to `fetch` when no curl is on PATH. Hiding curl is what
+  // makes the stub below observable.
+  Bun.which = ((_command: string) => null) as typeof Bun.which;
   const calls: string[] = [];
   globalThis.fetch = (async (input: string | URL | Request) => {
     const url = String(input);

--- a/apps/relay-server/README.md
+++ b/apps/relay-server/README.md
@@ -41,6 +41,27 @@ The bundle step is required because this app imports Bun workspace packages
 (`@kunai/relay`, `@kunai/providers`). It replaces Vercel's generated function
 handlers with standalone bundled handlers before `--prebuilt` upload.
 
+This app pins `typescript@5.9.3` in `package.json`: Vercel's `@vercel/node`
+builder crashes ("Cannot read properties of undefined (reading 'readFile')")
+on the repo-wide TypeScript 7 catalog entry. Keep the pin; `packages/relay`
+code is kept TS 5.9-compatible for the same reason (no `Headers.entries()`).
+
+**Redeploy after provider manifest host changes.** The RPC registry is built
+from `@kunai/providers` manifests at deploy time. If a provider's
+`relayProfile.upstreamHosts` changes upstream, an already-deployed relay keeps
+rejecting the new hosts with `host-not-allowed` until it is redeployed. After
+deploying, run the drift check to confirm the live registry matches the
+current manifests:
+
+```sh
+KUNAI_RELAY_BASE_URL=https://your-relay.vercel.app \
+KUNAI_RELAY_TOKEN=same-token-as-RELAY_TOKEN \
+bun run verify:deploy
+```
+
+The `registry-matches-current-manifests` check probes one upstream host per
+provider and fails loudly if the deployed registry still rejects it.
+
 `vercel.json` rewrites `/rpc/:providerId` to the Vercel function and pins execution to `iad1`. Change the region only if you know the provider works better from another Vercel region.
 
 Set `RELAY_TOKEN` for internet deployments:

--- a/apps/relay-server/package.json
+++ b/apps/relay-server/package.json
@@ -22,9 +22,7 @@
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
-  },
-  "peerDependencies": {
-    "typescript": "catalog:"
+    "@types/node": "catalog:",
+    "typescript": "5.9.3"
   }
 }

--- a/apps/relay-server/scripts/verify-relay-deploy.ts
+++ b/apps/relay-server/scripts/verify-relay-deploy.ts
@@ -64,6 +64,34 @@ if (token) {
       }
     },
   });
+  checks.push({
+    name: "registry-matches-current-manifests",
+    async run() {
+      const probes = [
+        { providerId: "allanime", url: "https://api.mkissa.net/" },
+        { providerId: "miruro", url: "https://www.miruro.bz/" },
+        { providerId: "rivestream", url: "https://www.rivestream.app/api" },
+        { providerId: "videasy", url: "https://api.speedracelight.com/seed" },
+        { providerId: "vidlink", url: "https://enc-dec.app/api" },
+      ] as const;
+      for (const probe of probes) {
+        const response = await fetch(`${baseUrl}/rpc/${probe.providerId}`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ method: "GET", upstreamUrl: probe.url, headers: {} }),
+        });
+        const text = await response.text();
+        if (text.includes("host-not-allowed")) {
+          throw new Error(
+            `${probe.providerId} rejects ${new URL(probe.url).host} — deployed registry is stale; redeploy from current manifests`,
+          );
+        }
+      }
+    },
+  });
 }
 
 let failed = 0;

--- a/bun.lock
+++ b/bun.lock
@@ -106,9 +106,7 @@
       "devDependencies": {
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
-      },
-      "peerDependencies": {
-        "typescript": "catalog:",
+        "typescript": "5.9.3",
       },
     },
     "packages/config": {
@@ -1891,6 +1889,8 @@
     "@dotenvx/dotenvx/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
     "@kunai/docs/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@kunai/relay-server/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@manypkg/find-root/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 

--- a/packages/providers/src/allmanga/api-client.ts
+++ b/packages/providers/src/allmanga/api-client.ts
@@ -704,6 +704,7 @@ export async function resolveEpisodeSources(opts: {
     const getUrl = `${apiUrl}?variables=${encodeURIComponent(JSON.stringify(vars))}&extensions=${encodeURIComponent(
       JSON.stringify({
         persistedQuery: { version: 1, sha256Hash: material.queryHash },
+        k: material.contentLane,
         aaReq,
       }),
     )}`;

--- a/packages/providers/src/allmanga/crypto.ts
+++ b/packages/providers/src/allmanga/crypto.ts
@@ -9,19 +9,22 @@ import { providerFetch } from "../runtime/fetch";
  *
  * Upstream left the ani-cli `72d7f72` "no buildId / scrape epoch+partB from HTML"
  * path. Live mkissa now:
- * - ships `buildId` `"81"` and four base64 mask fragments in the app chunk
+ * - ships `buildId` `"119"` and four base64 mask fragments in the app chunk
  * - boots keys via `GET /client-crypto/v1/bootstrap?buildId=&k=` with
  *   `x-build-id` + HMAC `x-aa-boot` (`aa-boot:{buildId}` then payload)
  * - signs `aaReq` as AES-GCM over `{v,ts,epoch,buildId,qh,k}` with IV
  *   `SHA-256(epoch:buildId:qh:ts:k)[0:12]`
+ * - rotates the epoch scale: 7-day epochs (604800000 ms), 1-day grace
  *
  * Mask fragments and buildId are recovered from the rotated string table in
  * `cdn.mkissa.net/.../chunks/*.js` (same values as browser `Cf` / `ud`).
+ * The episode persisted-query hash is SHA-256 of the interpolated `_9`
+ * episode GraphQL template in the crypto chunk (re-derived 2026-08-17).
  */
 
-export const ALLMANGA_BUILD_ID = "81";
+export const ALLMANGA_BUILD_ID = "119";
 export const ALLMANGA_QUERY_HASH =
-  "f4662f4b7510b26795dd53ef824a0bf1740fbbc5d1273fab18222ac831bca8d0";
+  "ca735f1436927eaf7abb05d1589bb93c43cf606d87eecc2030357c1aad8fb455";
 /** Episode GraphQL lane (`Lf` → `k7`). */
 export const ALLMANGA_CONTENT_LANE_EPISODE = "k7";
 export const ALLMANGA_KEY_GROUP = "mkissa";
@@ -29,7 +32,7 @@ export const ALLMANGA_BOOTSTRAP_URL = "https://api.mkissa.net/client-crypto/v1/b
 export const ALLMANGA_SITE_ORIGIN = "https://mkissa.to";
 
 /** Epoch length (ms) and near-boundary grace from live bootstrap JSON. */
-export const ALLMANGA_EPOCH_MS = 259_200_000;
+export const ALLMANGA_EPOCH_MS = 604_800_000;
 export const ALLMANGA_EPOCH_GRACE_MS = 86_400_000;
 /** aaReq timestamp bucket (5 minutes). */
 export const ALLMANGA_AA_REQ_BUCKET_MS = 300_000;
@@ -39,10 +42,10 @@ export const ALLMANGA_AA_REQ_BUCKET_MS = 300_000;
  * string-table rotation. Combined with `hashBuildId(buildId)` in `deriveMaskKey`.
  */
 export const ALLMANGA_MASK_FRAGMENTS = [
-  "O1c1LQKxjeA=",
-  "czMdvsR/WAM=",
-  "KElSgK/l8jM=",
-  "Q7wraL6U5Tg=",
+  "hbFWg2oyTVE=",
+  "5kzA8QKXvTE=",
+  "ROxjxlPAJ+8=",
+  "TdpAYUVrag8=",
 ] as const;
 
 /** How long derived crypto material stays trusted before a lazy refetch. */
@@ -56,9 +59,9 @@ export type AllMangaCryptoMaterial = {
   readonly contentLane: string;
 };
 
-/** Last-known-good material when bootstrap fails (epoch 6888, build 81). */
-export const ALLMANGA_KEY_HEX = "bf44b51b82ef0736c06e62a4b889dc5b8494f8cb6fe7e8b820dd33494b99c540";
-export const ALLMANGA_EPOCH = 6888;
+/** Last-known-good material when bootstrap fails (epoch 2954, build 119). */
+export const ALLMANGA_KEY_HEX = "cf5487de30b64387b21614d641cfcf6174d7f3e24f2e9c6433c916c867db8a1d";
+export const ALLMANGA_EPOCH = 2954;
 
 export const BUNDLED_ALLMANGA_CRYPTO: AllMangaCryptoMaterial = {
   keyHex: ALLMANGA_KEY_HEX,

--- a/packages/providers/src/allmanga/manifest.ts
+++ b/packages/providers/src/allmanga/manifest.ts
@@ -64,6 +64,6 @@ export const allanimeManifest = defineProviderManifest({
     "AllManga-compatible client uses local fetch/decode logic for search, catalog, and source resolution.",
     "The active CLI path is browserless; unsupported extracted embeds should return deterministic failure.",
     "Source inventory: Default, Yt-mp4, S-mp4, Mp4 (mp4upload scrape), Luf-Mp4, Ak. Filemoon is gone.",
-    "2026-08: mkissa crypto requires buildId=81 + /client-crypto/v1/bootstrap (x-aa-boot). ani-cli v5 moved primary to anidb.app.",
+    "2026-08: mkissa crypto requires buildId=119 (rotated from 81) + /client-crypto/v1/bootstrap (x-aa-boot), 7-day epochs. ani-cli v5 moved primary to anidb.app.",
   ],
 });

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -21,6 +21,7 @@ export const ANIDB_USER_AGENT =
 
 const episodeCache = new TTLCache<string, readonly AnidbEpisodeEntry[]>(1_800_000);
 const languageCache = new TTLCache<string, readonly AnidbLanguageEntry[]>(300_000);
+const malCache = new TTLCache<string, number | undefined>(3_600_000);
 
 export type AnidbEpisodeEntry = {
   readonly id: number;
@@ -164,14 +165,20 @@ export async function fetchAnidbMalId(
   showId: string,
   signal?: AbortSignal,
 ): Promise<number | undefined> {
+  const cached = malCache.get(showId);
+  if (cached !== undefined) return cached;
+
   try {
     const page = await anidbFetchText(`${ANIDB_BASE}/anime/${encodeURIComponent(showId)}`, {
       signal,
     });
     const mal = /https:\/\/myanimelist\.net\/anime\/(\d+)/.exec(page)?.[1];
     const parsed = mal ? Number(mal) : NaN;
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+    const result = Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+    malCache.set(showId, result);
+    return result;
   } catch {
+    malCache.set(showId, undefined);
     return undefined;
   }
 }
@@ -310,4 +317,5 @@ export async function resolveAnidbEpisodeStreams(options: {
 export function clearAnidbCachesForTest(): void {
   episodeCache.clear();
   languageCache.clear();
+  malCache.clear();
 }

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -1,5 +1,6 @@
 import type { ProviderRuntimeContext } from "@kunai/types";
 
+import { curlCipherArgs, resolveCurlCandidate } from "../shared/curl-impersonate";
 import { expandHlsMasterPlaylist } from "../shared/hls-ladder";
 import { TTLCache } from "../shared/provider-cache";
 import { anidbNumericId, parseAnidbBrowseHtml, type AnidbSearchResult } from "./browse-parser";
@@ -21,7 +22,7 @@ export const ANIDB_USER_AGENT =
 
 const episodeCache = new TTLCache<string, readonly AnidbEpisodeEntry[]>(1_800_000);
 const languageCache = new TTLCache<string, readonly AnidbLanguageEntry[]>(300_000);
-const malCache = new TTLCache<string, number | undefined>(3_600_000);
+const malCache = new TTLCache<string, number | null>(3_600_000);
 
 export type AnidbEpisodeEntry = {
   readonly id: number;
@@ -44,53 +45,16 @@ export type AnidbStreamLink = {
 };
 
 /**
- * curl-impersonate builds, most-recent browser first, then plain curl.
- *
- * Parity with ani-cli v5's `dep_ch_failover` list. anidb.app sits behind
- * Cloudflare, which fingerprints the TLS handshake — a browser User-Agent over
- * curl's own handshake is frequently still challenged, and a challenge page
- * parses to zero search results. Where an impersonate build exists we use it.
+ * curl-impersonate resolution lives in `shared/curl-impersonate.ts` (Miruro's
+ * Cloudflare pipe fallback uses the same candidates). Keep the anidb-named
+ * exports as thin delegates for the existing consumers.
  */
-const ANIDB_CURL_CANDIDATES = [
-  "curl_firefox135",
-  "curl_chrome136",
-  "curl_chrome116",
-  "curl_ff117",
-  "curl",
-] as const;
-
-/**
- * ani-cli sets these only on Darwin, and that restriction is load-bearing rather
- * than incidental: Windows `curl.exe` links Schannel, which rejects
- * `--tls13-ciphers` and does not understand OpenSSL cipher names, so passing
- * them there fails the request outright instead of hardening it. Linux curl
- * already negotiates an acceptable suite unaided.
- */
-const ANIDB_CIPHERS =
-  "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305";
-const ANIDB_TLS13_CIPHERS =
-  "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256";
-
-/**
- * An impersonate build already ships a matching handshake, so forcing ani-cli's
- * list over it would undo the fingerprint it exists to provide.
- */
-export function anidbCipherArgs(
-  impersonates: boolean,
-  platform: NodeJS.Platform = process.platform,
-): readonly string[] {
-  if (impersonates || platform !== "darwin") return [];
-  return ["--ciphers", ANIDB_CIPHERS, "--tls13-ciphers", ANIDB_TLS13_CIPHERS];
-}
+export const anidbCipherArgs = curlCipherArgs;
 
 export function resolveAnidbCurl(
   which: (command: string) => string | null = Bun.which,
 ): { readonly path: string; readonly impersonates: boolean } | null {
-  for (const candidate of ANIDB_CURL_CANDIDATES) {
-    const path = which(candidate);
-    if (path) return { path, impersonates: candidate !== "curl" };
-  }
-  return null;
+  return resolveCurlCandidate(which);
 }
 
 /**
@@ -165,8 +129,11 @@ export async function fetchAnidbMalId(
   showId: string,
   signal?: AbortSignal,
 ): Promise<number | undefined> {
+  // `null` is "this page has no MAL link", which is a real answer worth caching.
+  // A cache miss is `undefined`, so the two must not share a representation or
+  // every negative result re-scrapes AniDB on the resolve path.
   const cached = malCache.get(showId);
-  if (cached !== undefined) return cached;
+  if (cached !== undefined) return cached ?? undefined;
 
   try {
     const page = await anidbFetchText(`${ANIDB_BASE}/anime/${encodeURIComponent(showId)}`, {
@@ -174,11 +141,12 @@ export async function fetchAnidbMalId(
     });
     const mal = /https:\/\/myanimelist\.net\/anime\/(\d+)/.exec(page)?.[1];
     const parsed = mal ? Number(mal) : NaN;
-    const result = Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+    const result = Number.isFinite(parsed) && parsed > 0 ? parsed : null;
     malCache.set(showId, result);
-    return result;
+    return result ?? undefined;
   } catch {
-    malCache.set(showId, undefined);
+    // A transport failure says nothing about the show. Caching it would let one
+    // Cloudflare block or dropped connection suppress auto-skip for an hour.
     return undefined;
   }
 }

--- a/packages/providers/src/anidb/direct.ts
+++ b/packages/providers/src/anidb/direct.ts
@@ -301,6 +301,18 @@ export const anidbProviderModule: CoreProviderModule = {
       startupPriority: input.startupPriority,
     });
 
+    // Overlap the MAL scrape with stream resolution so it never adds a serial
+    // request to the resolve hot path. TTL-cached per show; a cache hit settles
+    // immediately. If resolve bails out early, the fetch just warms the cache.
+    const existingMalId = input.title.externalIds?.malId ?? input.title.malId;
+    const malIdPromise =
+      existingMalId !== undefined && existingMalId !== ""
+        ? Promise.resolve(String(existingMalId))
+        : fetchAnidbMalId(showId, context.signal).then(
+            (id) => (id !== undefined ? String(id) : undefined),
+            () => undefined,
+          );
+
     emitTraceEvent(events, context, {
       type: "provider:start",
       providerId: ANIDB_PROVIDER_ID,
@@ -364,13 +376,7 @@ export const anidbProviderModule: CoreProviderModule = {
         attributes: { sourceId, showId, ...routeAttributes },
       });
 
-      const existingMalId = input.title.externalIds?.malId ?? input.title.malId;
-      const malId =
-        existingMalId !== undefined && existingMalId !== ""
-          ? String(existingMalId)
-          : await fetchAnidbMalId(showId, context.signal)
-              .then((id) => (id !== undefined ? String(id) : undefined))
-              .catch(() => undefined);
+      const malId = await malIdPromise;
 
       return {
         status: "resolved",

--- a/packages/providers/src/anidb/direct.ts
+++ b/packages/providers/src/anidb/direct.ts
@@ -46,6 +46,7 @@ export {
   anidbNumericId,
   chooseAnidbSearchMatch,
   clearAnidbCachesForTest,
+  fetchAnidbMalId,
   looksLikeAnidbShowId,
   parseAnidbBrowseHtml,
   parseAnidbSeasonEvidence,
@@ -363,6 +364,14 @@ export const anidbProviderModule: CoreProviderModule = {
         attributes: { sourceId, showId, ...routeAttributes },
       });
 
+      const existingMalId = input.title.externalIds?.malId ?? input.title.malId;
+      const malId =
+        existingMalId !== undefined && existingMalId !== ""
+          ? String(existingMalId)
+          : await fetchAnidbMalId(showId, context.signal)
+              .then((id) => (id !== undefined ? String(id) : undefined))
+              .catch(() => undefined);
+
       return {
         status: "resolved",
         providerId: ANIDB_PROVIDER_ID,
@@ -374,7 +383,7 @@ export const anidbProviderModule: CoreProviderModule = {
         subtitles: [],
         externalIds: {
           anilistId: input.title.externalIds?.anilistId ?? input.title.anilistId,
-          malId: input.title.externalIds?.malId ?? input.title.malId,
+          malId,
           providerNativeIds: { [ANIDB_PROVIDER_ID]: showId },
         },
         cachePolicy,

--- a/packages/providers/src/miruro/direct.ts
+++ b/packages/providers/src/miruro/direct.ts
@@ -42,6 +42,7 @@ import {
   formatAnimeSourceDetail,
   miruroSubtitleDeliveryToMode,
 } from "../shared/anime-source-presentation";
+import { curlCipherArgs, resolveCurlCandidate } from "../shared/curl-impersonate";
 import { expandHlsMasterPlaylist, looksLikeHlsMasterUrl } from "../shared/hls-ladder";
 import { TTLCache } from "../shared/provider-cache";
 import {
@@ -1428,8 +1429,8 @@ async function fetchMiruroPipeBody(
     };
   }
 
-  const curlPath = Bun.which("curl");
-  if (!curlPath) {
+  const curl = resolveCurlCandidate();
+  if (!curl) {
     return {
       status: response.status || 403,
       text: responseText,
@@ -1440,7 +1441,8 @@ async function fetchMiruroPipeBody(
 
   const hasCurlHttp2 = detectCurlHttp2Support();
   const args = [
-    curlPath,
+    curl.path,
+    ...curlCipherArgs(curl.impersonates),
     "-sS",
     ...(hasCurlHttp2 ? ["--http2"] : []),
     "-L",

--- a/packages/providers/src/miruro/direct.ts
+++ b/packages/providers/src/miruro/direct.ts
@@ -1606,7 +1606,7 @@ async function pipeCall(
  * it, so the message shape and this predicate must not drift apart.
  */
 const MIRURO_WAF_BLOCK_MESSAGE =
-  "Miruro pipe blocked by Cloudflare WAF on multiple mirrors (HTTP 403 HTML)";
+  "Miruro pipe blocked by Cloudflare WAF on multiple mirrors (HTTP 403 HTML). A user-owned relay (providerRelay.baseUrl) in an ungated region can bypass this.";
 
 function isMiruroWafBlockError(error: Error): boolean {
   return error.message.includes("Cloudflare WAF on multiple mirrors");

--- a/packages/providers/src/miruro/manifest.ts
+++ b/packages/providers/src/miruro/manifest.ts
@@ -79,7 +79,7 @@ export const miruroManifest = defineProviderManifest({
     "Bun fetch often gets CF 403 HTML on pipe; production path falls back to curl --http2 with browser headers (dossier-proven on this machine).",
     "Primary hosts: www.miruro.bz, www.miruro.ru. Bare miruro.bz/.ru are 301 redirects to www. and still CF-block at the pipe path; miruro.com serves a different app shell with no /api/secure/pipe; miruro.tv/.to are TLS-dead — all stay off the resolve list.",
     "Uses Miruro pipe API with XOR/gzip decryption key 71951034f8fbcf53d89db52ceb3dc22c.",
-    "Still not the default anime auto-fallback (AniDB is the default, AllAnime the fallback); Miruro is available for manual pick when curl/http2 path works.",
+    "Not in the automatic anime lane: `animeProviderPriority` is `['anidb']` alone, since AllAnime was demoted too (2026-08-13, captcha gate). Miruro stays registered and manually selectable when the curl/http2 path works.",
     "May hit Cloudflare rate limits if called too frequently.",
     "2026-08-17: curl --http2 with browser headers also receives CF 403 HTML from some networks; the WAF block message now carries a relay hint.",
   ],

--- a/packages/providers/src/miruro/manifest.ts
+++ b/packages/providers/src/miruro/manifest.ts
@@ -81,5 +81,6 @@ export const miruroManifest = defineProviderManifest({
     "Uses Miruro pipe API with XOR/gzip decryption key 71951034f8fbcf53d89db52ceb3dc22c.",
     "Still not the default anime auto-fallback (AniDB is the default, AllAnime the fallback); Miruro is available for manual pick when curl/http2 path works.",
     "May hit Cloudflare rate limits if called too frequently.",
+    "2026-08-17: curl --http2 with browser headers also receives CF 403 HTML from some networks; the WAF block message now carries a relay hint.",
   ],
 });

--- a/packages/providers/src/shared/curl-impersonate.ts
+++ b/packages/providers/src/shared/curl-impersonate.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared curl / curl-impersonate resolution for Cloudflare-fronted providers.
+ *
+ * Cloudflare fingerprints the TLS handshake, so a browser User-Agent over
+ * plain curl's handshake is frequently still challenged. Where an impersonate
+ * build exists we use it; the candidate order matches ani-cli v5's
+ * `dep_ch_failover` list, most-recent browser first, then plain curl.
+ */
+const CURL_IMPERSONATE_CANDIDATES = [
+  "curl_firefox135",
+  "curl_chrome136",
+  "curl_chrome116",
+  "curl_ff117",
+  "curl",
+] as const;
+
+export type CurlCandidate = {
+  readonly path: string;
+  readonly impersonates: boolean;
+};
+
+/**
+ * ani-cli sets cipher flags only on Darwin, and that restriction is
+ * load-bearing: Windows `curl.exe` links Schannel, which rejects
+ * `--tls13-ciphers` and does not understand OpenSSL cipher names, so passing
+ * them there fails the request outright instead of hardening it.
+ */
+const CURL_CIPHERS =
+  "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305";
+const CURL_TLS13_CIPHERS =
+  "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256";
+
+/**
+ * An impersonate build already ships a matching handshake, so forcing
+ * ani-cli's cipher list over it would undo the fingerprint it exists to
+ * provide.
+ */
+export function curlCipherArgs(
+  impersonates: boolean,
+  platform: NodeJS.Platform = process.platform,
+): readonly string[] {
+  if (impersonates || platform !== "darwin") return [];
+  return ["--ciphers", CURL_CIPHERS, "--tls13-ciphers", CURL_TLS13_CIPHERS];
+}
+
+export function resolveCurlCandidate(
+  which: (command: string) => string | null = Bun.which,
+): CurlCandidate | null {
+  for (const candidate of CURL_IMPERSONATE_CANDIDATES) {
+    const path = which(candidate);
+    if (path) return { path, impersonates: candidate !== "curl" };
+  }
+  return null;
+}
+
+export function isCloudflareChallengeText(text: string): boolean {
+  return /just a moment/i.test(text);
+}

--- a/packages/providers/test/allmanga.test.ts
+++ b/packages/providers/test/allmanga.test.ts
@@ -346,7 +346,7 @@ describe("AllManga crypto material (mkissa bootstrap)", () => {
     expect(material?.keyHex).toBe(EXPECTED_KEY_HEX);
     expect(material?.epoch).toBe(6900);
     expect(material?.queryHash).toBe(ALLMANGA_QUERY_HASH);
-    expect(material?.buildId).toBe("81");
+    expect(material?.buildId).toBe("119");
 
     const again = await getAllMangaCryptoMaterial(TEST_CONTEXT, "ua");
     expect(again?.keyHex).toBe(EXPECTED_KEY_HEX);

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -594,4 +594,57 @@ describe("fetchAnidbMalId", () => {
       Bun.which = originalWhich;
     }
   });
+
+  test("caches a genuine absence instead of re-scraping every resolve", async () => {
+    // "No MAL link on the page" is an answer, not a miss. Representing it the
+    // same way as a cache miss silently disables the cache for every show
+    // without a MAL id, which is the population that gets scraped repeatedly.
+    clearAnidbCachesForTest();
+    const originalWhich = Bun.which;
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+
+    try {
+      Bun.which = ((_cmd: string) => null) as typeof Bun.which;
+      globalThis.fetch = (async () => {
+        fetchCalls++;
+        return new Response("<html><body>No links here</body></html>", { status: 200 });
+      }) as unknown as typeof fetch;
+
+      expect(await fetchAnidbMalId("no-mal-1")).toBeUndefined();
+      expect(await fetchAnidbMalId("no-mal-1")).toBeUndefined();
+      expect(fetchCalls).toBe(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+      Bun.which = originalWhich;
+    }
+  });
+
+  test("does not cache a transport failure, so a retry can still succeed", async () => {
+    // A Cloudflare block or dropped connection says nothing about the show.
+    // Caching it would suppress auto-skip for the full hour-long TTL.
+    clearAnidbCachesForTest();
+    const originalWhich = Bun.which;
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+
+    try {
+      Bun.which = ((_cmd: string) => null) as typeof Bun.which;
+      globalThis.fetch = (async () => {
+        fetchCalls++;
+        if (fetchCalls === 1) throw new Error("connection reset");
+        return new Response(
+          '<html><body><a href="https://myanimelist.net/anime/32612/Onigiri">MAL</a></body></html>',
+          { status: 200 },
+        );
+      }) as unknown as typeof fetch;
+
+      expect(await fetchAnidbMalId("flaky-1")).toBeUndefined();
+      expect(await fetchAnidbMalId("flaky-1")).toBe(32612);
+      expect(fetchCalls).toBe(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+      Bun.which = originalWhich;
+    }
+  });
 });

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -7,6 +7,7 @@ import {
   anidbProviderModule,
   chooseAnidbSearchMatch,
   clearAnidbCachesForTest,
+  fetchAnidbMalId,
   looksLikeAnidbShowId,
   parseAnidbBrowseHtml,
   parseAnidbSeasonEvidence,
@@ -459,5 +460,138 @@ describe("anidb direct resolve season routing", () => {
       }),
     );
     expect(result.externalIds?.providerNativeIds?.anidb).toBe("plain-show-700");
+  });
+
+  test("propagates resolved malId into externalIds when not provided in input", async () => {
+    clearAnidbCachesForTest();
+    const result = await resolveWithStub(
+      {
+        title: { id: "onigiri-3942", kind: "anime", title: "Onigiri" },
+        episode: { season: 1, episode: 1 },
+        mediaKind: "anime",
+        preferredAudioLanguage: "ja",
+        intent: "play",
+        allowedRuntimes: ["direct-http"],
+      } as Parameters<typeof anidbProviderModule.resolve>[0],
+      (async (input: unknown) => {
+        const url = String(
+          typeof input === "string" ? input : ((input as { url?: string })?.url ?? input),
+        );
+        if (url.includes("/anime/onigiri-3942")) {
+          return new Response('<a href="https://myanimelist.net/anime/32612/Onigiri">MAL</a>', {
+            status: 200,
+          });
+        }
+        if (url.includes("/api/frontend/anime/3942/episodes")) {
+          return new Response(JSON.stringify({ episodes: [{ id: 101, number: 1 }] }), {
+            status: 200,
+          });
+        }
+        if (/\/api\/frontend\/episode\/101\/languages/.test(url)) {
+          return new Response(
+            JSON.stringify({
+              languages: [
+                { code: "jpn", name: "Japanese", embed_url: "https://anidb.app/embed/jpn-1" },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/embed/")) {
+          return new Response("file: 'https://cdn.example/stream.m3u8'", { status: 200 });
+        }
+        if (url.includes("stream.m3u8")) {
+          return new Response("#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=800000\n720p.m3u8", {
+            status: 200,
+          });
+        }
+        return new Response("", { status: 404 });
+      }) as unknown as typeof fetch,
+    );
+
+    expect(result.status).toBe("resolved");
+    expect(result.externalIds?.malId).toBe("32612");
+    expect(result.externalIds?.providerNativeIds?.anidb).toBe("onigiri-3942");
+  });
+
+  test("preserves existing input malId over resolving new malId", async () => {
+    clearAnidbCachesForTest();
+    const result = await resolveWithStub(
+      {
+        title: {
+          id: "onigiri-3942",
+          kind: "anime",
+          title: "Onigiri",
+          externalIds: { malId: "99999" },
+        },
+        episode: { season: 1, episode: 1 },
+        mediaKind: "anime",
+        preferredAudioLanguage: "ja",
+        intent: "play",
+        allowedRuntimes: ["direct-http"],
+      } as Parameters<typeof anidbProviderModule.resolve>[0],
+      anidbFetchStub({
+        episodesByNumericId: {
+          "3942": [{ id: 101, number: 1 }],
+        },
+      }),
+    );
+
+    expect(result.status).toBe("resolved");
+    expect(result.externalIds?.malId).toBe("99999");
+  });
+});
+
+describe("fetchAnidbMalId", () => {
+  test("extracts MAL id from anime page and caches result", async () => {
+    clearAnidbCachesForTest();
+    const originalWhich = Bun.which;
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+
+    try {
+      Bun.which = ((_cmd: string) => null) as typeof Bun.which;
+      globalThis.fetch = (async (url: string) => {
+        fetchCalls++;
+        if (String(url).includes("/anime/onigiri-3942")) {
+          return new Response(
+            '<html><body><a href="https://myanimelist.net/anime/32612/Onigiri">MAL</a></body></html>',
+            { status: 200 },
+          );
+        }
+        return new Response("Not found", { status: 404 });
+      }) as unknown as typeof fetch;
+
+      const first = await fetchAnidbMalId("onigiri-3942");
+      expect(first).toBe(32612);
+      expect(fetchCalls).toBe(1);
+
+      // Second call hits TTL cache
+      const second = await fetchAnidbMalId("onigiri-3942");
+      expect(second).toBe(32612);
+      expect(fetchCalls).toBe(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+      Bun.which = originalWhich;
+    }
+  });
+
+  test("returns undefined on missing or invalid MAL URL", async () => {
+    clearAnidbCachesForTest();
+    const originalWhich = Bun.which;
+    const originalFetch = globalThis.fetch;
+
+    try {
+      Bun.which = ((_cmd: string) => null) as typeof Bun.which;
+      globalThis.fetch = (async () =>
+        new Response("<html><body>No links here</body></html>", {
+          status: 200,
+        })) as unknown as typeof fetch;
+
+      expect(await fetchAnidbMalId("unknown-123")).toBeUndefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+      Bun.which = originalWhich;
+    }
   });
 });

--- a/packages/relay/src/create-relay-fetch-port.ts
+++ b/packages/relay/src/create-relay-fetch-port.ts
@@ -80,11 +80,16 @@ function normalizeMethod(method: string): RelayRpcRequest["method"] | null {
 }
 
 function mergeHeaders(base: RelayHeadersInit | undefined, override: RelayHeadersInit | undefined) {
-  const headers = new Headers(base);
+  const merged: Record<string, string> = {};
+  new Headers(base).forEach((value, key) => {
+    merged[key] = value;
+  });
   if (override) {
-    new Headers(override).forEach((value, key) => headers.set(key, value));
+    new Headers(override).forEach((value, key) => {
+      merged[key] = value;
+    });
   }
-  return Object.fromEntries(headers.entries());
+  return merged;
 }
 
 async function bodyToString(

--- a/packages/relay/src/forward-headers.ts
+++ b/packages/relay/src/forward-headers.ts
@@ -8,6 +8,10 @@ const METADATA_HEADER_ALLOWLIST = new Set([
   "referer",
   "referrer",
   "user-agent",
+  "x-build-id",
+  "x-aa-boot",
+  "x-obfuscated",
+  "x-session-token",
 ]);
 
 const MEDIA_HEADER_ALLOWLIST = new Set([...METADATA_HEADER_ALLOWLIST, "range", "if-range"]);

--- a/packages/relay/src/forward-headers.ts
+++ b/packages/relay/src/forward-headers.ts
@@ -45,18 +45,16 @@ export function filterForwardHeaders(
   const allowed = kind === "media" ? MEDIA_HEADER_ALLOWLIST : METADATA_HEADER_ALLOWLIST;
   const output: Record<string, string> = {};
 
-  for (const [rawName, rawValue] of source.entries()) {
+  source.forEach((rawValue, rawName) => {
     const name = rawName.toLowerCase();
     const value = rawValue.trim();
     if (containsInvalidHeaderText(name) || containsInvalidHeaderText(value)) {
       throw new RelayValidationError("headers-rejected", "Unsafe header text rejected", 400);
     }
-    if (HOP_BY_HOP_HEADERS.has(name) || name === "authorization" || name === "cookie") {
-      continue;
-    }
-    if (!allowed.has(name)) continue;
+    if (HOP_BY_HOP_HEADERS.has(name) || name === "authorization" || name === "cookie") return;
+    if (!allowed.has(name)) return;
     output[canonicalHeaderName(name)] = value;
-  }
+  });
 
   return output;
 }

--- a/packages/relay/src/handler.ts
+++ b/packages/relay/src/handler.ts
@@ -14,7 +14,12 @@ import {
 } from "./types";
 
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
-const RELAY_RESPONSE_HEADERS = ["content-type", "content-length", "cache-control"] as const;
+const RELAY_RESPONSE_HEADERS = [
+  "content-type",
+  "content-length",
+  "cache-control",
+  "x-obfuscated",
+] as const;
 
 export async function handleRpcRequest(
   request: Request,


### PR DESCRIPTION
## What changed

- **AniDB now stamps MAL id into resolve results** — `fetchAnidbMalId` (TTL 1h) runs in parallel with stream resolution (no hot-path latency) and the result's `externalIds.malId` feeds AniSkip's direct short-circuit, replacing the fuzzy AniList title-search fallback for AniDB-sourced titles. Also added an AniSkip-side catalog lookup for AniDB show ids.
- **Miruro WAF block now names the escape hatch** — the failure message carries the user-relay hint; manifest + docs note that `curl --http2` is itself CF-403'd from some networks as of 2026-08-17.
- **Relay deploy fix** — `packages/relay` made TS 5.9-compatible (Vercel's `@vercel/node` crashes on repo-wide TypeScript 7), `apps/relay-server` pins `typescript@5.9.3`, and `verify:deploy` gained a `registry-matches-current-manifests` drift check (would have caught the stale-relay failure instantly).
- **Docs** — AllAnime 2026-08-17 relay findings (`AA_CRYPTO_MISSING_BUILD`: upstream rotated build constants; needs a fresh crypto intake from live chunks), Miruro relay-egress finding, relay redeploy requirements, allmanga dossier cleanup (Filemoon removed, Mp4 supported, GCM wording).

## Verification

- Unit: providers 343 pass, relay 26 pass, relay-server 4 pass, CLI 4196 pass; typecheck/lint/fmt/`verify:doc-paths` green.
- Live smokes: `anidb` ✅ (`hls.anidb.app`), `rivestream` ✅, `videasy` ✅ (`moon.peakstorm.top`), `youtube` ✅, `test:live:relay-allanime` ❌ (see below), `miruro` ❌ (WAF, expected).
- **Real playback**: resolved Onigiri E1 (anidb) and Dune (videasy) through the engine and played both in mpv (`--vo=null`), exit 0, no warnings.
- **Relay redeployed**: `relay-server-two.vercel.app` rebuilt from this branch (was 23 days stale, rejecting `api.mkissa.net`); `verify:deploy` now passes including the new drift check.

## Known follow-ups (not in this PR)

- **AllAnime sources return `AA_CRYPTO_MISSING_BUILD`** even through a working relay — upstream rotated the build/string-table material. Needs a provider-intake session re-deriving constants from `cdn.mkissa.net` live chunks. Catalog/search still work.
- **Miruro pipe is CF-gated even for the relay's Vercel `iad1` egress** — only an unproven region might clear it.