### PR TITLE
fix(shell): make picker commands and the Settings tab strip honest

### DIFF
--- a/.changeset/reachable-shell-surfaces.md
+++ b/.changeset/reachable-shell-surfaces.md
@@ -1,0 +1,8 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Make the shell's own surfaces reachable and readable at the terminal sizes people actually use.
+
+- `/analytics` and `/presence` answered "no matching commands" from the resume and starting-point pickers while the footer still advertised `[/] commands`. Both govern data leaving the machine, so being told they do not exist was the wrong answer. Picker command sets now come from one registry context instead of three hand-written arrays that had drifted apart.
+- The Settings section tabs were unreadable at 80 columns: twelve names were squeezed into two-character stumps that wrapped onto a second line, hiding which sections exist. The strip now scrolls around the active section, which is always shown in full, with `‹`/`›` marking what is off-screen.

--- a/apps/cli/src/app-shell/commands.ts
+++ b/apps/cli/src/app-shell/commands.ts
@@ -53,6 +53,12 @@ const POST_PLAYBACK_SURFACE_COMMANDS: readonly AppCommandId[] = [
   "diagnostics",
 ];
 
+/**
+ * Deliberately narrower than `COMMAND_CONTEXTS.modalPicker`: a media picker is
+ * nested inside an active browse or playback flow, so the palette stays local
+ * and non-destructive rather than offering overlays that would strand it.
+ * Locked by `command-registry.coverage.test.ts`.
+ */
 const MEDIA_PICKER_SURFACE_COMMANDS: readonly AppCommandId[] = ["diagnostics", "help"];
 
 function isMediaPickerOverlay(type: string): boolean {

--- a/apps/cli/src/app-shell/format/segmented.ts
+++ b/apps/cli/src/app-shell/format/segmented.ts
@@ -7,10 +7,102 @@ export type Segment = { readonly label: string; readonly text: string; readonly 
  */
 export function segmentGeometry(labels: readonly string[], activeIndex: number): Segment[] {
   if (labels.length === 0) return [];
-  const active = Math.max(0, Math.min(labels.length - 1, Math.trunc(activeIndex)));
+  const active = clampIndex(labels, activeIndex);
   return labels.map((label, index) => ({
     label,
     text: index === active ? ` ${label} ` : label,
     active: index === active,
   }));
+}
+
+export type SegmentWindow = {
+  readonly segments: readonly Segment[];
+  readonly hiddenBefore: number;
+  readonly hiddenAfter: number;
+};
+
+/** Gap rendered between two segments. */
+const SEGMENT_GAP = 2;
+/** Width of a `‹`/`›` overflow marker plus its gap. */
+const MARKER_WIDTH = 2;
+
+function clampIndex(labels: readonly string[], index: number): number {
+  return Math.max(0, Math.min(labels.length - 1, Math.trunc(index)));
+}
+
+function segmentWidth(label: string, active: boolean): number {
+  return active ? label.length + 2 : label.length;
+}
+
+/**
+ * Fit a tab strip into a fixed width by showing a window around the active tab.
+ *
+ * Letting the layout engine shrink the segments instead turns twelve section
+ * names into a column of two-character stumps that wrap into an unreadable
+ * second line — at 80 columns, the classic terminal default, the Settings
+ * strip became actively misleading about which sections exist.
+ *
+ * The active label is always shown in full, because it is the one piece of
+ * state the strip has to communicate. Neighbours are added outward until the
+ * width runs out, and the counts of what did not fit let the caller render
+ * `‹`/`›` so the strip reads as scrollable rather than complete.
+ */
+export function windowedSegmentGeometry(
+  labels: readonly string[],
+  activeIndex: number,
+  availableWidth: number,
+): SegmentWindow {
+  if (labels.length === 0) return { segments: [], hiddenBefore: 0, hiddenAfter: 0 };
+
+  const all = segmentGeometry(labels, activeIndex);
+  const active = clampIndex(labels, activeIndex);
+  const total = all.reduce(
+    (sum, seg, index) => sum + segmentWidth(seg.label, seg.active) + (index > 0 ? SEGMENT_GAP : 0),
+    0,
+  );
+  if (!Number.isFinite(availableWidth) || availableWidth <= 0 || total <= availableWidth) {
+    return { segments: all, hiddenBefore: 0, hiddenAfter: 0 };
+  }
+
+  let first = active;
+  let last = active;
+  // The active pill alone may exceed the budget on a very narrow terminal; it
+  // is still the only segment worth showing, so it is never dropped.
+  let used = segmentWidth(labels[active] ?? "", true);
+
+  // Reserve marker space up front rather than discovering mid-loop that adding
+  // a neighbour pushed the marker off the end.
+  const budget = availableWidth - MARKER_WIDTH * 2;
+
+  for (;;) {
+    const nextAfter = last + 1;
+    const nextBefore = first - 1;
+    const canAfter = nextAfter < labels.length;
+    const canBefore = nextBefore >= 0;
+    if (!canAfter && !canBefore) break;
+
+    // Forward first: later sections are the ones a user has not seen yet.
+    const takeAfter = canAfter;
+    const index = takeAfter ? nextAfter : nextBefore;
+    const cost = segmentWidth(labels[index] ?? "", false) + SEGMENT_GAP;
+    if (used + cost > budget) {
+      if (!takeAfter) break;
+      // Forward did not fit; backward may still be narrower.
+      if (!canBefore) break;
+      const backCost = segmentWidth(labels[nextBefore] ?? "", false) + SEGMENT_GAP;
+      if (used + backCost > budget) break;
+      first = nextBefore;
+      used += backCost;
+      continue;
+    }
+    if (takeAfter) last = nextAfter;
+    else first = nextBefore;
+    used += cost;
+  }
+
+  return {
+    segments: all.slice(first, last + 1),
+    hiddenBefore: first,
+    hiddenAfter: labels.length - 1 - last,
+  };
 }

--- a/apps/cli/src/app-shell/pickers/picker-action-context.ts
+++ b/apps/cli/src/app-shell/pickers/picker-action-context.ts
@@ -1,4 +1,4 @@
-import { resolveCommands, type AppCommandId } from "@/app-shell/commands";
+import { COMMAND_CONTEXTS, resolveCommands, type AppCommandId } from "@/app-shell/commands";
 import type { Container } from "@/container";
 import { effectiveFooterHints } from "@/container";
 
@@ -8,7 +8,7 @@ export function buildPickerActionContext({
   container,
   taskLabel,
   footerMode = effectiveFooterHints(container),
-  allowed = ["settings", "history", "diagnostics", "help", "about", "quit", "downloads", "library"],
+  allowed = COMMAND_CONTEXTS.modalPicker,
 }: {
   container: Container;
   taskLabel: string;

--- a/apps/cli/src/app-shell/primitives/ClaudeTabRow.tsx
+++ b/apps/cli/src/app-shell/primitives/ClaudeTabRow.tsx
@@ -1,9 +1,12 @@
 import { Box, Text } from "ink";
 import React from "react";
 
-import { segmentGeometry } from "../format/segmented";
+import { windowedSegmentGeometry } from "../format/segmented";
 import { truncateLine } from "../shell-text";
 import { palette } from "../shell-theme";
+
+/** Width the hint claims when one is present, so tabs are not measured against it. */
+const HINT_RESERVE = 20;
 
 /** Claude Code–style tier-1 tabs: active = rose accentFill pill + bold text. */
 export const ClaudeTabRow = React.memo(function ClaudeTabRow({
@@ -19,7 +22,13 @@ export const ClaudeTabRow = React.memo(function ClaudeTabRow({
   readonly maxWidth?: number;
   readonly dense?: boolean;
 }) {
-  const segments = segmentGeometry(labels, activeIndex);
+  const tabBudget =
+    maxWidth === undefined ? Number.POSITIVE_INFINITY : maxWidth - (hint ? HINT_RESERVE : 0);
+  const { segments, hiddenBefore, hiddenAfter } = windowedSegmentGeometry(
+    labels,
+    activeIndex,
+    tabBudget,
+  );
   return (
     <Box
       flexDirection="row"
@@ -29,18 +38,32 @@ export const ClaudeTabRow = React.memo(function ClaudeTabRow({
       width={maxWidth}
       overflow="hidden"
     >
+      {hiddenBefore > 0 ? (
+        <Box flexShrink={0}>
+          <Text color={palette.dim}>{"‹ "}</Text>
+        </Box>
+      ) : null}
       {segments.map((seg, i) => (
         <React.Fragment key={seg.label}>
           {i > 0 ? <Text color={palette.dim}>{"  "}</Text> : null}
-          <Text
-            bold={seg.active}
-            color={seg.active ? palette.text : palette.textDim}
-            backgroundColor={seg.active ? palette.accentFill : undefined}
-          >
-            {seg.text}
-          </Text>
+          {/* Never shrink: a squeezed tab strip renders section names as
+              unreadable stumps rather than dropping the ones that do not fit. */}
+          <Box flexShrink={0}>
+            <Text
+              bold={seg.active}
+              color={seg.active ? palette.text : palette.textDim}
+              backgroundColor={seg.active ? palette.accentFill : undefined}
+            >
+              {seg.text}
+            </Text>
+          </Box>
         </React.Fragment>
       ))}
+      {hiddenAfter > 0 ? (
+        <Box flexShrink={0}>
+          <Text color={palette.dim}>{" ›"}</Text>
+        </Box>
+      ) : null}
       {hint ? (
         <Box marginLeft={1} flexShrink={0}>
           <Text color={palette.dim} dimColor wrap="truncate">

--- a/apps/cli/src/domain/session/command-registry.ts
+++ b/apps/cli/src/domain/session/command-registry.ts
@@ -243,6 +243,38 @@ export const COMMAND_CONTEXTS = {
     "update",
     "quit",
   ],
+  /**
+   * Commands offered while a modal picker owns the screen.
+   *
+   * A picker is a question the shell is waiting on, so the set is limited to
+   * overlays that open, inform, and return. Anything that starts playback or
+   * moves to another catalog surface would strand that question with no way
+   * back to it.
+   *
+   * Kept here rather than inline at the call sites: the two picker surfaces
+   * previously carried their own hand-written arrays, which drifted apart and
+   * left `/analytics` and `/presence` answering "no matching commands" on a
+   * screen where the footer still advertised `[/] commands`.
+   */
+  modalPicker: [
+    "settings",
+    "providers",
+    "presence",
+    "analytics",
+    "analytics-show",
+    "notifications",
+    "history",
+    "stats",
+    "library",
+    "downloads",
+    "diagnostics",
+    "export-diagnostics",
+    "report-issue",
+    "docs",
+    "help",
+    "about",
+    "quit",
+  ],
 } as const satisfies Record<string, readonly AppCommandId[]>;
 
 export type CommandContextId = keyof typeof COMMAND_CONTEXTS;

--- a/apps/cli/src/session-flow.ts
+++ b/apps/cli/src/session-flow.ts
@@ -14,6 +14,7 @@ import { applyUserProviderSwitch } from "@/app/playback/playback-provider-switch
 import type { Container } from "@/container";
 import { projectWatchProgress } from "@/domain/continuation/watch-progress";
 import { resolveEpisodeAvailability } from "@/domain/playback/playback-policy";
+import { COMMAND_CONTEXTS, type AppCommandId } from "@/domain/session/command-registry";
 import type { EpisodeInfo, TitleInfo } from "@/domain/types";
 import type { EpisodePickerOption } from "@/domain/types";
 import { cyan, dim, yellow } from "@/menu";
@@ -177,20 +178,17 @@ export async function chooseMovieStartingPoint(opts: {
   return resolveMovieStartingChoice(picked, history);
 }
 
-const STARTING_POINT_PICKER_COMMANDS = [
-  "settings",
-  "history",
-  "diagnostics",
-  "help",
-  "about",
-  "quit",
-  "provider",
-] as const;
+/**
+ * The shared modal-picker set plus `provider`: these two pickers are the one
+ * place where switching provider mid-choice is meaningful, because the choice
+ * being made is which provider route to start on.
+ */
+const STARTING_POINT_PICKER_COMMANDS = [...COMMAND_CONTEXTS.modalPicker, "provider"] as const;
 
 function createPickerActionContext(
   container: Container | undefined,
   taskLabel: string,
-  allowed?: readonly (typeof STARTING_POINT_PICKER_COMMANDS)[number][],
+  allowed?: readonly AppCommandId[],
 ) {
   return container
     ? buildPickerActionContext({

--- a/apps/cli/test/unit/app-shell/format/segmented.test.ts
+++ b/apps/cli/test/unit/app-shell/format/segmented.test.ts
@@ -1,6 +1,30 @@
 import { describe, expect, test } from "bun:test";
 
-import { segmentGeometry } from "@/app-shell/format/segmented";
+import { segmentGeometry, windowedSegmentGeometry } from "@/app-shell/format/segmented";
+
+/** The real Settings sections, which is where the strip first overflowed. */
+const SETTINGS_SECTIONS = [
+  "General",
+  "Discover",
+  "Provider",
+  "Providers",
+  "YouTube",
+  "Language",
+  "Playback",
+  "Offline",
+  "Presence",
+  "Sync",
+  "Update",
+  "Danger Zone",
+] as const;
+
+function renderedWidth(window: ReturnType<typeof windowedSegmentGeometry>): number {
+  const tabs = window.segments.reduce(
+    (sum, seg, index) => sum + seg.text.length + (index > 0 ? 2 : 0),
+    0,
+  );
+  return tabs + (window.hiddenBefore > 0 ? 2 : 0) + (window.hiddenAfter > 0 ? 2 : 0);
+}
 
 describe("segmentGeometry", () => {
   test("marks the active segment and pads its label as a pill", () => {
@@ -15,5 +39,64 @@ describe("segmentGeometry", () => {
   });
   test("empty input yields empty geometry", () => {
     expect(segmentGeometry([], 0)).toEqual([]);
+  });
+});
+
+describe("windowedSegmentGeometry", () => {
+  test("keeps every segment when the strip already fits", () => {
+    const w = windowedSegmentGeometry(["All", "Series", "Anime"], 1, 80);
+    expect(w.segments).toHaveLength(3);
+    expect(w.hiddenBefore).toBe(0);
+    expect(w.hiddenAfter).toBe(0);
+  });
+
+  test("fits the twelve Settings sections into 80 columns", () => {
+    // The whole point: twelve labels do not fit, and squeezing them produced
+    // two-character stumps that wrapped into an unreadable second line.
+    for (let active = 0; active < SETTINGS_SECTIONS.length; active++) {
+      const w = windowedSegmentGeometry(SETTINGS_SECTIONS, active, 60);
+      expect(renderedWidth(w)).toBeLessThanOrEqual(60);
+      expect(w.segments.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("always shows the active section in full", () => {
+    for (let active = 0; active < SETTINGS_SECTIONS.length; active++) {
+      const w = windowedSegmentGeometry(SETTINGS_SECTIONS, active, 60);
+      const activeSeg = w.segments.find((seg) => seg.active);
+      expect(activeSeg?.label).toBe(SETTINGS_SECTIONS[active]);
+      expect(activeSeg?.text).toBe(` ${SETTINGS_SECTIONS[active]} `);
+    }
+  });
+
+  test("reports what is hidden so the caller can render scroll affordances", () => {
+    const last = SETTINGS_SECTIONS.length - 1;
+    const atEnd = windowedSegmentGeometry(SETTINGS_SECTIONS, last, 40);
+    expect(atEnd.hiddenBefore).toBeGreaterThan(0);
+    expect(atEnd.hiddenAfter).toBe(0);
+
+    const atStart = windowedSegmentGeometry(SETTINGS_SECTIONS, 0, 40);
+    expect(atStart.hiddenBefore).toBe(0);
+    expect(atStart.hiddenAfter).toBeGreaterThan(0);
+  });
+
+  test("keeps the active section rather than rendering nothing when it alone overflows", () => {
+    const w = windowedSegmentGeometry(SETTINGS_SECTIONS, 11, 4);
+    expect(w.segments).toHaveLength(1);
+    expect(w.segments[0]?.label).toBe("Danger Zone");
+  });
+
+  test("treats a missing or nonsensical width as unconstrained", () => {
+    for (const width of [0, -10, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const w = windowedSegmentGeometry(SETTINGS_SECTIONS, 3, width);
+      expect(w.segments).toHaveLength(SETTINGS_SECTIONS.length);
+    }
+  });
+
+  test("empty input yields an empty window", () => {
+    const w = windowedSegmentGeometry([], 0, 80);
+    expect(w.segments).toEqual([]);
+    expect(w.hiddenBefore).toBe(0);
+    expect(w.hiddenAfter).toBe(0);
   });
 });

--- a/apps/cli/test/unit/app-shell/settings-tab-strip-width.test.tsx
+++ b/apps/cli/test/unit/app-shell/settings-tab-strip-width.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+
+import { ClaudeTabRow } from "@/app-shell/primitives/ClaudeTabRow";
+import React from "react";
+
+import { render } from "../../harness/render-capture";
+
+/** The real Settings sections, in order. */
+const SETTINGS_SECTIONS = [
+  "General",
+  "Discover",
+  "Provider",
+  "Providers",
+  "YouTube",
+  "Language",
+  "Playback",
+  "Offline",
+  "Presence",
+  "Sync",
+  "Update",
+  "Danger Zone",
+];
+
+function stripAt(columns: number, activeIndex: number): string[] {
+  const handle = render(
+    <ClaudeTabRow
+      labels={SETTINGS_SECTIONS}
+      activeIndex={activeIndex}
+      hint="Tab / Shift+Tab"
+      maxWidth={columns}
+    />,
+    { columns },
+  );
+  const frame = handle.lastFrame();
+  handle.unmount();
+  return frame.split("\n").filter((line) => line.trim().length > 0);
+}
+
+describe("Settings tab strip at narrow widths", () => {
+  test("stays on one line at 80 columns instead of wrapping into stumps", () => {
+    // Twelve section names do not fit in 80 columns. Squeezing them produced a
+    // second line of two-character fragments ("GenDiscProvProvid…" over
+    // "era ove ide er") that hid which sections exist at all.
+    const lines = stripAt(80, 0);
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]?.length).toBeLessThanOrEqual(80);
+  });
+
+  test("shows the active section name in full at every position", () => {
+    for (const [index, section] of SETTINGS_SECTIONS.entries()) {
+      const lines = stripAt(80, index);
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toContain(section);
+    }
+  });
+
+  test("marks that there is more to scroll to", () => {
+    expect(stripAt(80, 0).join("")).toContain("›");
+    expect(stripAt(80, SETTINGS_SECTIONS.length - 1).join("")).toContain("‹");
+  });
+
+  test("survives a very narrow terminal without wrapping", () => {
+    for (const columns of [40, 50, 60, 70]) {
+      const lines = stripAt(columns, 5);
+      expect(lines).toHaveLength(1);
+      expect(lines[0]?.length).toBeLessThanOrEqual(columns);
+    }
+  });
+});

--- a/apps/cli/test/unit/app-shell/workflows-characterization.test.ts
+++ b/apps/cli/test/unit/app-shell/workflows-characterization.test.ts
@@ -21,6 +21,25 @@ describe("workflows characterization", () => {
     expect(typeof ctx.onAction).toBe("function");
   });
 
+  test("a picker offers the consent-bearing overlays, not a narrower hand-list", () => {
+    // These two were unreachable from the starting-point pickers while the
+    // footer still advertised `[/] commands`, because the surface carried its
+    // own array that had drifted from the registry. Analytics and presence are
+    // the ones that matter: both govern data leaving the machine, so "the
+    // command does not exist" is the wrong answer to give about them anywhere.
+    const { container } = createContainerFixture({
+      config: { minimalMode: false, footerHints: "detailed" },
+      shellChrome: { footerMode: "detailed" },
+    } as never);
+    const ids = buildPickerActionContext({ container, taskLabel: "Where to start?" }).commands.map(
+      (command) => command.id,
+    );
+
+    expect(ids).toContain("analytics");
+    expect(ids).toContain("presence");
+    expect(ids).toContain("settings");
+  });
+
   test("waitForOverlayClose resolves when overlay type is no longer on top", async () => {
     const { stateManager, closeTopOverlay } = createContainerFixture();
     stateManager.dispatch({


### PR DESCRIPTION
Closes #60. Closes #61.

Both surfaces told the user something untrue about the shell, and both were found by driving the real shell rather than reading it.

## Picker commands (#60)

`/analytics` and `/presence` answered **"no matching commands"** from the resume and starting-point pickers, while the footer on the same screen advertised `[/] commands` without qualification. Both commands govern data leaving the machine, so "that command does not exist" is the one answer they must never give.

The cause was three separate hand-written answers to "what works inside a picker":

| Where | Count |
| --- | --- |
| `MEDIA_PICKER_SURFACE_COMMANDS` | 2 |
| `buildPickerActionContext` default | 8 |
| `STARTING_POINT_PICKER_COMMANDS` | 7 |

They drifted as commands were added to the registry and not to the arrays. There is now a `modalPicker` entry in `COMMAND_CONTEXTS`, so new commands are offered or withheld by one decision — which `contract-conformance.test.ts` already covers.

Media pickers keep their deliberately narrow two-command palette. They nest inside an active browse or playback flow, and `command-registry.coverage.test.ts` locks that as a contract; I widened it first, saw two tests fail, and put it back.

## Settings tabs (#61)

Twelve section names in 80 columns were left to the layout engine to squeeze, which rendered them as two-character stumps wrapped across two misaligned lines:

```
 GenDiscProvProvidYouLangPlayOffline  PreSynUpdDange
 era ove ide er    ubeage bac continua encc  at r
```

Unreadable, and misleading enough that it hid whether an Analytics section existed at all. Now:

```
 General   Discover  Provider  Providers  YouTube › Tab / Shift+Tab
‹  YouTube   Language  Playback  Offline  Presence  Sync › Tab / Shift+Tab
‹ Playback  Offline  Presence  Sync  Update   Danger Zone  Tab / Shift+Tab
```

The strip windows around the active section, which is always drawn in full, with `‹`/`›` reporting what is off-screen. Segments no longer shrink, so overflow drops whole tabs instead of mangling every one.

## Verification

- Windowing is pure geometry (`windowedSegmentGeometry`) with its own tests, and the rendered result is checked through the Ink harness at 40, 50, 60, 70 and 80 columns — the layout engine is the thing that was misbehaving, so asserting on geometry alone would not have caught it.
- 4545 CLI unit tests, 0 fail. `fmt`, `lint` (0 warnings), `typecheck`, `verify:doc-paths` all clean.

Both issues reproduce on `origin/main` and predate the 0.3.0 work.

https://claude.ai/code/session_01X3LYuPf2BjMqY99JVecf8m