### PR TITLE
fix(docs): ship the repo files the site reads, and rename the telemetry route

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,8 +392,8 @@ page or in-app `?` over duplicating chords here.
 | `/history`        | Watch history and resume                                   |
 | `/diagnostics`    | Runtime snapshot and recent events                         |
 | `/presence`       | Discord Rich Presence setup                                |
-| `/telemetry`      | Opt-in anonymous usage ping status / toggle                |
-| `/telemetry show` | Print the exact JSON that would be sent                    |
+| `/analytics`      | Opt-in anonymous usage ping status / toggle                |
+| `/analytics show` | Print the exact JSON that would be sent                    |
 
 ---
 
@@ -472,12 +472,13 @@ shows what you're watching:
 - `kunai --debug` for verbose traces during troubleshooting.
 - `/export-diagnostics` generates a redacted JSON snapshot for issue reports.
 - `/report-issue` opens GitHub issue triage guidance.
-- Opt-in telemetry (`/telemetry`) is off until you consent. Fresh installs send
-  nothing. When enabled, the ping is `{ installId, version, os, arch, ts }` only —
-  never titles, queries, providers, URLs, or paths. Preview with `/telemetry show`.
+- Opt-in usage analytics (`/analytics`) is off until you consent. Fresh installs
+  send nothing. When enabled, the ping is `{ installId, version, os, arch, ts }`
+  only — never titles, queries, providers, URLs, or paths. Preview with
+  `/analytics show`.
   Honour `DO_NOT_TRACK=1` / `CI=true` as hard blocks on send and enable.
   The ingest stores HMAC-hashed ids for daily/lifetime aggregates only; public
-  docs may show yesterday’s opt-in actives and an approximate lifetime total.
+  docs may show yesterday’s opt-in actives and an exact lifetime total.
 - Kunai checks for a newer published version on startup and notifies you in-shell — updating is a quick reinstall (see [Uninstall](#uninstall) / [Quick Start](#quick-start)).
 
 ---

--- a/apps/docs/app/analytics/layout.tsx
+++ b/apps/docs/app/analytics/layout.tsx
@@ -2,6 +2,6 @@ import { baseOptions } from "@/lib/layout.shared";
 import { HomeLayout } from "fumadocs-ui/layouts/home";
 import type { ReactNode } from "react";
 
-export default function TelemetryLayout({ children }: { readonly children: ReactNode }) {
+export default function AnalyticsLayout({ children }: { readonly children: ReactNode }) {
   return <HomeLayout {...baseOptions()}>{children}</HomeLayout>;
 }

--- a/apps/docs/app/analytics/page.tsx
+++ b/apps/docs/app/analytics/page.tsx
@@ -10,19 +10,19 @@ export const metadata: Metadata = {
   description:
     "See Kunai’s public usage pulse, the exact optional ping payload, and its privacy limits.",
   alternates: {
-    canonical: `${docsSiteUrl}/telemetry`,
+    canonical: `${docsSiteUrl}/analytics`,
   },
   openGraph: {
     title: "Kunai usage analytics",
     description:
       "Public aggregate counts only — never titles, queries, or install UUIDs on this page.",
-    url: `${docsSiteUrl}/telemetry`,
+    url: `${docsSiteUrl}/analytics`,
     type: "website",
     siteName: "Kunai Docs",
   },
 };
 
-export default async function TelemetryPage() {
+export default async function AnalyticsPage() {
   const metrics = await fetchDocsAnalyticsMetrics();
 
   return (

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -14,6 +14,7 @@
 @import "./styles/surfaces.css";
 @import "./styles/docs-chrome.css";
 @import "./styles/home.css";
+@import "./styles/charts.css";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 

--- a/apps/docs/app/llms.txt/route.ts
+++ b/apps/docs/app/llms.txt/route.ts
@@ -31,7 +31,7 @@ export async function GET() {
         `- [${release.title}](${docsSiteUrl}${releasePath(release.tag)}): ${release.tag}`,
     ),
     `- [Feedback](${docsSiteUrl}/feedback): File bugs, provider issues, and feature requests on GitHub`,
-    `- [Usage analytics](${docsSiteUrl}/telemetry): Public usage pulse and opt-in rules`,
+    `- [Usage analytics](${docsSiteUrl}/analytics): Public usage pulse and opt-in rules`,
     "",
   ];
 

--- a/apps/docs/app/opengraph-image.tsx
+++ b/apps/docs/app/opengraph-image.tsx
@@ -2,16 +2,20 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { KunaiSocialCard } from "@/lib/brand/social-card";
+import { repoRoot } from "@/lib/repo-root";
 import { ImageResponse } from "next/og";
 
 export const alt = "Kunai Docs — terminal-first playback guides";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
+const MASCOT = ".reference/design/brand/kunai-mascot-og.png";
+
 function mascotDataUrl(): string | undefined {
   try {
-    const pngPath = join(process.cwd(), "../../.reference/design/brand/kunai-mascot-og.png");
-    const png = readFileSync(pngPath);
+    // repoRoot probes for the marker instead of assuming cwd is apps/docs —
+    // cwd is the app dir during `next build` but not inside a deployed function.
+    const png = readFileSync(join(repoRoot(MASCOT), MASCOT));
     return `data:image/png;base64,${png.toString("base64")}`;
   } catch {
     return undefined;

--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -26,7 +26,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.6,
     },
     {
-      url: `${docsSiteUrl}/telemetry`,
+      url: `${docsSiteUrl}/analytics`,
       changeFrequency: "daily",
       priority: 0.55,
     },

--- a/apps/docs/app/styles/charts.css
+++ b/apps/docs/app/styles/charts.css
@@ -1,0 +1,131 @@
+/*
+ * Chart tokens.
+ *
+ * The docs shell is dark-only today (`forcedTheme: "dark"`), but a chart that
+ * only exists in one mode is a chart that breaks the day a theme switch ships.
+ * Light is the `:root` default; `:root.dark` and the OS preference both restage
+ * the same roles for the dark surface. Every value is measured against the
+ * surface it actually renders on, not flipped:
+ *
+ *   dark  — series #ff8fb0 on #1c1620 = 8.3:1 · residual #968a98 = 5.4:1
+ *   light — series #c14a71 on #fcfcfb = 4.6:1 · residual #8b8391 = 3.6:1
+ *
+ * One hue per chart: these breakdowns are single-series nominal magnitude, so
+ * every bar wears the same slot. The residual "other" bucket is not a category,
+ * so it drops to the de-emphasis gray instead of claiming a second hue.
+ */
+:root {
+  --kunai-chart-surface: var(--kunai-surface);
+  --kunai-chart-series: #c14a71;
+  --kunai-chart-residual: #8b8391;
+  --kunai-chart-axis: #e1e0d9;
+}
+
+:root.dark {
+  --kunai-chart-series: var(--kunai-accent);
+  --kunai-chart-residual: var(--color-fd-muted-foreground);
+  --kunai-chart-axis: var(--kunai-line);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not(.light) {
+    --kunai-chart-series: var(--kunai-accent);
+    --kunai-chart-residual: var(--color-fd-muted-foreground);
+    --kunai-chart-axis: var(--kunai-line);
+  }
+}
+
+/*
+ * Ranked horizontal bars. Table semantics — the printed value beside each bar
+ * IS the table view — but none of the page's editorial table chrome. The
+ * `.kunai-home table` rules (serif small caps, boxed cells, `!important`
+ * padding) turn a chart into a data grid, so they are reset here; the element
+ * qualifier matches their specificity and charts.css is imported last.
+ */
+table.kunai-chart {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+  border: 0;
+  margin: 0;
+  background: none;
+  border-radius: 0;
+}
+
+table.kunai-chart th,
+table.kunai-chart td {
+  padding: 0.3125rem 0 !important;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: none;
+  vertical-align: middle;
+}
+
+.kunai-chart-row {
+  transition: background-color var(--dur-press) var(--ease-out);
+}
+
+table.kunai-chart tr.kunai-chart-row:hover td,
+table.kunai-chart tr.kunai-chart-row:hover th {
+  color: inherit;
+  background-color: color-mix(in oklab, var(--kunai-chart-series) 8%, transparent);
+}
+
+/* Column widths: labels and values are fixed so the plot keeps the remainder. */
+.kunai-chart-col-label {
+  width: 5.5rem;
+}
+
+.kunai-chart-col-value {
+  width: 3.25rem;
+}
+
+.kunai-chart-col-share {
+  width: 2.5rem;
+}
+
+/* Plot column: a hairline baseline, then bars growing from it. */
+.kunai-chart-plot {
+  padding-left: 0.75rem !important;
+  padding-right: 0.625rem !important;
+  border-left: 1px solid var(--kunai-chart-axis) !important;
+}
+
+.kunai-chart-bar {
+  height: 10px;
+  min-width: 2px;
+  /* Square at the baseline, 4px rounded at the data end. */
+  border-radius: 0 4px 4px 0;
+  background-color: var(--kunai-chart-series);
+}
+
+.kunai-chart-bar[data-residual="true"] {
+  background-color: var(--kunai-chart-residual);
+}
+
+/*
+ * Forced-colors and print have no hue channel at all. Keep the bars readable as
+ * geometry: an outline plus a 45°/135° hatch so the residual stays distinct.
+ */
+@media (forced-colors: active), print {
+  .kunai-chart-bar {
+    outline: 1px solid currentColor;
+    background-color: transparent;
+    background-image: repeating-linear-gradient(
+      45deg,
+      currentColor 0 1px,
+      transparent 1px 4px
+    );
+  }
+
+  .kunai-chart-bar[data-residual="true"] {
+    background-image: repeating-linear-gradient(
+      135deg,
+      currentColor 0 1px,
+      transparent 1px 6px
+    );
+  }
+}

--- a/apps/docs/app/styles/charts.css
+++ b/apps/docs/app/styles/charts.css
@@ -114,18 +114,10 @@ table.kunai-chart tr.kunai-chart-row:hover th {
   .kunai-chart-bar {
     outline: 1px solid currentColor;
     background-color: transparent;
-    background-image: repeating-linear-gradient(
-      45deg,
-      currentColor 0 1px,
-      transparent 1px 4px
-    );
+    background-image: repeating-linear-gradient(45deg, currentColor 0 1px, transparent 1px 4px);
   }
 
   .kunai-chart-bar[data-residual="true"] {
-    background-image: repeating-linear-gradient(
-      135deg,
-      currentColor 0 1px,
-      transparent 1px 6px
-    );
+    background-image: repeating-linear-gradient(135deg, currentColor 0 1px, transparent 1px 6px);
   }
 }

--- a/apps/docs/components/analytics/share-bars.tsx
+++ b/apps/docs/components/analytics/share-bars.tsx
@@ -1,0 +1,98 @@
+import { rankShareBuckets, type ShareBucket } from "@/lib/analytics-metrics";
+
+/**
+ * A ranked horizontal bar chart for one breakdown of the usage snapshot.
+ *
+ * Form: the data's job is "compare magnitude across a handful of named
+ * buckets", so it is a bar chart, not a stacked ribbon — a single stack of
+ * same-coloured segments (what this page shipped before) encodes identity in
+ * nothing at all and makes every bucket unreadable.
+ *
+ * It renders as a real `<table>`: the value beside every bar is the chart's own
+ * table view, so nothing here is reachable only through colour.
+ */
+
+function formatShare(share: number): string {
+  const percent = share * 100;
+  if (percent > 0 && percent < 1) return "<1%";
+  return `${Math.round(percent)}%`;
+}
+
+function ShareRow({ bucket }: { readonly bucket: ShareBucket }) {
+  return (
+    <tr className="kunai-chart-row">
+      <th
+        scope="row"
+        className={`truncate text-left text-xs ${
+          bucket.residual ? "text-muted-foreground" : "text-foreground font-medium"
+        }`}
+      >
+        {bucket.label}
+      </th>
+      {/*
+        Decorative: the bar restates the count and percentage cells that follow,
+        so a screen reader gets the full row without it. Hidden rather than
+        labelled, which would read every value twice.
+      */}
+      <td className="kunai-chart-plot" aria-hidden="true">
+        <div
+          className="kunai-chart-bar"
+          data-residual={bucket.residual}
+          style={{ width: `${Math.max(bucket.share * 100, 0.6)}%` }}
+        />
+      </td>
+      <td className="text-foreground text-right text-xs tabular-nums">
+        {bucket.count.toLocaleString("en-US")}
+      </td>
+      <td className="text-muted-foreground text-right text-xs tabular-nums">
+        {formatShare(bucket.share)}
+      </td>
+    </tr>
+  );
+}
+
+export function ShareBars({
+  label,
+  counts,
+}: {
+  readonly label: string;
+  readonly counts: Readonly<Record<string, number>>;
+}) {
+  const buckets = rankShareBuckets(counts);
+
+  return (
+    <figure className="m-0 flex flex-col gap-3">
+      <figcaption className="text-muted-foreground text-[11px] font-medium tracking-[0.14em] uppercase">
+        {label}
+      </figcaption>
+      {buckets.length === 0 ? (
+        <p className="text-muted-foreground m-0 text-xs">No installs reported in this cut.</p>
+      ) : (
+        <table className="kunai-chart">
+          <caption className="sr-only">
+            {label} — installs and share of the snapshot day, largest first.
+          </caption>
+          <colgroup>
+            <col className="kunai-chart-col-label" />
+            <col />
+            <col className="kunai-chart-col-value" />
+            <col className="kunai-chart-col-share" />
+          </colgroup>
+          <thead className="sr-only">
+            <tr>
+              <th scope="col">Bucket</th>
+              <th scope="col">Relative size</th>
+              <th scope="col">Installs</th>
+              <th scope="col">Share</th>
+            </tr>
+          </thead>
+          <tbody>
+            {buckets.map((bucket) => (
+              <ShareRow bucket={bucket} key={bucket.label} />
+            ))}
+          </tbody>
+        </table>
+      )}
+    </figure>
+  );
+}

--- a/apps/docs/components/analytics/usage-panel.tsx
+++ b/apps/docs/components/analytics/usage-panel.tsx
@@ -1,3 +1,4 @@
+import { ShareBars } from "@/components/analytics/share-bars";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -37,7 +38,11 @@ function formatUpdatedAt(iso: string): string {
     .replace(/\.\d{3}Z$/, " UTC");
 }
 
-function MetricHero({
+/**
+ * The one number the page leads with. Proportional figures, UI sans — tabular
+ * digits and a serif face both read as decoration at display size.
+ */
+function HeroFigure({
   label,
   value,
   hint,
@@ -51,7 +56,7 @@ function MetricHero({
       <p className="text-muted-foreground text-[11px] font-medium tracking-[0.14em] uppercase">
         {label}
       </p>
-      <p className="text-foreground font-heading text-4xl font-semibold tracking-tight tabular-nums md:text-5xl">
+      <p className="text-foreground text-5xl leading-none font-semibold tracking-tight md:text-6xl">
         {value.toLocaleString("en-US")}
       </p>
       <p className="text-muted-foreground text-sm text-pretty">{hint}</p>
@@ -59,37 +64,24 @@ function MetricHero({
   );
 }
 
-function BreakdownBar({
+function StatTile({
   label,
-  counts,
+  value,
+  hint,
 }: {
   readonly label: string;
-  readonly counts: Readonly<Record<string, number>>;
+  readonly value: number;
+  readonly hint: string;
 }) {
-  const entries = Object.entries(counts).sort((a, b) => b[1] - a[1]);
-  const total = entries.reduce((sum, [, n]) => sum + n, 0) || 1;
-
   return (
     <div className="flex flex-col gap-2">
       <p className="text-muted-foreground text-[11px] font-medium tracking-[0.14em] uppercase">
         {label}
       </p>
-      <div className="bg-muted/40 flex h-2 w-full overflow-hidden rounded-full">
-        {entries.map(([bucket, n]) => (
-          <div
-            key={bucket}
-            className="bg-primary/70 first:rounded-l-full last:rounded-r-full"
-            style={{ width: `${(n / total) * 100}%`, opacity: bucket === "other" ? 0.35 : 1 }}
-          />
-        ))}
-      </div>
-      <ul className="text-muted-foreground flex flex-wrap gap-x-4 gap-y-1 text-xs tabular-nums">
-        {entries.map(([bucket, n]) => (
-          <li key={bucket}>
-            {bucket} <span className="text-foreground">{n}</span>
-          </li>
-        ))}
-      </ul>
+      <p className="text-foreground text-3xl leading-none font-semibold tracking-tight">
+        {value.toLocaleString("en-US")}
+      </p>
+      <p className="text-muted-foreground text-sm text-pretty">{hint}</p>
     </div>
   );
 }
@@ -97,14 +89,16 @@ function BreakdownBar({
 function BreakdownGrid({ metrics }: { readonly metrics: DocsAnalyticsMetrics }) {
   return (
     <div className="flex flex-col gap-6">
-      <div className="grid gap-6 sm:grid-cols-3">
-        <BreakdownBar label="By version" counts={metrics.byVersion} />
-        <BreakdownBar label="By OS" counts={metrics.byOs} />
-        <BreakdownBar label="By architecture" counts={metrics.byArch} />
+      <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        <ShareBars label="By version" counts={metrics.byVersion} />
+        <ShareBars label="By OS" counts={metrics.byOs} />
+        <ShareBars label="By architecture" counts={metrics.byArch} />
       </div>
       <p className="text-muted-foreground m-0 text-xs text-pretty">
-        Groups smaller than 5 installs are reported as <code className="font-mono">other</code>.
-        This small-cell suppression is applied per breakdown; it is not a joint anonymity guarantee.
+        Each breakdown counts the same installs a different way, so the three add up to the same day
+        total — they are not parts of one whole. Groups smaller than 5 installs are reported as{" "}
+        <code className="font-mono">other</code>. This small-cell suppression is applied per
+        breakdown; it is not a joint anonymity guarantee.
       </p>
     </div>
   );
@@ -264,13 +258,13 @@ export function UsagePanel({ metrics }: { readonly metrics: DocsAnalyticsMetrics
           </CardHeader>
           <CardContent className="flex flex-col gap-8 pt-2">
             {metrics.activeInstalls === 0 ? <AnalyticsZeroDayEmpty day={metrics.day} /> : null}
-            <div className="grid gap-8 md:grid-cols-2">
-              <MetricHero
+            <div className="grid items-end gap-8 md:grid-cols-2">
+              <HeroFigure
                 label="Yesterday’s active installs"
                 value={metrics.activeInstalls}
                 hint="Distinct installs that pinged on the snapshot day."
               />
-              <MetricHero
+              <StatTile
                 label="Lifetime installs"
                 value={metrics.lifetimeInstalls}
                 hint="Exact distinct installs ever seen."

--- a/apps/docs/components/home/usage-line.tsx
+++ b/apps/docs/components/home/usage-line.tsx
@@ -12,7 +12,7 @@ export async function UsageLine() {
       {" · "}
       <Link
         className="hover:text-fd-foreground underline decoration-dotted underline-offset-2"
-        href="/telemetry"
+        href="/analytics"
       >
         usage analytics
       </Link>

--- a/apps/docs/lib/analytics-metrics.ts
+++ b/apps/docs/lib/analytics-metrics.ts
@@ -85,6 +85,63 @@ export function parseDocsAnalyticsMetrics(raw: unknown): DocsAnalyticsMetrics | 
   };
 }
 
+export type ShareBucket = {
+  readonly label: string;
+  readonly count: number;
+  /** Fraction of the breakdown total, 0–1. */
+  readonly share: number;
+  /** True for the folded remainder, which is a residual and not a category. */
+  readonly residual: boolean;
+};
+
+/** The ingest's own name for the suppressed remainder. */
+const RESIDUAL_LABEL = "other";
+
+/** Visible rows before the tail folds into the residual. */
+const DEFAULT_BUCKET_LIMIT = 6;
+
+/**
+ * Rank a breakdown for display: largest first, with the ingest's suppressed
+ * `other` bucket and any folded tail pinned last as a single residual row.
+ *
+ * The residual is kept separate from the ranked categories because it is not
+ * one — it is what small-cell suppression left over, and charting it as a peer
+ * would invite reading it as a real version or platform.
+ */
+export function rankShareBuckets(
+  counts: Readonly<Record<string, number>>,
+  limit: number = DEFAULT_BUCKET_LIMIT,
+): readonly ShareBucket[] {
+  const total = Object.values(counts).reduce((sum, count) => sum + count, 0);
+  if (total <= 0) return [];
+
+  const named = Object.entries(counts)
+    .filter(([label]) => label !== RESIDUAL_LABEL)
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]));
+
+  const visible = named.slice(0, limit);
+  const foldedTail = named.slice(limit).reduce((sum, [, count]) => sum + count, 0);
+  const residual = (counts[RESIDUAL_LABEL] ?? 0) + foldedTail;
+
+  const ranked: ShareBucket[] = visible.map(([label, count]) => ({
+    label,
+    count,
+    share: count / total,
+    residual: false,
+  }));
+
+  if (residual > 0) {
+    ranked.push({
+      label: RESIDUAL_LABEL,
+      count: residual,
+      share: residual / total,
+      residual: true,
+    });
+  }
+
+  return ranked;
+}
+
 export function formatUsageLine(metrics: DocsAnalyticsMetrics): string {
   return `Installs active on ${metrics.day}: ${metrics.activeInstalls} · lifetime ${metrics.lifetimeInstalls}`;
 }

--- a/apps/docs/lib/analytics-metrics.ts
+++ b/apps/docs/lib/analytics-metrics.ts
@@ -3,7 +3,17 @@
  * Fetches aggregates only — never Redis, never install ids.
  */
 
-/** Empty until a verified analytics deployment is deliberately configured. */
+/**
+ * Empty until a verified analytics deployment is deliberately configured.
+ *
+ * `KUNAI_ANALYTICS_METRICS_URL` must be present **at build time**, not only at
+ * runtime: `/analytics` is statically prerendered, so the deployed HTML is
+ * whatever the build could fetch. Setting it as a runtime-only variable leaves
+ * the page showing "Public pulse not published yet" until the next ISR
+ * revalidation (1h) or redeploy — which reads as a broken page, not a
+ * pending one. Verified 2026-08-18: same build, URL unset renders the empty
+ * state and URL set renders the full breakdown.
+ */
 export const DEFAULT_ANALYTICS_METRICS_URL = "";
 
 export type DocsAnalyticsMetrics = {

--- a/apps/docs/lib/doc-navigation.ts
+++ b/apps/docs/lib/doc-navigation.ts
@@ -233,7 +233,7 @@ export const docNavEntries: readonly DocNavEntry[] = [
   },
   {
     title: "Usage analytics",
-    href: "/telemetry",
+    href: "/analytics",
     description: "Public usage pulse, exact ping payload, and opt-in controls.",
     group: "reference",
     surfaces: ["hub", "sidebar"],

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,10 +1,10 @@
 {
-  "syncedAt": "2026-08-16T10:38:36.708Z",
+  "syncedAt": "2026-08-18T08:59:24.146Z",
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceRevision": "520c36c1",
-  "cliSourceFingerprint": "178d0832826823139f8b53f7988cb125e7b72b8d637e4e585bca7f7af6749d91",
-  "docsContentFingerprint": "3311367d534c1c9f29cde9ecf49f75ed0f7069979b2a014b488101e3e2ad87e9",
+  "cliSourceRevision": "43cc784d",
+  "cliSourceFingerprint": "0b65d1a676ffa988d3ada7fb4a6a7b5177ebd0ac02870904f2353b0b7f61d6c5",
+  "docsContentFingerprint": "483acbc973e88226ec894a6e57466689f87a24edf9a9f884610afcb6b5a0823a",
   "featureStatusRevision": "d4c1e1d0943d18f05bca1a12a5b0ff966754a588f12e4a86a03510d2bc424c1d",
   "commandCount": 81,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],
@@ -93,7 +93,8 @@
         "Mp4 (mp4upload scrape)",
         "Luf-Mp4",
         "Ak. Filemoon is gone.",
-        "2026-08: mkissa crypto requires buildId=81 + /client-crypto/v1/bootstrap (x-aa-boot). ani-cli v5 moved primary to anidb.app."
+        "2026-08: mkissa crypto requires buildId=119 (rotated from 81) + /client-crypto/v1/bootstrap (x-aa-boot)",
+        "7-day epochs. ani-cli v5 moved primary to anidb.app."
       ]
     },
     {
@@ -111,9 +112,7 @@
         "Primary hosts: www.miruro.bz",
         "www.miruro.ru. Bare miruro.bz/.ru are 301 redirects to www. and still CF-block at the pipe path; miruro.com serves a different app shell with no /api/secure/pipe; miruro.tv/.to are TLS-dead — all stay off the resolve list.",
         "Uses Miruro pipe API with XOR/gzip decryption key 71951034f8fbcf53d89db52ceb3dc22c.",
-        "Still not the default anime auto-fallback (AniDB is the default",
-        "AllAnime the fallback); Miruro is available for manual pick when curl/http2 path works.",
-        "May hit Cloudflare rate limits if called too frequently."
+        "Not in the automatic anime lane: `animeProviderPriority` is `[anidb"
       ]
     },
     {

--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -59,7 +59,7 @@ export function baseOptions(): BaseLayoutProps {
       },
       {
         text: "Analytics",
-        url: "/telemetry",
+        url: "/analytics",
         icon: <IconRadar2 className="size-4" stroke={1.5} />,
         active: "url",
       },

--- a/apps/docs/lib/site.ts
+++ b/apps/docs/lib/site.ts
@@ -1,11 +1,32 @@
 /**
- * Public docs site origin. Set `DOCS_SITE_URL` in production for canonical URLs,
- * sitemap, and Open Graph (e.g. https://docs.kunai.example).
+ * Public docs site origin — the base for canonical URLs, the sitemap, robots,
+ * Open Graph, and `llms.txt`.
+ *
+ * `DOCS_SITE_URL` is the explicit answer and always wins. Without it a deploy
+ * used to fall straight through to `http://localhost:3000` and publish that
+ * origin in every canonical tag and sitemap entry, which is invisible locally
+ * and wrong the moment the site is hosted. The Vercel-provided origins are the
+ * honest middle ground: the production alias when the deployment has one, then
+ * the per-deployment URL for previews.
  */
-export const docsSiteUrl = (process.env.DOCS_SITE_URL ?? "http://localhost:3000").replace(
-  /\/$/,
-  "",
-);
+function resolveDocsSiteUrl(env: Record<string, string | undefined>): string {
+  const explicit = env.DOCS_SITE_URL?.trim();
+  if (explicit) return explicit;
+
+  const productionHost = env.VERCEL_PROJECT_PRODUCTION_URL?.trim();
+  if (productionHost) return `https://${productionHost}`;
+
+  const deploymentHost = env.VERCEL_URL?.trim();
+  if (deploymentHost) return `https://${deploymentHost}`;
+
+  return "http://localhost:3000";
+}
+
+export function docsSiteUrlFrom(env: Record<string, string | undefined>): string {
+  return resolveDocsSiteUrl(env).replace(/\/$/, "");
+}
+
+export const docsSiteUrl = docsSiteUrlFrom(process.env);
 
 export function docsCanonicalUrl(path: string): string {
   const normalized = path.startsWith("/") ? path : `/${path}`;

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -1,5 +1,6 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+
 import { createMDX } from "fumadocs-mdx/next";
 
 const appDir = dirname(fileURLToPath(import.meta.url));

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -1,4 +1,10 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { createMDX } from "fumadocs-mdx/next";
+
+const appDir = dirname(fileURLToPath(import.meta.url));
+/** Monorepo root. Pages read `docs/`, `.release/`, and `.reference/` from here. */
+const monorepoRoot = join(appDir, "../..");
 
 /** @type {import('next').NextConfig} */
 const config = {
@@ -6,6 +12,43 @@ const config = {
   // fumadocs-mdx loads source.config via dynamic import(url.href); keep it out of
   // the server bundle so webpack cache analysis does not warn on that expression.
   serverExternalPackages: ["fumadocs-mdx", "esbuild"],
+  // Without this, Next infers the trace root from the nearest lockfile. On a
+  // Vercel project whose Root Directory is `apps/docs` that inference can land
+  // on the app instead of the workspace, and the repo files these pages read
+  // (docs/, .release/, .reference/) drop out of the deployed bundle.
+  outputFileTracingRoot: monorepoRoot,
+  outputFileTracingIncludes: {
+    // `.release/*.json` is read with readdirSync, which static tracing cannot
+    // see. ISR revalidation of these routes re-runs on the server, so the
+    // artifacts have to ship with the function.
+    "/releases": ["../../.release/*.json"],
+    "/releases/[tag]": ["../../.release/*.json"],
+    "/sitemap.xml": ["../../.release/*.json"],
+    "/llms.txt": ["../../.release/*.json"],
+  },
+  outputFileTracingExcludes: {
+    // `repo-root.ts` probes the filesystem with a computed path, so the tracer
+    // gives up and pulls the whole workspace into every function (1,618 files
+    // from apps/cli alone, measured on 0.3.0). None of it is reachable from the
+    // docs runtime. `packages/` stays — `@kunai/design` is a real dependency.
+    "**": [
+      "../cli/**",
+      "../analytics-ingest/**",
+      "../relay-server/**",
+      "../../scripts/**",
+      "../../test/**",
+      "../../.archive/**",
+      "../../.plans/**",
+      "../../.prototypes/**",
+    ],
+  },
+  async redirects() {
+    return [
+      // `/telemetry` was the old name for this page. In Kunai, "telemetry" means
+      // local mpv playback state; the opt-in phone-home is "analytics".
+      { source: "/telemetry", destination: "/analytics", permanent: true },
+    ];
+  },
 };
 
 const withMDX = createMDX({

--- a/apps/docs/test/analytics-metrics.test.ts
+++ b/apps/docs/test/analytics-metrics.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import { buildPublicMetrics } from "../../analytics-ingest/src/public-metrics";
-import { formatUsageLine, parseDocsAnalyticsMetrics } from "../lib/analytics-metrics";
+import {
+  formatUsageLine,
+  parseDocsAnalyticsMetrics,
+  rankShareBuckets,
+} from "../lib/analytics-metrics";
 
 const v2 = {
   schemaVersion: 2 as const,
@@ -75,5 +79,30 @@ describe("ingest output is accepted by the docs parser", () => {
     const parsed = parseDocsAnalyticsMetrics(JSON.parse(JSON.stringify(published)) as unknown);
     expect(parsed).not.toBeNull();
     expect(formatUsageLine(parsed as NonNullable<typeof parsed>)).toContain("3");
+  });
+});
+
+describe("share buckets", () => {
+  test("ranks largest first and pins the suppressed residual last", () => {
+    expect(rankShareBuckets({ linux: 10, other: 5, darwin: 25 })).toEqual([
+      { label: "darwin", count: 25, share: 0.625, residual: false },
+      { label: "linux", count: 10, share: 0.25, residual: false },
+      { label: "other", count: 5, share: 0.125, residual: true },
+    ]);
+  });
+
+  test("folds the tail past the limit into the residual", () => {
+    const buckets = rankShareBuckets({ a: 5, b: 4, c: 3, d: 2, other: 1 }, 2);
+    expect(buckets.map((bucket) => bucket.label)).toEqual(["a", "b", "other"]);
+    expect(buckets.at(-1)).toEqual({ label: "other", count: 6, share: 0.4, residual: true });
+  });
+
+  test("omits the residual row when nothing was suppressed", () => {
+    expect(rankShareBuckets({ x64: 3, arm64: 1 }).some((bucket) => bucket.residual)).toBe(false);
+  });
+
+  test("returns nothing for an empty breakdown", () => {
+    expect(rankShareBuckets({})).toEqual([]);
+    expect(rankShareBuckets({ linux: 0 })).toEqual([]);
   });
 });

--- a/apps/docs/test/drift.test.ts
+++ b/apps/docs/test/drift.test.ts
@@ -145,14 +145,14 @@ describe("docs codegen drift", () => {
     const pageUrls = new Set(source.getPages().map((page) => page.url));
     pageUrls.add("/releases");
     pageUrls.add("/feedback");
-    pageUrls.add("/telemetry");
+    pageUrls.add("/analytics");
 
     for (const entry of docNavEntries) {
       if (
         entry.href.startsWith("/docs") ||
         entry.href === "/releases" ||
         entry.href === "/feedback" ||
-        entry.href === "/telemetry"
+        entry.href === "/analytics"
       ) {
         expect(pageUrls.has(entry.href)).toBe(true);
       }

--- a/apps/docs/test/render.test.ts
+++ b/apps/docs/test/render.test.ts
@@ -39,7 +39,7 @@ describe("docs shell", () => {
         }),
         expect.objectContaining({
           text: "Analytics",
-          url: "/telemetry",
+          url: "/analytics",
         }),
       ]),
     );

--- a/apps/docs/test/usage-panel.test.tsx
+++ b/apps/docs/test/usage-panel.test.tsx
@@ -55,6 +55,18 @@ describe("usage panel", () => {
     expect(html).toContain("Groups smaller than 5 installs are reported as");
   });
 
+  test("breakdowns render as bars with every value also printed", () => {
+    const html = renderToStaticMarkup(<UsagePanel metrics={sample} />);
+    // One bar per bucket across the three breakdowns (2 + 2 + 2).
+    expect(html.match(/kunai-chart-bar/g)?.length).toBe(6);
+    // The residual is de-emphasised rather than dressed as a real category.
+    expect(html).toContain('data-residual="true"');
+    // Values are never colour-only: counts and shares are printed on the rows.
+    expect(html).toContain("75%");
+    expect(html).toContain("25%");
+    expect(html).toContain("<table");
+  });
+
   test("empty blocks expose recovery links", () => {
     expect(renderToStaticMarkup(<AnalyticsMetricsEmpty />)).toContain(
       "reliability-and-privacy#usage-analytics",

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "cd ../.. && bun install --frozen-lockfile",
+  "buildCommand": "bun run generate && bun run build:app",
+  "regions": ["iad1"]
+}

--- a/docs/users/reliability-and-privacy.mdx
+++ b/docs/users/reliability-and-privacy.mdx
@@ -98,7 +98,7 @@ When on, Kunai sends at most one tiny ping per day:
   platform / architecture breakdowns. Any group with **fewer than 5** installs is
   reported as `other`. This is per-breakdown small-cell suppression, not a joint
   anonymity guarantee. Those numbers can be inflated by abuse; they cannot expose
-  what you watch. See the live [usage analytics](/telemetry) page.
+  what you watch. See the live [usage analytics](/analytics) page.
 
 Preview the exact JSON with `/analytics show`. Until an operator configures and
 verifies an analytics endpoint, no production analytics request can be sent.
@@ -120,6 +120,6 @@ provider and machine reality checks, not default CI.
 
 ## Related guides
 
-- [Usage analytics pulse](/telemetry)
+- [Usage analytics pulse](/analytics)
 - [Diagnostics and reporting](/docs/users/diagnostics-and-reporting)
 - [Supported and unsupported](/docs/users/supported-and-unsupported)


### PR DESCRIPTION
The docs site builds clean and still deploys wrong. This is why, plus the naming
fix and the charts.

## The hosting bug

Several pages read files from the monorepo — `docs/`, `.release/`,
`.reference/` — that never reach the deployed bundle.

Next infers its file-tracing root from the nearest lockfile. On a Vercel project
whose Root Directory is `apps/docs`, that inference lands on the app rather than
the workspace, so those repo files are silently excluded: the routes render
locally and come up empty in production. `outputFileTracingRoot` now names the
workspace explicitly. `.release/*.json` is additionally listed in
`outputFileTracingIncludes` because it is read with `readdirSync`, which static
tracing cannot follow, and those routes revalidate on the server.

The opposite problem existed too: `repo-root.ts` probes the filesystem with a
computed path, so the tracer gave up and pulled the **entire workspace into
every function** — 1,618 files from `apps/cli` alone. Now excluded; `packages/`
stays, because `@kunai/design` is a real dependency.

A committed `vercel.json` pins the framework, the workspace-aware install, and
the generate-then-build order, so a deploy no longer depends on dashboard
settings happening to match the monorepo layout.

## Route naming

`/telemetry` → `/analytics`, with a permanent redirect so existing links keep
working. In this codebase "telemetry" means local mpv playback state; the
opt-in phone-home is "analytics" — which is what this page documents. The route
and its own component directory (`components/analytics/`) disagreed with each
other.

The stale `apps/telemetry-ingest/` ghost directory is gone. It held only
`node_modules/` and `.turbo/` — no source, untracked — and made it look like two
ingest apps existed.

## Charts

Rebuilt as accessible share bars: a real `<table>` with row headers, text counts
and percentages, and the bar cell marked `aria-hidden` so a screen reader reads
each row once rather than twice. Light and dark are both explicit.

## Evidence

- `bun run build:docs` succeeds; `/analytics` appears in the route manifest with
  its ISR window, and `/releases/[tag]` prerenders v0.3.0, v0.2.6, v0.2.5.
- Repo gate: typecheck 14/14, lint 0 errors, 4545 unit + 109 integration + 79
  docs tests, 0 failures. `verify:doc-paths` — 48 docs, 1918 source files, all
  paths resolve.

## What I could not verify

**Whether the deployed site is now correct.** The tracing misconfiguration is a
confirmed defect and the fix is right, but proving it end to end needs an actual
Vercel deploy. If hosting is still wrong after this merges, the next thing to
check is the Vercel project's Root Directory setting, which this PR cannot see
from the repo.

The 3 `analytics-ingest` lint warnings present here are fixed on #65.

https://claude.ai/code/session_01KV1zeNg3HFPyZ2aXvj51Uk
