### PR TITLE
fix(youtube): repair the YouTube lane and make it survive upstream rotation

### DIFF
--- a/apps/analytics-ingest/scripts/migrate.ts
+++ b/apps/analytics-ingest/scripts/migrate.ts
@@ -6,6 +6,7 @@ import { neon } from "@neondatabase/serverless";
 
 // Side-effecting: honours NEON_FETCH_ENDPOINT so the schema lands in the same
 // database the tests query. Must precede the client below.
+// oxlint-disable-next-line import/no-unassigned-import -- the side effect is the point
 import "../src/neon-fetch-endpoint";
 import { splitSqlStatements } from "../src/sql-statements";
 

--- a/apps/analytics-ingest/test/postgres-ingest-lifecycle.test.ts
+++ b/apps/analytics-ingest/test/postgres-ingest-lifecycle.test.ts
@@ -13,6 +13,7 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 
 // Side-effecting: honours NEON_FETCH_ENDPOINT. Must precede store construction.
+// oxlint-disable-next-line import/no-unassigned-import -- the side effect is the point
 import "../src/neon-fetch-endpoint";
 import { hashInstallId, ingestAnalyticsPing, RAW_RETENTION_DAYS } from "../src/ingest";
 import { createPostgresAnalyticsStore } from "../src/postgres-store";

--- a/apps/analytics-ingest/test/postgres-store.test.ts
+++ b/apps/analytics-ingest/test/postgres-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 // Side-effecting: honours NEON_FETCH_ENDPOINT. Must precede store construction.
+// oxlint-disable-next-line import/no-unassigned-import -- the side effect is the point
 import "../src/neon-fetch-endpoint";
 import { createPostgresAnalyticsStore, RECORD_PING_SQL } from "../src/postgres-store";
 

--- a/apps/cli/src/services/providers/youtube-playback-options.ts
+++ b/apps/cli/src/services/providers/youtube-playback-options.ts
@@ -1,6 +1,21 @@
 import { buildYoutubeYtdlProfile, getYoutubeProviderConfig } from "@kunai/providers/youtube";
 import type { StreamCandidate } from "@kunai/types";
 
+/**
+ * Extractor args for this specific stream.
+ *
+ * Each YouTube source is one player client, and the stream carries the args that
+ * select it. Falling back to the global config would collapse every lane onto the
+ * same client and silently defeat failover.
+ */
+function extractorArgsFor(selected: StreamCandidate): string | undefined {
+  const metadata = selected.metadata as { readonly extractorArgs?: string } | undefined;
+  if (typeof metadata?.extractorArgs === "string" && metadata.extractorArgs.trim()) {
+    return metadata.extractorArgs;
+  }
+  return getYoutubeProviderConfig().extractorArgs;
+}
+
 export function resolveYoutubeYtdlRawOptions(
   selected: StreamCandidate,
   subtitleLanguage?: string,
@@ -14,7 +29,7 @@ export function resolveYoutubeYtdlRawOptions(
   return buildYoutubeYtdlProfile({
     cookiesFromBrowser: config.cookiesFromBrowser,
     cookiesFile: config.cookiesFile,
-    extractorArgs: config.extractorArgs,
+    extractorArgs: extractorArgsFor(selected),
     sponsorblockRemove: config.sponsorblockRemove,
     isLive,
     qualityLabel: selected.qualityLabel,
@@ -35,7 +50,7 @@ export function resolveYtdlFormatFromCandidate(selected: StreamCandidate): strin
   return buildYoutubeYtdlProfile({
     cookiesFromBrowser: config.cookiesFromBrowser,
     cookiesFile: config.cookiesFile,
-    extractorArgs: config.extractorArgs,
+    extractorArgs: extractorArgsFor(selected),
     sponsorblockRemove: config.sponsorblockRemove,
     isLive,
     qualityLabel: selected.qualityLabel,

--- a/apps/cli/src/services/youtube/youtube-diagnostics-probes.ts
+++ b/apps/cli/src/services/youtube/youtube-diagnostics-probes.ts
@@ -1,21 +1,23 @@
 import type { Container } from "@/container";
 import type { DiagnosticEvent } from "@/services/diagnostics/DiagnosticsStore";
 import { probeInvidiousHealth } from "@/services/youtube/invidious-health";
-import { probeYtDlpAsync } from "@/services/ytdlp/YtDlpService";
+import { probeYtDlpAsync, probeYtDlpPlugins } from "@/services/ytdlp/YtDlpService";
 
 export type YoutubeDiagnosticsProbe = {
   readonly ytDlp: { readonly available: boolean; readonly version?: string };
   readonly invidious: Awaited<ReturnType<typeof probeInvidiousHealth>>;
+  readonly poToken: { readonly provider: boolean; readonly plugins: readonly string[] };
 };
 
 export async function runYoutubeDiagnosticsProbes(
   container: Container,
 ): Promise<YoutubeDiagnosticsProbe> {
-  const [ytDlp, invidious] = await Promise.all([
+  const [ytDlp, invidious, plugins] = await Promise.all([
     probeYtDlpAsync(),
     probeInvidiousHealth({
       preferredInstanceUrl: container.config.youtubeMetadata.instanceUrl,
     }),
+    probeYtDlpPlugins(),
   ]);
 
   container.diagnosticsService.record({
@@ -32,8 +34,20 @@ export async function runYoutubeDiagnosticsProbes(
       : `Invidious unhealthy: ${invidious.error ?? "unknown"}`,
     context: { ...invidious },
   });
+  container.diagnosticsService.record({
+    category: "provider",
+    operation: "youtube.potoken.probe",
+    message: plugins.poTokenProvider
+      ? `PO Token provider: ${plugins.plugins.join(", ") || "present"}`
+      : "No PO Token provider — YouTube may answer 403 on media URLs",
+    context: { ...plugins },
+  });
 
-  return { ytDlp, invidious };
+  return {
+    ytDlp,
+    invidious,
+    poToken: { provider: plugins.poTokenProvider, plugins: plugins.plugins },
+  };
 }
 
 export function extractYoutubeProbeFromEvents(
@@ -41,6 +55,7 @@ export function extractYoutubeProbeFromEvents(
 ): YoutubeDiagnosticsProbe | null {
   const ytEvent = recentEvents.find((event) => event.operation === "youtube.ytdlp.probe");
   const invEvent = recentEvents.find((event) => event.operation === "youtube.invidious.health");
+  const potEvent = recentEvents.find((event) => event.operation === "youtube.potoken.probe");
   if (!ytEvent && !invEvent) return null;
 
   const ytContext = ytEvent?.context as
@@ -55,6 +70,9 @@ export function extractYoutubeProbeFromEvents(
         readonly error?: string;
       }
     | undefined;
+  const potContext = potEvent?.context as
+    | { readonly poTokenProvider?: boolean; readonly plugins?: readonly string[] }
+    | undefined;
 
   return {
     ytDlp: {
@@ -68,6 +86,10 @@ export function extractYoutubeProbeFromEvents(
       instanceCount: invContext?.instanceCount,
       error: invContext?.error,
     },
+    poToken: {
+      provider: potContext?.poTokenProvider === true,
+      plugins: Array.isArray(potContext?.plugins) ? potContext.plugins : [],
+    },
   };
 }
 
@@ -77,8 +99,14 @@ export function formatYoutubeDiagnosticsDetail(probe: YoutubeDiagnosticsProbe): 
   readonly toolingTone: "success" | "warning" | "neutral";
   readonly invidiousTone: "success" | "warning" | "neutral";
 } {
+  // A missing PO Token provider is the usual reason a resolve succeeds and then
+  // playback 403s, so name it next to the tool it belongs to rather than leaving
+  // the user to discover it from a failed stream.
+  const poTokenNote = probe.poToken.provider
+    ? " · PO Token provider ready"
+    : " · no PO Token provider (YouTube may 403)";
   const tooling = probe.ytDlp.available
-    ? `yt-dlp ${probe.ytDlp.version ?? "ready"}`
+    ? `yt-dlp ${probe.ytDlp.version ?? "ready"}${poTokenNote}`
     : "yt-dlp missing (required for YouTube playback quality + downloads)";
   const invidious = probe.invidious.ok
     ? `${probe.invidious.instance ?? "instance"} · ${probe.invidious.latencyMs ?? "?"}ms · ${probe.invidious.instanceCount ?? 1} available`

--- a/apps/cli/src/services/ytdlp/YtDlpService.ts
+++ b/apps/cli/src/services/ytdlp/YtDlpService.ts
@@ -16,6 +16,77 @@ export function probeYtDlp(): { readonly available: boolean; readonly version?: 
   return { available: true };
 }
 
+export type YtDlpPluginProbe = {
+  /** yt-dlp answered the probe at all. */
+  readonly available: boolean;
+  /** A PO Token provider plugin (e.g. bgutil) is loaded. */
+  readonly poTokenProvider: boolean;
+  /** Plugin names yt-dlp reported, for diagnostics. */
+  readonly plugins: readonly string[];
+};
+
+/**
+ * Ask yt-dlp which plugins it loaded.
+ *
+ * YouTube requires a Proof-of-Origin token for GVS (media) requests on most player
+ * clients; without one, media URLs can answer 403 even though extraction succeeded.
+ * yt-dlp cannot mint these itself — it needs a provider plugin — so knowing whether
+ * one is installed is the difference between diagnosing a 403 and guessing at it.
+ *
+ * `ytsearch0:` resolves to an empty result set, so this costs no real extraction.
+ */
+export async function probeYtDlpPlugins(): Promise<YtDlpPluginProbe> {
+  if (!Bun.which("yt-dlp")) return { available: false, poTokenProvider: false, plugins: [] };
+  try {
+    const proc = await spawnYtDlpWithTimeout({
+      args: ["--verbose", "--simulate", "ytsearch0:x"],
+      timeoutMs: 15_000,
+      maxStdoutBytes: 64 * 1024,
+      maxStderrBytes: 256 * 1024,
+    });
+    // yt-dlp writes its debug banner to stderr.
+    return parseYtDlpPluginProbe(`${proc.stderr}\n${proc.stdout}`);
+  } catch {
+    return { available: false, poTokenProvider: false, plugins: [] };
+  }
+}
+
+/** Exported for tests: parse the `--verbose` debug banner. */
+export function parseYtDlpPluginProbe(output: string): YtDlpPluginProbe {
+  const plugins = new Set<string>();
+  let poTokenProvider = false;
+
+  for (const line of output.split("\n")) {
+    const providers = line.match(/\[pot\]\s*PO Token Providers:\s*(.+)$/i);
+    if (providers?.[1]) {
+      const named = providers[1].trim();
+      if (named && named.toLowerCase() !== "none") {
+        poTokenProvider = true;
+        for (const entry of named.split(",")) {
+          const name = entry.trim();
+          if (name) plugins.add(name);
+        }
+      }
+      continue;
+    }
+    const extractor = line.match(/(?:Extractor|Postprocessor) Plugins:\s*(.+)$/i);
+    if (extractor?.[1]) {
+      const named = extractor[1].trim();
+      if (named && named.toLowerCase() !== "none") {
+        for (const entry of named.split(",")) {
+          const name = entry.trim();
+          if (name) plugins.add(name);
+          // The bgutil provider registers as an extractor plugin and is the
+          // community-standard PO Token source, so it counts as one.
+          if (/bgutil|pot|po.?token/i.test(name)) poTokenProvider = true;
+        }
+      }
+    }
+  }
+
+  return { available: true, poTokenProvider, plugins: [...plugins] };
+}
+
 export async function probeYtDlpAsync(): Promise<{
   readonly available: boolean;
   readonly version?: string;

--- a/apps/cli/test/unit/app-shell/panel-data.test.ts
+++ b/apps/cli/test/unit/app-shell/panel-data.test.ts
@@ -127,6 +127,7 @@ describe("panel-data", () => {
           latencyMs: 120,
           instanceCount: 3,
         },
+        poToken: { provider: true, plugins: ["BgUtilHTTP"] },
       },
     });
 

--- a/apps/cli/test/unit/mpv/youtube-ytdl-args.test.ts
+++ b/apps/cli/test/unit/mpv/youtube-ytdl-args.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import { buildMpvArgs } from "@/mpv";
+import { DEFAULT_CONFIG, DEFAULT_YOUTUBE_EXTRACTOR_ARGS } from "@kunai/config";
+import { buildYoutubeMpvYtdlRawOptions, joinMpvYtdlRawOptions } from "@kunai/providers/youtube";
 
 describe("buildMpvArgs youtube playback", () => {
   test("adds ytdl-format for YouTube watch URLs", () => {
@@ -52,5 +54,44 @@ describe("buildMpvArgs youtube playback", () => {
       "--ytdl-raw-options=sponsorblock-remove=%13%sponsor,intro,live-from-start=no",
     );
     expect(args).toContain("--script-opts=ytdlautoformat-domains=");
+  });
+});
+
+describe("shipped YouTube extractor-args default", () => {
+  test("the default is set and names only clients that serve playable media URLs", () => {
+    // yt-dlp's own client order leads with ANDROID_VR, whose media URLs 403 at
+    // playback time. Extraction still succeeds, so an unset default fails only
+    // once mpv opens the stream — no test or gate catches it upstream of here.
+    expect(DEFAULT_CONFIG.youtubeMetadata.extractorArgs).toBe(DEFAULT_YOUTUBE_EXTRACTOR_ARGS);
+    expect(DEFAULT_YOUTUBE_EXTRACTOR_ARGS).toMatch(/^youtube:player_client=/);
+
+    const clients = DEFAULT_YOUTUBE_EXTRACTOR_ARGS.split("=")[1]?.split(",") ?? [];
+    // More than one, so a single client rotating out does not break playback.
+    expect(clients.length).toBeGreaterThan(1);
+    for (const client of clients) {
+      expect(["mweb", "tv_simply"]).toContain(client);
+    }
+  });
+
+  test("the default survives the trip into mpv's ytdl-raw-options", () => {
+    const args = buildMpvArgs(
+      {
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        headers: {},
+        subtitle: null,
+        displayTitle: "Never Gonna Give You Up",
+        requiresYtdl: true,
+        ytdlRawOptions: joinMpvYtdlRawOptions(
+          buildYoutubeMpvYtdlRawOptions({ extractorArgs: DEFAULT_YOUTUBE_EXTRACTOR_ARGS }),
+        ),
+      },
+      null,
+    );
+
+    const rawOptions = args.find((arg) => arg.startsWith("--ytdl-raw-options="));
+    expect(rawOptions).toBeDefined();
+    expect(rawOptions).toContain(
+      `extractor-args=%${DEFAULT_YOUTUBE_EXTRACTOR_ARGS.length}%${DEFAULT_YOUTUBE_EXTRACTOR_ARGS}`,
+    );
   });
 });

--- a/apps/cli/test/unit/services/ytdlp/ytdlp-plugin-probe.test.ts
+++ b/apps/cli/test/unit/services/ytdlp/ytdlp-plugin-probe.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseYtDlpPluginProbe } from "@/services/ytdlp/YtDlpService";
+
+/**
+ * YouTube requires a Proof-of-Origin token for media requests on most player
+ * clients. yt-dlp cannot mint one itself, so when no provider plugin is loaded a
+ * resolve succeeds and playback then answers 403 — the failure the user actually
+ * sees. These cases pin the parse of yt-dlp's `--verbose` banner that tells us
+ * which case we are in.
+ */
+describe("parseYtDlpPluginProbe", () => {
+  test("reports no provider on a stock yt-dlp install", () => {
+    const probe = parseYtDlpPluginProbe(
+      [
+        "[debug] Plugin directories: none",
+        "[debug] [youtube] [pot] PO Token Providers: none",
+        "[debug] [youtube] [pot] PO Token Cache Providers: memory",
+      ].join("\n"),
+    );
+
+    expect(probe.available).toBe(true);
+    expect(probe.poTokenProvider).toBe(false);
+    expect(probe.plugins).toEqual([]);
+  });
+
+  test("detects a provider from the pot banner and names it", () => {
+    const probe = parseYtDlpPluginProbe(
+      "[debug] [youtube] [pot] PO Token Providers: BgUtilHTTP-0.9.0, BgUtilScript-0.9.0",
+    );
+
+    expect(probe.poTokenProvider).toBe(true);
+    expect(probe.plugins).toEqual(["BgUtilHTTP-0.9.0", "BgUtilScript-0.9.0"]);
+  });
+
+  test("detects the bgutil provider when it only shows as an extractor plugin", () => {
+    const probe = parseYtDlpPluginProbe("[debug] Extractor Plugins: BgUtilPot");
+
+    expect(probe.poTokenProvider).toBe(true);
+    expect(probe.plugins).toEqual(["BgUtilPot"]);
+  });
+
+  test("an unrelated extractor plugin does not count as a token provider", () => {
+    const probe = parseYtDlpPluginProbe("[debug] Extractor Plugins: SomeOtherSite");
+
+    expect(probe.poTokenProvider).toBe(false);
+    expect(probe.plugins).toEqual(["SomeOtherSite"]);
+  });
+
+  test("cache providers are not mistaken for token providers", () => {
+    // `memory` is always present and says nothing about minting tokens.
+    const probe = parseYtDlpPluginProbe(
+      [
+        "[debug] [youtube] [pot] PO Token Providers: none",
+        "[debug] [youtube] [pot] PO Token Cache Providers: memory",
+        "[debug] [youtube] [pot] PO Token Cache Spec Providers: webpo",
+      ].join("\n"),
+    );
+
+    expect(probe.poTokenProvider).toBe(false);
+  });
+});

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,9 +1,9 @@
 {
-  "syncedAt": "2026-08-16T10:38:36.708Z",
+  "syncedAt": "2026-08-18T09:20:14.960Z",
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceRevision": "520c36c1",
-  "cliSourceFingerprint": "178d0832826823139f8b53f7988cb125e7b72b8d637e4e585bca7f7af6749d91",
+  "cliSourceRevision": "92ac3977",
+  "cliSourceFingerprint": "0b65d1a676ffa988d3ada7fb4a6a7b5177ebd0ac02870904f2353b0b7f61d6c5",
   "docsContentFingerprint": "3311367d534c1c9f29cde9ecf49f75ed0f7069979b2a014b488101e3e2ad87e9",
   "featureStatusRevision": "d4c1e1d0943d18f05bca1a12a5b0ff966754a588f12e4a86a03510d2bc424c1d",
   "commandCount": 81,
@@ -93,7 +93,8 @@
         "Mp4 (mp4upload scrape)",
         "Luf-Mp4",
         "Ak. Filemoon is gone.",
-        "2026-08: mkissa crypto requires buildId=81 + /client-crypto/v1/bootstrap (x-aa-boot). ani-cli v5 moved primary to anidb.app."
+        "2026-08: mkissa crypto requires buildId=119 (rotated from 81) + /client-crypto/v1/bootstrap (x-aa-boot)",
+        "7-day epochs. ani-cli v5 moved primary to anidb.app."
       ]
     },
     {
@@ -111,9 +112,7 @@
         "Primary hosts: www.miruro.bz",
         "www.miruro.ru. Bare miruro.bz/.ru are 301 redirects to www. and still CF-block at the pipe path; miruro.com serves a different app shell with no /api/secure/pipe; miruro.tv/.to are TLS-dead — all stay off the resolve list.",
         "Uses Miruro pipe API with XOR/gzip decryption key 71951034f8fbcf53d89db52ceb3dc22c.",
-        "Still not the default anime auto-fallback (AniDB is the default",
-        "AllAnime the fallback); Miruro is available for manual pick when curl/http2 path works.",
-        "May hit Cloudflare rate limits if called too frequently."
+        "Not in the automatic anime lane: `animeProviderPriority` is `[anidb"
       ]
     },
     {

--- a/packages/config/src/defaults.ts
+++ b/packages/config/src/defaults.ts
@@ -4,6 +4,20 @@ export const DEFAULT_OFFLINE_FREE_SPACE_RESERVE_BYTES = 2 * 1024 * 1024 * 1024;
 export const DEFAULT_UNKNOWN_EPISODE_ESTIMATE_BYTES = 768 * 1024 * 1024;
 export const DEFAULT_OFFLINE_RUNWAY_TARGET = 2;
 
+/**
+ * yt-dlp player clients Kunai asks for by default.
+ *
+ * yt-dlp 2026.07.04 (current latest) leads with ANDROID_VR, whose media URLs answer
+ * 403 Forbidden at playback time — extraction succeeds, so nothing fails until mpv
+ * opens the stream and the user sees "Playback failed on this stream". Verified
+ * 2026-08-18: `default`, `tv`, `web_safari` and `ios` all fail; `mweb` and
+ * `tv_simply` both play. Two are named so one rotating out does not break playback.
+ *
+ * This is a default, not a pin — Settings › YouTube › extractor args overrides it,
+ * and it should be revisited whenever yt-dlp's own client order changes.
+ */
+export const DEFAULT_YOUTUBE_EXTRACTOR_ARGS = "youtube:player_client=mweb,tv_simply";
+
 export const DEFAULT_CONFIG: KitsuneConfig = {
   defaultMode: "series",
   // Series automatic lane (2026-07-16): Videasy first (fast seed+neon path), then Rivestream, VidLink.
@@ -22,7 +36,7 @@ export const DEFAULT_CONFIG: KitsuneConfig = {
   animeProviderPriority: ["anidb"],
   youtubeProviderPriority: ["youtube"],
   youtubeLanguageProfile: { audio: "original", subtitle: "en", quality: "1080p" },
-  youtubeMetadata: {},
+  youtubeMetadata: { extractorArgs: DEFAULT_YOUTUBE_EXTRACTOR_ARGS },
   subLang: "en",
   wyzieApiKey: "",
   animeLang: "sub",

--- a/packages/providers/src/youtube/direct.ts
+++ b/packages/providers/src/youtube/direct.ts
@@ -44,6 +44,7 @@ import type {
 } from "./youtube-metadata";
 import { createYoutubeMetadataService } from "./youtube-metadata-service";
 import { buildYtdlFormatSelector, defaultYtdlPlaybackFormat } from "./yt-dlp-metadata";
+import { parseYoutubePlayerClients, withYoutubePlayerClient } from "./ytdl-options";
 
 export { YOUTUBE_PROVIDER_ID, youtubeManifest };
 
@@ -346,47 +347,80 @@ async function resolveYoutube(
           qualityLabels[0])
         : qualityLabels[0];
 
-    const sourceId = `source:${YOUTUBE_PROVIDER_ID}:youtube`;
+    // One source per player client. Clients fail independently — one answers 403 on
+    // media URLs while another plays the same video — and which one works rotates
+    // without notice. Naming them separately lets the existing startup source
+    // failover walk them, so a 403 retries the next client instead of ending
+    // playback. A single configured client stays a single source.
+    const playerClients = parseYoutubePlayerClients(globalYoutubeConfig.extractorArgs);
+    const lanes =
+      playerClients.length > 0
+        ? playerClients.map((client) => ({
+            client,
+            sourceId: `source:${YOUTUBE_PROVIDER_ID}:${client}`,
+            label: `YouTube · ${client}`,
+            extractorArgs: withYoutubePlayerClient(globalYoutubeConfig.extractorArgs, client),
+          }))
+        : [
+            {
+              client: null,
+              sourceId: `source:${YOUTUBE_PROVIDER_ID}:youtube`,
+              label: "YouTube",
+              extractorArgs: globalYoutubeConfig.extractorArgs,
+            },
+          ];
 
-    const streams: StreamCandidate[] = qualityLabels.map((entry) => {
-      const streamId = `stream:${YOUTUBE_PROVIDER_ID}:${videoId}:${entry.label}`;
-      const ytdlFormat = isLive
-        ? defaultYtdlPlaybackFormat()
-        : buildYtdlFormatSelector(entry.label);
-      return {
-        id: streamId,
+    const streamId = (label: string, client: string | null) =>
+      client
+        ? `stream:${YOUTUBE_PROVIDER_ID}:${videoId}:${client}:${label}`
+        : `stream:${YOUTUBE_PROVIDER_ID}:${videoId}:${label}`;
+
+    const streams: StreamCandidate[] = lanes.flatMap((lane, laneIndex) =>
+      qualityLabels.map((entry) => ({
+        id: streamId(entry.label, lane.client),
         providerId: YOUTUBE_PROVIDER_ID,
-        sourceId,
+        sourceId: lane.sourceId,
         variantId: `variant:${YOUTUBE_PROVIDER_ID}:${entry.label}`,
         url: watchUrl,
-        protocol: "youtube",
-        container: "unknown",
+        protocol: "youtube" as const,
+        container: "unknown" as const,
         qualityLabel: entry.label,
         qualityRank: entry.rank,
         requiresYtdl: true,
         headers: {},
-        confidence: ytInfo ? 0.95 : 0.85,
+        // Later lanes are fallbacks, so rank them below the first.
+        confidence: (ytInfo ? 0.95 : 0.85) - laneIndex * 0.05,
         cachePolicy,
         metadata: {
-          ytdlFormat,
+          ytdlFormat: isLive ? defaultYtdlPlaybackFormat() : buildYtdlFormatSelector(entry.label),
+          // Read back by the player so each lane asks yt-dlp for its own client
+          // rather than the global default.
+          extractorArgs: lane.extractorArgs,
+          playerClient: lane.client,
           videoId,
           durationSeconds: ytInfo?.durationSeconds,
           isLive,
           liveStatus,
         },
-      };
-    });
+      })),
+    );
 
-    const selectedStreamId = `stream:${YOUTUBE_PROVIDER_ID}:${videoId}:${selectedQuality?.label ?? "best"}`;
+    const primaryLane = lanes[0];
+    const selectedStreamId = streamId(
+      selectedQuality?.label ?? "best",
+      primaryLane?.client ?? null,
+    );
 
+    // One variant per quality, listing that quality's stream in every lane so the
+    // failover order is preserved when a viewer picks a specific quality.
     const variants: ProviderVariantCandidate[] = qualityLabels.map((entry) => ({
       id: `variant:${YOUTUBE_PROVIDER_ID}:${entry.label}`,
       providerId: YOUTUBE_PROVIDER_ID,
-      sourceId,
+      sourceId: primaryLane?.sourceId ?? `source:${YOUTUBE_PROVIDER_ID}:youtube`,
       qualityLabel: entry.label,
       qualityRank: entry.rank,
       protocol: "youtube",
-      streamIds: [`stream:${YOUTUBE_PROVIDER_ID}:${videoId}:${entry.label}`],
+      streamIds: lanes.map((lane) => streamId(entry.label, lane.client)),
       confidence: 0.9,
     }));
 
@@ -407,19 +441,17 @@ async function resolveYoutube(
       status: "resolved",
       providerId: YOUTUBE_PROVIDER_ID,
       selectedStreamId,
-      sources: [
-        {
-          id: sourceId,
-          providerId: YOUTUBE_PROVIDER_ID,
-          kind: "provider-api",
-          label: "YouTube",
-          host: "youtube.com",
-          status: "selected",
-          confidence: 0.95,
-          requiresRuntime: "direct-http",
-          cachePolicy,
-        },
-      ],
+      sources: lanes.map((lane, laneIndex) => ({
+        id: lane.sourceId,
+        providerId: YOUTUBE_PROVIDER_ID,
+        kind: "provider-api" as const,
+        label: lane.label,
+        host: "youtube.com",
+        status: laneIndex === 0 ? ("selected" as const) : ("available" as const),
+        confidence: 0.95 - laneIndex * 0.05,
+        requiresRuntime: "direct-http" as const,
+        cachePolicy,
+      })),
       streams,
       variants: variants.length > 0 ? variants : undefined,
       subtitles,

--- a/packages/providers/src/youtube/direct.ts
+++ b/packages/providers/src/youtube/direct.ts
@@ -21,7 +21,12 @@ import type {
 
 import { createExhaustedResult, emitTraceEvent } from "../shared/resolve-helpers";
 import { formatDurationSeconds } from "./format-duration";
-import { buildYoutubeWatchUrl, parseYoutubeCatalogId, toYoutubeVideoCatalogId } from "./ids";
+import {
+  buildYoutubeWatchUrl,
+  parseYoutubeCatalogId,
+  toYoutubeVideoCatalogId,
+  youtubeThumbnailUrl,
+} from "./ids";
 import {
   invidiousGetChannelVideos,
   invidiousGetPlaylist,
@@ -154,12 +159,16 @@ async function searchYoutubeViaYtsearch(
           live_status?: string;
         };
         if (!entry.id || !entry.title) continue;
+        // `--flat-playlist` returns `thumbnail: null` on every entry (the images live
+        // in a `thumbnails[]` array it does not flatten), so without this fallback the
+        // whole yt-dlp search lane renders with empty posters.
+        const poster = entry.thumbnail ?? youtubeThumbnailUrl(entry.id);
         results.push({
           id: toYoutubeVideoCatalogId(entry.id),
           type: "movie",
           title: entry.title,
           overview: "",
-          posterPath: entry.thumbnail ?? null,
+          posterPath: poster,
           metadataSource: "yt-dlp",
           durationSeconds: entry.duration,
           channelTitle: entry.uploader,
@@ -169,8 +178,8 @@ async function searchYoutubeViaYtsearch(
           contentShape: "video",
           externalIds: { youtubeId: entry.id, youtubeChannelId: entry.channel_id },
           artwork: {
-            thumbnailUrl: entry.thumbnail,
-            posterUrl: entry.thumbnail,
+            thumbnailUrl: poster,
+            posterUrl: poster,
           },
         });
       } catch {

--- a/packages/providers/src/youtube/direct.ts
+++ b/packages/providers/src/youtube/direct.ts
@@ -36,6 +36,7 @@ import { YOUTUBE_PROVIDER_ID, youtubeManifest } from "./manifest";
 import { mapInvidiousSearchResults, mapPipedSearchResults } from "./map-search-result";
 import { pipedSearch } from "./piped-client";
 import { spawnYtDlpWithTimeout } from "./spawn-ytdlp";
+import { boundYoutubeSubtitleTracks } from "./subtitle-language";
 import type {
   YoutubeMetadataCachePort,
   YoutubeMetadataService,
@@ -389,7 +390,11 @@ async function resolveYoutube(
       confidence: 0.9,
     }));
 
-    const subtitles: SubtitleCandidate[] = mapYoutubeMetadataSubtitles(ytInfo, cachePolicy);
+    const subtitles: SubtitleCandidate[] = mapYoutubeMetadataSubtitles(
+      ytInfo,
+      cachePolicy,
+      input.preferredSubtitleLanguage,
+    );
 
     const endedAt = context.now();
     emitTraceEvent(events, context, {
@@ -467,10 +472,13 @@ async function resolveYoutube(
 function mapYoutubeMetadataSubtitles(
   info: YoutubeVideoMetadata | null,
   cachePolicy: StreamCandidate["cachePolicy"],
+  subtitlePreference: string | undefined,
 ): SubtitleCandidate[] {
   if (!info) return [];
   const subtitles: SubtitleCandidate[] = [];
-  for (const track of info.subtitles) {
+  // Bounded at resolve time, not in the cached metadata: the full inventory stays
+  // cached so changing the language preference does not require a re-fetch.
+  for (const track of boundYoutubeSubtitleTracks(info.subtitles, subtitlePreference)) {
     if (!track.url) continue;
     subtitles.push({
       id: `subtitle:${YOUTUBE_PROVIDER_ID}:${track.language}:${track.ext ?? "vtt"}`,

--- a/packages/providers/src/youtube/ids.ts
+++ b/packages/providers/src/youtube/ids.ts
@@ -43,6 +43,19 @@ export function parseYoutubeCatalogId(id: string): {
   return { kind: "unknown", nativeId: id };
 }
 
+/**
+ * Poster URL derived from a video id alone.
+ *
+ * Every search backend drops thumbnails somewhere: `yt-dlp --flat-playlist` returns
+ * `thumbnail: null`, Piped omits it on some instances, and Invidious points at an
+ * instance that may already be cooling down. `i.ytimg.com` needs no lookup and is
+ * served straight from YouTube's CDN, so it is the honest floor for any video we
+ * can name — a result should never render with an empty poster.
+ */
+export function youtubeThumbnailUrl(videoId: string): string {
+  return `https://i.ytimg.com/vi/${encodeURIComponent(videoId)}/hqdefault.jpg`;
+}
+
 export function buildYoutubeWatchUrl(videoId: string): string {
   return `https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`;
 }

--- a/packages/providers/src/youtube/invidious-instance-pool.ts
+++ b/packages/providers/src/youtube/invidious-instance-pool.ts
@@ -49,12 +49,7 @@ export async function fetchHealthyInvidiousInstances(
     string,
     InvidiousInstanceRecord,
   ])[];
-  const instances = payload
-    .map(([host, meta]) => {
-      if (meta?.api === false) return null;
-      return normalizeInstanceUrl(host);
-    })
-    .filter((value): value is string => Boolean(value));
+  const instances = selectReachableInstances(payload);
 
   cachedInstances = { fetchedAt: now, instances };
   return filterAvailableInstances(instances, now);
@@ -76,6 +71,43 @@ export async function pickInvidiousInstance(
     throw new Error("No healthy Invidious instances available");
   }
   return instance;
+}
+
+/** Overlay networks a plain machine has no route to; reaching them needs a proxy we never spawn. */
+const UNREACHABLE_HOST_SUFFIXES = [".onion", ".i2p", ".ygg"] as const;
+
+function isReachableInstance(url: string): boolean {
+  let host: string;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+    host = parsed.hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return !UNREACHABLE_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix));
+}
+
+/**
+ * Pick the instances worth trying, reachability first.
+ *
+ * Upstream's `api` flag is not dependable in either direction: as of 2026-08 every
+ * working clearnet instance reports `api: false` while the `api: true`/`null` entries
+ * are Tor, I2P and Yggdrasil addresses. Filtering on `api` alone therefore yielded a
+ * pool of exclusively unroutable hosts, and each search burned three 15s timeouts
+ * before falling back. So reachability is the hard filter and `api` is only a
+ * preference — applied when it actually selects something, ignored when it does not,
+ * which keeps this correct whichever way upstream flips next.
+ */
+function selectReachableInstances(
+  payload: readonly (readonly [string, InvidiousInstanceRecord])[],
+): readonly string[] {
+  const reachable = payload
+    .map(([host, meta]) => ({ url: normalizeInstanceUrl(meta?.uri?.trim() || host), meta }))
+    .filter((entry) => isReachableInstance(entry.url));
+  const apiEnabled = reachable.filter((entry) => entry.meta?.api === true);
+  const selected = apiEnabled.length > 0 ? apiEnabled : reachable;
+  return [...new Set(selected.map((entry) => entry.url))];
 }
 
 function filterAvailableInstances(instances: readonly string[], now: number): readonly string[] {

--- a/packages/providers/src/youtube/map-search-result.ts
+++ b/packages/providers/src/youtube/map-search-result.ts
@@ -4,6 +4,7 @@ import {
   toYoutubeChannelCatalogId,
   toYoutubePlaylistCatalogId,
   toYoutubeVideoCatalogId,
+  youtubeThumbnailUrl,
 } from "./ids";
 import type {
   InvidiousRecommendedVideo,
@@ -46,13 +47,15 @@ function mapLiveStatus(item: InvidiousSearchVideo): YouTubeLiveStatus {
 
 export function mapInvidiousSearchItem(item: InvidiousSearchItem): ProviderSearchResult | null {
   if (item.type === "video") {
+    const poster =
+      pickInvidiousThumbnail(item.videoThumbnails) ?? youtubeThumbnailUrl(item.videoId);
     return {
       id: toYoutubeVideoCatalogId(item.videoId),
       type: "movie",
       title: item.title,
       year: publishedYearFromEpochSeconds(item.published),
       overview: item.description ?? "",
-      posterPath: pickInvidiousThumbnail(item.videoThumbnails),
+      posterPath: poster,
       metadataSource: "Invidious",
       durationSeconds: item.lengthSeconds,
       channelTitle: item.author,
@@ -68,8 +71,8 @@ export function mapInvidiousSearchItem(item: InvidiousSearchItem): ProviderSearc
         youtubeChannelId: item.authorId,
       },
       artwork: {
-        thumbnailUrl: pickInvidiousThumbnail(item.videoThumbnails) ?? undefined,
-        posterUrl: pickInvidiousThumbnail(item.videoThumbnails) ?? undefined,
+        thumbnailUrl: poster,
+        posterUrl: poster,
       },
     };
   }
@@ -130,13 +133,14 @@ export function mapPipedSearchItem(item: PipedSearchItem): ProviderSearchResult 
   if (!videoId || !item.title) return null;
   const uploadedMs = item.uploaded && item.uploaded > 0 ? item.uploaded : undefined;
   const channelId = extractPipedChannelId(item.uploaderUrl);
+  const poster = item.thumbnail ?? youtubeThumbnailUrl(videoId);
   return {
     id: toYoutubeVideoCatalogId(videoId),
     type: "movie",
     title: item.title,
     year: uploadedMs ? String(new Date(uploadedMs).getUTCFullYear()) : undefined,
     overview: item.shortDescription ?? "",
-    posterPath: item.thumbnail ?? null,
+    posterPath: poster,
     metadataSource: "Piped",
     durationSeconds: item.duration,
     channelTitle: item.uploaderName,
@@ -150,8 +154,8 @@ export function mapPipedSearchItem(item: PipedSearchItem): ProviderSearchResult 
       ...(channelId ? { youtubeChannelId: channelId } : {}),
     },
     artwork: {
-      posterUrl: item.thumbnail,
-      thumbnailUrl: item.thumbnail,
+      posterUrl: poster,
+      thumbnailUrl: poster,
     },
   };
 }
@@ -179,7 +183,7 @@ export function mapInvidiousRecommendedVideo(
   const videoId = item.videoId?.trim();
   const title = item.title?.trim();
   if (!videoId || !title) return null;
-  const poster = pickInvidiousThumbnail(item.videoThumbnails);
+  const poster = pickInvidiousThumbnail(item.videoThumbnails) ?? youtubeThumbnailUrl(videoId);
   return {
     id: toYoutubeVideoCatalogId(videoId),
     type: "movie",
@@ -199,12 +203,10 @@ export function mapInvidiousRecommendedVideo(
       youtubeId: videoId,
       ...(item.authorId ? { youtubeChannelId: item.authorId } : {}),
     },
-    artwork: poster
-      ? {
-          posterUrl: poster,
-          thumbnailUrl: poster,
-        }
-      : undefined,
+    artwork: {
+      posterUrl: poster,
+      thumbnailUrl: poster,
+    },
   };
 }
 

--- a/packages/providers/src/youtube/subtitle-language.ts
+++ b/packages/providers/src/youtube/subtitle-language.ts
@@ -102,6 +102,57 @@ export function buildYoutubeSubtitlePreferencePlan(
   };
 }
 
+/**
+ * Hard ceiling on attached subtitle tracks.
+ *
+ * A backstop, not the primary filter: if YouTube adds a new caption family the
+ * language rules below do not anticipate, the picker still stays usable.
+ */
+const MAX_ATTACHED_SUBTITLE_TRACKS = 25;
+
+/** Does a yt-dlp caption language tag answer to the configured language? */
+function matchesPreferredLanguage(language: string, preferred: string): boolean {
+  // yt-dlp tags look like `en`, `en-US`, `en-orig`, `eng`, `zh-Hans`.
+  const base = language.trim().toLowerCase().split(/[-_]/)[0] ?? "";
+  if (!base) return false;
+  const normalized = normalizeSubtitleLanguage(base) ?? base;
+  return normalized === preferred || base === preferred || ISO_639_2_ALIASES[preferred] === base;
+}
+
+/** Is this the video's own caption track rather than a machine translation of it? */
+function isOriginalLanguageTrack(language: string): boolean {
+  return language.trim().toLowerCase().endsWith("-orig");
+}
+
+/**
+ * Bound the attached subtitle inventory to tracks a person might actually pick.
+ *
+ * YouTube auto-translates captions into ~160 languages and yt-dlp faithfully reports
+ * every one, so attaching them all buried the two or three useful tracks in a list
+ * nobody can scroll (157 machine translations on a typical video). Manual tracks are
+ * human-authored and few, so they are always kept; machine translations are kept only
+ * for the configured language, plus the video's own original-language track.
+ */
+export function boundYoutubeSubtitleTracks<
+  T extends { readonly language: string; readonly source: "manual" | "auto" },
+>(tracks: readonly T[], preference: string | undefined): readonly T[] {
+  const plan = buildYoutubeSubtitlePreferencePlan(preference);
+  if (plan.mpvSlang === "no") return [];
+
+  // `original` carries no language of its own; English is the floor when nothing
+  // is configured, so a default install still gets captions rather than none.
+  const preferred =
+    plan.preferLanguage && plan.preferLanguage !== "original" ? plan.preferLanguage : "en";
+
+  const kept = tracks.filter(
+    (track) =>
+      track.source === "manual" ||
+      isOriginalLanguageTrack(track.language) ||
+      matchesPreferredLanguage(track.language, preferred),
+  );
+  return kept.slice(0, MAX_ATTACHED_SUBTITLE_TRACKS);
+}
+
 /** Map user subtitle prefs to mpv slang + yt-dlp sub-langs. */
 export function toYoutubeSubtitlePreferenceTokens(
   preference: string | undefined,

--- a/packages/providers/src/youtube/ytdl-options.ts
+++ b/packages/providers/src/youtube/ytdl-options.ts
@@ -9,6 +9,43 @@ export type YoutubeYtdlOptionsInput = {
   readonly subtitleLanguage?: string;
 };
 
+const PLAYER_CLIENT_PATTERN = /(^|;)\s*youtube:([^;]*\b)?player_client=([^;]*)/i;
+
+/**
+ * The player clients an extractor-args string asks for, in order.
+ *
+ * Each client is a separate way of asking YouTube for the same video, and they
+ * fail independently — one 403s on media URLs while another plays. Naming them
+ * individually is what lets playback fail over between them instead of dying on
+ * whichever one yt-dlp happened to pick.
+ */
+export function parseYoutubePlayerClients(extractorArgs: string | undefined): readonly string[] {
+  const match = extractorArgs?.match(PLAYER_CLIENT_PATTERN);
+  if (!match?.[3]) return [];
+  return [
+    ...new Set(
+      match[3]
+        .split(",")
+        .map((client) => client.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+/** Rewrite extractor args to request exactly one player client, preserving other keys. */
+export function withYoutubePlayerClient(extractorArgs: string | undefined, client: string): string {
+  const trimmed = extractorArgs?.trim();
+  if (!trimmed) return `youtube:player_client=${client}`;
+  if (!PLAYER_CLIENT_PATTERN.test(trimmed)) {
+    return `${trimmed};youtube:player_client=${client}`;
+  }
+  return trimmed.replace(
+    PLAYER_CLIENT_PATTERN,
+    (_full, lead: string, prefix: string | undefined) =>
+      `${lead}youtube:${prefix ?? ""}player_client=${client}`,
+  );
+}
+
 /** Build yt-dlp CLI args shared by metadata extract, download, and mpv raw-options. */
 export function buildYoutubeYtdlCliArgs(options: YoutubeYtdlOptionsInput): string[] {
   const args: string[] = [];

--- a/packages/providers/test/youtube/ids.test.ts
+++ b/packages/providers/test/youtube/ids.test.ts
@@ -6,6 +6,7 @@ import {
   isYoutubeWatchUrl,
   parseYoutubeCatalogId,
   toYoutubeChannelCatalogId,
+  youtubeThumbnailUrl,
 } from "@kunai/providers/youtube";
 
 describe("youtube ids", () => {
@@ -38,5 +39,17 @@ describe("youtube ids", () => {
     expect(isYoutubeCollectionCatalogId("youtube-channel:UC123")).toBe(true);
     expect(isYoutubeCollectionCatalogId("youtube-playlist:PL123")).toBe(true);
     expect(isYoutubeCollectionCatalogId("youtube:abc12345678")).toBe(false);
+  });
+
+  test("youtubeThumbnailUrl derives a CDN poster from a video id alone", () => {
+    expect(youtubeThumbnailUrl("0v1MKQDr7d8")).toBe(
+      "https://i.ytimg.com/vi/0v1MKQDr7d8/hqdefault.jpg",
+    );
+  });
+
+  test("youtubeThumbnailUrl escapes ids so they cannot break out of the path", () => {
+    expect(youtubeThumbnailUrl("../../evil")).toBe(
+      "https://i.ytimg.com/vi/..%2F..%2Fevil/hqdefault.jpg",
+    );
   });
 });

--- a/packages/providers/test/youtube/invidious-instance-pool.test.ts
+++ b/packages/providers/test/youtube/invidious-instance-pool.test.ts
@@ -6,6 +6,65 @@ import {
   pickInvidiousInstance,
 } from "@kunai/providers/youtube";
 
+describe("invidious instance reachability", () => {
+  // Upstream now reports every working clearnet instance as `api: false`, while
+  // every `api: null` entry is a non-routable overlay-network address. Selecting
+  // on `api` alone therefore keeps only the hosts a normal machine cannot reach.
+  const UPSTREAM_SHAPE = JSON.stringify([
+    ["invidious.nerdvpn.de", { api: false, uri: "https://invidious.nerdvpn.de" }],
+    ["inv.nadeko.net", { api: false, uri: "https://inv.nadeko.net" }],
+    ["inv.nadeko.ygg", { api: null, uri: "https://inv.nadeko.ygg" }],
+    ["nadeko.b32.i2p", { api: null, uri: "http://nadeko.b32.i2p" }],
+    ["invidious-nerdvpn.i2p", { api: null, uri: "http://invidious-nerdvpn.i2p" }],
+    ["nadeko.onion", { api: null, uri: "http://nadeko.onion" }],
+  ]);
+
+  // The pool caches the fetched list for 15 minutes in module scope, so each
+  // case advances the clock past that window and stays below the later
+  // "invidious instance pool" cases, which would otherwise read this fixture.
+  async function fetchWith(body: string, now: number) {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(body, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof fetch;
+    try {
+      return await fetchHealthyInvidiousInstances({
+        instancesUrl: `https://fixtures.test/instances-${now}.json`,
+        now: () => now,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }
+
+  test("keeps reachable clearnet instances and drops overlay-network hosts", async () => {
+    const instances = await fetchWith(UPSTREAM_SHAPE, 1_800_000_000_000);
+    expect(instances).toEqual(["https://invidious.nerdvpn.de", "https://inv.nadeko.net"]);
+  });
+
+  test("never returns a .onion, .i2p or .ygg address", async () => {
+    const instances = await fetchWith(UPSTREAM_SHAPE, 1_800_002_000_000);
+    expect(instances.length).toBeGreaterThan(0);
+    for (const instance of instances) {
+      expect(instance).not.toMatch(/\.(onion|i2p|ygg)$/);
+    }
+  });
+
+  test("prefers api-enabled hosts when upstream marks any clearnet host api:true", async () => {
+    const instances = await fetchWith(
+      JSON.stringify([
+        ["quiet.invidious.test", { api: false, uri: "https://quiet.invidious.test" }],
+        ["loud.invidious.test", { api: true, uri: "https://loud.invidious.test" }],
+        ["hidden.onion", { api: true, uri: "http://hidden.onion" }],
+      ]),
+      1_800_004_000_000,
+    );
+    expect(instances).toEqual(["https://loud.invidious.test"]);
+  });
+});
+
 describe("invidious instance pool", () => {
   test("preferredInstanceUrl normalizes custom instance", async () => {
     const instances = await fetchHealthyInvidiousInstances({

--- a/packages/providers/test/youtube/resolve-youtube.fixture.test.ts
+++ b/packages/providers/test/youtube/resolve-youtube.fixture.test.ts
@@ -97,4 +97,92 @@ describe("resolveYoutube", () => {
     expect(selected?.requiresYtdl).toBe(true);
     expect(result.streams.length).toBeGreaterThan(0);
   });
+
+  /**
+   * Each configured player client becomes its own source. Clients fail
+   * independently — one answers 403 on media URLs while another plays the same
+   * video — so this is what lets startup source failover retry a different client
+   * instead of ending playback.
+   */
+  describe("player-client failover lanes", () => {
+    function seedMetadataCache() {
+      const cache = new Map<string, unknown>();
+      const seeded = normalizeYtDlpVideoInfo(
+        {
+          id: FIXTURE_VIDEO_ID,
+          title: "Me at the zoo",
+          duration: 19,
+          formats: [{ format_id: "18", height: 360, vcodec: "avc1", acodec: "mp4a", tbr: 500 }],
+        },
+        FIXTURE_VIDEO_ID,
+      );
+      return {
+        get: (videoId: string) => (videoId === FIXTURE_VIDEO_ID ? seeded : cache.get(videoId)),
+        set: (videoId: string, info: unknown) => {
+          cache.set(videoId, info);
+        },
+      } as never;
+    }
+
+    test("one source per configured client, each carrying only its own client", async () => {
+      if (!Bun.which("yt-dlp")) return;
+      configureYoutubeProvider({
+        metadataCache: seedMetadataCache(),
+        extractorArgs: "youtube:player_client=mweb,tv_simply",
+      });
+
+      const resolve = youtubeProviderModule.resolve;
+      if (!resolve) throw new Error("YouTube provider resolve adapter is not configured");
+      const result = await resolve(buildResolveInput(), TEST_CONTEXT);
+
+      expect(result.status).toBe("resolved");
+      expect(result.sources.map((source) => source.id)).toEqual([
+        "source:youtube:mweb",
+        "source:youtube:tv_simply",
+      ]);
+      // Exactly one selected lane; the rest are failover candidates.
+      expect(result.sources.filter((source) => source.status === "selected")).toHaveLength(1);
+
+      const args = result.streams.map(
+        (stream) => (stream.metadata as { extractorArgs?: string }).extractorArgs,
+      );
+      expect(args).toContain("youtube:player_client=mweb");
+      expect(args).toContain("youtube:player_client=tv_simply");
+      // A lane must never carry the full multi-client list, or failover is a no-op.
+      expect(args.some((value) => value?.includes(","))).toBe(false);
+    });
+
+    test("each quality variant lists every lane so a chosen quality can still fail over", async () => {
+      if (!Bun.which("yt-dlp")) return;
+      configureYoutubeProvider({
+        metadataCache: seedMetadataCache(),
+        extractorArgs: "youtube:player_client=mweb,tv_simply",
+      });
+
+      const resolve = youtubeProviderModule.resolve;
+      if (!resolve) throw new Error("YouTube provider resolve adapter is not configured");
+      const result = await resolve(buildResolveInput(), TEST_CONTEXT);
+
+      expect(result.variants?.length).toBeGreaterThan(0);
+      for (const variant of result.variants ?? []) {
+        expect(variant.streamIds).toHaveLength(2);
+        expect(new Set(variant.streamIds).size).toBe(2);
+      }
+    });
+
+    test("a single configured client stays a single source", async () => {
+      if (!Bun.which("yt-dlp")) return;
+      configureYoutubeProvider({
+        metadataCache: seedMetadataCache(),
+        extractorArgs: "youtube:player_client=mweb",
+      });
+
+      const resolve = youtubeProviderModule.resolve;
+      if (!resolve) throw new Error("YouTube provider resolve adapter is not configured");
+      const result = await resolve(buildResolveInput(), TEST_CONTEXT);
+
+      expect(result.sources).toHaveLength(1);
+      expect(result.sources[0]?.id).toBe("source:youtube:mweb");
+    });
+  });
 });

--- a/packages/providers/test/youtube/resolve-youtube.fixture.test.ts
+++ b/packages/providers/test/youtube/resolve-youtube.fixture.test.ts
@@ -136,12 +136,12 @@ describe("resolveYoutube", () => {
       const result = await resolve(buildResolveInput(), TEST_CONTEXT);
 
       expect(result.status).toBe("resolved");
-      expect(result.sources.map((source) => source.id)).toEqual([
+      expect(result.sources?.map((source) => source.id)).toEqual([
         "source:youtube:mweb",
         "source:youtube:tv_simply",
       ]);
       // Exactly one selected lane; the rest are failover candidates.
-      expect(result.sources.filter((source) => source.status === "selected")).toHaveLength(1);
+      expect(result.sources?.filter((source) => source.status === "selected")).toHaveLength(1);
 
       const args = result.streams.map(
         (stream) => (stream.metadata as { extractorArgs?: string }).extractorArgs,
@@ -182,7 +182,7 @@ describe("resolveYoutube", () => {
       const result = await resolve(buildResolveInput(), TEST_CONTEXT);
 
       expect(result.sources).toHaveLength(1);
-      expect(result.sources[0]?.id).toBe("source:youtube:mweb");
+      expect(result.sources?.[0]?.id).toBe("source:youtube:mweb");
     });
   });
 });

--- a/packages/providers/test/youtube/subtitle-language.test.ts
+++ b/packages/providers/test/youtube/subtitle-language.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  boundYoutubeSubtitleTracks,
   buildYoutubeSubtitlePreferencePlan,
   toYoutubeSubtitlePreferenceTokens,
 } from "../../src/youtube/subtitle-language";
@@ -49,5 +50,67 @@ describe("toYoutubeSubtitlePreferenceTokens", () => {
       mpvSlang: "no",
       ytdlpSubLangs: null,
     });
+  });
+});
+
+describe("boundYoutubeSubtitleTracks", () => {
+  type Track = { readonly language: string; readonly source: "manual" | "auto" };
+
+  /** Shape of a real video: a couple of human tracks under ~157 machine translations. */
+  const REAL_WORLD: readonly Track[] = [
+    { language: "en", source: "manual" },
+    { language: "ja", source: "manual" },
+    { language: "en-orig", source: "auto" },
+    { language: "en", source: "auto" },
+    { language: "en-US", source: "auto" },
+    ...Array.from({ length: 157 }, (_, index) => ({
+      language: `mt${index}`,
+      source: "auto" as const,
+    })),
+  ];
+
+  test("keeps every human-authored track and drops the machine-translation flood", () => {
+    const bounded = boundYoutubeSubtitleTracks(REAL_WORLD, "en");
+
+    expect(bounded.filter((track) => track.source === "manual")).toHaveLength(2);
+    expect(bounded.some((track) => track.language.startsWith("mt"))).toBe(false);
+    expect(bounded).toHaveLength(5);
+  });
+
+  test("keeps the original-language track even when it is not the preferred language", () => {
+    const bounded = boundYoutubeSubtitleTracks(REAL_WORLD, "de");
+    expect(bounded.map((track) => track.language)).toContain("en-orig");
+  });
+
+  test("matches regional and ISO 639-2 spellings of the preferred language", () => {
+    const tracks: readonly Track[] = [
+      { language: "en-GB", source: "auto" },
+      { language: "eng", source: "auto" },
+      { language: "fr", source: "auto" },
+    ];
+    expect(boundYoutubeSubtitleTracks(tracks, "en").map((track) => track.language)).toEqual([
+      "en-GB",
+      "eng",
+    ]);
+  });
+
+  test("falls back to English when no language is configured", () => {
+    const tracks: readonly Track[] = [
+      { language: "en", source: "auto" },
+      { language: "fr", source: "auto" },
+    ];
+    expect(boundYoutubeSubtitleTracks(tracks, undefined).map((t) => t.language)).toEqual(["en"]);
+  });
+
+  test("attaches nothing when subtitles are turned off", () => {
+    expect(boundYoutubeSubtitleTracks(REAL_WORLD, "none")).toEqual([]);
+  });
+
+  test("caps the inventory even if every track somehow qualifies", () => {
+    const tracks: readonly Track[] = Array.from({ length: 200 }, (_, index) => ({
+      language: `manual${index}`,
+      source: "manual" as const,
+    }));
+    expect(boundYoutubeSubtitleTracks(tracks, "en")).toHaveLength(25);
   });
 });

--- a/packages/providers/test/youtube/ytdl-options.test.ts
+++ b/packages/providers/test/youtube/ytdl-options.test.ts
@@ -71,4 +71,17 @@ describe("youtube ytdl options", () => {
     const args = buildYoutubeYtdlCliArgs({ subtitleLanguage: "none" });
     expect(args).not.toContain("--sub-langs");
   });
+
+  test("a multi-client extractor-args value reaches both yt-dlp and mpv intact", () => {
+    const extractorArgs = "youtube:player_client=mweb,tv_simply";
+
+    const args = buildYoutubeYtdlCliArgs({ extractorArgs });
+    expect(args).toContain("--extractor-args");
+    expect(args).toContain(extractorArgs);
+
+    // mpv sub-option values are length-prefixed; a miscount silently truncates the
+    // client list back toward yt-dlp's own default, which is the 403-ing one.
+    const joined = joinMpvYtdlRawOptions(buildYoutubeMpvYtdlRawOptions({ extractorArgs }));
+    expect(joined).toContain(`extractor-args=%${extractorArgs.length}%${extractorArgs}`);
+  });
 });

--- a/packages/providers/test/youtube/ytdl-options.test.ts
+++ b/packages/providers/test/youtube/ytdl-options.test.ts
@@ -6,6 +6,8 @@ import {
   buildYoutubeYtdlCliArgs,
   joinMpvScriptOpts,
   joinMpvYtdlRawOptions,
+  parseYoutubePlayerClients,
+  withYoutubePlayerClient,
 } from "@kunai/providers/youtube";
 
 describe("youtube ytdl options", () => {
@@ -70,6 +72,28 @@ describe("youtube ytdl options", () => {
   test("skips sub-langs when subtitles are disabled", () => {
     const args = buildYoutubeYtdlCliArgs({ subtitleLanguage: "none" });
     expect(args).not.toContain("--sub-langs");
+  });
+
+  test("parseYoutubePlayerClients reads the requested clients in order", () => {
+    expect(parseYoutubePlayerClients("youtube:player_client=mweb,tv_simply")).toEqual([
+      "mweb",
+      "tv_simply",
+    ]);
+    expect(parseYoutubePlayerClients("youtube:player_client=mweb,mweb")).toEqual(["mweb"]);
+    expect(parseYoutubePlayerClients("youtube:skip=hls")).toEqual([]);
+    expect(parseYoutubePlayerClients(undefined)).toEqual([]);
+  });
+
+  test("withYoutubePlayerClient narrows to one client and keeps other keys", () => {
+    expect(withYoutubePlayerClient("youtube:player_client=mweb,tv_simply", "tv_simply")).toBe(
+      "youtube:player_client=tv_simply",
+    );
+    // A user's unrelated extractor args must survive the rewrite.
+    expect(withYoutubePlayerClient("youtube:skip=hls", "mweb")).toBe(
+      "youtube:skip=hls;youtube:player_client=mweb",
+    );
+    expect(withYoutubePlayerClient(undefined, "mweb")).toBe("youtube:player_client=mweb");
+    expect(withYoutubePlayerClient("", "mweb")).toBe("youtube:player_client=mweb");
   });
 
   test("a multi-client extractor-args value reaches both yt-dlp and mpv intact", () => {


### PR DESCRIPTION
0.3.0 headlines the YouTube lane, and the lane did not work. Three independent
defects, none caught by CI or by `test:live:youtube` — whose fixture is "Me at
the zoo" (2005), a video old enough to dodge all three.

## The three defects

**Search took ~45s before falling back.** The Invidious pool selected instances
on upstream's `api` flag. That flag has inverted: every working clearnet
instance now reports `api: false`, while the `api: null` entries are Tor, I2P
and Yggdrasil addresses. The filter therefore discarded all five reachable
instances and kept six with no route, so each search burned three 15s timeouts.
Reachability is now the hard filter and `api` only a preference — applied when
it selects something, ignored when it does not, which stays correct whichever
way upstream flips next.

**Every search result had an empty poster.** `yt-dlp --flat-playlist` returns
`thumbnail: null` (the images live in a `thumbnails[]` array it does not
flatten), and that lane serves every search once Invidious fails. Video results
now fall back to the `i.ytimg.com` URL derived from the video id, which needs no
lookup and cannot be missing. A tell-tale that you were on this path: exactly 12
results, the `ytsearch` limit.

**Playback failed with "Playback failed on this stream".** yt-dlp 2026.07.04
(current latest — updating does not help) leads with ANDROID_VR, whose media
URLs answer 403. Extraction succeeds, so nothing fails until mpv opens the
stream.

## Making the third one stay fixed

A hardcoded client is a guess with a shelf life, so each configured player
client is now its own resolve source carrying the extractor args that select it,
and every quality variant lists that quality's stream in all lanes. Startup
source failover already walks an ordered source list before hopping providers,
so it now retries the next client on a dead stream — no new failover machinery.
With one client configured the shape is exactly as before.

## Also here

- **Subtitles bounded.** A typical video attached 157 machine translations,
  burying the useful tracks. Human-authored tracks are always kept; translations
  only for the configured language, plus the original-language track, under a
  hard cap. (`--extractor-args skip=translated_subs` was measured first and does
  not reduce the set.)
- **PO Token readiness surfaced.** YouTube requires a Proof-of-Origin token for
  media requests on most clients and yt-dlp cannot mint one. Diagnostics now
  report whether a provider plugin is loaded — this is the usual reason a
  resolve succeeds and playback then 403s.
- **Workspace lint to zero.** Three `no-unassigned-import` warnings on
  deliberate load-order-sensitive side-effect imports in `analytics-ingest`,
  suppressed at the line rather than restructuring the code.

## Evidence

Client behaviour was measured through yt-dlp's own downloader, so requests carry
the originating client's headers — a raw `curl` of a media URL gives false 403s
regardless of client, which is a trap worth knowing. Reproducible 2/2 per client
across two videos:

| client | `0v1MKQDr7d8` | `dQw4w9WgXcQ` |
| --- | --- | --- |
| `default` | 403 | 403 |
| `web_safari` | no format | ok |
| `mweb` | ok | ok |
| `tv_simply` | ok | ok |

Gate: 4552 unit, 109 integration, 359 provider, 0 failures; typecheck, lint
(0 warnings, 0 errors) and format clean; `test:live:youtube` green.

## Still open

`test:live:youtube` remains pinned to the 2005 fixture and asserts only that
resolution produced a watch URL — it never proves a modern video plays. That is
why all three defects shipped. Worth fixing before the next release.

https://claude.ai/code/session_01KV1zeNg3HFPyZ2aXvj51Uk
