### PR TITLE
refactor(playback): rename local mpv telemetry to playback stats

### DIFF
--- a/.docs/architecture.md
+++ b/.docs/architecture.md
@@ -176,7 +176,7 @@ Production resolution is browserless by default:
   start from observed player events
 - treats IPC bootstrap failure as an ownership failure: terminate and reap the
   exact spawned child before provider fallback can create another player
-- keeps socket cleanup and final telemetry bounded after process exit
+- keeps socket cleanup and final playback stats bounded after process exit
 
 This is part of the repo's reliability contract. Changes are fine, but recovery under kill signals, EOF, or expired stream URLs needs to remain solid.
 

--- a/.docs/debugging-map.md
+++ b/.docs/debugging-map.md
@@ -151,7 +151,7 @@ to confirm sixel support; if it times out, capability falls back to half-block.
 `KUNAI_IMAGE_PROTOCOL=sixel` forces it; `kunai doctor` reports the resolved
 renderer and the reason it was chosen. `half-block` only improves text-mode fallback.
 The Now Playing rail intentionally uses half-block on Sixel terminals because
-its one-second telemetry frames otherwise replay and blink the framebuffer;
+its one-second playback-stats frames otherwise replay and blink the framebuffer;
 browse and post-play should still use sharp Sixel output.
 
 **Providers behave differently than on Linux.** The `curl.exe` Windows ships in

--- a/.docs/diagnostics-guide.md
+++ b/.docs/diagnostics-guide.md
@@ -192,7 +192,7 @@ is omitted entirely, so a clean session shows one short block instead of three
 headings and a lot of nothing.
 
 The split exists because "unknown" is not a fault. A subsystem with no data yet
-(`Provider — Unknown · no resolve telemetry yet`) previously sat in the same
+(`Provider — Unknown · no resolve traces yet`) previously sat in the same
 visual channel as a real failure, so nothing stood out. Anything `degraded`,
 `recoverable`, or `blocked` is a fault; only `unknown` is unknown. The mapping
 in `diagnostics-dashboard-model.ts` is exhaustive over `DiagnosticSeverity`, so

--- a/.docs/download-offline-onboarding.md
+++ b/.docs/download-offline-onboarding.md
@@ -166,7 +166,7 @@ was looked up as `tmdb:1339713` and a healthy file reported "Downloaded file una
   recap, preview, and credits behavior does not unexpectedly change between streamed and
   downloaded files.
 - `--offline` is a transient runtime override: it sets offline connectivity before startup
-  workers begin, skips download processing, update checks, telemetry, and sync identity work,
+  workers begin, skips download processing, update checks, analytics, and sync identity work,
   and opens the local library without provider resolution.
 - An offline-library launch keeps its explicit local-only origin through episode selection and
   playback. The validated local source is handed to the local mpv path, including local subtitle

--- a/.docs/engineering-guide.md
+++ b/.docs/engineering-guide.md
@@ -187,7 +187,7 @@ Bun-first means using Bun primitives where they are the clearly better choice. I
 - **Config reads**: `Bun.file().json()` for config and capability notice files
 - **Crypto IDs**: `crypto.randomUUID()` and `crypto.getRandomValues()` (not `node:crypto` `randomUUID`/`randomBytes`)
 - **Atomic writes**: `Bun.write()` + Node `rename`/`unlink` via shared `infra/fs/atomic-write.ts` helpers (`writeAtomicText`, `writeAtomicBytes`, `writeAtomicJson`)
-- **End-file telemetry**: Promise-based `endFileReceived` races `Bun.sleep(1500)` instead of a 50ms polling loop
+- **End-file stats**: Promise-based `endFileReceived` races `Bun.sleep(1500)` instead of a 50ms polling loop
 
 ### Keep Node Intentionally
 

--- a/.docs/glossary.md
+++ b/.docs/glossary.md
@@ -74,20 +74,29 @@ anime work that arrived through the TMDB/series lane keep its AniList/MAL histor
 unit; pure western series are never forced. Every offline lookup resolves through
 one title id.
 
-## Resolve trace vs analytics
+## Playback stats vs resolve trace vs analytics
 
-Two different things are called telemetry. Do not conflate them.
+Three different things get read as "usage data". Only one of them leaves the
+machine. Do not conflate them.
 
+- **Playback stats** — local-only mpv playback state: position, duration, cache
+  ahead, buffering, seeking, video-output readiness. Read over the mpv IPC
+  socket by `apps/cli/src/infra/player/mpv-stats.ts`, projected for the shell by
+  `apps/cli/src/domain/playback/playback-stats-snapshot.ts`. Never persisted,
+  never sent.
 - **Resolve trace** — local-only, full detail, never leaves the machine. Built by
   `packages/core/src/trace.ts`, persisted through
   `apps/cli/src/services/diagnostics/ResolveTraceSink.ts`, wired in production in
   `apps/cli/src/container/bootstrap-persistence.ts`.
-- **Analytics** — opt-in product telemetry that does leave the machine
+- **Analytics** — the opt-in usage ping that does leave the machine
   (`apps/analytics-ingest`). Payload-bounded by
   `.docs/analytics-privacy-contract.md`, and deliberately cannot carry a title
   id — so it can never diagnose a resolve.
 
-A resolve question is answered by traces, never by analytics.
+A resolve question is answered by traces, never by analytics. The word
+_telemetry_ is retired here: it once named both the first and the third, which is
+exactly the ambiguity these names remove. `/telemetry` survives only as a typed
+alias for the `/analytics` command.
 
 ## Download job vs offline asset
 

--- a/.docs/mpv-in-process-reconnect.md
+++ b/.docs/mpv-in-process-reconnect.md
@@ -22,7 +22,7 @@ After a successful reload, **external subtitles are re-attached** from the curre
 
 1. **`network-read-dead`** (from `playback-watchdog`): demuxer reports network + underrun + `raw-input-rate === 0` while paused-for-cache, sustained for ~8s. Fires at most once per stall incident from the watchdog; **reconnect attempts** are still capped per cycle.
 
-2. **Premature EOF** (telemetry guard): `end-file` with `eof` was **demoted** to `unknown` because trusted progress was inconsistent with a full watch (`eofDemotedByPrematureGuard`).
+2. **Premature EOF** (playback-stats guard): `end-file` with `eof` was **demoted** to `unknown` because trusted progress was inconsistent with a full watch (`eofDemotedByPrematureGuard`).
 
 3. **`end-file` with `error`** while **`demuxer-via-network`** was true: treat as a reconnectable network demuxer error before surfacing a terminal failure.
 
@@ -89,7 +89,7 @@ session exists" and includes the bootstrap states `loading`/`ready`, while
 `isPlaybackTransportStarted()` means "bootstrap is over" and does not. Surfaces
 deciding whether to keep a loading presentation need the latter.
 
-## Telemetry and UI
+## Playback stats and UI
 
 - Diagnostics / shell may show **`mpv-in-process-reconnect`** events (`started` | `complete` | `failed`) with attempt number and a short `detail` (trigger + error when failed).
 - Seek policy lives in `apps/cli/src/infra/player/mpv-in-process-reconnect.ts` (`computeInProcessReconnectSeek`).

--- a/.docs/poster-image-rendering.md
+++ b/.docs/poster-image-rendering.md
@@ -35,7 +35,7 @@ Use `@/image` or `apps/cli/src/image/index.ts` (the old `apps/cli/src/image.ts` 
 - **WezTerm stays on sixel** even though it also implements the iTerm2 protocol, because the sixel overlay path is the verified one there. `KUNAI_IMAGE_PROTOCOL=iterm` gives higher fidelity for users who want it; promoting it to the default needs a real-terminal check first.
 - **Half-block is the universal floor.** It decodes in-process and needs no external binary, which is what makes posters work on Windows at all — `chafa` is effectively never installed there.
 - **Ink app shell**: sixel posters reserve a blank measured Ink rectangle. A shared overlay manager uses absolute cursor movement to redraw navigation surfaces after Ink frames and applies Yazi's three-move ConPTY workaround on Windows. Removal and movement rely on the Ink commit that changed the pane; same-slot image replacement clears and paints atomically so old pixels cannot flash through. Terminals that answer the kitty probe but implement no Unicode placeholders (WezTerm's opt-in mode, Konsole) still use text renderers for Kitty.
-- **Now Playing**: unrelated one-second playback telemetry does not resend the framebuffer payload. Its high-frequency rail repaints only when the poster pane commits; history, browse, and other navigation surfaces repaint after Ink frames so a later metadata commit cannot erase a newly displayed cached poster.
+- **Now Playing**: unrelated one-second playback stats do not resend the framebuffer payload. Its high-frequency rail repaints only when the poster pane commits; history, browse, and other navigation surfaces repaint after Ink frames so a later metadata commit cannot erase a newly displayed cached poster.
 
 Details live in `apps/cli/src/image/capability.ts`.
 

--- a/.docs/provider-dossiers/tmdb-embed-aggregator-research.md
+++ b/.docs/provider-dossiers/tmdb-embed-aggregator-research.md
@@ -509,7 +509,7 @@ If the project wants a VidAPI provider module, the shape would be:
   premature.
 - Should the project emit a usage metric when calling the API? The VidAPI
   embed business model is driven by iframe views; CLI usage is invisible to
-  them, which is good for stealth but also means no telemetry to know if
+  them, which is good for stealth but also means no signal to know if
   the IP gets flagged.
 - Should the project surface "this title is unavailable in VidAPI" (the
   Arcane S2E1 case) as a clean error message or a generic "no sources" UI?

--- a/.docs/title-provider-health-and-cache-reset.md
+++ b/.docs/title-provider-health-and-cache-reset.md
@@ -48,7 +48,7 @@ Background prune default: **7 days** (`providerHealthRetentionDays`). Title-scop
 ### 2.3 Visibility
 
 - **Provider picker** — health badge per provider (`down`, `degraded`, failure count, skipped note)
-- **Runtime health line** — merges resolve telemetry with persisted memory for the active provider
+- **Runtime health line** — merges resolve traces with persisted memory for the active provider
 - **Diagnostics panel** — **Provider memory** section lists lane providers with effective status and fallback eligibility
 - **Resolve feedback** — when providers are skipped: `Miruro (down) skipped in auto-fallback — /reset-provider-health to retry`
 

--- a/.plans/013-split-ink-shell-host-surface.md
+++ b/.plans/013-split-ink-shell-host-surface.md
@@ -21,7 +21,7 @@
 
 ## Current state
 
-- `ink-shell.tsx:29-45` imports mix host concerns (`registerExitHandler`/`requestHardExit` from graceful-exit, `markInteractiveShellMounted`, `deleteAllKittyImages`, `recordRender` diagnostics, playback telemetry) with rendering.
+- `ink-shell.tsx:29-45` imports mix host concerns (`registerExitHandler`/`requestHardExit` from graceful-exit, `markInteractiveShellMounted`, `deleteAllKittyImages`, `recordRender` diagnostics, playback stats) with rendering.
 - 26 `useState` at the root component (grep-verified); timer effects at `:404`, `:619`, `:637`, `:661` (plan 008 addresses the timer-driven ones).
 - Overlay mechanisms present: `root-overlay-shell.tsx`, `overlay-panel.tsx`, `picker-overlay.tsx`, `overlay-picker-row.tsx`, `root-overlay-model.ts`, `overlay-back-stack.ts`, `root-workflow-dispatch.ts`, `root-overlay-bridge.ts`, plus `command-router.ts`.
 

--- a/.plans/provider-result-contract.md
+++ b/.plans/provider-result-contract.md
@@ -126,7 +126,7 @@ No provider should be marked "subtitle ready" unless:
 
 ## Phase Order
 
-1. Fix MPV telemetry/history sign-off.
+1. Fix MPV playback-stats/history sign-off.
 2. Temporarily harden English subtitle selection in CLI shared helpers.
 3. Finish provider dossiers with subtitle evidence.
 4. Define `@kunai/core` provider interfaces/adapters.

--- a/apps/cli/src/app-shell/MediaPanel.tsx
+++ b/apps/cli/src/app-shell/MediaPanel.tsx
@@ -101,7 +101,7 @@ function PosterSlot({
       {poster.kind !== "none" ? (
         <PosterOutput
           poster={poster}
-          // Playback telemetry renders every second. The pane itself still
+          // Playback stats render every second. The pane itself still
           // repaints when it commits, but unrelated timer frames must not resend
           // a large Sixel payload and make Windows Terminal blink.
           repaintAfterInkRender={placementSlot !== "playing-rail"}

--- a/apps/cli/src/app-shell/loading-shell-runtime.ts
+++ b/apps/cli/src/app-shell/loading-shell-runtime.ts
@@ -84,7 +84,7 @@ export function shouldShowPlaybackRuntimeStrip(input: {
 // ── 4-stage loading UX ──────────────────────────────────────────────────────
 
 // "preparing-provider" is emitted from AppRoot LoadingShell while playbackStatus is "loading".
-// Will be connected when provider-resolution telemetry is plumbed in.
+// Will be connected when provider-resolution traces are plumbed in.
 const STAGE_ORDER: readonly LoadingShellStage[] = [
   "finding-stream",
   "preparing-provider",

--- a/apps/cli/src/app-shell/loading-shell.tsx
+++ b/apps/cli/src/app-shell/loading-shell.tsx
@@ -100,7 +100,7 @@ function useRuntimeHealthLine(
 ): ShellPanelLine | undefined {
   // Hold the latest getter in a ref so the polling effect depends only on
   // refreshMs. The getter is rebuilt inline every parent render (and the parent
-  // re-renders on every playback telemetry tick), so depending on its identity
+  // re-renders on every playback stats tick), so depending on its identity
   // would tear down and restart the interval constantly.
   const getRuntimeHealthRef = React.useRef(getRuntimeHealth);
   React.useEffect(() => {
@@ -569,7 +569,7 @@ export const LoadingShell = React.memo(function LoadingShell({
     state.subtitleStatus?.toLowerCase().includes("ready"),
   );
 
-  // Active control-surface state, derived from existing playback telemetry — the
+  // Active control-surface state, derived from existing playback stats — the
   // playing body renders structured rows (health · tracks · session · up next)
   // instead of one scattered facts strip. Color = state; weight = hierarchy.
   const activeTracksLine = isPlaying

--- a/apps/cli/src/app-shell/playback-mount-shell.tsx
+++ b/apps/cli/src/app-shell/playback-mount-shell.tsx
@@ -19,9 +19,9 @@ import {
 } from "@/domain/media/content-kind";
 import type { MediaItemIdentity } from "@/domain/media/media-item-identity";
 import {
-  describePlaybackTelemetrySnapshot,
-  type PlaybackTelemetrySnapshot,
-} from "@/domain/playback/playback-telemetry-snapshot";
+  describePlaybackStatsSnapshot,
+  type PlaybackStatsSnapshot,
+} from "@/domain/playback/playback-stats-snapshot";
 import type { DecodedTrackSelection } from "@/domain/playback/track-capabilities";
 import { formatQueueEntryLabel } from "@/domain/queue/queue-entry-label";
 import type { SessionState } from "@/domain/session/SessionState";
@@ -95,7 +95,7 @@ export type PlaybackRootContentInput = {
   readonly activeProvider: { metadata: { name: string } } | undefined;
   readonly hasStreamCandidates: boolean;
   readonly isSeriesPlayback: boolean;
-  readonly activePlaybackTelemetrySnapshot?: PlaybackTelemetrySnapshot | null;
+  readonly activePlaybackStatsSnapshot?: PlaybackStatsSnapshot | null;
   readonly canGoNext: boolean;
   readonly canGoPrevious: boolean;
   readonly canToggleAutoplay: boolean;
@@ -121,7 +121,7 @@ export function buildPlaybackRootLoadingShellState(
     activeProvider,
     hasStreamCandidates,
     isSeriesPlayback,
-    activePlaybackTelemetrySnapshot,
+    activePlaybackStatsSnapshot,
     canGoNext,
     canGoPrevious,
     canToggleAutoplay,
@@ -176,14 +176,14 @@ export function buildPlaybackRootLoadingShellState(
     // and substring-matching it lit "Trying another source" over successful
     // resolves. Alarm state comes from `problem` below, which is structured.
     problem: state.playbackProblem,
-    currentPosition: activePlaybackTelemetrySnapshot?.positionSeconds,
-    duration: activePlaybackTelemetrySnapshot?.durationSeconds,
+    currentPosition: activePlaybackStatsSnapshot?.positionSeconds,
+    duration: activePlaybackStatsSnapshot?.durationSeconds,
     bufferHealth:
       state.playbackStatus === "stalled"
         ? "stalled"
-        : state.playbackStatus === "buffering" || activePlaybackTelemetrySnapshot?.pausedForCache
+        : state.playbackStatus === "buffering" || activePlaybackStatsSnapshot?.pausedForCache
           ? "buffering"
-          : activePlaybackTelemetrySnapshot
+          : activePlaybackStatsSnapshot
             ? "healthy"
             : undefined,
     playbackSourceLine: formatPlaybackSourceLine(state.stream) ?? undefined,
@@ -282,9 +282,7 @@ export function PlaybackRootContent(input: PlaybackRootContentInput) {
     input;
   useEffect(preloadTracksPanelModules, []);
   const playbackIsActive = isPlaybackSessionActive(state.playbackStatus);
-  const [telemetrySnapshot, setTelemetrySnapshot] = useState<PlaybackTelemetrySnapshot | null>(
-    null,
-  );
+  const [statsSnapshot, setStatsSnapshot] = useState<PlaybackStatsSnapshot | null>(null);
 
   // Count this playback against the key card's budget once it actually starts,
   // so the card retires after being seen rather than after N launches that may
@@ -300,30 +298,27 @@ export function PlaybackRootContent(input: PlaybackRootContentInput) {
   useEffect(() => {
     if (!playbackIsActive) return undefined;
     const refreshSnapshot = () => {
-      setTelemetrySnapshot(input.container.playerControl.getTelemetrySnapshot());
+      setStatsSnapshot(input.container.playerControl.getStatsSnapshot());
     };
     refreshSnapshot();
     const timer = setInterval(refreshSnapshot, 1_000);
     return () => clearInterval(timer);
   }, [input.container.playerControl, playbackIsActive]);
 
-  const activePlaybackTelemetrySnapshot = playbackIsActive ? telemetrySnapshot : null;
-  const telemetryInput = useMemo(
+  const activePlaybackStatsSnapshot = playbackIsActive ? statsSnapshot : null;
+  const statsInput = useMemo(
     () => ({
       ...input,
-      activePlaybackTelemetrySnapshot,
+      activePlaybackStatsSnapshot,
       playbackTrace:
         state.playbackNote ??
-        (activePlaybackTelemetrySnapshot
-          ? describePlaybackTelemetrySnapshot(activePlaybackTelemetrySnapshot)
+        (activePlaybackStatsSnapshot
+          ? describePlaybackStatsSnapshot(activePlaybackStatsSnapshot)
           : input.playbackTrace),
     }),
-    [activePlaybackTelemetrySnapshot, input, state.playbackNote],
+    [activePlaybackStatsSnapshot, input, state.playbackNote],
   );
-  const loadingState = useMemo(
-    () => buildPlaybackRootLoadingShellState(telemetryInput),
-    [telemetryInput],
-  );
+  const loadingState = useMemo(() => buildPlaybackRootLoadingShellState(statsInput), [statsInput]);
 
   /**
    * The playing title as a media item, or null when nothing is playing.

--- a/apps/cli/src/app-shell/sixel-overlay.ts
+++ b/apps/cli/src/app-shell/sixel-overlay.ts
@@ -99,7 +99,7 @@ export class SixelOverlayManager {
   /**
    * Called from Ink's onRender hook. Component registration already runs after
    * the commit and schedules a paint when pixels or geometry changed. Repainting
-   * every unchanged overlay here made one-second playback telemetry blink the
+   * every unchanged overlay here made one-second playback stats blink the
    * poster continuously on ConPTY.
    */
   afterInkRender(): void {

--- a/apps/cli/src/app-shell/types.ts
+++ b/apps/cli/src/app-shell/types.ts
@@ -218,7 +218,7 @@ export type LoadingShellState = {
   stage?: LoadingShellStage;
   /** Human-readable sub-status within the current stage (e.g. "Resolving direct link…"). */
   stageDetail?: string;
-  /** Dominant slow startup phase from playback.startup.phases telemetry. */
+  /** Dominant slow startup phase from the playback.startup.phases diagnostic event. */
   dominantPhaseLabel?: string;
   progress?: number; // 0-100 or undefined for indeterminate
   details?: string;
@@ -238,7 +238,7 @@ export type LoadingShellState = {
   autoplayPaused?: boolean;
   isSeriesPlayback?: boolean;
   fallbackProviderName?: string;
-  /** Playback supervision telemetry (populated when operation === "playing"). */
+  /** Playback supervision stats (populated when operation === "playing"). */
   currentPosition?: number;
   duration?: number;
   qualityLabel?: string;

--- a/apps/cli/src/app/playback/playback-status-policy.ts
+++ b/apps/cli/src/app/playback/playback-status-policy.ts
@@ -80,7 +80,7 @@ function accept(
   };
 }
 
-/** Accepted, but carries no authority to move the status (telemetry, copy, tracks). */
+/** Accepted, but carries no authority to move the status (playback stats, copy, tracks). */
 function informational(current: PlaybackStatusSnapshot): PlaybackStatusDecision {
   return { accepted: true, snapshot: current, statusChanged: false, clearFeedback: false };
 }

--- a/apps/cli/src/domain/playback/playback-stats-snapshot.ts
+++ b/apps/cli/src/domain/playback/playback-stats-snapshot.ts
@@ -1,4 +1,4 @@
-export type PlaybackTelemetrySnapshot = {
+export type PlaybackStatsSnapshot = {
   readonly positionSeconds?: number;
   readonly durationSeconds?: number;
   readonly cacheAheadSeconds?: number;
@@ -10,7 +10,7 @@ export type PlaybackTelemetrySnapshot = {
   readonly updatedAt: number;
 };
 
-export function describePlaybackTelemetrySnapshot(snapshot: PlaybackTelemetrySnapshot): string {
+export function describePlaybackStatsSnapshot(snapshot: PlaybackStatsSnapshot): string {
   const parts: string[] = [];
 
   if (
@@ -53,7 +53,7 @@ export function describePlaybackTelemetrySnapshot(snapshot: PlaybackTelemetrySna
     parts.push("video output pending");
   }
 
-  return parts.join(" · ") || "telemetry pending";
+  return parts.join(" · ") || "stats pending";
 }
 
 function formatPlaybackTime(seconds: number): string {

--- a/apps/cli/src/domain/types.ts
+++ b/apps/cli/src/domain/types.ts
@@ -193,13 +193,13 @@ export interface TitleAlias {
 }
 
 export type EndReason = "eof" | "quit" | "error" | "unknown";
-export type PlaybackTelemetrySource = "ipc" | "unknown";
+export type PlaybackStatsSource = "ipc" | "unknown";
 
 export interface PlaybackResult {
   readonly watchedSeconds: number;
   readonly duration: number;
   readonly endReason: EndReason;
-  readonly resultSource?: PlaybackTelemetrySource;
+  readonly resultSource?: PlaybackStatsSource;
   readonly playerExitedCleanly?: boolean;
   readonly playerExitCode?: number | null;
   readonly playerExitSignal?: string | null;
@@ -211,7 +211,7 @@ export interface PlaybackResult {
    *  Updated on small forward steps AND user seeks (both forward and backward).
    *  Unlike lastTrustedProgressSeconds, this CAN go down when the user seeks backward. */
   readonly lastReliableProgressSeconds?: number;
-  /** True when mpv reported EOF but telemetry suggests the network stream died early. */
+  /** True when mpv reported EOF but playback stats suggest the network stream died early. */
   readonly suspectedDeadStream?: boolean;
   /** True when a terminal manifest response rejected this stream before mpv was launched. */
   readonly streamRejectedBeforePlayerLaunch?: boolean;

--- a/apps/cli/src/infra/player/PersistentMpvSession.ts
+++ b/apps/cli/src/infra/player/PersistentMpvSession.ts
@@ -41,16 +41,16 @@ import {
 import { shouldEmitPlaybackProgress } from "./mpv-playback-kernel";
 import type { MpvUrlKind } from "./mpv-playback-url";
 import type { MpvRuntimeOptions } from "./mpv-runtime-options";
-import { buildPersistentLoadfileCommand } from "./mpv-stream-http-headers";
 import {
   applyEndFileEvent,
-  createPlayerTelemetryState,
+  createPlayerStatsState,
   finalizePlaybackResult,
   noteStreamStall,
   noteTrustedSeek,
   recordPlayerExit,
-  type PlayerTelemetryState,
-} from "./mpv-telemetry";
+  type PlayerStatsState,
+} from "./mpv-stats";
+import { buildPersistentLoadfileCommand } from "./mpv-stream-http-headers";
 import { PersistentMpvPropertyRouter } from "./persistent-mpv-property-router";
 import type { PersistentMpvSessionRuntime } from "./persistent-mpv-runtime";
 import { PersistentReadyWorkExecutor } from "./persistent-ready-work-executor";
@@ -70,7 +70,7 @@ import {
   pruneSkippedPlaybackSegmentKeys,
 } from "./playback-skip";
 import { createPlaybackWatchdog, type PlaybackWatchdog } from "./playback-watchdog";
-import { buildPlaybackTelemetrySnapshot } from "./PlaybackTelemetrySnapshot";
+import { buildPlaybackStatsSnapshot } from "./PlaybackStatsSnapshot";
 import type { ActivePlayerControl, MpvRequestedAction } from "./PlayerControlService";
 import type { LateSubtitleAttachment, PlayerPlaybackEvent } from "./PlayerService";
 import { extractExternalSubtitleIds } from "./subtitle-track-cache";
@@ -135,7 +135,7 @@ type PlayerCycleOptions = {
 };
 
 type PlayerCycleState = {
-  telemetry: PlayerTelemetryState;
+  stats: PlayerStatsState;
   resolve: (result: PlaybackResult) => void;
   promise: Promise<PlaybackResult>;
   playerReadyNotified: boolean;
@@ -299,8 +299,8 @@ export class PersistentMpvSession {
       skipCurrentSegment: async () => this.skipCurrentSegment(),
       updateTiming: (timing) => this.updateTiming(timing),
       updateAutoSkipEnabled: (enabled) => this.updateAutoSkipEnabled(enabled),
-      getTelemetrySnapshot: () =>
-        this.activeCycle ? buildPlaybackTelemetrySnapshot(this.activeCycle.telemetry) : null,
+      getStatsSnapshot: () =>
+        this.activeCycle ? buildPlaybackStatsSnapshot(this.activeCycle.stats) : null,
       showOsdMessage: async (text, durationMs) => {
         await this.ipcSession?.send(["show-text", text, durationMs], 1_000);
       },
@@ -437,7 +437,7 @@ export class PersistentMpvSession {
         error: `stream unreachable: ${preflight.reason}`,
       });
       this.clearPendingFileLoadIf(fileLoadId, generation);
-      cycle.telemetry.endReason = "error";
+      cycle.stats.endReason = "error";
       this.activeCycle = null;
       cycle.resolve({
         watchedSeconds: 0,
@@ -591,7 +591,7 @@ export class PersistentMpvSession {
     const emitPlaybackEvent = (event: PlayerPlaybackEvent) => {
       const active = this.activeCycle;
       if (active && (event.type === "stream-stalled" || event.type === "ipc-stalled")) {
-        noteStreamStall(active.telemetry, Date.now());
+        noteStreamStall(active.stats, Date.now());
       }
       this.currentCycleOptions().onPlaybackEvent?.(event);
       if (
@@ -751,13 +751,13 @@ export class PersistentMpvSession {
     options: PlayerCycleOptions,
     cycleOptions: { acceptPlaybackProperties?: boolean } = {},
   ): PlayerCycleState {
-    const telemetry = createPlayerTelemetryState(this.ipcEndpoint.path);
+    const stats = createPlayerStatsState(this.ipcEndpoint.path);
     let resolve!: (result: PlaybackResult) => void;
     const promise = new Promise<PlaybackResult>((res) => {
       resolve = res;
     });
     const cycle: PlayerCycleState = {
-      telemetry,
+      stats,
       resolve,
       promise,
       playerReadyNotified: false,
@@ -1031,7 +1031,7 @@ export class PersistentMpvSession {
   }
 
   private maybeEmitPlaybackProgress(cycle: PlayerCycleState, observedAt: number): void {
-    const sample = cycle.telemetry.latestIpcSample;
+    const sample = cycle.stats.latestIpcSample;
     if (
       !shouldEmitPlaybackProgress(
         cycle,
@@ -1056,7 +1056,7 @@ export class PersistentMpvSession {
 
   private fireNearEofIfNeeded(positionSeconds: number): void {
     if (this.nearEofFired) return;
-    const duration = this.activeCycle?.telemetry.latestIpcSample?.durationSeconds ?? 0;
+    const duration = this.activeCycle?.stats.latestIpcSample?.durationSeconds ?? 0;
     const triggerSeconds = resolveNearEofPrefetchTriggerSeconds(
       duration,
       this.currentCycleOptions().timing,
@@ -1193,7 +1193,7 @@ export class PersistentMpvSession {
     const seekResult = await this.ipcSession.send(["seek", target, "absolute"], 2_000);
     if (seekResult.ok) {
       this.currentPositionSeconds = target;
-      noteTrustedSeek(this.activeCycle.telemetry, target);
+      noteTrustedSeek(this.activeCycle.stats, target);
     }
   }
 
@@ -1367,8 +1367,8 @@ export class PersistentMpvSession {
       this.hasLoadedFile = false;
 
       if (active) {
-        recordPlayerExit(active.telemetry, exit);
-        const result = finalizePlaybackResult(active.telemetry, {
+        recordPlayerExit(active.stats, exit);
+        const result = finalizePlaybackResult(active.stats, {
           socketPathCleanedUp: shouldUnlinkUnixSocket(this.ipcEndpoint)
             ? !existsSync(this.ipcEndpoint.path)
             : true,
@@ -1432,19 +1432,19 @@ export class PersistentMpvSession {
       this.currentCycleOptions().onNearEof?.();
     }
 
-    applyEndFileEvent(active.telemetry, reason, observedAt, { fileError });
-    const result = finalizePlaybackResult(active.telemetry, {
+    applyEndFileEvent(active.stats, reason, observedAt, { fileError });
+    const result = finalizePlaybackResult(active.stats, {
       socketPathCleanedUp: false,
     });
 
-    const latest = active.telemetry.latestIpcSample ?? active.telemetry.lastNonZeroSample;
+    const latest = active.stats.latestIpcSample ?? active.stats.lastNonZeroSample;
     const networkish = latest?.demuxerViaNetwork === true;
-    const demoted = active.telemetry.eofDemotedByPrematureGuard;
+    const demoted = active.stats.eofDemotedByPrematureGuard;
     const seekFrom = Math.max(result.watchedSeconds, this.currentPositionSeconds);
     const durationForSeek =
       result.duration > 0
         ? result.duration
-        : (active.telemetry.lastNonZeroSample?.durationSeconds ?? 0);
+        : (active.stats.lastNonZeroSample?.durationSeconds ?? 0);
 
     const shouldTryReconnect =
       this.mpvInProcessStreamReconnectEnabled &&
@@ -1476,7 +1476,7 @@ export class PersistentMpvSession {
     const active = this.activeCycle;
     if (!active || !this.ipcSession) return;
 
-    const latest = active.telemetry.latestIpcSample;
+    const latest = active.stats.latestIpcSample;
     const duration = latest?.durationSeconds ?? 0;
     const reloaded = await this.runSameUrlReconnect(
       active,
@@ -1542,13 +1542,13 @@ export class PersistentMpvSession {
         detail: trigger,
       });
 
-      const savedEndReason = active.telemetry.endReason;
-      const savedMaxTrusted = active.telemetry.maxTrustedProgressSeconds;
-      const savedLastReliable = active.telemetry.lastReliableProgressSeconds;
-      active.telemetry = createPlayerTelemetryState(this.ipcEndpoint.path);
-      active.telemetry.endReason = savedEndReason;
-      active.telemetry.maxTrustedProgressSeconds = savedMaxTrusted;
-      active.telemetry.lastReliableProgressSeconds = savedLastReliable;
+      const savedEndReason = active.stats.endReason;
+      const savedMaxTrusted = active.stats.maxTrustedProgressSeconds;
+      const savedLastReliable = active.stats.lastReliableProgressSeconds;
+      active.stats = createPlayerStatsState(this.ipcEndpoint.path);
+      active.stats.endReason = savedEndReason;
+      active.stats.maxTrustedProgressSeconds = savedMaxTrusted;
+      active.stats.lastReliableProgressSeconds = savedLastReliable;
       // Reconnect reloads the same cycle: keep its generation, but retire the
       // previous pending owner so two load owners never coexist.
       this.pendingInProcessReconnect = {

--- a/apps/cli/src/infra/player/PlaybackStatsSnapshot.ts
+++ b/apps/cli/src/infra/player/PlaybackStatsSnapshot.ts
@@ -1,12 +1,10 @@
-import type { PlaybackTelemetrySnapshot } from "@/domain/playback/playback-telemetry-snapshot";
+import type { PlaybackStatsSnapshot } from "@/domain/playback/playback-stats-snapshot";
 
-import type { PlayerTelemetryState } from "./mpv-telemetry";
+import type { PlayerStatsState } from "./mpv-stats";
 
-export type { PlaybackTelemetrySnapshot } from "@/domain/playback/playback-telemetry-snapshot";
+export type { PlaybackStatsSnapshot } from "@/domain/playback/playback-stats-snapshot";
 
-export function buildPlaybackTelemetrySnapshot(
-  state: PlayerTelemetryState,
-): PlaybackTelemetrySnapshot | null {
+export function buildPlaybackStatsSnapshot(state: PlayerStatsState): PlaybackStatsSnapshot | null {
   const sample = state.latestIpcSample;
   if (!sample) return null;
 

--- a/apps/cli/src/infra/player/PlayerControlService.ts
+++ b/apps/cli/src/infra/player/PlayerControlService.ts
@@ -1,4 +1,4 @@
-import type { PlaybackTelemetrySnapshot } from "@/domain/playback/playback-telemetry-snapshot";
+import type { PlaybackStatsSnapshot } from "@/domain/playback/playback-stats-snapshot";
 import type { EpisodeInfo, PlaybackTimingMetadata, SubtitleTrack } from "@/domain/types";
 
 import type { SubtitleAttachmentResult } from "./persistent-subtitle-manager";
@@ -70,7 +70,7 @@ export interface ActivePlayerControl {
   updateTiming?(timing: PlaybackTimingMetadata | null): void;
   updateAutoSkipEnabled?(enabled: boolean): void;
   getTimingSnapshot?(): PlaybackTimingMetadata | null;
-  getTelemetrySnapshot?(): PlaybackTelemetrySnapshot | null;
+  getStatsSnapshot?(): PlaybackStatsSnapshot | null;
   showOsdMessage?(text: string, durationMs: number): Promise<void>;
   /** Full-window loading overlay via Lua (`user-data/kunai-loading`); survives idle between files. */
   setEpisodeTransitionLoading?(message: string | null): Promise<void>;
@@ -118,5 +118,5 @@ export interface PlayerControlService {
   returnToSearchFromPlayback(reason?: string): Promise<boolean>;
   updateCurrentPlaybackTiming(timing: PlaybackTimingMetadata | null, reason?: string): void;
   updateCurrentPlaybackAutoSkipEnabled(enabled: boolean, reason?: string): void;
-  getTelemetrySnapshot(): PlaybackTelemetrySnapshot | null;
+  getStatsSnapshot(): PlaybackStatsSnapshot | null;
 }

--- a/apps/cli/src/infra/player/PlayerControlServiceImpl.ts
+++ b/apps/cli/src/infra/player/PlayerControlServiceImpl.ts
@@ -1,4 +1,4 @@
-import type { PlaybackTelemetrySnapshot } from "@/domain/playback/playback-telemetry-snapshot";
+import type { PlaybackStatsSnapshot } from "@/domain/playback/playback-stats-snapshot";
 import type { EpisodeInfo, PlaybackTimingMetadata } from "@/domain/types";
 import type { Logger } from "@/infra/logger/Logger";
 import { buildSubtitleDiagnosticEvent } from "@/services/diagnostics/diagnostic-event-helpers";
@@ -487,8 +487,8 @@ export class PlayerControlServiceImpl implements PlayerControlService {
     active.updateAutoSkipEnabled(enabled);
   }
 
-  getTelemetrySnapshot(): PlaybackTelemetrySnapshot | null {
-    return this.active?.getTelemetrySnapshot?.() ?? null;
+  getStatsSnapshot(): PlaybackStatsSnapshot | null {
+    return this.active?.getStatsSnapshot?.() ?? null;
   }
 
   private async stopWithAction(

--- a/apps/cli/src/infra/player/mpv-stats.ts
+++ b/apps/cli/src/infra/player/mpv-stats.ts
@@ -1,6 +1,6 @@
 import type { EndReason, PlaybackResult } from "@/domain/types";
 
-export interface PlayerTelemetrySample {
+export interface PlayerStatsSample {
   source: "ipc";
   observedAt: number;
   positionSeconds: number;
@@ -29,10 +29,10 @@ export interface PlayerTelemetrySample {
   endReason?: EndReason;
 }
 
-export interface PlayerTelemetryState {
+export interface PlayerStatsState {
   readonly socketPath?: string;
-  latestIpcSample: PlayerTelemetrySample | null;
-  lastNonZeroSample: PlayerTelemetrySample | null;
+  latestIpcSample: PlayerStatsSample | null;
+  lastNonZeroSample: PlayerStatsSample | null;
   endReason: EndReason;
   playerExitedCleanly: boolean;
   playerExitCode: number | null;
@@ -75,14 +75,14 @@ function normalizeNumber(value: unknown): number {
   return 0;
 }
 
-function isMeaningful(sample: Pick<PlayerTelemetrySample, "positionSeconds" | "durationSeconds">) {
+function isMeaningful(sample: Pick<PlayerStatsSample, "positionSeconds" | "durationSeconds">) {
   return sample.positionSeconds > 0 || sample.durationSeconds > 0;
 }
 
 function preferStrongerProgressSample(
-  existing: PlayerTelemetrySample | null,
-  candidate: PlayerTelemetrySample,
-): PlayerTelemetrySample {
+  existing: PlayerStatsSample | null,
+  candidate: PlayerStatsSample,
+): PlayerStatsSample {
   if (!existing) return candidate;
 
   if (candidate.positionSeconds > existing.positionSeconds) return candidate;
@@ -94,7 +94,7 @@ function preferStrongerProgressSample(
   return existing;
 }
 
-export function createPlayerTelemetryState(socketPath?: string): PlayerTelemetryState {
+export function createPlayerStatsState(socketPath?: string): PlayerStatsState {
   return {
     socketPath,
     latestIpcSample: null,
@@ -122,7 +122,7 @@ const EOF_TRUST_TAIL_MIN_SEC = 120;
 const EOF_TRUST_PERCENT_POS_MIN = 95;
 
 /** Called when the playback watchdog reports stream/ipc stall (correlate with spurious EOF). */
-export function noteStreamStall(state: PlayerTelemetryState, observedAtMs: number): void {
+export function noteStreamStall(state: PlayerStatsState, observedAtMs: number): void {
   const pos = state.latestIpcSample?.positionSeconds ?? 0;
   state.lastStreamStallAtMs = observedAtMs;
   if (pos > 0) {
@@ -131,7 +131,7 @@ export function noteStreamStall(state: PlayerTelemetryState, observedAtMs: numbe
 }
 
 function advanceTrustedProgressSeconds(
-  state: PlayerTelemetryState,
+  state: PlayerStatsState,
   prevPositionSeconds: number,
   newPositionSeconds: number,
   durationSeconds: number,
@@ -170,7 +170,7 @@ function advanceTrustedProgressSeconds(
   }
 }
 
-export function noteTrustedSeek(state: PlayerTelemetryState, positionSeconds: number): void {
+export function noteTrustedSeek(state: PlayerStatsState, positionSeconds: number): void {
   if (!Number.isFinite(positionSeconds) || positionSeconds <= 0) return;
   state.maxTrustedProgressSeconds = Math.max(state.maxTrustedProgressSeconds, positionSeconds);
   state.lastReliableProgressSeconds = Math.max(state.lastReliableProgressSeconds, positionSeconds);
@@ -196,8 +196,8 @@ function eofTrustTailSeconds(durationSeconds: number): number {
 }
 
 function shouldDemotePrematureEof(
-  state: PlayerTelemetryState,
-  sample: PlayerTelemetrySample | null | undefined,
+  state: PlayerStatsState,
+  sample: PlayerStatsSample | null | undefined,
   durationSeconds: number,
   maxTrusted: number,
   observedAtMs: number,
@@ -242,8 +242,8 @@ function shouldDemotePrematureEof(
 }
 
 function shouldDemotePauseDroppedEof(
-  state: PlayerTelemetryState,
-  sample: PlayerTelemetrySample | null | undefined,
+  state: PlayerStatsState,
+  sample: PlayerStatsSample | null | undefined,
   durationSeconds: number,
   maxTrusted: number,
   observedAtMs: number,
@@ -276,7 +276,7 @@ export function mapMpvEndReason(reason: string | null | undefined): EndReason {
 }
 
 export function applyObservedPropertySample(
-  state: PlayerTelemetryState,
+  state: PlayerStatsState,
   update: {
     name: string;
     value: unknown;
@@ -296,7 +296,7 @@ export function applyObservedPropertySample(
     durationSeconds: 0,
   };
 
-  const next: PlayerTelemetrySample = {
+  const next: PlayerStatsSample = {
     ...base,
     source: "ipc",
     observedAt,
@@ -426,7 +426,7 @@ export type EndFileEventContext = {
 };
 
 export function applyEndFileEvent(
-  state: PlayerTelemetryState,
+  state: PlayerStatsState,
   reason: string | null | undefined,
   observedAt = Date.now(),
   context: EndFileEventContext = {},
@@ -487,7 +487,7 @@ export function applyEndFileEvent(
 
   if (!base) return;
 
-  const finalSample: PlayerTelemetrySample = {
+  const finalSample: PlayerStatsSample = {
     ...base,
     source: "ipc",
     observedAt,
@@ -517,7 +517,7 @@ export function applyEndFileEvent(
 }
 
 export function recordPlayerExit(
-  state: PlayerTelemetryState,
+  state: PlayerStatsState,
   exit: {
     code: number | null;
     signal: NodeJS.Signals | null;
@@ -545,7 +545,7 @@ export function recordPlayerExit(
 }
 
 export function finalizePlaybackResult(
-  state: PlayerTelemetryState,
+  state: PlayerStatsState,
   cleanup: CleanupStatus,
 ): PlaybackResult {
   const chosen =

--- a/apps/cli/src/infra/player/persistent-mpv-property-router.ts
+++ b/apps/cli/src/infra/player/persistent-mpv-property-router.ts
@@ -1,15 +1,15 @@
 import type { PlaybackTimingMetadata, SubtitleTrack } from "@/domain/types";
 
 import type { MpvIpcSession } from "./mpv-ipc";
-import { applyObservedPropertySample, type PlayerTelemetryState } from "./mpv-telemetry";
+import { applyObservedPropertySample, type PlayerStatsState } from "./mpv-stats";
 import type { PersistentSubtitleManager } from "./persistent-subtitle-manager";
 import type { MpvRequestedAction } from "./PlayerControlService";
 import type { PlayerPlaybackEvent } from "./PlayerService";
 
-type LatestIpcSample = NonNullable<PlayerTelemetryState["latestIpcSample"]>;
+type LatestIpcSample = NonNullable<PlayerStatsState["latestIpcSample"]>;
 
 export type PersistentMpvPropertyCycle = {
-  telemetry: PlayerTelemetryState;
+  stats: PlayerStatsState;
   acceptPlaybackProperties: boolean;
   playerReadyNotified: boolean;
   playerStartedNotified: boolean;
@@ -83,14 +83,14 @@ export class PersistentMpvPropertyRouter {
     if (!active) return;
 
     applyObservedPropertySample(
-      active.telemetry,
+      active.stats,
       { name, value, observedAt },
       { acceptPlaybackProperties: active.acceptPlaybackProperties },
     );
     if (!active.acceptPlaybackProperties) return;
 
-    if (active.telemetry.latestIpcSample) {
-      this.deps.observeWatchdog(active.telemetry.latestIpcSample);
+    if (active.stats.latestIpcSample) {
+      this.deps.observeWatchdog(active.stats.latestIpcSample);
     }
 
     if ((name === "time-pos" || name === "playback-time") && typeof value === "number") {

--- a/apps/cli/src/infra/player/persistent-ready-work-executor.ts
+++ b/apps/cli/src/infra/player/persistent-ready-work-executor.ts
@@ -4,7 +4,7 @@ import type { MpvUrlKind } from "@/infra/player/mpv-playback-url";
 import { collectAdditionalSubtitleTracks, shouldApplyStartAtSeek } from "@/mpv";
 
 import type { MpvIpcSession } from "./mpv-ipc";
-import { noteTrustedSeek, type PlayerTelemetryState } from "./mpv-telemetry";
+import { noteTrustedSeek, type PlayerStatsState } from "./mpv-stats";
 import {
   resolvePersistentStartSeekTarget,
   type PersistentResumeStartChoice,
@@ -26,7 +26,7 @@ export type PersistentReadyWorkOptions = {
 };
 
 export type PersistentReadyWorkCycle = {
-  telemetry: PlayerTelemetryState;
+  stats: PlayerStatsState;
   playerReadyNotified: boolean;
   onPlayerReady?: () => void;
   onPlaybackEvent?: (event: PlayerPlaybackEvent) => void;
@@ -123,13 +123,13 @@ export class PersistentReadyWorkExecutor {
         options.onPlaybackEvent?.({ type: "resolving-playback" });
         if (this.deps.getLoadStartAt() !== null && target === this.deps.getLoadStartAt()) {
           this.deps.setCurrentPositionSeconds(target);
-          noteTrustedSeek(cycle.telemetry, target);
+          noteTrustedSeek(cycle.stats, target);
         } else {
           const seekResult = await ipcSession.send(["seek", target, "absolute"], 2_000);
           if (!isCurrent()) return;
           if (seekResult.ok) {
             this.deps.setCurrentPositionSeconds(target);
-            noteTrustedSeek(cycle.telemetry, target);
+            noteTrustedSeek(cycle.stats, target);
           }
         }
       }

--- a/apps/cli/src/infra/player/playback-watchdog.ts
+++ b/apps/cli/src/infra/player/playback-watchdog.ts
@@ -1,8 +1,8 @@
-import type { PlayerTelemetrySample } from "./mpv-telemetry";
+import type { PlayerStatsSample } from "./mpv-stats";
 import type { PlayerPlaybackEvent } from "./PlayerService";
 
 export interface PlaybackWatchdog {
-  observe(sample: PlayerTelemetrySample): void;
+  observe(sample: PlayerStatsSample): void;
   stop(): void;
 }
 
@@ -26,7 +26,7 @@ export function createPlaybackWatchdog(
   const networkReadDeadAfterMs = options?.networkReadDeadAfterMs ?? 8_000;
   const networkSampleEveryMs = options?.networkSampleEveryMs ?? 2_500;
   const slowNetworkAfterMs = options?.slowNetworkAfterMs ?? 6_000;
-  let latest: PlayerTelemetrySample | null = null;
+  let latest: PlayerStatsSample | null = null;
   let lastPosition = 0;
   let lastProgressAt = Date.now();
   let lastCacheAheadSeconds = 0;

--- a/apps/cli/src/mpv.ts
+++ b/apps/cli/src/mpv.ts
@@ -46,12 +46,12 @@ import { MpvLaunchError } from "@/infra/player/mpv-launch-error";
 import {
   applyEndFileEvent,
   applyObservedPropertySample,
-  createPlayerTelemetryState,
+  createPlayerStatsState,
   finalizePlaybackResult,
   noteStreamStall,
   noteTrustedSeek,
   recordPlayerExit,
-} from "@/infra/player/mpv-telemetry";
+} from "@/infra/player/mpv-stats";
 import { findActivePlaybackSkip, type PlaybackSkipConfig } from "@/infra/player/playback-skip";
 import { createPlaybackWatchdog } from "@/infra/player/playback-watchdog";
 import type { ActivePlayerControl } from "@/infra/player/PlayerControlService";
@@ -101,12 +101,12 @@ export async function launchMpv(opts: {
   const args = buildMpvArgs(opts, ipcServerCliArg(ipcEndpoint), {
     mpv: opts.mpv,
   });
-  const telemetry = createPlayerTelemetryState(ipcEndpoint.path);
-  noteTrustedSeek(telemetry, opts.startAt ?? 0);
+  const stats = createPlayerStatsState(ipcEndpoint.path);
+  noteTrustedSeek(stats, opts.startAt ?? 0);
   const baseEmit = opts.onPlaybackEvent ?? (() => {});
   const emitPlaybackEvent = (event: PlayerPlaybackEvent) => {
     if (event.type === "stream-stalled" || event.type === "ipc-stalled") {
-      noteStreamStall(telemetry, Date.now());
+      noteStreamStall(stats, Date.now());
     }
     baseEmit(event);
   };
@@ -130,7 +130,7 @@ export async function launchMpv(opts: {
       opts,
       sessionId,
       ipcEndpoint,
-      telemetry,
+      stats,
       emitPlaybackEvent,
     );
   } finally {
@@ -144,7 +144,7 @@ async function launchMpvInner(
   opts: Parameters<typeof launchMpv>[0],
   sessionId: string,
   ipcEndpoint: ReturnType<typeof createMpvIpcEndpoint>,
-  telemetry: ReturnType<typeof createPlayerTelemetryState>,
+  stats: ReturnType<typeof createPlayerStatsState>,
   emitPlaybackEvent: (event: PlayerPlaybackEvent) => void,
 ): Promise<PlaybackResult> {
   let ipcSession: MpvIpcSession | null = null;
@@ -181,7 +181,7 @@ async function launchMpvInner(
     emitPlaybackEvent({ type: "playback-started" });
   };
   const maybeEmitPlaybackProgress = (observedAt: number) => {
-    const sample = telemetry.latestIpcSample;
+    const sample = stats.latestIpcSample;
     if (
       !shouldEmitPlaybackProgress(
         playbackProgressThrottle,
@@ -308,9 +308,9 @@ async function launchMpvInner(
     ipcSession = await openMpvIpcSession({
       endpoint: ipcEndpoint,
       onPropertyUpdate: ({ name, value, observedAt }) => {
-        applyObservedPropertySample(telemetry, { name, value, observedAt });
-        if (telemetry.latestIpcSample) {
-          watchdog.observe(telemetry.latestIpcSample);
+        applyObservedPropertySample(stats, { name, value, observedAt });
+        if (stats.latestIpcSample) {
+          watchdog.observe(stats.latestIpcSample);
         }
         if ((name === "time-pos" || name === "playback-time") && typeof value === "number") {
           currentPositionSeconds = value;
@@ -322,7 +322,7 @@ async function launchMpvInner(
         }
       },
       onEndFile: ({ reason, fileError, observedAt }) => {
-        applyEndFileEvent(telemetry, reason, observedAt, { fileError });
+        applyEndFileEvent(stats, reason, observedAt, { fileError });
         endFileResolve?.(reason);
       },
       onCommandResult: (result) => {
@@ -383,7 +383,7 @@ async function launchMpvInner(
   });
 
   const exit = await exitPromise;
-  recordPlayerExit(telemetry, exit);
+  recordPlayerExit(stats, exit);
 
   // Check if preflight returned a definitive failure before mpv started.
   // This catches dead URLs early so we can skip to fallback without waiting
@@ -430,7 +430,7 @@ async function launchMpvInner(
 
   opts.onControlReady?.(null);
 
-  return finalizePlaybackResult(telemetry, { socketPathCleanedUp });
+  return finalizePlaybackResult(stats, { socketPathCleanedUp });
 }
 
 export function shouldAbortLaunchForDefinitivePreflight(

--- a/apps/cli/src/services/diagnostics/ResolveTraceSink.ts
+++ b/apps/cli/src/services/diagnostics/ResolveTraceSink.ts
@@ -13,7 +13,7 @@ export type ResolveTraceStore = Pick<ResolveTraceRepository, "add" | "listRecent
  * and **never leave the machine**.
  *
  * Retention is owned by the repository and `packages/storage/src/maintenance.ts`;
- * this class adds no second policy. Every call is best-effort: telemetry must
+ * this class adds no second policy. Every call is best-effort: trace persistence must
  * never be able to fail a playback.
  */
 export class ResolveTraceSink {

--- a/apps/cli/src/services/diagnostics/diagnostics-insight.ts
+++ b/apps/cli/src/services/diagnostics/diagnostics-insight.ts
@@ -747,7 +747,7 @@ function resolveProviderReason(
     return timeline.message || `${timelineProvider} · ${runtimeDetail}`;
   }
 
-  return runtimeDetail || `${provider} · no resolve telemetry yet`;
+  return runtimeDetail || `${provider} · no resolve traces yet`;
 }
 
 function resolveDiscordReason(presenceSnapshot: PresenceSnapshot | null | undefined): string {

--- a/apps/cli/src/services/diagnostics/runtime-health.ts
+++ b/apps/cli/src/services/diagnostics/runtime-health.ts
@@ -148,7 +148,7 @@ export function summarizePlaybackNetworkHealth(
   if (!event || !context || !eventType) {
     return {
       label: "Network",
-      detail: "waiting for mpv network telemetry",
+      detail: "waiting for mpv network stats",
       tone: "neutral",
     };
   }
@@ -257,7 +257,7 @@ export function summarizeProviderHealth(
     }
     return {
       label: "Provider",
-      detail: `${provider} · no resolve telemetry yet`,
+      detail: `${provider} · no resolve traces yet`,
       tone: "neutral",
     };
   }
@@ -373,28 +373,28 @@ export function buildRuntimeHealthSnapshot(input: {
   readonly memorySamples?: readonly RuntimeMemorySample[];
   readonly persistedProviderHealth?: ProviderHealth;
 }): RuntimeHealthSnapshot {
-  const telemetryProvider = summarizeProviderHealth(input.recentEvents, input.currentProvider);
+  const eventProvider = summarizeProviderHealth(input.recentEvents, input.currentProvider);
   const effective = resolveEffectiveProviderHealth(input.persistedProviderHealth);
   const persistedBadge = formatProviderHealthBadge(effective ?? undefined);
   const healthDetail = persistedBadge
     ? appendProviderHealthResetHint(
-        `${telemetryProvider.detail}  ·  health: ${persistedBadge}`,
+        `${eventProvider.detail}  ·  health: ${persistedBadge}`,
         effective?.effectiveStatus,
       )
-    : telemetryProvider.detail;
+    : eventProvider.detail;
   const healthTone =
     effective?.effectiveStatus === "down"
       ? ("error" as const)
       : effective?.effectiveStatus === "degraded"
         ? ("warning" as const)
-        : telemetryProvider.tone;
+        : eventProvider.tone;
   const provider = persistedBadge
     ? {
-        label: telemetryProvider.label,
+        label: eventProvider.label,
         detail: healthDetail,
         tone: healthTone,
       }
-    : telemetryProvider;
+    : eventProvider;
 
   return {
     network: summarizePlaybackNetworkHealth(input.recentEvents),

--- a/apps/cli/test/integration/resolve-trace-persistence.test.ts
+++ b/apps/cli/test/integration/resolve-trace-persistence.test.ts
@@ -6,7 +6,7 @@ import { ResolveTraceSink } from "@/services/diagnostics/ResolveTraceSink";
 import { openKunaiDatabase, ResolveTraceRepository, runMigrations } from "@kunai/storage";
 
 /**
- * The sink deliberately swallows storage faults so telemetry can never fail a
+ * The sink deliberately swallows storage faults so trace persistence can never fail a
  * playback. That makes a schema mismatch silent: traces would simply never
  * appear and nothing would say why. These tests close that gap by driving a
  * finalized trace through the real repository and a real migrated database.

--- a/apps/cli/test/unit/app-shell/diagnostics-dashboard-model.test.ts
+++ b/apps/cli/test/unit/app-shell/diagnostics-dashboard-model.test.ts
@@ -26,7 +26,7 @@ describe("buildDiagnosticsSections", () => {
   test("separates unknown from broken", () => {
     const sections = buildDiagnosticsSections([
       row("discord", "blocked", "Could not connect"),
-      row("provider", "unknown", "no resolve telemetry yet"),
+      row("provider", "unknown", "no resolve traces yet"),
       row("cache", "healthy", "No cache issue"),
     ]);
 

--- a/apps/cli/test/unit/app-shell/loading-shell-runtime.test.ts
+++ b/apps/cli/test/unit/app-shell/loading-shell-runtime.test.ts
@@ -143,7 +143,7 @@ describe("loading shell runtime policy", () => {
     });
   });
 
-  test("loading copy ignores informational mpv telemetry notes", () => {
+  test("loading copy ignores informational mpv stats notes", () => {
     expect(normalizeLoadingIssue("Audio track switched in mpv (id 1)")).toBeNull();
     expect(normalizeLoadingIssue("Intro skipped automatically")).toBeNull();
     expect(normalizeLoadingIssue("12s buffering")).toBeNull();

--- a/apps/cli/test/unit/app/playback-phase-events.test.ts
+++ b/apps/cli/test/unit/app/playback-phase-events.test.ts
@@ -181,7 +181,7 @@ test("describePlayerEvent surfaces player control failures verbatim", () => {
   });
 });
 
-test("describePlayerEvent returns empty descriptors for silent telemetry", () => {
+test("describePlayerEvent returns empty descriptors for silent stats", () => {
   const describe = describePlayerEventFor();
   expect(describe({ type: "network-sample" })).toEqual({});
 });

--- a/apps/cli/test/unit/app/playback-status-policy.test.ts
+++ b/apps/cli/test/unit/app/playback-status-policy.test.ts
@@ -221,7 +221,7 @@ describe("transitionPlaybackStatus — pause is authoritative", () => {
     expect(decision.snapshot).toEqual(snapshot("playing"));
   });
 
-  test("buffer telemetry while paused is accepted but cannot change status", () => {
+  test("buffer stats while paused is accepted but cannot change status", () => {
     const decision = transitionPlaybackStatus(snapshot("paused"), {
       kind: "player-event",
       generation: GEN,

--- a/apps/cli/test/unit/infra/player/mpv-stats.test.ts
+++ b/apps/cli/test/unit/infra/player/mpv-stats.test.ts
@@ -3,14 +3,14 @@ import { describe, expect, test } from "bun:test";
 import {
   applyEndFileEvent,
   applyObservedPropertySample,
-  createPlayerTelemetryState,
+  createPlayerStatsState,
   finalizePlaybackResult,
   mapMpvEndReason,
   noteStreamStall,
   recordPlayerExit,
-} from "@/infra/player/mpv-telemetry";
+} from "@/infra/player/mpv-stats";
 
-describe("mpv-telemetry", () => {
+describe("mpv-stats", () => {
   test("maps mpv end-file reasons into domain end reasons", () => {
     expect(mapMpvEndReason("eof")).toBe("eof");
     expect(mapMpvEndReason("quit")).toBe("quit");
@@ -20,22 +20,22 @@ describe("mpv-telemetry", () => {
   });
 
   test("prefers the strongest latest ipc snapshot for eof playback", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/mpv.sock");
-    applyObservedPropertySample(telemetry, {
+    const stats = createPlayerStatsState("/tmp/mpv.sock");
+    applyObservedPropertySample(stats, {
       name: "playback-time",
       value: 1437,
       observedAt: 100,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "duration",
       value: 1440,
       observedAt: 110,
     });
-    applyEndFileEvent(telemetry, "eof", 120);
-    recordPlayerExit(telemetry, { code: 0, signal: null });
+    applyEndFileEvent(stats, "eof", 120);
+    recordPlayerExit(stats, { code: 0, signal: null });
 
     expect(
-      finalizePlaybackResult(telemetry, {
+      finalizePlaybackResult(stats, {
         socketPathCleanedUp: true,
       }),
     ).toEqual({
@@ -55,36 +55,36 @@ describe("mpv-telemetry", () => {
   });
 
   test("uses the last non-zero ipc sample when later idle updates zero the live snapshot", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/mpv.sock");
-    applyObservedPropertySample(telemetry, {
+    const stats = createPlayerStatsState("/tmp/mpv.sock");
+    applyObservedPropertySample(stats, {
       name: "playback-time",
       value: 612,
       observedAt: 100,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "duration",
       value: 1440,
       observedAt: 110,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "idle-active",
       value: true,
       observedAt: 120,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "playback-time",
       value: 0,
       observedAt: 130,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "duration",
       value: 0,
       observedAt: 140,
     });
-    recordPlayerExit(telemetry, { code: 0, signal: "SIGTERM" });
+    recordPlayerExit(stats, { code: 0, signal: "SIGTERM" });
 
     expect(
-      finalizePlaybackResult(telemetry, {
+      finalizePlaybackResult(stats, {
         socketPathCleanedUp: true,
       }),
     ).toEqual({
@@ -104,33 +104,33 @@ describe("mpv-telemetry", () => {
   });
 
   test("uses last non-zero position when quit with final sample stuck at zero", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/mpv.sock");
-    applyObservedPropertySample(telemetry, {
+    const stats = createPlayerStatsState("/tmp/mpv.sock");
+    applyObservedPropertySample(stats, {
       name: "playback-time",
       value: 300,
       observedAt: 100,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "duration",
       value: 1_500,
       observedAt: 110,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "playback-time",
       value: 0,
       observedAt: 120,
     });
-    recordPlayerExit(telemetry, { code: 0, signal: "SIGTERM" });
+    recordPlayerExit(stats, { code: 0, signal: "SIGTERM" });
 
-    const result = finalizePlaybackResult(telemetry, { socketPathCleanedUp: true });
+    const result = finalizePlaybackResult(stats, { socketPathCleanedUp: true });
     expect(result.watchedSeconds).toBe(300);
     expect(result.endReason).toBe("quit");
   });
 
   test("can ignore stale playback samples while mpv is replacing files", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/mpv.sock");
+    const stats = createPlayerStatsState("/tmp/mpv.sock");
     applyObservedPropertySample(
-      telemetry,
+      stats,
       {
         name: "playback-time",
         value: 612,
@@ -139,7 +139,7 @@ describe("mpv-telemetry", () => {
       { acceptPlaybackProperties: false },
     );
     applyObservedPropertySample(
-      telemetry,
+      stats,
       {
         name: "duration",
         value: 1440,
@@ -147,20 +147,20 @@ describe("mpv-telemetry", () => {
       },
       { acceptPlaybackProperties: false },
     );
-    recordPlayerExit(telemetry, { code: 0, signal: "SIGTERM" });
+    recordPlayerExit(stats, { code: 0, signal: "SIGTERM" });
 
-    const result = finalizePlaybackResult(telemetry, { socketPathCleanedUp: true });
+    const result = finalizePlaybackResult(stats, { socketPathCleanedUp: true });
     expect(result.watchedSeconds).toBe(0);
     expect(result.duration).toBe(0);
     expect(result.lastNonZeroPositionSeconds).toBe(0);
   });
 
   test("maps clean instant exits without eof evidence to quit", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/mpv.sock");
-    recordPlayerExit(telemetry, { code: 0, signal: null });
+    const stats = createPlayerStatsState("/tmp/mpv.sock");
+    recordPlayerExit(stats, { code: 0, signal: null });
 
     expect(
-      finalizePlaybackResult(telemetry, {
+      finalizePlaybackResult(stats, {
         socketPathCleanedUp: true,
       }),
     ).toEqual({
@@ -179,12 +179,12 @@ describe("mpv-telemetry", () => {
     });
   });
 
-  test("returns an error result for non-clean instant exits with no useful telemetry", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/mpv.sock");
-    recordPlayerExit(telemetry, { code: 2, signal: null });
+  test("returns an error result for non-clean instant exits with no useful stats", () => {
+    const stats = createPlayerStatsState("/tmp/mpv.sock");
+    recordPlayerExit(stats, { code: 2, signal: null });
 
     expect(
-      finalizePlaybackResult(telemetry, {
+      finalizePlaybackResult(stats, {
         socketPathCleanedUp: false,
       }),
     ).toEqual({
@@ -204,25 +204,25 @@ describe("mpv-telemetry", () => {
   });
 
   test("does not inflate progress when pause updates arrive", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/mpv.sock");
-    applyObservedPropertySample(telemetry, {
+    const stats = createPlayerStatsState("/tmp/mpv.sock");
+    applyObservedPropertySample(stats, {
       name: "playback-time",
       value: 64,
       observedAt: 100,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "duration",
       value: 600,
       observedAt: 101,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "pause",
       value: true,
       observedAt: 120,
     });
-    recordPlayerExit(telemetry, { code: 0, signal: "SIGTERM" });
+    recordPlayerExit(stats, { code: 0, signal: "SIGTERM" });
 
-    const result = finalizePlaybackResult(telemetry, {
+    const result = finalizePlaybackResult(stats, {
       socketPathCleanedUp: true,
     });
 
@@ -232,57 +232,57 @@ describe("mpv-telemetry", () => {
   });
 
   test("demotes eof to unknown after a recent stream stall when trusted progress is far from duration", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/mpv.sock");
+    const stats = createPlayerStatsState("/tmp/mpv.sock");
     for (let pos = 0; pos <= 400; pos += 50) {
-      applyObservedPropertySample(telemetry, {
+      applyObservedPropertySample(stats, {
         name: "playback-time",
         value: pos,
         observedAt: 1_000 + pos,
       });
     }
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "duration",
       value: 2000,
       observedAt: 2_000,
     });
-    noteStreamStall(telemetry, 2_100_000);
-    applyObservedPropertySample(telemetry, {
+    noteStreamStall(stats, 2_100_000);
+    applyObservedPropertySample(stats, {
       name: "playback-time",
       value: 2000,
       observedAt: 2_100_050,
     });
-    applyEndFileEvent(telemetry, "eof", 2_100_120);
-    recordPlayerExit(telemetry, { code: 0, signal: null });
+    applyEndFileEvent(stats, "eof", 2_100_120);
+    recordPlayerExit(stats, { code: 0, signal: null });
 
-    const result = finalizePlaybackResult(telemetry, { socketPathCleanedUp: true });
+    const result = finalizePlaybackResult(stats, { socketPathCleanedUp: true });
     expect(result.endReason).toBe("unknown");
     expect(result.watchedSeconds).toBe(400);
     expect(result.duration).toBe(2000);
   });
 
   test("demotes eof for network demuxer when trusted progress is far below duration (no stall)", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/mpv.sock");
+    const stats = createPlayerStatsState("/tmp/mpv.sock");
     for (let pos = 0; pos <= 400; pos += 50) {
-      applyObservedPropertySample(telemetry, {
+      applyObservedPropertySample(stats, {
         name: "playback-time",
         value: pos,
         observedAt: 1_000 + pos,
       });
     }
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "duration",
       value: 2000,
       observedAt: 2_000,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "demuxer-via-network",
       value: true,
       observedAt: 2_010,
     });
-    applyEndFileEvent(telemetry, "eof", 2_050_000);
-    recordPlayerExit(telemetry, { code: 0, signal: null });
+    applyEndFileEvent(stats, "eof", 2_050_000);
+    recordPlayerExit(stats, { code: 0, signal: null });
 
-    const result = finalizePlaybackResult(telemetry, { socketPathCleanedUp: true });
+    const result = finalizePlaybackResult(stats, { socketPathCleanedUp: true });
     expect(result.endReason).toBe("unknown");
     expect(result.watchedSeconds).toBe(400);
     expect(result.lastTrustedProgressSeconds).toBe(400);
@@ -290,112 +290,112 @@ describe("mpv-telemetry", () => {
   });
 
   test("demotes eof without stall when trusted progress is still very early in a long file", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/mpv.sock");
+    const stats = createPlayerStatsState("/tmp/mpv.sock");
     for (let pos = 0; pos <= 200; pos += 50) {
-      applyObservedPropertySample(telemetry, {
+      applyObservedPropertySample(stats, {
         name: "playback-time",
         value: pos,
         observedAt: 1_000 + pos,
       });
     }
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "duration",
       value: 2000,
       observedAt: 2_000,
     });
-    applyEndFileEvent(telemetry, "eof", 2_050_000);
-    recordPlayerExit(telemetry, { code: 0, signal: null });
+    applyEndFileEvent(stats, "eof", 2_050_000);
+    recordPlayerExit(stats, { code: 0, signal: null });
 
-    const result = finalizePlaybackResult(telemetry, { socketPathCleanedUp: true });
+    const result = finalizePlaybackResult(stats, { socketPathCleanedUp: true });
     expect(result.endReason).toBe("unknown");
     expect(result.watchedSeconds).toBe(200);
   });
 
   test("does not trust a first playback sample that jumps straight to network eof", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/mpv.sock");
-    applyObservedPropertySample(telemetry, {
+    const stats = createPlayerStatsState("/tmp/mpv.sock");
+    applyObservedPropertySample(stats, {
       name: "duration",
       value: 2_000,
       observedAt: 1_000,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "demuxer-via-network",
       value: true,
       observedAt: 1_010,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "playback-time",
       value: 2_000,
       observedAt: 1_020,
     });
-    applyEndFileEvent(telemetry, "eof", 1_030);
-    recordPlayerExit(telemetry, { code: 0, signal: null });
+    applyEndFileEvent(stats, "eof", 1_030);
+    recordPlayerExit(stats, { code: 0, signal: null });
 
-    const result = finalizePlaybackResult(telemetry, { socketPathCleanedUp: true });
+    const result = finalizePlaybackResult(stats, { socketPathCleanedUp: true });
     expect(result.endReason).toBe("unknown");
     expect(result.watchedSeconds).toBe(0);
     expect(result.lastTrustedProgressSeconds).toBe(0);
   });
 
   test("demotes eof after a paused network stream disconnects without eof-reached evidence", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/mpv.sock");
-    applyObservedPropertySample(telemetry, {
+    const stats = createPlayerStatsState("/tmp/mpv.sock");
+    applyObservedPropertySample(stats, {
       name: "playback-time",
       value: 2_400,
       observedAt: 1_000,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "duration",
       value: 2_820,
       observedAt: 1_010,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "demuxer-via-network",
       value: true,
       observedAt: 1_020,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "pause",
       value: true,
       observedAt: 1_100,
     });
-    applyEndFileEvent(telemetry, "eof", 901_100);
-    recordPlayerExit(telemetry, { code: 0, signal: null });
+    applyEndFileEvent(stats, "eof", 901_100);
+    recordPlayerExit(stats, { code: 0, signal: null });
 
-    const result = finalizePlaybackResult(telemetry, { socketPathCleanedUp: true });
+    const result = finalizePlaybackResult(stats, { socketPathCleanedUp: true });
     expect(result.endReason).toBe("unknown");
     expect(result.watchedSeconds).toBe(2_400);
     expect(result.duration).toBe(2_820);
   });
 
   test("demotes preview-cap eof at 24/30 minutes using percent-pos and trusted progress", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/mpv.sock");
+    const stats = createPlayerStatsState("/tmp/mpv.sock");
     for (let pos = 0; pos <= 1_440; pos += 50) {
-      applyObservedPropertySample(telemetry, {
+      applyObservedPropertySample(stats, {
         name: "playback-time",
         value: pos,
         observedAt: 1_000 + pos,
       });
     }
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "duration",
       value: 1_800,
       observedAt: 2_000,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "percent-pos",
       value: 80,
       observedAt: 2_010,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "demuxer-via-network",
       value: true,
       observedAt: 2_020,
     });
-    applyEndFileEvent(telemetry, "eof", 2_050);
-    recordPlayerExit(telemetry, { code: 0, signal: null });
+    applyEndFileEvent(stats, "eof", 2_050);
+    recordPlayerExit(stats, { code: 0, signal: null });
 
-    const result = finalizePlaybackResult(telemetry, { socketPathCleanedUp: true });
+    const result = finalizePlaybackResult(stats, { socketPathCleanedUp: true });
     expect(result.endReason).toBe("unknown");
     expect(result.suspectedDeadStream).toBe(true);
     expect(result.lastTrustedProgressSeconds).toBeGreaterThanOrEqual(1_400);
@@ -403,88 +403,88 @@ describe("mpv-telemetry", () => {
   });
 
   test("maps mpv end-file file_error to error with suspected dead stream", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/mpv.sock");
-    applyObservedPropertySample(telemetry, {
+    const stats = createPlayerStatsState("/tmp/mpv.sock");
+    applyObservedPropertySample(stats, {
       name: "playback-time",
       value: 900,
       observedAt: 1_000,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "duration",
       value: 1_800,
       observedAt: 1_010,
     });
-    applyEndFileEvent(telemetry, "eof", 1_100, { fileError: "failed to open stream" });
-    recordPlayerExit(telemetry, { code: 0, signal: null });
+    applyEndFileEvent(stats, "eof", 1_100, { fileError: "failed to open stream" });
+    recordPlayerExit(stats, { code: 0, signal: null });
 
-    const result = finalizePlaybackResult(telemetry, { socketPathCleanedUp: true });
+    const result = finalizePlaybackResult(stats, { socketPathCleanedUp: true });
     expect(result.endReason).toBe("error");
     expect(result.suspectedDeadStream).toBe(true);
     expect(result.watchedSeconds).toBe(900);
   });
 
   test("trusts eof after pause when mpv explicitly reports eof-reached", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/mpv.sock");
-    applyObservedPropertySample(telemetry, {
+    const stats = createPlayerStatsState("/tmp/mpv.sock");
+    applyObservedPropertySample(stats, {
       name: "playback-time",
       value: 2_815,
       observedAt: 1_000,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "duration",
       value: 2_820,
       observedAt: 1_010,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "pause",
       value: true,
       observedAt: 1_100,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "eof-reached",
       value: true,
       observedAt: 1_200,
     });
-    applyEndFileEvent(telemetry, "eof", 1_210);
-    recordPlayerExit(telemetry, { code: 0, signal: null });
+    applyEndFileEvent(stats, "eof", 1_210);
+    recordPlayerExit(stats, { code: 0, signal: null });
 
-    const result = finalizePlaybackResult(telemetry, { socketPathCleanedUp: true });
+    const result = finalizePlaybackResult(stats, { socketPathCleanedUp: true });
     expect(result.endReason).toBe("eof");
     expect(result.watchedSeconds).toBe(2_820);
   });
 
   test("tracks mpv buffering and seeking diagnostics without changing progress", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/mpv.sock");
-    applyObservedPropertySample(telemetry, {
+    const stats = createPlayerStatsState("/tmp/mpv.sock");
+    applyObservedPropertySample(stats, {
       name: "playback-time",
       value: 32,
       observedAt: 100,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "paused-for-cache",
       value: true,
       observedAt: 110,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "demuxer-cache-duration",
       value: 5.25,
       observedAt: 111,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "cache-speed",
       value: 1_000_000,
       observedAt: 112,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "seeking",
       value: true,
       observedAt: 113,
     });
 
-    expect(telemetry.latestIpcSample?.positionSeconds).toBe(32);
-    expect(telemetry.latestIpcSample?.pausedForCache).toBe(true);
-    expect(telemetry.latestIpcSample?.demuxerCacheDurationSeconds).toBe(5.25);
-    expect(telemetry.latestIpcSample?.cacheSpeedBytesPerSecond).toBe(1_000_000);
-    expect(telemetry.latestIpcSample?.seeking).toBe(true);
+    expect(stats.latestIpcSample?.positionSeconds).toBe(32);
+    expect(stats.latestIpcSample?.pausedForCache).toBe(true);
+    expect(stats.latestIpcSample?.demuxerCacheDurationSeconds).toBe(5.25);
+    expect(stats.latestIpcSample?.cacheSpeedBytesPerSecond).toBe(1_000_000);
+    expect(stats.latestIpcSample?.seeking).toBe(true);
   });
 });

--- a/apps/cli/test/unit/infra/player/persistent-mpv-property-router.test.ts
+++ b/apps/cli/test/unit/infra/player/persistent-mpv-property-router.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { MpvIpcCommandResult, MpvIpcSession } from "@/infra/player/mpv-ipc";
-import { createPlayerTelemetryState } from "@/infra/player/mpv-telemetry";
+import { createPlayerStatsState } from "@/infra/player/mpv-stats";
 import { PersistentMpvPropertyRouter } from "@/infra/player/persistent-mpv-property-router";
 import { PersistentSubtitleManager } from "@/infra/player/persistent-subtitle-manager";
 
@@ -30,7 +30,7 @@ describe("PersistentMpvPropertyRouter", () => {
     const subtitleManager = new PersistentSubtitleManager();
     const router = new PersistentMpvPropertyRouter({
       getActiveCycle: () => ({
-        telemetry: createPlayerTelemetryState("/tmp/kunai-test.sock"),
+        stats: createPlayerStatsState("/tmp/kunai-test.sock"),
         acceptPlaybackProperties: false,
         playerReadyNotified: false,
         playerStartedNotified: false,
@@ -99,10 +99,10 @@ describe("PersistentMpvPropertyRouter", () => {
   test("accepts playback samples, updates position, and emits ready/start progress hooks", () => {
     const events: unknown[] = [];
     let currentPosition = 0;
-    const telemetry = createPlayerTelemetryState("/tmp/kunai-test.sock");
+    const stats = createPlayerStatsState("/tmp/kunai-test.sock");
     const router = new PersistentMpvPropertyRouter({
       getActiveCycle: () => ({
-        telemetry,
+        stats,
         acceptPlaybackProperties: true,
         playerReadyNotified: false,
         playerStartedNotified: false,
@@ -125,7 +125,7 @@ describe("PersistentMpvPropertyRouter", () => {
       maybeRearmSkippedSegmentsOnBackwardSeek: () => {},
       getCurrentPositionSeconds: () => currentPosition,
       maybeEmitPlaybackProgress: (cycle, observedAt) => {
-        events.push({ type: "progress-hook", observedAt, sample: cycle.telemetry.latestIpcSample });
+        events.push({ type: "progress-hook", observedAt, sample: cycle.stats.latestIpcSample });
       },
       handleSegmentSkipProgress: async () => {},
       fireNearEofIfNeeded: () => {},

--- a/apps/cli/test/unit/infra/player/persistent-ready-work-executor.test.ts
+++ b/apps/cli/test/unit/infra/player/persistent-ready-work-executor.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { PlaybackGeneration } from "@/domain/playback/playback-generation";
 import type { MpvIpcCommandResult, MpvIpcSession } from "@/infra/player/mpv-ipc";
-import { createPlayerTelemetryState } from "@/infra/player/mpv-telemetry";
+import { createPlayerStatsState } from "@/infra/player/mpv-stats";
 import { PersistentReadyWorkExecutor } from "@/infra/player/persistent-ready-work-executor";
 import { PersistentSubtitleManager } from "@/infra/player/persistent-subtitle-manager";
 
@@ -28,7 +28,7 @@ function createFakeIpc(): { ipc: MpvIpcSession; commands: readonly unknown[][] }
 
 function createCycle(events: unknown[]) {
   return {
-    telemetry: createPlayerTelemetryState("/tmp/kunai-test.sock"),
+    stats: createPlayerStatsState("/tmp/kunai-test.sock"),
     playerReadyNotified: false,
     onPlayerReady: () => events.push("ready-callback"),
     onPlaybackEvent: (event: unknown) => events.push(event),

--- a/apps/cli/test/unit/infra/player/playback-stats-snapshot.test.ts
+++ b/apps/cli/test/unit/infra/player/playback-stats-snapshot.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
-import { describePlaybackTelemetrySnapshot } from "@/domain/playback/playback-telemetry-snapshot";
-import {
-  applyObservedPropertySample,
-  createPlayerTelemetryState,
-} from "@/infra/player/mpv-telemetry";
-import { buildPlaybackTelemetrySnapshot } from "@/infra/player/PlaybackTelemetrySnapshot";
+import { describePlaybackStatsSnapshot } from "@/domain/playback/playback-stats-snapshot";
+import { applyObservedPropertySample, createPlayerStatsState } from "@/infra/player/mpv-stats";
+import { buildPlaybackStatsSnapshot } from "@/infra/player/PlaybackStatsSnapshot";
 import { PlayerControlServiceImpl } from "@/infra/player/PlayerControlServiceImpl";
 
 function makeService() {
@@ -26,52 +23,52 @@ function makeService() {
   });
 }
 
-describe("playback telemetry snapshot", () => {
-  test("builds a read-only snapshot from the latest mpv telemetry sample", () => {
-    const telemetry = createPlayerTelemetryState("/tmp/kunai-mpv.sock");
+describe("playback stats snapshot", () => {
+  test("builds a read-only snapshot from the latest mpv stats sample", () => {
+    const stats = createPlayerStatsState("/tmp/kunai-mpv.sock");
 
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "playback-time",
       value: 734,
       observedAt: 1_000,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "duration",
       value: 1_440,
       observedAt: 1_010,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "demuxer-cache-duration",
       value: 8.45,
       observedAt: 1_020,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "cache-speed",
       value: 2_000_000,
       observedAt: 1_030,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "cache-buffering-state",
       value: 73,
       observedAt: 1_040,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "paused-for-cache",
       value: true,
       observedAt: 1_050,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "seeking",
       value: false,
       observedAt: 1_060,
     });
-    applyObservedPropertySample(telemetry, {
+    applyObservedPropertySample(stats, {
       name: "vo-configured",
       value: true,
       observedAt: 1_070,
     });
 
-    expect(buildPlaybackTelemetrySnapshot(telemetry)).toEqual({
+    expect(buildPlaybackStatsSnapshot(stats)).toEqual({
       positionSeconds: 734,
       durationSeconds: 1_440,
       cacheAheadSeconds: 8.45,
@@ -86,7 +83,7 @@ describe("playback telemetry snapshot", () => {
 
   test("formats snapshot progress and network diagnostics for shell display", () => {
     expect(
-      describePlaybackTelemetrySnapshot({
+      describePlaybackStatsSnapshot({
         positionSeconds: 734,
         durationSeconds: 1_440,
         cacheAheadSeconds: 8.45,
@@ -100,7 +97,7 @@ describe("playback telemetry snapshot", () => {
     ).toBe("12:14 / 24:00 · 8.5s cached · 2.0 MB/s · buffering 73%");
 
     expect(
-      describePlaybackTelemetrySnapshot({
+      describePlaybackStatsSnapshot({
         seeking: true,
         voConfigured: false,
         updatedAt: 1_080,
@@ -108,15 +105,15 @@ describe("playback telemetry snapshot", () => {
     ).toBe("seeking · video output pending");
   });
 
-  test("PlayerControlServiceImpl exposes the active player telemetry snapshot", () => {
+  test("PlayerControlServiceImpl exposes the active player stats snapshot", () => {
     const service = makeService();
 
-    expect(service.getTelemetrySnapshot()).toBeNull();
+    expect(service.getStatsSnapshot()).toBeNull();
 
     service.setActive({
       id: "player-1",
       async stop() {},
-      getTelemetrySnapshot() {
+      getStatsSnapshot() {
         return {
           positionSeconds: 12,
           durationSeconds: 120,
@@ -125,7 +122,7 @@ describe("playback telemetry snapshot", () => {
       },
     });
 
-    expect(service.getTelemetrySnapshot()).toEqual({
+    expect(service.getStatsSnapshot()).toEqual({
       positionSeconds: 12,
       durationSeconds: 120,
       updatedAt: 1_000,

--- a/apps/cli/test/unit/services/attention/AttentionRefreshWorker.test.ts
+++ b/apps/cli/test/unit/services/attention/AttentionRefreshWorker.test.ts
@@ -91,7 +91,7 @@ test("worker passes cancellation into provider refresh and stops after abort", a
   expect(calls).toEqual(["first:false"]);
 });
 
-test("worker records budget telemetry and executes only planned ids", async () => {
+test("worker records budget stats and executes only planned ids", async () => {
   const diagnostics: string[] = [];
   const calls: string[] = [];
   const worker = new AttentionRefreshWorker({

--- a/apps/cli/test/unit/services/diagnostics/resolve-trace-sink.test.ts
+++ b/apps/cli/test/unit/services/diagnostics/resolve-trace-sink.test.ts
@@ -30,7 +30,7 @@ describe("ResolveTraceSink", () => {
     expect(added[0]?.id).toBe("resolve-1");
   });
 
-  test("a storage fault never escapes — a resolve must not fail on telemetry", () => {
+  test("a storage fault never escapes — a resolve must not fail on trace persistence", () => {
     const sink = new ResolveTraceSink(
       store({
         add: () => {

--- a/apps/cli/test/unit/services/diagnostics/runtime-health.test.ts
+++ b/apps/cli/test/unit/services/diagnostics/runtime-health.test.ts
@@ -114,7 +114,7 @@ describe("runtime health diagnostics", () => {
     });
   });
 
-  test("summarizes physical provider attempt telemetry without a legacy resolve-start event", () => {
+  test("summarizes physical provider attempt traces without a legacy resolve-start event", () => {
     const health = buildRuntimeHealthSnapshot({
       currentProvider: "vidking",
       recentEvents: [

--- a/packages/core/test/provider-cycle-racing.test.ts
+++ b/packages/core/test/provider-cycle-racing.test.ts
@@ -245,7 +245,7 @@ describe("runProviderCycle racing", () => {
 
     const attempt = result.attempts[0];
     expect(attempt).toBeDefined();
-    // A collapsed startedAt would erase the latency the telemetry spine exists
+    // A collapsed startedAt would erase the latency the resolve-trace spine exists
     // to measure.
     expect(attempt?.startedAt).not.toBe(attempt?.endedAt);
   });


### PR DESCRIPTION
## Why

`telemetry` named two unrelated things:

- **(A) Local mpv playback state** — position, duration, cache ahead, buffering,
  seeking, VO readiness. Read over the IPC socket, rendered in the shell, never
  persisted and never sent.
- **(B) The opt-in usage ping** — already correctly and consistently called
  **analytics** (`services/analytics`, `domain/analytics`, `apps/analytics-ingest`).

Seeing `telemetry` in a diff told you nothing about which one you had, and the
privacy-sensitive one was the one you could not afford to guess wrong about.

## What changed

Concept A is now **playback stats** — mpv's own word for the same numbers, so
the name matches the source of the data. **Nothing in (B) was renamed.**

| Before | After |
| --- | --- |
| `apps/cli/src/infra/player/mpv-telemetry.ts` | `mpv-stats.ts` |
| `apps/cli/src/infra/player/PlaybackTelemetrySnapshot.ts` | `PlaybackStatsSnapshot.ts` |
| `apps/cli/src/domain/playback/playback-telemetry-snapshot.ts` | `playback-stats-snapshot.ts` |
| `PlayerTelemetryState` / `PlayerTelemetrySample` | `PlayerStatsState` / `PlayerStatsSample` |
| `PlaybackTelemetrySnapshot` / `PlaybackTelemetrySource` | `PlaybackStatsSnapshot` / `PlaybackStatsSource` |
| `createPlayerTelemetryState()` | `createPlayerStatsState()` |
| `buildPlaybackTelemetrySnapshot()` / `describePlaybackTelemetrySnapshot()` | `buildPlaybackStatsSnapshot()` / `describePlaybackStatsSnapshot()` |
| `getTelemetrySnapshot()` | `getStatsSnapshot()` |
| `cycle.telemetry` | `cycle.stats` |

Diagnostics prose and copy that said "telemetry" while meaning **resolve traces**
now says traces (`no resolve traces yet`), and `.docs/glossary.md` records all
three terms — playback stats, resolve trace, analytics — so the collision cannot
quietly return.

## Deliberately not changed

- `/telemetry` and `/telemetry show` stay as typed aliases for `/analytics`.
  Removing them would break muscle memory, and with concept A renamed the word
  now unambiguously means the analytics feature to a user.
- `apps/docs/`, `packages/providers/`, `packages/config/` — other work in flight.
- `.archive/` — history, never rewritten.

## Scope discipline

Pure rename. No logic, control flow, or signature shape changed — every changed
line is a name, a comment, a test title, a display string, or formatter reflow
caused by a shorter identifier. `AGENTS.md` calls mass-renaming for style
unwelcome; this one is justified by the ambiguity, not by taste, so it stops at
the vocabulary.

## Verification

| Check | Result |
| --- | --- |
| `bun run typecheck` | 14/14 tasks pass |
| `bun run lint` | 0 errors (3 pre-existing `analytics-ingest` warnings, untouched) |
| `bun run fmt` | clean |
| `bun run verify:doc-paths` | 48 docs, 1916 source files, all paths resolve |
| `bun run build` | 10/10 tasks, host binary builds |
| `bun run test` | 4545 unit pass / 665 files, 109 integration pass, 0 fail |

Test counts match the `main` baseline (`43cc784d`) exactly — 4545 unit, 109
integration — verified by running the suite on a detached checkout of `main` in
the same worktree.

https://claude.ai/code/session_01KV1zeNg3HFPyZ2aXvj51Uk
