### PR TITLE
chore(analytics-ingest): silence no-unassigned-import in the hardening suite

### DIFF
--- a/apps/analytics-ingest/test/postgres-hardening.test.ts
+++ b/apps/analytics-ingest/test/postgres-hardening.test.ts
@@ -11,6 +11,7 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 
 // Side-effecting: honours NEON_FETCH_ENDPOINT. Must precede store construction.
+// oxlint-disable-next-line import/no-unassigned-import -- the side effect is the point
 import "../src/neon-fetch-endpoint";
 import { hashInstallId } from "../src/ingest";
 import { DEFAULT_ANALYTICS_LIMITS } from "../src/limits";


### PR DESCRIPTION
The hardening suite landed after the other three side-effect imports were
suppressed, so it reintroduced the workspace's only lint warning.

Same deliberate load-order-sensitive import: `../src/neon-fetch-endpoint` must
run before the Neon client is constructed. Suppressed at the line rather than
restructuring load-order-sensitive code to satisfy a linter.

Takes `main` back to 0 warnings and 0 errors across all 12 lint tasks.

https://claude.ai/code/session_01KV1zeNg3HFPyZ2aXvj51Uk