### PR TITLE
AniDB episode metadata + post-play season progress

### DIFF
--- a/.docs/provider-dossiers/anidb-metadata-capabilities.md
+++ b/.docs/provider-dossiers/anidb-metadata-capabilities.md
@@ -49,8 +49,10 @@ crosswalk.
 
 ### Live HTTP XML
 
-The following live request succeeded on 2026-08-18 using the registered
-`anidb` client name and returned the current XML shape for AID `17617`:
+The following live request succeeded on 2026-08-18 with the client name
+`anidb` (that the endpoint answered is the evidence here; this dossier makes no
+claim that the name is registered to this project) and returned the current XML
+shape for AID `17617`:
 
 [`httpapi?request=anime&...&aid=17617`](http://api.anidb.net:9001/httpapi?request=anime&client=anidb&clientver=1&protover=1&aid=17617)
 
@@ -197,3 +199,34 @@ The repository already has places for the missing data:
 7. **Keep drift fixtures current.** The provider tests now cover official XML,
    title-page crosswalks, episode JSON, language responses, and embed parsing.
    Keep volatile stream tokens out of committed fixtures.
+
+## Request Budget
+
+Official AniDB's terms are strict about repeat traffic and it answers abuse by
+blocking the client name, so the provider treats the official API as a
+once-per-series read:
+
+- One `request=anime` call per show, cached for 30 days in process and seeded
+  into the shared episode-metadata cache. Nothing here may run per episode or
+  per playback.
+- A response carrying `<error>` (rate limit, ban, invalid client values) arrives
+  as HTTP 200. It is never cached: caching what it parses to would suppress
+  every episode title for that show until the TTL expired, long after the block
+  lifted.
+- AniList is still called for stills even when titles are complete (one
+  request). Jikan, which pages 100 episodes at a time under a rate limit, is
+  skipped whenever official titles already cover the catalog.
+
+Measured on 2026-08-18 for Gintama (`gintama-1816`, 200 playable episodes):
+cold `listEpisodes` 4.4s with 200/200 titles, synopses, air dates, and stills;
+warm 1ms.
+
+## Known Limitation: Positional Stills
+
+AniList `streamingEpisodes` is an ordered array with no episode numbers, so
+stills are matched by position. When a stream catalog's numbering has gaps —
+`anidb.app` carries 200 of Gintama's 201 official episodes, with no `2` — a
+still can drift from its episode. The provider accepts this because the
+alternative is no stills at all, and it is the same trade-off AllManga and
+Miruro already make. A numbered still source (TMDB episode images, Jikan
+`/pictures`) would remove the guesswork.

--- a/.docs/provider-dossiers/anidb-metadata-capabilities.md
+++ b/.docs/provider-dossiers/anidb-metadata-capabilities.md
@@ -1,0 +1,199 @@
+---
+status: current
+lastReviewed: "2026-08-18"
+---
+
+# AniDB Metadata And API Capabilities
+
+> Agent-facing (L3). Research dossier for the active `anidb` provider. This is
+> not a claim that AniDB authorizes or operates the stream sources used by
+> `anidb.app`.
+
+## Executive Summary
+
+There are two different services in this repository's AniDB path:
+
+- **Official AniDB:** `anidb.net` and `api.anidb.net:9001`. The live HTTP API is
+  a rich anime catalog. It exposes anime titles, title languages/types, dates,
+  episode numbers/types, episode titles, air dates, lengths, summaries,
+  relations, external resources, and an anime-level poster filename.
+- **The active stream site:** `anidb.app`. Its current frontend exposes a
+  separate catalog identity, episode IDs, per-episode `eng`/`jpn` embed choices,
+  and an HLS player source. Its numeric IDs are not official AniDB AIDs.
+
+For example, the `anidb.app` page for Frieren uses slug ID `1663` and links to
+official AniDB AID `17617`. The active provider calls
+`/api/frontend/anime/1663/episodes`, not the official AniDB API for AID `17617`.
+Do not use the slug suffix as an AniDB database ID without an explicit
+crosswalk.
+
+## Capability Matrix
+
+| Capability                     | Official AniDB HTTP/XML                                                                                                                               | Current `anidb.app` behavior                                                                                                                                                                                                                                                       | Kunai `anidb` provider                                                                                      |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Anime title metadata           | **Yes.** `<type>`, episode count, start/end dates, description, ratings, creators, resources, and titles.                                             | **Yes, partial.** Page title, native/alternate title, synopsis, genres, runtime, ratings, and cross-links are rendered.                                                                                                                                                            | Search keeps one scraped result title only. It does not map official title variants or rich title metadata. |
+| Episode numbers                | **Yes.** `<epno type="1">` for regular episodes and other types for specials, openings/endings, previews, etc.                                        | **Yes, partial.** JSON returns `id`, `number`, `number2`, and `filler`.                                                                                                                                                                                                            | Keeps only positive `id`, `number`, and optional `filler`.                                                  |
+| Episode titles                 | **Yes.** Multiple localized `<title>` elements occur on each episode.                                                                                 | **Not in the observed episode JSON.**                                                                                                                                                                                                                                              | Official XML title, preferring English, is mapped; external metadata can fill a missing title.              |
+| Episode air dates              | **Yes.** `<airdate>YYYY-MM-DD</airdate>`.                                                                                                             | **Not in the observed episode JSON.**                                                                                                                                                                                                                                              | Official XML air date is mapped, with external metadata as fallback.                                        |
+| Episode length                 | **Yes.** `<length>` is present; live values are minute-scale integers such as `25` and `30`.                                                          | The title page displays a series runtime, but the episode-list JSON did not return per-episode length.                                                                                                                                                                             | Not currently surfaced by the shared episode contract.                                                      |
+| Episode synopsis               | **Yes.** `<summary>` may be present.                                                                                                                  | Not in the observed episode-list JSON.                                                                                                                                                                                                                                             | Official XML synopsis is mapped, with external metadata as fallback.                                        |
+| Episode thumbnails/images      | **No evidence in the official HTTP anime response.** The response has `<picture>` for the anime and characters, but no episode-level `<picture>`.     | No per-episode thumbnail field was observed. The player uses the anime poster as artwork.                                                                                                                                                                                          | AniList stills are used when available; otherwise the title-page poster is a truthful fallback.             |
+| Poster/artwork                 | **Yes, anime-level.** XML returns a filename such as `295082.jpg`; the official image CDN serves it. No backdrop field was observed.                  | Yes, but the page currently uses `cdn.xlsbox.com`, a separate image host.                                                                                                                                                                                                          | Title-page poster is carried into episode options; search/resolve do not invent a separate backdrop.        |
+| Relations                      | **Yes.** `<relatedanime>` includes typed relations such as `Sequel`; similar anime and recommendations are also present.                              | Not relied on for the active stream flow.                                                                                                                                                                                                                                          | Season routing searches title text; it does not consume official relation data.                             |
+| Language/title variants        | **Yes.** Anime and episode titles carry `xml:lang`; anime titles also carry types such as `main`, `official`, and `synonym`.                          | One primary title plus one alternate/native title is visible in the sampled page.                                                                                                                                                                                                  | No variant inventory; only the selected browse-card title is kept.                                          |
+| Dub/sub/audio catalog metadata | **Not in the verified anime XML.** No `audio`, `dub`, `sub`, or track fields were present. `resources` are external entity links, not audio evidence. | **Yes, as stream availability.** The frontend language endpoint returned `eng`/`English` and `jpn`/`Japanese` embed choices for the sample episode. This is provider runtime data, not official AniDB catalog metadata.                                                            | Maps exact `eng` to `dub` and exact `jpn` to `sub`; missing requested modes fail closed.                    |
+| Playable media streams         | **No.** The verified official anime XML contains catalog data and external resources, not media URLs or manifests.                                    | **Yes.** The returned embed page configures JW Player with an HLS `master.m3u8` source on `hls.anidb.app`.                                                                                                                                                                         | **Yes.** Extracts the embed's `file:` value and expands the HLS ladder into direct candidates.              |
+| Subtitle tracks                | **No official track URL was found.** The verified catalog XML has no subtitle-track fields.                                                           | **No independently addressable track was observed.** The current embed config contains JW Player captions styling but no `tracks` array or VTT/SRT URL. This does not prove that every title is hardsubbed; it proves only that no soft-track evidence was exposed in this sample. | Always returns `subtitles: []`; subtitle delivery remains unknown.                                          |
+
+## Official AniDB Evidence
+
+### Live HTTP XML
+
+The following live request succeeded on 2026-08-18 using the registered
+`anidb` client name and returned the current XML shape for AID `17617`:
+
+[`httpapi?request=anime&...&aid=17617`](http://api.anidb.net:9001/httpapi?request=anime&client=anidb&clientver=1&protover=1&aid=17617)
+
+Relevant fields in that response:
+
+- Anime-level fields: `<type>`, `<episodecount>`, `<startdate>`, `<enddate>`,
+  `<description>`, `<picture>`, `<resources>`, and `<titles>`.
+- Anime titles: `xml:lang` values include `ja`, `en`, `de`, `fr`, `pt-BR`,
+  `zh-Hans`, and others; title `type` values include `main`, `official`, and
+  `synonym`.
+- Relations: `<relatedanime><anime id="18886" type="Sequel">...` was present.
+- Regular episodes: each record has an episode ID, `<epno type="1">`,
+  `<length>`, `<airdate>`, localized titles, and sometimes `<summary>` and
+  external resources.
+- Non-regular entries are represented in the same catalog with other episode
+  number types, including `S` specials, `C` opening/ending content, and `T`
+  previews. A consumer must not flatten all entries into one regular-episode
+  sequence without preserving the `epno` type.
+- The live response includes `<picture>295082.jpg</picture>` for the anime and
+  many character pictures, but no episode picture element.
+
+The public HTTP endpoint is an anime request that embeds episode metadata. A
+direct probe of `request=episode` returned `error code=320 request type invalid`,
+and the same happened for `request=file`. This bounds the finding to the
+current public HTTP API endpoint: it is not evidence that no file metadata has
+ever existed in other AniDB interfaces, but it is evidence that the endpoint
+used here is not a media-file or subtitle delivery API.
+
+### Images
+
+For the `picture` filename returned by the official API, the current official
+image path is:
+
+- Legacy image URL: `https://img7.anidb.net/pics/anime/295082.jpg`
+- Current CDN target: `https://cdn.anidb.net/images/main/295082.jpg`
+
+The legacy URL currently redirects through the official AniDB image service to
+the CDN target, which returned `image/jpeg` and `200`. The XML gives a filename,
+not a full URL. No episode-image URL or current image-policy text could be
+retrieved from the official wiki in this environment.
+
+### Official Documentation And XSD Access
+
+Official documentation targets:
+
+- [AniDB HTTP API](https://wiki.anidb.net/w/HTTP_API)
+- [AniDB HTTP API definition](https://wiki.anidb.net/w/HTTP_API_Definition)
+- [AniDB official site](https://anidb.net/)
+
+The official wiki returned HTTP `403` for the API and image-policy pages during
+this research. The guessed legacy downloads
+`https://anidb.net/api/anime.xsd`, `episode.xsd`, and `file.xsd` returned `404`;
+`http://api.anidb.net:9001/httpapi.xsd` returned an AniDB API error rather than
+an XSD. Therefore this dossier cites the live XML response for field claims and
+does not claim a current downloadable XSD URL. Re-check the official wiki/XSD
+before implementing a strict schema validator.
+
+## Current `anidb.app` Evidence
+
+The following are live first-party pages for the host used by the repository's
+provider. They are cited as stream-site behavior, not as official AniDB API
+documentation:
+
+- [`anidb.app` home](https://anidb.app/) currently advertises HD playback,
+  adaptive quality, and sub/dub switching.
+- [Frieren title page](https://anidb.app/anime/frieren-beyond-journeys-end-1663)
+  renders a poster from `cdn.xlsbox.com`, shows `24m`, and links to official
+  AniDB AID `17617`, MAL, AniList, and Kitsu.
+- [`/api/frontend/anime/1663/episodes`](https://anidb.app/api/frontend/anime/1663/episodes)
+  returned records shaped like `{ id, number, number2, filler }` and no title,
+  air date, length, synopsis, or thumbnail fields.
+- [`/api/frontend/episode/3062/languages`](https://anidb.app/api/frontend/episode/3062/languages)
+  returned `eng`/`English` and `jpn`/`Japanese` with opaque `/embed/...` URLs.
+- The embed page returned by that endpoint configured JW Player with one HLS
+  `master.m3u8` source and the anime poster as `image`. Its config had captions
+  styling but no subtitle-track URL or `tracks` array. The source URL is
+  intentionally not copied here because it is a volatile media locator.
+
+## Repository Comparison
+
+### Active Provider Flow
+
+- `packages/providers/src/anidb/client.ts:18-21` sets the provider base to
+  `https://anidb.app`, not `anidb.net`.
+- `packages/providers/src/anidb/client.ts:116-125` searches scraped browse HTML.
+- `packages/providers/src/anidb/client.ts` retains episode ID, positive numeric
+  episode number, and filler from the stream catalog; the title-page crosswalk
+  and official XML parser provide episode titles, dates, and synopses separately.
+- `packages/providers/src/anidb/client.ts:189-223` retains language code/name
+  and the embed URL, but not a catalog audio-language model.
+- `packages/providers/src/anidb/client.ts:225-231` extracts a `file:` value
+  from the embed page; `:269-282` expands the HLS master into stream links.
+- `packages/providers/src/anidb/direct.ts` does not advertise unprobed audio
+  modes. Its episode list merges official AniDB XML with AniList/Jikan metadata,
+  populating episode names, detail/synopsis, release dates, external ids, and
+  artwork.
+- `packages/providers/src/anidb/direct.ts` returns direct HLS results, the
+  selected episode's release/artwork, external IDs, and an empty `subtitles`
+  array because no concrete track URL is exposed.
+- `packages/providers/src/anidb/manifest.ts:5-54` correctly declares an
+  anime-only direct HTTP stream provider. It does not declare catalog metadata
+  enrichment or subtitle-track support.
+- The module is production-wired by
+  `apps/cli/src/container/bootstrap-providers.ts:36-68`.
+
+### Relevant Contracts
+
+The repository already has places for the missing data:
+
+- `packages/types/src/index.ts:568-588` supports `nativeTitle`, `englishTitle`,
+  `altNames`, release/artwork, language evidence, and duration on search rows.
+- `packages/types/src/index.ts:605-615` supports episode `name`, release, and
+  artwork on episode options.
+- `packages/types/src/index.ts:211-223` supports provider subtitle candidates
+  with URL, language, format, and cache policy.
+- `packages/types/src/index.ts:286-295` supports resolve-level subtitles,
+  release, artwork, and external IDs.
+
+## Concrete Gaps And Next Steps
+
+1. **Keep identities separate.** Model official AniDB AID and the
+   `anidb.app` stream-site ID as different namespaces. The active provider now
+   follows the title page's explicit `anidb.net/anime/{aid}` cross-link rather
+   than treating `1663` as official AID `1663`.
+2. **Keep the metadata authority explicit.** Official AniDB XML is now the
+   primary episode metadata source; AniList/Jikan remain best-effort fallback
+   sources for thumbnails and fields absent from the official response.
+3. **Preserve official episode semantics.** The XML parser keeps only
+   `epno type="1"` records for the stream site's regular episode list, so
+   specials, openings/endings, and previews are not silently flattened into the
+   playable sequence. Current `anidb.app` JSON is insufficient for a full
+   non-regular catalog.
+4. **Fill contract fields only from evidence.** Official metadata can populate
+   title variants, episode names, air dates, lengths, release info, relations,
+   and poster artwork. It cannot justify stream audio or subtitle claims.
+5. **Downgrade audio/subtitle assertions.** Keep `eng`/`jpn` as per-episode
+   runtime availability from `anidb.app`; do not describe it as official AniDB
+   dub metadata. Keep `subtitles: []` unless a future live sample exposes a
+   concrete track URL or the media is independently proven hardsubbed.
+6. **Verify image terms before product use.** The official CDN path is
+   technically usable, but the current image policy was not retrievable here;
+   confirm attribution, caching, and redistribution terms before adding an
+   artwork cache.
+7. **Keep drift fixtures current.** The provider tests now cover official XML,
+   title-page crosswalks, episode JSON, language responses, and embed parsing.
+   Keep volatile stream tokens out of committed fixtures.

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -630,6 +630,19 @@ instead of pretending those fields came from `anidb.app`.
   metadata, but its AIDs must not be confused with the numeric ids in `anidb.app` URLs. See
   [the metadata capability dossier](./provider-dossiers/anidb-metadata-capabilities.md).
 
+The cost model matters as much as the data, because this runs in front of the episode picker:
+
+- Official AniDB XML is **one request for the whole series**, cached for a month and seeded into
+  the shared episode-metadata cache, so a second listing of the same show is free.
+- AniList runs even when every title is already known — it is a single request and the only source
+  of episode stills AniDB has.
+- Jikan is the expensive pass (100 episodes per page, strict rate limit) and is **skipped** when
+  official titles already cover the catalog, matching the AllManga path via
+  `shouldSkipExternalEpisodeMetadataEnrichment()`.
+- An official response that carries `<error>` (rate limit, ban, bad client credentials) is never
+  cached. Caching what it parses to would suppress every episode title for that show for a month
+  after the block lifted.
+
 ### AniDB season routing and episode numbering
 
 AniDB models each season as its own title, so `routeAnidbSeason()` in

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -609,6 +609,27 @@ used by search and resolve so they cannot drift apart:
   markup) become results, so nav, breadcrumb, related-rail and footer links cannot become
   `results[0]` and pin the wrong show.
 
+### AniDB metadata and language evidence
+
+The active `anidb.app` episode endpoint is a stream catalog, not a rich episode metadata catalog:
+it currently returns episode ids, numbers, and filler flags. `anidb.listEpisodes()` first follows
+the title page's explicit cross-link to the official AniDB AID and enriches from the official XML
+catalog. It then uses the existing shared AniList/Jikan path for still thumbnails and missing fields
+when the title identity carries an AniList or MAL id. This keeps the metadata authority explicit
+instead of pretending those fields came from `anidb.app`.
+
+- `anidb.app` language evidence is per episode: `jpn` is the sub/original embed and `eng` is the
+  dub embed when present. Search does not advertise both modes blindly; availability is confirmed
+  only by the episode languages response.
+- A missing requested language is an exhausted AniDB attempt. It must not fall back to the other
+  language and label the stream incorrectly.
+- The embed probe currently exposes an HLS source but no independently addressable subtitle track.
+  AniDB results keep `subtitles: []` and mark subtitle delivery unknown; `jpn` is not sufficient
+  evidence that captions are hardcoded.
+- Official AniDB XML is a separate catalog namespace. It can provide richer anime and episode
+  metadata, but its AIDs must not be confused with the numeric ids in `anidb.app` URLs. See
+  [the metadata capability dossier](./provider-dossiers/anidb-metadata-capabilities.md).
+
 ### AniDB season routing and episode numbering
 
 AniDB models each season as its own title, so `routeAnidbSeason()` in

--- a/apps/cli/src/app/bootstrap/episode-info-from-catalog.ts
+++ b/apps/cli/src/app/bootstrap/episode-info-from-catalog.ts
@@ -16,7 +16,13 @@ export function episodeInfoFromSelection(args: {
       season,
       episode,
       name: match?.name ?? match?.label,
-      ...(match?.previewImageUrl ? { artwork: { thumbnailUrl: match.previewImageUrl } } : {}),
+      airDate: match?.airDate ?? match?.release?.airDate,
+      overview: match?.overview ?? match?.detail,
+      externalIds: match?.externalIds,
+      release: match?.release,
+      artwork:
+        match?.artwork ??
+        (match?.previewImageUrl ? { thumbnailUrl: match.previewImageUrl } : undefined),
     };
   }
 

--- a/apps/cli/src/app/playback/PlaybackPhase.ts
+++ b/apps/cli/src/app/playback/PlaybackPhase.ts
@@ -3474,6 +3474,7 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
             recommendationRail,
             historyRepository,
             diagnosticsService,
+            readWatchedEntries: () => historyRepository.listByTitleIdentity(historyTitleLookup),
             getMode: () => stateManager.getState().mode,
             getAutoplaySessionPaused: () => stateManager.getState().autoplaySessionPaused,
             getAutoskipSessionPaused: () => stateManager.getState().autoskipSessionPaused,

--- a/apps/cli/src/app/playback/playback-post-play-entry.ts
+++ b/apps/cli/src/app/playback/playback-post-play-entry.ts
@@ -39,6 +39,7 @@ export type CreatePostPlaybackMenuDepsInput = {
   readonly recommendationRail: PostPlaybackRecommendationRail;
   readonly historyRepository: Container["historyRepository"];
   readonly diagnosticsService: Container["diagnosticsService"];
+  readonly readWatchedEntries: PostPlaybackMenuDeps["readWatchedEntries"];
 
   readonly getMode: () => ShellMode;
   readonly getAutoplaySessionPaused: () => boolean;
@@ -110,6 +111,7 @@ export function createPostPlaybackMenuDeps(
     recommendationRail: input.recommendationRail,
     historyRepository: input.historyRepository,
     diagnosticsService: input.diagnosticsService,
+    readWatchedEntries: input.readWatchedEntries,
     getMode: input.getMode,
     getAutoplaySessionPaused: input.getAutoplaySessionPaused,
     getAutoskipSessionPaused: input.getAutoskipSessionPaused,

--- a/apps/cli/src/app/playback/run-post-playback-menu.ts
+++ b/apps/cli/src/app/playback/run-post-playback-menu.ts
@@ -69,6 +69,7 @@ import {
 import type { PhaseResult } from "@/app/session/Phase";
 import type { Container } from "@/container";
 import { episodeThumbKey } from "@/domain/catalog/title-detail";
+import { projectFurthestWatchedEpisode } from "@/domain/continuation/watch-progress";
 import { resolveContentKind } from "@/domain/media/content-kind";
 import { toHistoryTimestamp } from "@/domain/playback/playback-history";
 import { didPlaybackEndNearNaturalEnd } from "@/domain/playback/playback-policy";
@@ -97,6 +98,12 @@ export type PostPlaybackMenuDeps = {
   readonly recommendationRail: PostPlaybackRecommendationRail;
   readonly historyRepository: Container["historyRepository"];
   readonly diagnosticsService: Container["diagnosticsService"];
+  /**
+   * Reads this title's history NOW. The iteration's `watchedEntries` snapshot is
+   * taken before the episode plays, so season progress read from it is always one
+   * episode stale — and reads 0 on a first watch.
+   */
+  readonly readWatchedEntries: () => readonly HistoryProgress[];
 
   readonly getMode: () => ShellMode;
   readonly getAutoplaySessionPaused: () => boolean;
@@ -421,13 +428,25 @@ export async function runPostPlaybackMenu(
             (option) => option.value === `${priorEpisode.season}:${priorEpisode.episode}`,
           )
         : undefined;
+      const postPlayTitleDetail = peekTitleDetail(title.id, title.type);
+      const isFilmStructure = title.type === "movie" || postPlayTitleDetail?.type === "movie";
       const episodesInCurrentSeason = iteration.shellEpisodePicker.options.filter((option) =>
         option.value.startsWith(`${currentEpisode.season}:`),
       ).length;
-      const watchedEpisodes = iteration.watchedEntries.filter((entry: HistoryProgress) =>
-        title.type === "series" ? entry.season === currentEpisode.season : true,
-      ).length;
-      const postPlayTitleDetail = peekTitleDetail(title.id, title.type);
+      // ONE season total for both the "E08 of N" line and the progress bar. The
+      // playable list wins over the catalog count: the two disagree often (a
+      // provider carrying 200 of a catalog's 201 episodes), and a denominator you
+      // cannot reach is the wrong one to show next to a playable episode number.
+      const seasonEpisodeTotal = isFilmStructure
+        ? undefined
+        : episodesInCurrentSeason || title.episodeCount;
+      // Furthest episode reached, read AFTER the episode played. The iteration
+      // snapshot predates this episode's history row, so it reads 0 on a first watch.
+      const watchedEpisodes = projectFurthestWatchedEpisode({
+        entries: deps.readWatchedEntries(),
+        ...(title.type === "series" ? { season: currentEpisode.season } : {}),
+        currentEpisode: currentEpisode.episode,
+      });
       const nextEpisodeThumbUrl =
         upcomingEpisode && postPlayTitleDetail?.artwork?.episodeThumbnails
           ? postPlayTitleDetail.artwork.episodeThumbnails[
@@ -472,11 +491,7 @@ export async function runPostPlaybackMenu(
             : { label: "Ready for next action", tone: "success" },
           footerMode: "minimal",
           postPlayState,
-          episodeLabel: buildPostPlayEpisodeLabel(
-            title,
-            currentEpisode,
-            episodesInCurrentSeason || undefined,
-          ),
+          episodeLabel: buildPostPlayEpisodeLabel(title, currentEpisode, seasonEpisodeTotal),
           nextEpisodeLabel: buildPostPlayNextEpisodeLabel(
             upcomingEpisode,
             nextEpisodePickerOption?.label,
@@ -489,16 +504,12 @@ export async function runPostPlaybackMenu(
           queueNextEntryId,
           nextEpisodeThumbUrl,
           previousEpisodeThumbUrl,
-          totalEpisodes:
-            title.type === "movie" || postPlayTitleDetail?.type === "movie"
-              ? undefined
-              : (title.episodeCount ?? iteration.shellEpisodePicker.options.length),
+          totalEpisodes: seasonEpisodeTotal,
           watchedEpisodes,
           currentSeason: currentEpisode.season,
           currentEpisode: currentEpisode.episode,
           contentKind: resolveContentKind(title, mode),
-          titleType:
-            title.type === "movie" || postPlayTitleDetail?.type === "movie" ? "movie" : title.type,
+          titleType: isFilmStructure ? "movie" : title.type,
           // Carry the session's captured video metadata so the post-play `video`
           // panel keeps channel/views/length facts that were shown during playback.
           videoMeta: container.stateManager.getState().videoMeta,

--- a/apps/cli/src/domain/continuation/watch-progress.ts
+++ b/apps/cli/src/domain/continuation/watch-progress.ts
@@ -96,6 +96,40 @@ export function projectSeriesProgress(input: SeriesProgressInput): SeriesProgres
   };
 }
 
+export type FurthestWatchedEpisodeInput = {
+  /** History rows for one title. Rows outside `season` are ignored when it is set. */
+  readonly entries: readonly {
+    readonly season?: number | null;
+    readonly episode?: number | null;
+    readonly absoluteEpisode?: number | null;
+  }[];
+  /** Season to scope to. Omit for absolute/anime numbering, where every row counts. */
+  readonly season?: number;
+  /** Episode being watched right now; progress is never behind where you already are. */
+  readonly currentEpisode?: number;
+};
+
+/**
+ * How deep into the season the viewer has reached — the FURTHEST episode with
+ * history, not the number of history rows.
+ *
+ * Counting rows answers "how many episodes did you start from this machine",
+ * which is not what a season progress bar means: jumping straight to E08 is
+ * eight episodes deep, and a fresh row for the episode you just watched is not
+ * "1 of 201". `currentEpisode` keeps the bar honest during the very first watch,
+ * when the history row for it may not be written yet.
+ */
+export function projectFurthestWatchedEpisode(input: FurthestWatchedEpisodeInput): number {
+  const furthest = input.entries.reduce((deepest, entry) => {
+    if (input.season !== undefined && (entry.season ?? 1) !== input.season) return deepest;
+    const reached =
+      finitePositive(entry.absoluteEpisode ?? undefined) ??
+      finitePositive(entry.episode ?? undefined);
+    return reached && reached > deepest ? reached : deepest;
+  }, 0);
+  return Math.max(furthest, finitePositive(input.currentEpisode) ?? 0);
+}
+
 function finiteNonNegative(value: number | undefined): number | null {
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, value) : null;
 }

--- a/apps/cli/src/domain/types.ts
+++ b/apps/cli/src/domain/types.ts
@@ -95,6 +95,11 @@ export interface EpisodePickerOption {
   readonly name?: string;
   readonly detail?: string;
   readonly previewImageUrl?: string;
+  readonly airDate?: string;
+  readonly overview?: string;
+  readonly externalIds?: ProviderExternalIds;
+  readonly release?: ProviderReleaseInfo;
+  readonly artwork?: ProviderArtworkInfo;
   /** Total episode count for the series, if known. Used to detect completion. */
   readonly totalEpisodeCount?: number;
 }

--- a/apps/cli/src/services/providers/ProviderRegistry.ts
+++ b/apps/cli/src/services/providers/ProviderRegistry.ts
@@ -133,6 +133,11 @@ export class ProviderRegistryImpl implements ProviderRegistry {
                 name: ep.name,
                 detail: ep.detail,
                 previewImageUrl: ep.artwork?.thumbnailUrl,
+                airDate: ep.release?.airDate,
+                overview: ep.detail,
+                externalIds: ep.externalIds,
+                release: ep.release,
+                artwork: ep.artwork,
                 totalEpisodeCount: ep.totalEpisodeCount,
               }));
             }

--- a/apps/cli/test/unit/app/episode-info-from-catalog.test.ts
+++ b/apps/cli/test/unit/app/episode-info-from-catalog.test.ts
@@ -11,9 +11,21 @@ describe("episodeInfoFromSelection", () => {
       episode: 2,
       isAnime: true,
       titleId: "anilist:21",
-      animeEpisodes: [{ index: 2, label: "Episode 2 · Cherry", name: "Cherry" }],
+      animeEpisodes: [
+        {
+          index: 2,
+          label: "Episode 2 · Cherry",
+          name: "Cherry",
+          detail: "A deterministic anime episode.",
+          release: { airDate: "2026-01-02" },
+          artwork: { thumbnailUrl: "https://img.example/episode-2.jpg" },
+        },
+      ],
     });
     expect(info.name).toBe("Cherry");
+    expect(info.overview).toBe("A deterministic anime episode.");
+    expect(info.airDate).toBe("2026-01-02");
+    expect(info.artwork?.thumbnailUrl).toBe("https://img.example/episode-2.jpg");
   });
 
   test("falls back to TMDB cache for series when warmed", async () => {

--- a/apps/cli/test/unit/app/playback/run-post-playback-menu.test.ts
+++ b/apps/cli/test/unit/app/playback/run-post-playback-menu.test.ts
@@ -107,6 +107,7 @@ function createDeps(overrides: Partial<PostPlaybackMenuDeps> = {}): TestDeps {
     historyRepository: {
       listByTitle: () => [],
     } as unknown as PostPlaybackMenuDeps["historyRepository"],
+    readWatchedEntries: () => [],
     diagnosticsService: {
       record: () => {},
     } as unknown as PostPlaybackMenuDeps["diagnosticsService"],
@@ -164,6 +165,60 @@ function createDeps(overrides: Partial<PostPlaybackMenuDeps> = {}): TestDeps {
 }
 
 describe("runPostPlaybackMenu", () => {
+  test("season progress reads history AFTER the episode played, and one total feeds both lines", async () => {
+    // Reproduces the post-play screen showing "E08 of 200" beside "0 / 201 · 0%":
+    // the count came from a pre-playback snapshot (empty on a first watch) and the
+    // two totals came from two different sources.
+    const run = createRun();
+    const iteration = createBaseIteration({
+      episodeAvailability: {
+        nextEpisode: { season: 1, episode: 9 },
+        previousEpisode: { season: 1, episode: 7 },
+        nextSeasonEpisode: null,
+        upcomingNext: null,
+        animeNextReleaseUnknown: false,
+        tmdbUnavailable: false,
+      },
+    });
+    // The picker is the playable list: 200 episodes, all in season 1.
+    const playableEpisodes = {
+      options: Array.from({ length: 200 }, (_, index) => ({
+        label: `Episode ${index + 1}`,
+        value: `1:${index + 1}`,
+      })),
+      subtitle: "",
+      initialIndex: 0,
+    };
+
+    let seenState: { totalEpisodes?: number; watchedEpisodes?: number; episodeLabel?: string } = {};
+    const deps = createDeps({
+      readWatchedEntries: () =>
+        [{ season: 1, episode: 8 }] as unknown as ReturnType<
+          PostPlaybackMenuDeps["readWatchedEntries"]
+        >,
+      openPlaybackShell: async (input) => {
+        seenState = input.state;
+        return "quit";
+      },
+    });
+
+    await runPostPlaybackMenu(
+      run,
+      {
+        ...iteration,
+        // Catalog says 201 episodes; the playable list carries 200.
+        title: { ...title, episodeCount: 201 },
+        currentEpisode: { season: 1, episode: 8 },
+        shellEpisodePicker: playableEpisodes,
+      },
+      deps,
+    );
+
+    expect(seenState.watchedEpisodes).toBe(8);
+    expect(seenState.totalEpisodes).toBe(200);
+    expect(seenState.episodeLabel).toContain("of 200");
+  });
+
   test("near-end auto-next uses stopAfterCurrentAtMenuEntry snapshot (B1)", async () => {
     let countdownOffered = false;
     const run = createRun();

--- a/apps/cli/test/unit/domain/continuation/watch-progress.test.ts
+++ b/apps/cli/test/unit/domain/continuation/watch-progress.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { projectSeriesProgress, projectWatchProgress } from "@/domain/continuation/watch-progress";
+import {
+  projectFurthestWatchedEpisode,
+  projectSeriesProgress,
+  projectWatchProgress,
+} from "@/domain/continuation/watch-progress";
 
 describe("watch progress projection", () => {
   test("clamps in-progress percentages to user-facing resume range", () => {
@@ -83,5 +87,54 @@ describe("series progress projection (distinct from episode progress)", () => {
     expect(series.percentage).toBeNull();
     expect(series.caughtUp).toBe(false);
     expect(series.seriesCompleted).toBe(false);
+  });
+});
+
+describe("furthest watched episode projection", () => {
+  const entry = (
+    season: number | undefined,
+    episode: number | undefined,
+    absoluteEpisode?: number,
+  ) => ({ season, episode, absoluteEpisode });
+
+  test("reports how far into the season the viewer has reached, not how many rows exist", () => {
+    // Jumping straight to E08 is 8 episodes deep, not one episode watched.
+    expect(
+      projectFurthestWatchedEpisode({
+        entries: [entry(1, 8)],
+        season: 1,
+      }),
+    ).toBe(8);
+  });
+
+  test("ignores entries from other seasons", () => {
+    expect(
+      projectFurthestWatchedEpisode({
+        entries: [entry(1, 8), entry(2, 12)],
+        season: 1,
+      }),
+    ).toBe(8);
+  });
+
+  test("keeps season-less rows when no season is scoped (anime absolute numbering)", () => {
+    expect(
+      projectFurthestWatchedEpisode({
+        entries: [entry(undefined, undefined, 40), entry(undefined, 12)],
+      }),
+    ).toBe(40);
+  });
+
+  test("never reports less than the episode currently being watched", () => {
+    expect(
+      projectFurthestWatchedEpisode({
+        entries: [entry(1, 3)],
+        season: 1,
+        currentEpisode: 8,
+      }),
+    ).toBe(8);
+  });
+
+  test("no history and no current episode is zero, not a guess", () => {
+    expect(projectFurthestWatchedEpisode({ entries: [] })).toBe(0);
   });
 });

--- a/apps/cli/test/unit/services/providers/provider-registry.test.ts
+++ b/apps/cli/test/unit/services/providers/provider-registry.test.ts
@@ -195,7 +195,17 @@ test("listEpisodes receives the full title identity and language preferences", a
     },
     async listEpisodes(input): Promise<ProviderEpisodeOption[]> {
       received = input as unknown as Record<string, unknown>;
-      return [{ index: 1, label: "Episode 1", totalEpisodeCount: 1 }];
+      return [
+        {
+          index: 1,
+          label: "Episode 1 · Pilot",
+          name: "Pilot",
+          detail: "The first episode",
+          release: { airDate: "2026-01-02" },
+          artwork: { thumbnailUrl: "https://img.example/episode-1.jpg" },
+          totalEpisodeCount: 1,
+        },
+      ];
     },
   };
 
@@ -207,7 +217,7 @@ test("listEpisodes receives the full title identity and language preferences", a
   } as unknown as ProviderEngine;
 
   const registry = new ProviderRegistryImpl(engine);
-  await registry.get("hooked")?.listEpisodes?.({
+  const episodes = await registry.get("hooked")?.listEpisodes?.({
     title: {
       id: "anilist:21",
       name: "One Piece",
@@ -223,4 +233,13 @@ test("listEpisodes receives the full title identity and language preferences", a
   expect(title.title).toBe("One Piece");
   expect((received as unknown as Record<string, unknown>).preferredAudioLanguage).toBe("dub");
   expect((received as unknown as Record<string, unknown>).preferredSubtitleLanguage).toBe("en");
+  expect(episodes?.[0]).toMatchObject({
+    name: "Pilot",
+    detail: "The first episode",
+    overview: "The first episode",
+    airDate: "2026-01-02",
+    release: { airDate: "2026-01-02" },
+    previewImageUrl: "https://img.example/episode-1.jpg",
+    artwork: { thumbnailUrl: "https://img.example/episode-1.jpg" },
+  });
 });

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,9 +1,9 @@
 {
-  "syncedAt": "2026-08-16T10:38:36.708Z",
+  "syncedAt": "2026-08-18T09:20:14.960Z",
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceRevision": "520c36c1",
-  "cliSourceFingerprint": "178d0832826823139f8b53f7988cb125e7b72b8d637e4e585bca7f7af6749d91",
+  "cliSourceRevision": "92ac3977",
+  "cliSourceFingerprint": "0b65d1a676ffa988d3ada7fb4a6a7b5177ebd0ac02870904f2353b0b7f61d6c5",
   "docsContentFingerprint": "3311367d534c1c9f29cde9ecf49f75ed0f7069979b2a014b488101e3e2ad87e9",
   "featureStatusRevision": "d4c1e1d0943d18f05bca1a12a5b0ff966754a588f12e4a86a03510d2bc424c1d",
   "commandCount": 81,
@@ -93,7 +93,8 @@
         "Mp4 (mp4upload scrape)",
         "Luf-Mp4",
         "Ak. Filemoon is gone.",
-        "2026-08: mkissa crypto requires buildId=81 + /client-crypto/v1/bootstrap (x-aa-boot). ani-cli v5 moved primary to anidb.app."
+        "2026-08: mkissa crypto requires buildId=119 (rotated from 81) + /client-crypto/v1/bootstrap (x-aa-boot)",
+        "7-day epochs. ani-cli v5 moved primary to anidb.app."
       ]
     },
     {
@@ -111,9 +112,7 @@
         "Primary hosts: www.miruro.bz",
         "www.miruro.ru. Bare miruro.bz/.ru are 301 redirects to www. and still CF-block at the pipe path; miruro.com serves a different app shell with no /api/secure/pipe; miruro.tv/.to are TLS-dead — all stay off the resolve list.",
         "Uses Miruro pipe API with XOR/gzip decryption key 71951034f8fbcf53d89db52ceb3dc22c.",
-        "Still not the default anime auto-fallback (AniDB is the default",
-        "AllAnime the fallback); Miruro is available for manual pick when curl/http2 path works.",
-        "May hit Cloudflare rate limits if called too frequently."
+        "Not in the automatic anime lane: `animeProviderPriority` is `[anidb"
       ]
     },
     {

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,9 +1,9 @@
 {
-  "syncedAt": "2026-08-18T09:20:14.960Z",
+  "syncedAt": "2026-08-18T09:48:12.014Z",
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceRevision": "92ac3977",
-  "cliSourceFingerprint": "0b65d1a676ffa988d3ada7fb4a6a7b5177ebd0ac02870904f2353b0b7f61d6c5",
+  "cliSourceRevision": "4c0d2839",
+  "cliSourceFingerprint": "5aefbd00ff1678a77db02086a899294bd24b78c38a1ce45bd8cbb65eb4e4f4f8",
   "docsContentFingerprint": "3311367d534c1c9f29cde9ecf49f75ed0f7069979b2a014b488101e3e2ad87e9",
   "featureStatusRevision": "d4c1e1d0943d18f05bca1a12a5b0ff966754a588f12e4a86a03510d2bc424c1d",
   "commandCount": 81,
@@ -68,6 +68,8 @@
         "Parity with ani-cli v5.0 (2026-08-01): browse search",
         "/api/frontend anime episodes + episode languages",
         "embed → HLS master.",
+        "Episode metadata follows the explicit anidb.app → official anidb.net AID cross-link",
+        "then reads official XML; AniList/Jikan fill missing fields and still artwork.",
         "Bun/fetch often gets Cloudflare 403 on anidb.app HTML/API; production path uses curl with a Chrome UA (dossier-proven).",
         "HLS media on hls.anidb.app usually works with native fetch after the embed URL is obtained.",
         "Sub = Japanese audio (jpn embed); dub = English audio (eng embed) when the languages API exposes it."

--- a/packages/providers/src/allmanga/api-client.ts
+++ b/packages/providers/src/allmanga/api-client.ts
@@ -8,6 +8,7 @@ import {
   enrichEpisodeOptionsWithAnimeMetadata,
   fetchAnimeEpisodeMetadataByNumber,
   getSeededEpisodeMetadata,
+  mergeExternalEpisodeMetadataInto,
   parseAllMangaEpisodeNumber,
   seedEpisodeMetadataFromProvider,
   shouldSkipExternalEpisodeMetadataEnrichment,
@@ -15,6 +16,7 @@ import {
 } from "../shared/anime-metadata";
 import { expandHlsMasterPlaylist } from "../shared/hls-ladder";
 import { TTLCache } from "../shared/provider-cache";
+import { createTimeoutSignal } from "../shared/timeout-signal";
 import {
   ALLMANGA_BUILD_ID,
   ALLMANGA_CRYPTO_MATERIAL_TTL_MS,
@@ -493,27 +495,6 @@ export function clearAllMangaProviderCachesForTest(): void {
   retrySleep = (ms, signal) => sleepAbortable(ms, signal);
 }
 
-type AbortSignalConstructorWithAny = typeof AbortSignal & {
-  readonly any?: (signals: readonly AbortSignal[]) => AbortSignal;
-};
-
-function createTimeoutSignal(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
-  const timeoutSignal = AbortSignal.timeout(timeoutMs);
-  if (!signal) return timeoutSignal;
-  const abortSignal = AbortSignal as AbortSignalConstructorWithAny;
-  if (abortSignal.any) return abortSignal.any([signal, timeoutSignal]);
-
-  const controller = new AbortController();
-  const abort = (source: AbortSignal) => {
-    if (!controller.signal.aborted) controller.abort(source.reason);
-  };
-  if (signal.aborted) abort(signal);
-  if (timeoutSignal.aborted) abort(timeoutSignal);
-  signal.addEventListener("abort", () => abort(signal), { once: true });
-  timeoutSignal.addEventListener("abort", () => abort(timeoutSignal), { once: true });
-  return controller.signal;
-}
-
 export async function loadAvailableEpisodesDetail(
   context: ProviderRuntimeContext,
   apiUrl: string,
@@ -901,23 +882,7 @@ export async function fetchAllMangaEpisodeCatalog(opts: {
   if (!anilistId && !malId) return baseEpisodes;
 
   const externalMetadata = await fetchAnimeEpisodeMetadataByNumber({ anilistId, malId }, signal);
-  for (const [number, meta] of externalMetadata) {
-    const existing = metadata.get(number);
-    if (!existing) {
-      metadata.set(number, meta);
-      continue;
-    }
-    metadata.set(number, {
-      number,
-      title: existing.title ?? meta.title,
-      synopsis: existing.synopsis ?? meta.synopsis,
-      airDate: existing.airDate ?? meta.airDate,
-      thumbnail: existing.thumbnail ?? meta.thumbnail,
-      isFiller: existing.isFiller ?? meta.isFiller,
-      isRecap: existing.isRecap ?? meta.isRecap,
-      source: "merged",
-    });
-  }
+  mergeExternalEpisodeMetadataInto(metadata, externalMetadata);
 
   if (metadata.size === 0) return baseEpisodes;
 

--- a/packages/providers/src/anidb/browse-parser.ts
+++ b/packages/providers/src/anidb/browse-parser.ts
@@ -1,3 +1,5 @@
+import { decodeMarkupEntities, markupToPlainText, stripScriptBlocks } from "../shared/markup-text";
+
 /**
  * Pure AniDB browse-markup parsing.
  *
@@ -38,7 +40,7 @@ export function anidbNumericId(showId: string): number | null {
 }
 
 export function parseAnidbSeasonEvidence(title: string): AnidbSeasonEvidence {
-  const normalizedTitle = decodeHtmlEntities(title).replace(/\s+/g, " ").trim();
+  const normalizedTitle = decodeMarkupEntities(title).replace(/\s+/g, " ").trim();
   const match =
     /\bseason\s+(\d+)\b/i.exec(normalizedTitle) ??
     /\b(\d+)(?:st|nd|rd|th)\s+season\b/i.exec(normalizedTitle) ??
@@ -141,7 +143,7 @@ function hasNestedElement(body: string): boolean {
 }
 
 function parseAnidbShowIdFromHref(href: string | undefined): string | null {
-  const decoded = decodeHtmlEntities(href ?? "").trim();
+  const decoded = decodeMarkupEntities(href ?? "").trim();
   const match = /^(?:(?:https?:)?\/\/anidb\.app)?\/anime\/([^/?#]+)(?:[/?#].*)?$/i.exec(decoded);
   const id = (match?.[1] ?? "").trim();
   return looksLikeAnidbShowId(id) ? id : null;
@@ -150,30 +152,7 @@ function parseAnidbShowIdFromHref(href: string | undefined): string | null {
 function extractAnidbTitle(attrs: string, body: string): string {
   const anchorTitle = extractAttribute(attrs, "title") ?? extractAttribute(attrs, "aria-label");
   const imageAlt = IMAGE_ALT_PATTERN.exec(body)?.[1];
-  const nestedText = stripTags(stripScriptBlocks(body));
-  const decoded = decodeHtmlEntities(anchorTitle ?? imageAlt ?? nestedText);
-  // A raw ESC/BEL byte in the response body is the other half of the entity
-  // vector closed in decodeCodePoint(); `\s` matches neither, so without this
-  // they would survive into terminal output.
-  return stripControlCharacters(decoded).replace(/\s+/g, " ").trim();
-}
-
-/**
- * Drops C0/C1 controls but keeps tab/LF/CR, which the whitespace collapse below
- * turns into a single space -- stripping them outright would weld "Foo\nBar"
- * into "FooBar". Written as a code-point scan rather than a regex: a character
- * class of raw control characters is exactly what `no-control-regex` forbids,
- * and the scan reuses the same predicate the entity decoder checks.
- */
-function stripControlCharacters(value: string): string {
-  let out = "";
-  for (const character of value) {
-    const codePoint = character.codePointAt(0) ?? 0;
-    const isCollapsibleWhitespace = codePoint === 0x09 || codePoint === 0x0a || codePoint === 0x0d;
-    if (isControlCodePoint(codePoint) && !isCollapsibleWhitespace) continue;
-    out += character;
-  }
-  return out;
+  return markupToPlainText(anchorTitle ?? imageAlt ?? stripScriptBlocks(body));
 }
 
 /**
@@ -190,125 +169,12 @@ const ATTRIBUTE_PATTERNS = {
 
 const IMAGE_ALT_PATTERN = /<img\b[^>]*\salt\s*=\s*["']([^"']*)["']/i;
 
-/**
- * Removes `<script>…</script>` spans by scanning, not by regex.
- *
- * `/<script\b[\s\S]*?<\/script(?:[\s/][^>]*)?>/` is polynomial: the lazy body
- * advances one character at a time and each position re-scans `[^>]*` to the end,
- * so input repeating `</script\t` with no `>` degrades quadratically. This runs on
- * fetched provider markup, so that is a denial-of-service vector, not a nicety.
- *
- * Tag-name boundaries follow HTML: a name ends at whitespace, `/`, or `>`, and the
- * rest of an end tag is ignored — `</script>`, `</script >`, `</script\t\n bar>`
- * and `</script/>` all close, `</scriptfoo>` does not. An unterminated `<script`
- * drops the remainder: leaving it would put raw script source in a title.
- */
-function stripScriptBlocks(body: string): string {
-  const lowered = body.toLowerCase();
-  let out = "";
-  let cursor = 0;
-  for (;;) {
-    const open = indexOfTag(lowered, "<script", cursor);
-    if (open === -1) return out + body.slice(cursor);
-    const openEnd = body.indexOf(">", open);
-    if (openEnd === -1) return `${out + body.slice(cursor, open)} `;
-    const close = indexOfTag(lowered, "</script", openEnd + 1);
-    if (close === -1) return `${out + body.slice(cursor, open)} `;
-    const closeEnd = body.indexOf(">", close);
-    if (closeEnd === -1) return `${out + body.slice(cursor, open)} `;
-    out += `${body.slice(cursor, open)} `;
-    cursor = closeEnd + 1;
-  }
-}
-
-/**
- * Replaces `/<[^>]+>/g` for the same reason as stripScriptBlocks: on a body of
- * many `<` with no `>`, every `<` restarts a scan to end of input. Here the
- * failing `indexOf(">")` can happen at most once, because it returns
- * immediately, so the walk stays linear.
- *
- * Faithful to the regex it replaces: a tag needs at least one character between
- * the brackets, so a literal `<>` is text, and an unclosed `<` keeps the rest of
- * the string as text rather than discarding it.
- */
-function stripTags(value: string): string {
-  let out = "";
-  let cursor = 0;
-  for (;;) {
-    const open = value.indexOf("<", cursor);
-    if (open === -1) return out + value.slice(cursor);
-    const close = value.indexOf(">", open + 1);
-    if (close === -1) return out + value.slice(cursor);
-    if (close === open + 1) {
-      out += value.slice(cursor, close + 1);
-      cursor = close + 1;
-      continue;
-    }
-    out += `${value.slice(cursor, open)} `;
-    cursor = close + 1;
-  }
-}
-
-/** `indexOf` for a tag whose name ends at the match — not `<scriptfoo>`. */
-function indexOfTag(lowered: string, tag: string, from: number): number {
-  for (
-    let index = lowered.indexOf(tag, from);
-    index !== -1;
-    index = lowered.indexOf(tag, index + 1)
-  ) {
-    const next = lowered.charCodeAt(index + tag.length);
-    // whitespace, `/`, `>`, or end of input all terminate the tag name.
-    if (Number.isNaN(next) || next === 0x2f || next === 0x3e || next <= 0x20) return index;
-  }
-  return -1;
-}
-
 function extractAttribute(
   attrs: string,
   name: keyof typeof ATTRIBUTE_PATTERNS,
 ): string | undefined {
   const value = ATTRIBUTE_PATTERNS[name].exec(attrs)?.[1];
   return value?.trim() ? value : undefined;
-}
-
-const HTML_ENTITY_PATTERN = /&(?:#x([0-9a-f]+)|#(\d+)|(amp|lt|gt|quot|apos));/gi;
-
-const NAMED_ENTITIES: Record<string, string> = {
-  amp: "&",
-  lt: "<",
-  gt: ">",
-  quot: '"',
-  apos: "'",
-};
-
-function decodeCodePoint(raw: string, codePoint: number): string {
-  // Reject out-of-range values and the lone-surrogate block, which would
-  // otherwise produce an ill-formed title string.
-  if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) return raw;
-  if (codePoint >= 0xd800 && codePoint <= 0xdfff) return raw;
-  // Refuse to manufacture control characters. `&#27;` is plain ASCII in the
-  // response body, so a provider needs no raw ESC byte to smuggle one -- the
-  // decoder would mint it. These titles are printed straight to a terminal,
-  // where ESC drives cursor movement, screen clears, and OSC 52 clipboard
-  // writes. C0 (0x00-0x1f, 0x7f) and C1 (0x80-0x9f) are left as inert text.
-  if (isControlCodePoint(codePoint)) return raw;
-  return String.fromCodePoint(codePoint);
-}
-
-function isControlCodePoint(codePoint: number): boolean {
-  return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
-}
-
-/** Single pass, so `&amp;lt;` decodes to the literal `&lt;` and never to `<`. */
-function decodeHtmlEntities(value: string): string {
-  return value.replace(
-    HTML_ENTITY_PATTERN,
-    (raw: string, hex?: string, decimal?: string, named?: string) => {
-      if (hex !== undefined) return decodeCodePoint(raw, Number.parseInt(hex, 16));
-      if (decimal !== undefined) return decodeCodePoint(raw, Number.parseInt(decimal, 10));
-      return NAMED_ENTITIES[named?.toLowerCase() ?? ""] ?? raw;
-    },
-  );
 }
 
 function normalizeTitle(value: string): string {

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -3,6 +3,7 @@ import type { ProviderRuntimeContext } from "@kunai/types";
 import type { AnimeEpisodeMetadata } from "../shared/anime-metadata";
 import { curlCipherArgs, resolveCurlCandidate } from "../shared/curl-impersonate";
 import { expandHlsMasterPlaylist } from "../shared/hls-ladder";
+import { markupToPlainText } from "../shared/markup-text";
 import { TTLCache } from "../shared/provider-cache";
 import { createTimeoutSignal } from "../shared/timeout-signal";
 import { anidbNumericId, parseAnidbBrowseHtml, type AnidbSearchResult } from "./browse-parser";
@@ -246,7 +247,7 @@ export async function fetchAnidbOfficialEpisodeMetadata(
   }
 }
 
-function parseAnidbOfficialEpisodeMetadata(xml: string): Map<number, AnimeEpisodeMetadata> {
+export function parseAnidbOfficialEpisodeMetadata(xml: string): Map<number, AnimeEpisodeMetadata> {
   const metadata = new Map<number, AnimeEpisodeMetadata>();
   const episodePattern = /<episode\b[^>]*>([\s\S]*?)<\/episode>/gi;
   let match: RegExpExecArray | null;
@@ -301,34 +302,11 @@ function readXmlAttribute(attributes: string, name: string): string | undefined 
 }
 
 function normalizeXmlText(value: string): string {
-  return decodeXmlEntities(value.replace(/<[^>]+>/g, ""))
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function decodeXmlEntities(value: string): string {
-  return value.replace(
-    /&(?:#x([0-9a-f]+)|#(\d+)|(amp|lt|gt|quot|apos));/gi,
-    (raw, hex?: string, decimal?: string, named?: string) => {
-      if (hex !== undefined) return decodeXmlCodePoint(raw, Number.parseInt(hex, 16));
-      if (decimal !== undefined) return decodeXmlCodePoint(raw, Number.parseInt(decimal, 10));
-      return (
-        { amp: "&", lt: "<", gt: ">", quot: '"', apos: "'" }[named?.toLowerCase() ?? ""] ?? raw
-      );
-    },
-  );
-}
-
-function decodeXmlCodePoint(raw: string, codePoint: number): string {
-  if (
-    !Number.isInteger(codePoint) ||
-    codePoint < 0 ||
-    codePoint > 0x10ffff ||
-    (codePoint >= 0xd800 && codePoint <= 0xdfff)
-  ) {
-    return raw;
-  }
-  return String.fromCodePoint(codePoint);
+  // Official summaries carry markup and numeric entities, and land straight in
+  // terminal output. `markupToPlainText` is the same hardened path the browse
+  // scraper uses: script spans first, then tags, entities decoded once, and no
+  // decoded control character — `&#27;` must never become a live ESC byte.
+  return markupToPlainText(value);
 }
 
 function readMetaContent(html: string, property: string): string | undefined {

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -1,5 +1,6 @@
 import type { ProviderRuntimeContext } from "@kunai/types";
 
+import type { AnimeEpisodeMetadata } from "../shared/anime-metadata";
 import { curlCipherArgs, resolveCurlCandidate } from "../shared/curl-impersonate";
 import { expandHlsMasterPlaylist } from "../shared/hls-ladder";
 import { TTLCache } from "../shared/provider-cache";
@@ -23,6 +24,19 @@ export const ANIDB_USER_AGENT =
 const episodeCache = new TTLCache<string, readonly AnidbEpisodeEntry[]>(1_800_000);
 const languageCache = new TTLCache<string, readonly AnidbLanguageEntry[]>(300_000);
 const malCache = new TTLCache<string, number | null>(3_600_000);
+const externalIdsCache = new TTLCache<
+  string,
+  {
+    readonly malId: number | null;
+    readonly anilistId: string | null;
+    readonly officialAid: number | null;
+    readonly posterUrl: string | null;
+  }
+>(3_600_000);
+const officialEpisodeMetadataCache = new TTLCache<
+  string,
+  ReadonlyMap<number, AnimeEpisodeMetadata>
+>(30 * 24 * 60 * 60 * 1000);
 
 export type AnidbEpisodeEntry = {
   readonly id: number;
@@ -39,6 +53,7 @@ export type AnidbLanguageEntry = {
 export type AnidbStreamLink = {
   readonly url: string;
   readonly quality: string;
+  readonly audioMode: "sub" | "dub";
   readonly referer: string;
   readonly protocol: "hls";
   readonly container: "m3u8";
@@ -135,20 +150,183 @@ export async function fetchAnidbMalId(
   const cached = malCache.get(showId);
   if (cached !== undefined) return cached ?? undefined;
 
+  const ids = await fetchAnidbExternalIds(showId, signal);
+  if (!ids) return undefined;
+  const result = ids?.malId ?? null;
+  malCache.set(showId, result);
+  return result ?? undefined;
+}
+
+export type AnidbExternalIds = {
+  readonly malId?: number;
+  readonly anilistId?: string;
+  readonly officialAid?: number;
+  readonly posterUrl?: string;
+};
+
+export async function fetchAnidbExternalIds(
+  showId: string,
+  signal?: AbortSignal,
+): Promise<AnidbExternalIds | undefined> {
+  const cached = externalIdsCache.get(showId);
+  if (cached) {
+    return {
+      malId: cached.malId ?? undefined,
+      anilistId: cached.anilistId ?? undefined,
+      officialAid: cached.officialAid ?? undefined,
+      posterUrl: cached.posterUrl ?? undefined,
+    };
+  }
+
   try {
     const page = await anidbFetchText(`${ANIDB_BASE}/anime/${encodeURIComponent(showId)}`, {
       signal,
     });
     const mal = /https:\/\/myanimelist\.net\/anime\/(\d+)/.exec(page)?.[1];
-    const parsed = mal ? Number(mal) : NaN;
-    const result = Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-    malCache.set(showId, result);
-    return result ?? undefined;
+    const parsedMal = mal ? Number(mal) : NaN;
+    const malId = Number.isFinite(parsedMal) && parsedMal > 0 ? parsedMal : null;
+    const anilistId = /https:\/\/anilist\.co\/anime\/(\d+)/.exec(page)?.[1] ?? null;
+    const official = /https:\/\/anidb\.net\/anime\/(\d+)/.exec(page)?.[1];
+    const parsedOfficial = official ? Number(official) : NaN;
+    const officialAid =
+      Number.isFinite(parsedOfficial) && parsedOfficial > 0 ? parsedOfficial : null;
+    const posterUrl = readMetaContent(page, "og:image") ?? null;
+    externalIdsCache.set(showId, { malId, anilistId, officialAid, posterUrl });
+    return {
+      malId: malId ?? undefined,
+      anilistId: anilistId ?? undefined,
+      officialAid: officialAid ?? undefined,
+      posterUrl: posterUrl ?? undefined,
+    };
   } catch {
-    // A transport failure says nothing about the show. Caching it would let one
-    // Cloudflare block or dropped connection suppress auto-skip for an hour.
+    // A transport failure says nothing about the show. Do not cache it or let a
+    // Cloudflare block suppress metadata and auto-skip for the full TTL.
     return undefined;
   }
+}
+
+export async function fetchAnidbOfficialEpisodeMetadata(
+  officialAid: number,
+  signal?: AbortSignal,
+): Promise<ReadonlyMap<number, AnimeEpisodeMetadata>> {
+  const cacheKey = String(officialAid);
+  const cached = officialEpisodeMetadataCache.get(cacheKey);
+  if (cached) return new Map(cached);
+
+  try {
+    const response = await fetch(
+      `http://api.anidb.net:9001/httpapi?request=anime&client=anidb&clientver=1&protover=1&aid=${officialAid}`,
+      {
+        headers: { Accept: "text/xml", "User-Agent": ANIDB_USER_AGENT },
+        signal: signal ?? AbortSignal.timeout(15_000),
+      },
+    );
+    if (!response.ok) return new Map();
+    const xml = await response.text();
+    const metadata = parseAnidbOfficialEpisodeMetadata(xml);
+    officialEpisodeMetadataCache.set(cacheKey, metadata);
+    return new Map(metadata);
+  } catch {
+    return new Map();
+  }
+}
+
+function parseAnidbOfficialEpisodeMetadata(xml: string): Map<number, AnimeEpisodeMetadata> {
+  const metadata = new Map<number, AnimeEpisodeMetadata>();
+  const episodePattern = /<episode\b[^>]*>([\s\S]*?)<\/episode>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = episodePattern.exec(xml)) !== null) {
+    const block = match[1] ?? "";
+    const epno = readXmlElement(block, "epno");
+    if (readXmlAttribute(epno.attributes, "type") !== "1") continue;
+    const number = Number(epno.value);
+    if (!Number.isInteger(number) || number < 1) continue;
+
+    const title = readPreferredAnidbEpisodeTitle(block);
+    const synopsis = readXmlElement(block, "summary").value;
+    const airDate = readXmlElement(block, "airdate").value;
+    metadata.set(number, {
+      number,
+      title: title || undefined,
+      synopsis: synopsis || undefined,
+      airDate: airDate || undefined,
+      source: "anidb",
+    });
+  }
+  return metadata;
+}
+
+function readPreferredAnidbEpisodeTitle(block: string): string {
+  const titles = [...block.matchAll(/<title\b([^>]*)>([\s\S]*?)<\/title>/gi)].map((match) => ({
+    language: readXmlAttribute(match[1] ?? "", "xml:lang"),
+    value: normalizeXmlText(match[2] ?? ""),
+  }));
+  return (
+    titles.find((title) => title.language === "en")?.value ??
+    titles.find((title) => title.language === "x-jat")?.value ??
+    titles[0]?.value ??
+    ""
+  );
+}
+
+function readXmlElement(
+  block: string,
+  name: string,
+): { readonly attributes: string; readonly value: string } {
+  const match = new RegExp(`<${name}\\b([^>]*)>([\\s\\S]*?)</${name}>`, "i").exec(block);
+  return {
+    attributes: match?.[1] ?? "",
+    value: normalizeXmlText(match?.[2] ?? ""),
+  };
+}
+
+function readXmlAttribute(attributes: string, name: string): string | undefined {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`${escapedName}\\s*=\\s*["']([^"']*)["']`, "i").exec(attributes)?.[1];
+}
+
+function normalizeXmlText(value: string): string {
+  return decodeXmlEntities(value.replace(/<[^>]+>/g, ""))
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function decodeXmlEntities(value: string): string {
+  return value.replace(
+    /&(?:#x([0-9a-f]+)|#(\d+)|(amp|lt|gt|quot|apos));/gi,
+    (raw, hex?: string, decimal?: string, named?: string) => {
+      if (hex !== undefined) return decodeXmlCodePoint(raw, Number.parseInt(hex, 16));
+      if (decimal !== undefined) return decodeXmlCodePoint(raw, Number.parseInt(decimal, 10));
+      return (
+        { amp: "&", lt: "<", gt: ">", quot: '"', apos: "'" }[named?.toLowerCase() ?? ""] ?? raw
+      );
+    },
+  );
+}
+
+function decodeXmlCodePoint(raw: string, codePoint: number): string {
+  if (
+    !Number.isInteger(codePoint) ||
+    codePoint < 0 ||
+    codePoint > 0x10ffff ||
+    (codePoint >= 0xd800 && codePoint <= 0xdfff)
+  ) {
+    return raw;
+  }
+  return String.fromCodePoint(codePoint);
+}
+
+function readMetaContent(html: string, property: string): string | undefined {
+  const escaped = property.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const propertyFirst = new RegExp(
+    `<meta\\b[^>]*property=["']${escaped}["'][^>]*content=["']([^"']+)["']`,
+    "i",
+  );
+  const contentFirst = new RegExp(
+    `<meta\\b[^>]*content=["']([^"']+)["'][^>]*property=["']${escaped}["']`,
+    "i",
+  );
+  return propertyFirst.exec(html)?.[1] ?? contentFirst.exec(html)?.[1];
 }
 
 export async function fetchAnidbEpisodes(
@@ -244,11 +422,9 @@ export async function resolveAnidbEpisodeStreams(options: {
 
   const languages = await fetchAnidbLanguages(episode.id, options.signal);
   const preferredCode = options.audioMode === "dub" ? "eng" : "jpn";
-  const fallbackCode = options.audioMode === "dub" ? "jpn" : "eng";
-  const language =
-    languages.find((entry) => entry.code === preferredCode) ??
-    languages.find((entry) => entry.code === fallbackCode) ??
-    languages[0];
+  // Do not silently play the other language and label it as the requested mode.
+  // The caller can then fall back to another provider or let the user switch.
+  const language = languages.find((entry) => entry.code === preferredCode);
   if (!language) return [];
 
   const masterUrl = await fetchAnidbMasterUrl(language.embedUrl, options.signal);
@@ -276,6 +452,7 @@ export async function resolveAnidbEpisodeStreams(options: {
   return variants.map((variant) => ({
     url: variant.url,
     quality: variant.qualityLabel,
+    audioMode: options.audioMode,
     referer: ANIDB_REFERER,
     protocol: "hls" as const,
     container: "m3u8" as const,
@@ -286,4 +463,6 @@ export function clearAnidbCachesForTest(): void {
   episodeCache.clear();
   languageCache.clear();
   malCache.clear();
+  externalIdsCache.clear();
+  officialEpisodeMetadataCache.clear();
 }

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -4,6 +4,7 @@ import type { AnimeEpisodeMetadata } from "../shared/anime-metadata";
 import { curlCipherArgs, resolveCurlCandidate } from "../shared/curl-impersonate";
 import { expandHlsMasterPlaylist } from "../shared/hls-ladder";
 import { TTLCache } from "../shared/provider-cache";
+import { createTimeoutSignal } from "../shared/timeout-signal";
 import { anidbNumericId, parseAnidbBrowseHtml, type AnidbSearchResult } from "./browse-parser";
 
 export {
@@ -18,6 +19,14 @@ export {
 
 export const ANIDB_BASE = "https://anidb.app";
 export const ANIDB_REFERER = "https://anidb.app/";
+/**
+ * Official AniDB HTTP API. Read-only, one request per series, cached for a
+ * month: AniDB's terms are strict about repeat traffic and it answers abuse by
+ * banning the client name, so nothing here may run per episode or per playback.
+ */
+export const ANIDB_HTTP_API = "http://api.anidb.net:9001/httpapi";
+export const ANIDB_HTTP_API_CLIENT = "anidb";
+export const ANIDB_HTTP_API_CLIENT_VERSION = "1";
 export const ANIDB_USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
@@ -215,15 +224,21 @@ export async function fetchAnidbOfficialEpisodeMetadata(
 
   try {
     const response = await fetch(
-      `http://api.anidb.net:9001/httpapi?request=anime&client=anidb&clientver=1&protover=1&aid=${officialAid}`,
+      `${ANIDB_HTTP_API}?request=anime&client=${ANIDB_HTTP_API_CLIENT}&clientver=${ANIDB_HTTP_API_CLIENT_VERSION}&protover=1&aid=${officialAid}`,
       {
         headers: { Accept: "text/xml", "User-Agent": ANIDB_USER_AGENT },
-        signal: signal ?? AbortSignal.timeout(15_000),
+        signal: createTimeoutSignal(signal, 15_000),
       },
     );
     if (!response.ok) return new Map();
     const xml = await response.text();
+    // AniDB answers rate limits, bans, and bad client credentials with HTTP 200
+    // and an <error> body. Caching what that parses to (nothing) would suppress
+    // every episode title for this show for the full TTL, long after the block
+    // lifted — so an empty read stays uncached and simply retries next time.
+    if (/<error\b/i.test(xml)) return new Map();
     const metadata = parseAnidbOfficialEpisodeMetadata(xml);
+    if (metadata.size === 0) return new Map();
     officialEpisodeMetadataCache.set(cacheKey, metadata);
     return new Map(metadata);
   } catch {

--- a/packages/providers/src/anidb/direct.ts
+++ b/packages/providers/src/anidb/direct.ts
@@ -17,8 +17,13 @@ import type {
 
 import { resolveAnimeAudioIntent } from "../shared/anime-audio-intent";
 import {
+  anidbEpisodeMetadataCacheKey,
   enrichEpisodeOptionsWithAnimeMetadata,
   fetchAnimeEpisodeMetadataByNumber,
+  mergeExternalEpisodeMetadataInto,
+  mergeSeededEpisodeMetadataInto,
+  seedEpisodeMetadataFromProvider,
+  shouldSkipExternalEpisodeMetadataEnrichment,
   type AnimeEpisodeMetadata,
 } from "../shared/anime-metadata";
 import {
@@ -231,42 +236,40 @@ export const anidbProviderModule: CoreProviderModule = {
     if (!showId) return null;
     const episodes = await fetchAnidbEpisodes(showId, context.signal);
     if (episodes.length === 0) return [];
+
     const suppliedMalId = input.title.externalIds?.malId ?? input.title.malId;
     const suppliedAnilistId = input.title.externalIds?.anilistId ?? input.title.anilistId;
     const pageIds = await fetchAnidbExternalIds(showId, context.signal);
     const malId = suppliedMalId?.trim() ? suppliedMalId : pageIds?.malId;
     const anilistId = suppliedAnilistId ?? pageIds?.anilistId;
     const metadataMalId = malId === undefined ? undefined : String(malId);
+
+    // Official AniDB is the title/synopsis/air-date authority for this provider
+    // and answers in one request for the whole series, so it runs first and its
+    // values win. Seeded so a second listing (or the same show under another
+    // surface) does not pay for it again.
+    const metadataCacheKey = anidbEpisodeMetadataCacheKey(showId);
     const metadata = new Map<number, AnimeEpisodeMetadata>();
-    if (pageIds?.officialAid) {
-      for (const [number, meta] of await fetchAnidbOfficialEpisodeMetadata(
-        pageIds.officialAid,
-        context.signal,
-      )) {
-        metadata.set(number, meta);
-      }
+    mergeSeededEpisodeMetadataInto(metadata, metadataCacheKey);
+    if (metadata.size === 0 && pageIds?.officialAid) {
+      const official = await fetchAnidbOfficialEpisodeMetadata(pageIds.officialAid, context.signal);
+      for (const [number, meta] of official) metadata.set(number, meta);
+      seedEpisodeMetadataFromProvider(metadataCacheKey, [...official.values()]);
     }
-    const externalMetadata = await fetchAnimeEpisodeMetadataByNumber(
-      { anilistId, malId: metadataMalId },
-      context.signal,
-    );
-    for (const [number, meta] of externalMetadata) {
-      const existing = metadata.get(number);
-      metadata.set(
-        number,
-        existing
-          ? {
-              ...existing,
-              title: existing.title ?? meta.title,
-              synopsis: existing.synopsis ?? meta.synopsis,
-              airDate: existing.airDate ?? meta.airDate,
-              thumbnail: existing.thumbnail ?? meta.thumbnail,
-              isFiller: existing.isFiller ?? meta.isFiller,
-              isRecap: existing.isRecap ?? meta.isRecap,
-              source: "merged",
-            }
-          : meta,
+
+    // AniDB publishes no episode stills, so AniList still runs for artwork even
+    // when every title is already known — but the paginated, rate-limited Jikan
+    // pass is skipped, which is the slow half.
+    if (anilistId || metadataMalId) {
+      const pass = shouldSkipExternalEpisodeMetadataEnrichment(metadata, episodes.length)
+        ? "artwork"
+        : "full";
+      const externalMetadata = await fetchAnimeEpisodeMetadataByNumber(
+        { anilistId, malId: metadataMalId },
+        context.signal,
+        pass,
       );
+      mergeExternalEpisodeMetadataInto(metadata, externalMetadata);
     }
 
     const baseEpisodes = episodes.map(
@@ -275,6 +278,8 @@ export const anidbProviderModule: CoreProviderModule = {
         label: `Episode ${episode.number}`,
         detail: episode.filler ? "Filler" : undefined,
         totalEpisodeCount: episodes.length,
+        // Series poster as the still fallback: an empty art slot reads as a
+        // broken row, and AniDB has no per-episode image of its own.
         artwork: pageIds?.posterUrl ? { thumbnailUrl: pageIds.posterUrl } : undefined,
         externalIds: {
           anilistId,

--- a/packages/providers/src/anidb/direct.ts
+++ b/packages/providers/src/anidb/direct.ts
@@ -17,6 +17,11 @@ import type {
 
 import { resolveAnimeAudioIntent } from "../shared/anime-audio-intent";
 import {
+  enrichEpisodeOptionsWithAnimeMetadata,
+  fetchAnimeEpisodeMetadataByNumber,
+  type AnimeEpisodeMetadata,
+} from "../shared/anime-metadata";
+import {
   animeQualityFields,
   formatAnimeSourceArchetype,
   formatAnimeSourceDetail,
@@ -30,6 +35,8 @@ import {
   anidbNumericId,
   chooseAnidbSearchMatch,
   fetchAnidbEpisodes,
+  fetchAnidbExternalIds,
+  fetchAnidbOfficialEpisodeMetadata,
   fetchAnidbMalId,
   looksLikeAnidbShowId,
   parseAnidbSeasonEvidence,
@@ -46,6 +53,8 @@ export {
   anidbNumericId,
   chooseAnidbSearchMatch,
   clearAnidbCachesForTest,
+  fetchAnidbExternalIds,
+  fetchAnidbOfficialEpisodeMetadata,
   fetchAnidbMalId,
   looksLikeAnidbShowId,
   parseAnidbBrowseHtml,
@@ -132,19 +141,19 @@ function buildAnidbSourceInventory(
 
 function linksToCandidates(
   links: readonly AnidbStreamLink[],
-  audioMode: "sub" | "dub",
   cachePolicy: ReturnType<typeof createProviderCachePolicy>,
 ): {
   readonly streams: StreamCandidate[];
   readonly variants: ProviderVariantCandidate[];
   readonly sourceId: string;
 } {
+  const audioMode = links[0]?.audioMode ?? "sub";
   const sourceId = `source:${ANIDB_PROVIDER_ID}:${audioMode}`;
   const streams: StreamCandidate[] = [];
   const variants: ProviderVariantCandidate[] = [];
   const sourceDetail = formatAnimeSourceDetail({
     audio: audioMode,
-    subtitleMode: audioMode === "sub" ? "hard" : "unknown",
+    subtitleMode: "unknown",
   });
   const archetype = formatAnimeSourceArchetype({
     audio: audioMode,
@@ -168,8 +177,6 @@ function linksToCandidates(
       qualityRank: quality.qualityRank,
       presentation: audioMode,
       audioLanguages: audioMode === "dub" ? ["en"] : ["ja"],
-      hardSubLanguage: audioMode === "sub" ? "en" : undefined,
-      subtitleDelivery: audioMode === "sub" ? "hardcoded" : undefined,
       flavorArchetype: archetype,
       flavorLabel: audioMode === "dub" ? "Dub" : "Sub",
       serverName: "anidb",
@@ -211,19 +218,9 @@ export const anidbProviderModule: CoreProviderModule = {
         type: "series",
         title: result.title,
         metadataSource: "AniDB",
-        availableAudioModes: ["sub", "dub"],
-        subtitleAvailability: "hardsub",
         externalIds: {
           providerNativeIds: { [ANIDB_PROVIDER_ID]: result.id },
         },
-        languageEvidence: [
-          {
-            role: "audio",
-            normalizedLanguage: "ja",
-            nativeLabel: "sub",
-            confidence: 0.8,
-          },
-        ],
       });
     }
     return mapped;
@@ -234,18 +231,60 @@ export const anidbProviderModule: CoreProviderModule = {
     if (!showId) return null;
     const episodes = await fetchAnidbEpisodes(showId, context.signal);
     if (episodes.length === 0) return [];
-    const malId = await fetchAnidbMalId(showId, context.signal);
-    return episodes.map(
+    const suppliedMalId = input.title.externalIds?.malId ?? input.title.malId;
+    const suppliedAnilistId = input.title.externalIds?.anilistId ?? input.title.anilistId;
+    const pageIds = await fetchAnidbExternalIds(showId, context.signal);
+    const malId = suppliedMalId?.trim() ? suppliedMalId : pageIds?.malId;
+    const anilistId = suppliedAnilistId ?? pageIds?.anilistId;
+    const metadataMalId = malId === undefined ? undefined : String(malId);
+    const metadata = new Map<number, AnimeEpisodeMetadata>();
+    if (pageIds?.officialAid) {
+      for (const [number, meta] of await fetchAnidbOfficialEpisodeMetadata(
+        pageIds.officialAid,
+        context.signal,
+      )) {
+        metadata.set(number, meta);
+      }
+    }
+    const externalMetadata = await fetchAnimeEpisodeMetadataByNumber(
+      { anilistId, malId: metadataMalId },
+      context.signal,
+    );
+    for (const [number, meta] of externalMetadata) {
+      const existing = metadata.get(number);
+      metadata.set(
+        number,
+        existing
+          ? {
+              ...existing,
+              title: existing.title ?? meta.title,
+              synopsis: existing.synopsis ?? meta.synopsis,
+              airDate: existing.airDate ?? meta.airDate,
+              thumbnail: existing.thumbnail ?? meta.thumbnail,
+              isFiller: existing.isFiller ?? meta.isFiller,
+              isRecap: existing.isRecap ?? meta.isRecap,
+              source: "merged",
+            }
+          : meta,
+      );
+    }
+
+    const baseEpisodes = episodes.map(
       (episode): ProviderEpisodeOption => ({
         index: episode.number,
         label: `Episode ${episode.number}`,
         detail: episode.filler ? "Filler" : undefined,
         totalEpisodeCount: episodes.length,
+        artwork: pageIds?.posterUrl ? { thumbnailUrl: pageIds.posterUrl } : undefined,
         externalIds: {
+          anilistId,
           malId: malId ? String(malId) : undefined,
         },
       }),
     );
+    return metadata.size > 0
+      ? enrichEpisodeOptionsWithAnimeMetadata(baseEpisodes, metadata)
+      : baseEpisodes;
   },
 
   async resolve(input, context) {
@@ -353,7 +392,7 @@ export const anidbProviderModule: CoreProviderModule = {
         });
       }
 
-      const { streams, variants, sourceId } = linksToCandidates(links, audioMode, cachePolicy);
+      const { streams, variants, sourceId } = linksToCandidates(links, cachePolicy);
       const selection = selectReadyStream(streams, {
         startupPriority: input.startupPriority,
         qualityPreference: input.qualityPreference,
@@ -387,6 +426,8 @@ export const anidbProviderModule: CoreProviderModule = {
         streams,
         variants,
         subtitles: [],
+        release: input.episode?.release,
+        artwork: input.episode?.artwork,
         externalIds: {
           anilistId: input.title.externalIds?.anilistId ?? input.title.anilistId,
           malId,

--- a/packages/providers/src/anidb/manifest.ts
+++ b/packages/providers/src/anidb/manifest.ts
@@ -48,6 +48,7 @@ export const anidbManifest = defineProviderManifest({
   },
   notes: [
     "Parity with ani-cli v5.0 (2026-08-01): browse search, /api/frontend anime episodes + episode languages, embed → HLS master.",
+    "Episode metadata follows the explicit anidb.app → official anidb.net AID cross-link, then reads official XML; AniList/Jikan fill missing fields and still artwork.",
     "Bun/fetch often gets Cloudflare 403 on anidb.app HTML/API; production path uses curl with a Chrome UA (dossier-proven).",
     "HLS media on hls.anidb.app usually works with native fetch after the embed URL is obtained.",
     "Sub = Japanese audio (jpn embed); dub = English audio (eng embed) when the languages API exposes it.",

--- a/packages/providers/src/rivestream/direct.ts
+++ b/packages/providers/src/rivestream/direct.ts
@@ -43,6 +43,7 @@ import {
 } from "../shared/source-inventory";
 import { selectReadyStream } from "../shared/startup-selection";
 import { normalizeIsoLanguageCode } from "../shared/subtitle-helpers";
+import { createTimeoutSignal } from "../shared/timeout-signal";
 import { rivestreamManifest, RIVESTREAM_PROVIDER_ID } from "./manifest";
 
 export { RIVESTREAM_PROVIDER_ID };
@@ -104,27 +105,6 @@ type RivestreamResolvedCandidate = {
   readonly variants: readonly ProviderVariantCandidate[];
   readonly subtitles: readonly SubtitleCandidate[];
 };
-
-type AbortSignalConstructorWithAny = typeof AbortSignal & {
-  readonly any?: (signals: readonly AbortSignal[]) => AbortSignal;
-};
-
-function createTimeoutSignal(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
-  const timeout = AbortSignal.timeout(timeoutMs);
-  if (!signal) return timeout;
-  const abortSignal = AbortSignal as AbortSignalConstructorWithAny;
-  if (abortSignal.any) return abortSignal.any([signal, timeout]);
-  // Manual combine fallback so the timeout is never dropped.
-  const controller = new AbortController();
-  const abortFrom = (source: AbortSignal) => {
-    if (!controller.signal.aborted) controller.abort(source.reason);
-  };
-  if (signal.aborted) abortFrom(signal);
-  else signal.addEventListener("abort", () => abortFrom(signal), { once: true });
-  if (timeout.aborted) abortFrom(timeout);
-  else timeout.addEventListener("abort", () => abortFrom(timeout), { once: true });
-  return controller.signal;
-}
 
 function getRivestreamRawSources(
   data: RivestreamSourceResponse["data"],

--- a/packages/providers/src/shared/anime-metadata.ts
+++ b/packages/providers/src/shared/anime-metadata.ts
@@ -1,6 +1,7 @@
 import type { ProviderEpisodeOption } from "@kunai/types";
 
 import { TTLCache } from "./provider-cache";
+import { createTimeoutSignal } from "./timeout-signal";
 
 export type AnimeEpisodeMetadataSource =
   | "anidb"
@@ -38,6 +39,10 @@ export function allMangaEpisodeMetadataCacheKey(showId: string, mode: "sub" | "d
 
 export function miruroEpisodeMetadataCacheKey(anilistId: string): string {
   return `miruro:${anilistId}`;
+}
+
+export function anidbEpisodeMetadataCacheKey(showId: string): string {
+  return `anidb:${showId}`;
 }
 
 export function seedEpisodeMetadataFromProvider(
@@ -117,8 +122,11 @@ type AniListStreamingEpisode = {
   readonly thumbnail?: string | null;
 };
 
-function metadataCacheKey(ids: { readonly anilistId?: string; readonly malId?: string }): string {
-  return `${ids.anilistId ?? ""}|${ids.malId ?? ""}`;
+function metadataCacheKey(
+  ids: { readonly anilistId?: string; readonly malId?: string },
+  pass: EpisodeMetadataPass,
+): string {
+  return `${ids.anilistId ?? ""}|${ids.malId ?? ""}|${pass}`;
 }
 
 function pickLongerTitle(
@@ -158,7 +166,7 @@ function mergeEpisodeMetadata(
 async function fetchJson<T>(url: string, signal?: AbortSignal): Promise<T | null> {
   try {
     const response = await fetch(url, {
-      signal: signal ?? AbortSignal.timeout(20_000),
+      signal: createTimeoutSignal(signal, 20_000),
       headers: { Accept: "application/json" },
     });
     if (!response.ok) return null;
@@ -209,7 +217,7 @@ async function fetchAniListStreamingEpisodes(
   try {
     const response = await fetch(ANILIST_GRAPHQL, {
       method: "POST",
-      signal: signal ?? AbortSignal.timeout(20_000),
+      signal: createTimeoutSignal(signal, 20_000),
       headers: { "Content-Type": "application/json", Accept: "application/json" },
       body: JSON.stringify({
         query: `query ($id: Int) {
@@ -268,6 +276,17 @@ export function mergeMiruroPipeEpisodeMetadata(
   }
 }
 
+/**
+ * Which external passes a caller still needs.
+ *
+ * "artwork" is the cheap half: one AniList call for stills. "full" adds the
+ * Jikan episode list, which pages 100 at a time under a strict rate limit —
+ * worth it for a bare catalog, pure latency for a provider that already knows
+ * every episode title. Callers decide with
+ * `shouldSkipExternalEpisodeMetadataEnrichment`.
+ */
+export type EpisodeMetadataPass = "full" | "artwork";
+
 /** Fetch episode titles/synopses/stills keyed by absolute episode number.
  *
  * @deprecated Prefer provider-native episode metadata (Miruro pipe, AllManga
@@ -278,9 +297,13 @@ export function mergeMiruroPipeEpisodeMetadata(
 export async function fetchAnimeEpisodeMetadataByNumber(
   ids: { readonly anilistId?: string; readonly malId?: string },
   signal?: AbortSignal,
+  pass: EpisodeMetadataPass = "full",
 ): Promise<Map<number, AnimeEpisodeMetadata>> {
-  const cacheKey = metadataCacheKey(ids);
-  const cached = metadataCache.get(cacheKey);
+  // A completed full pass already contains everything the artwork pass would
+  // fetch, so it answers both; the reverse is not true.
+  const cached =
+    metadataCache.get(metadataCacheKey(ids, "full")) ??
+    (pass === "artwork" ? metadataCache.get(metadataCacheKey(ids, "artwork")) : undefined);
   if (cached) return new Map(cached);
 
   const merged = new Map<number, AnimeEpisodeMetadata>();
@@ -293,15 +316,43 @@ export async function fetchAnimeEpisodeMetadataByNumber(
     }
   }
 
-  if (Number.isFinite(malId) && malId > 0) {
+  if (pass === "full" && Number.isFinite(malId) && malId > 0) {
     const jikanEpisodes = await fetchJikanEpisodes(malId, signal);
     for (const [number, meta] of jikanEpisodes) {
       mergeEpisodeMetadata(merged, number, meta);
     }
   }
 
-  metadataCache.set(cacheKey, merged);
+  metadataCache.set(metadataCacheKey(ids, pass), merged);
   return merged;
+}
+
+/**
+ * Fill gaps in `target` from an external source. Provider-native values win
+ * field by field: the provider knows its own catalog, the external source is
+ * only there for what the provider does not carry.
+ */
+export function mergeExternalEpisodeMetadataInto(
+  target: Map<number, AnimeEpisodeMetadata>,
+  external: ReadonlyMap<number, AnimeEpisodeMetadata>,
+): void {
+  for (const [number, meta] of external) {
+    const existing = target.get(number);
+    if (!existing) {
+      target.set(number, meta);
+      continue;
+    }
+    target.set(number, {
+      number,
+      title: existing.title ?? meta.title,
+      synopsis: existing.synopsis ?? meta.synopsis,
+      airDate: existing.airDate ?? meta.airDate,
+      thumbnail: existing.thumbnail ?? meta.thumbnail,
+      isFiller: existing.isFiller ?? meta.isFiller,
+      isRecap: existing.isRecap ?? meta.isRecap,
+      source: "merged",
+    });
+  }
 }
 
 export function parseAllMangaEpisodeNumber(episode: ProviderEpisodeOption): number {

--- a/packages/providers/src/shared/anime-metadata.ts
+++ b/packages/providers/src/shared/anime-metadata.ts
@@ -2,7 +2,13 @@ import type { ProviderEpisodeOption } from "@kunai/types";
 
 import { TTLCache } from "./provider-cache";
 
-export type AnimeEpisodeMetadataSource = "anilist" | "jikan" | "miruro" | "allmanga" | "merged";
+export type AnimeEpisodeMetadataSource =
+  | "anidb"
+  | "anilist"
+  | "jikan"
+  | "miruro"
+  | "allmanga"
+  | "merged";
 
 export type AnimeEpisodeMetadata = {
   readonly number: number;

--- a/packages/providers/src/shared/markup-text.ts
+++ b/packages/providers/src/shared/markup-text.ts
@@ -1,0 +1,163 @@
+// =============================================================================
+// markup-text.ts — turning fetched provider markup into text that is safe to
+// print to a terminal.
+//
+// Every helper here exists because the naive one-liner is wrong in a way that
+// only shows up on hostile or malformed input: a regex that degrades to
+// quadratic time, a tag strip that leaves `<script` behind, an entity decoder
+// that mints a raw ESC byte into a string headed for stdout. Scraped HTML and
+// scraped XML have the same problem, so they share one implementation.
+// =============================================================================
+
+/**
+ * Removes `<script>…</script>` spans by scanning, not by regex.
+ *
+ * `/<script\b[\s\S]*?<\/script(?:[\s/][^>]*)?>/` is polynomial: the lazy body
+ * advances one character at a time and each position re-scans `[^>]*` to the end,
+ * so input repeating `</script\t` with no `>` degrades quadratically. This runs on
+ * fetched provider markup, so that is a denial-of-service vector, not a nicety.
+ *
+ * Tag-name boundaries follow HTML: a name ends at whitespace, `/`, or `>`, and the
+ * rest of an end tag is ignored — `</script>`, `</script >`, `</script\t\n bar>`
+ * and `</script/>` all close, `</scriptfoo>` does not. An unterminated `<script`
+ * drops the remainder: leaving it would put raw script source in a title.
+ */
+export function stripScriptBlocks(body: string): string {
+  const lowered = body.toLowerCase();
+  let out = "";
+  let cursor = 0;
+  for (;;) {
+    const open = indexOfTag(lowered, "<script", cursor);
+    if (open === -1) return out + body.slice(cursor);
+    const openEnd = body.indexOf(">", open);
+    if (openEnd === -1) return `${out + body.slice(cursor, open)} `;
+    const close = indexOfTag(lowered, "</script", openEnd + 1);
+    if (close === -1) return `${out + body.slice(cursor, open)} `;
+    const closeEnd = body.indexOf(">", close);
+    if (closeEnd === -1) return `${out + body.slice(cursor, open)} `;
+    out += `${body.slice(cursor, open)} `;
+    cursor = closeEnd + 1;
+  }
+}
+
+/**
+ * Replaces `/<[^>]+>/g` for the same reason as stripScriptBlocks: on a body of
+ * many `<` with no `>`, every `<` restarts a scan to end of input. Here the
+ * failing `indexOf(">")` can happen at most once, because it returns
+ * immediately, so the walk stays linear.
+ *
+ * Faithful to the regex it replaces: a tag needs at least one character between
+ * the brackets, so a literal `<>` is text, and an unclosed `<` keeps the rest of
+ * the string as text rather than discarding it.
+ *
+ * Run it after `stripScriptBlocks`, never instead of it: one pass over
+ * `<<script>script>alert(1)</script>` leaves a live `<script` behind.
+ */
+export function stripTags(value: string): string {
+  let out = "";
+  let cursor = 0;
+  for (;;) {
+    const open = value.indexOf("<", cursor);
+    if (open === -1) return out + value.slice(cursor);
+    const close = value.indexOf(">", open + 1);
+    if (close === -1) return out + value.slice(cursor);
+    if (close === open + 1) {
+      out += value.slice(cursor, close + 1);
+      cursor = close + 1;
+      continue;
+    }
+    out += `${value.slice(cursor, open)} `;
+    cursor = close + 1;
+  }
+}
+
+/** `indexOf` for a tag whose name ends at the match — not `<scriptfoo>`. */
+function indexOfTag(lowered: string, tag: string, from: number): number {
+  for (
+    let index = lowered.indexOf(tag, from);
+    index !== -1;
+    index = lowered.indexOf(tag, index + 1)
+  ) {
+    const next = lowered.charCodeAt(index + tag.length);
+    // whitespace, `/`, `>`, or end of input all terminate the tag name.
+    if (Number.isNaN(next) || next === 0x2f || next === 0x3e || next <= 0x20) return index;
+  }
+  return -1;
+}
+
+/**
+ * Drops C0/C1 controls but keeps tab/LF/CR, which a whitespace collapse then
+ * turns into a single space -- stripping them outright would weld "Foo\nBar"
+ * into "FooBar". Written as a code-point scan rather than a regex: a character
+ * class of raw control characters is exactly what `no-control-regex` forbids,
+ * and the scan reuses the same predicate the entity decoder checks.
+ */
+export function stripControlCharacters(value: string): string {
+  let out = "";
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    const isCollapsibleWhitespace = codePoint === 0x09 || codePoint === 0x0a || codePoint === 0x0d;
+    if (isControlCodePoint(codePoint) && !isCollapsibleWhitespace) continue;
+    out += character;
+  }
+  return out;
+}
+
+const HTML_ENTITY_PATTERN = /&(?:#x([0-9a-f]+)|#(\d+)|(amp|lt|gt|quot|apos));/gi;
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+};
+
+function decodeCodePoint(raw: string, codePoint: number): string {
+  // Reject out-of-range values and the lone-surrogate block, which would
+  // otherwise produce an ill-formed title string.
+  if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) return raw;
+  if (codePoint >= 0xd800 && codePoint <= 0xdfff) return raw;
+  // Refuse to manufacture control characters. `&#27;` is plain ASCII in the
+  // response body, so a provider needs no raw ESC byte to smuggle one -- the
+  // decoder would mint it. These titles are printed straight to a terminal,
+  // where ESC drives cursor movement, screen clears, and OSC 52 clipboard
+  // writes. C0 (0x00-0x1f, 0x7f) and C1 (0x80-0x9f) are left as inert text.
+  if (isControlCodePoint(codePoint)) return raw;
+  return String.fromCodePoint(codePoint);
+}
+
+function isControlCodePoint(codePoint: number): boolean {
+  return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+}
+
+/**
+ * Single pass, so `&amp;lt;` decodes to the literal `&lt;` and never to `<`.
+ *
+ * The five named entities are the XML predefined set, which is also the subset
+ * that matters in scraped HTML titles, so HTML and XML share this decoder.
+ */
+export function decodeMarkupEntities(value: string): string {
+  return value.replace(
+    HTML_ENTITY_PATTERN,
+    (raw: string, hex?: string, decimal?: string, named?: string) => {
+      if (hex !== undefined) return decodeCodePoint(raw, Number.parseInt(hex, 16));
+      if (decimal !== undefined) return decodeCodePoint(raw, Number.parseInt(decimal, 10));
+      return NAMED_ENTITIES[named?.toLowerCase() ?? ""] ?? raw;
+    },
+  );
+}
+
+/**
+ * The whole pipeline for one field of scraped markup: no scripts, no tags, no
+ * smuggled control characters, entities decoded exactly once, whitespace
+ * collapsed. Anything printed to the terminal from a provider response should
+ * come through here.
+ */
+export function markupToPlainText(value: string): string {
+  const decoded = decodeMarkupEntities(stripTags(stripScriptBlocks(value)));
+  // A raw ESC/BEL byte in the response body is the other half of the entity
+  // vector closed in decodeCodePoint(); `\s` matches neither, so without this
+  // they would survive into terminal output.
+  return stripControlCharacters(decoded).replace(/\s+/g, " ").trim();
+}

--- a/packages/providers/src/shared/timeout-signal.ts
+++ b/packages/providers/src/shared/timeout-signal.ts
@@ -1,0 +1,31 @@
+type AbortSignalConstructorWithAny = typeof AbortSignal & {
+  readonly any?: (signals: readonly AbortSignal[]) => AbortSignal;
+};
+
+/**
+ * Combine a caller's cancellation with a per-request deadline.
+ *
+ * `signal ?? AbortSignal.timeout(ms)` reads like it does this and does not: a
+ * caller that passes a signal silently loses the deadline, so one hung upstream
+ * holds the whole resolve open until something else gives up. Always combine.
+ */
+export function createTimeoutSignal(
+  signal: AbortSignal | undefined,
+  timeoutMs: number,
+): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  if (!signal) return timeoutSignal;
+  const abortSignal = AbortSignal as AbortSignalConstructorWithAny;
+  if (abortSignal.any) return abortSignal.any([signal, timeoutSignal]);
+
+  // Manual combine fallback so the timeout is never dropped.
+  const controller = new AbortController();
+  const abort = (source: AbortSignal) => {
+    if (!controller.signal.aborted) controller.abort(source.reason);
+  };
+  if (signal.aborted) abort(signal);
+  if (timeoutSignal.aborted) abort(timeoutSignal);
+  signal.addEventListener("abort", () => abort(signal), { once: true });
+  timeoutSignal.addEventListener("abort", () => abort(timeoutSignal), { once: true });
+  return controller.signal;
+}

--- a/packages/providers/test/anidb-episode-metadata-cost.test.ts
+++ b/packages/providers/test/anidb-episode-metadata-cost.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ProviderRuntimeContext } from "@kunai/types";
+
+import { anidbProviderModule, clearAnidbCachesForTest } from "../src/anidb/direct";
+import { clearAnimeMetadataCacheForTest } from "../src/shared/anime-metadata";
+
+// What this file protects: AniDB's own metadata is one request for a whole
+// series, while Jikan pages 100 episodes at a time under a rate limit. Paying
+// for Jikan when every title is already known is pure latency in front of the
+// episode picker, and it is invisible in a correctness-only test — both passes
+// produce the same titles.
+
+const ANIDB_PAGE =
+  '<a href="https://myanimelist.net/anime/5678/Plain-Show">MAL</a>' +
+  '<a href="https://anilist.co/anime/1234">AniList</a>' +
+  '<a href="https://anidb.net/anime/9876">AniDB</a>' +
+  '<meta property="og:image" content="https://img.example/poster.jpg">';
+
+const OFFICIAL_XML = `<?xml version="1.0"?>
+  <anime id="9876">
+    <episode id="1"><epno type="1">1</epno><airdate>2020-01-02</airdate>
+      <title xml:lang="en">The Beginning</title></episode>
+    <episode id="2"><epno type="1">2</epno><airdate>2020-01-09</airdate>
+      <title xml:lang="en">The Journey</title></episode>
+  </anime>`;
+
+const OFFICIAL_ERROR = "<error code='500'>Client Values Missing or Invalid</error>";
+
+const listInput = {
+  title: { id: "plain-show-700", kind: "anime" as const, title: "Plain Show" },
+  preferredAudioLanguage: "ja",
+};
+const listContext = { now: () => new Date().toISOString() } as ProviderRuntimeContext;
+
+function stubAnidbFetch(officialBody: string): string[] {
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: unknown) => {
+    const url = String(input);
+    calls.push(url);
+    if (url.includes("/api/frontend/anime/700/episodes")) {
+      return new Response(
+        JSON.stringify({
+          episodes: [
+            { id: 70001, number: 1 },
+            { id: 70002, number: 2 },
+          ],
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.includes("/anime/plain-show-700")) return new Response(ANIDB_PAGE, { status: 200 });
+    if (url.includes("api.anidb.net:9001")) return new Response(officialBody, { status: 200 });
+    if (url.includes("graphql.anilist.co")) {
+      return new Response(
+        JSON.stringify({
+          data: {
+            Media: {
+              streamingEpisodes: [
+                { title: "The Beginning", thumbnail: "https://img.example/ep-1.jpg" },
+                { title: "The Journey", thumbnail: "https://img.example/ep-2.jpg" },
+              ],
+            },
+          },
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.includes("api.jikan.moe")) {
+      return new Response(
+        JSON.stringify({
+          data: [
+            { mal_id: 1, title: "The Beginning", aired: "2020-01-02T00:00:00+00:00", filler: true },
+          ],
+          pagination: { has_next_page: false },
+        }),
+        { status: 200 },
+      );
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+async function withStubbedRuntime<T>(
+  officialBody: string,
+  run: (calls: string[]) => Promise<T>,
+): Promise<T> {
+  const originalWhich = Bun.which;
+  const originalFetch = globalThis.fetch;
+  clearAnidbCachesForTest();
+  clearAnimeMetadataCacheForTest();
+  // Force the fetch path; the production path shells out to curl-impersonate.
+  Bun.which = ((_command: string) => null) as typeof Bun.which;
+  const calls = stubAnidbFetch(officialBody);
+  try {
+    return await run(calls);
+  } finally {
+    globalThis.fetch = originalFetch;
+    Bun.which = originalWhich;
+    clearAnidbCachesForTest();
+    clearAnimeMetadataCacheForTest();
+  }
+}
+
+const countCalls = (calls: readonly string[], host: string) =>
+  calls.filter((url) => url.includes(host)).length;
+
+describe("anidb episode metadata cost", () => {
+  test("skips the paginated Jikan pass when official AniDB already titles every episode", async () => {
+    await withStubbedRuntime(OFFICIAL_XML, async (calls) => {
+      const episodes = await anidbProviderModule.listEpisodes?.(listInput, listContext);
+
+      expect(episodes?.map((episode) => episode.name)).toEqual(["The Beginning", "The Journey"]);
+      expect(countCalls(calls, "api.jikan.moe")).toBe(0);
+      // AniList still runs: one request, and the only source of episode stills.
+      expect(countCalls(calls, "graphql.anilist.co")).toBe(1);
+      expect(episodes?.[0]?.artwork?.thumbnailUrl).toBe("https://img.example/ep-1.jpg");
+    });
+  });
+
+  test("falls back to the full external pass when official metadata is unavailable", async () => {
+    await withStubbedRuntime(OFFICIAL_ERROR, async (calls) => {
+      const episodes = await anidbProviderModule.listEpisodes?.(listInput, listContext);
+      expect(countCalls(calls, "api.jikan.moe")).toBe(1);
+      // Filler is a Jikan-only signal, so its presence proves the pass ran and
+      // its answer reached the option, not just that a request was made.
+      expect(episodes?.[0]?.label).toContain("Filler");
+    });
+  });
+
+  test("an error answer is never cached as 'this show has no episode metadata'", async () => {
+    await withStubbedRuntime(OFFICIAL_ERROR, async (calls) => {
+      await anidbProviderModule.listEpisodes?.(listInput, listContext);
+      expect(countCalls(calls, "api.anidb.net:9001")).toBe(1);
+
+      // Only the shared external cache is dropped; the official-metadata cache
+      // must not be holding an empty answer from the failed read.
+      clearAnimeMetadataCacheForTest();
+      await anidbProviderModule.listEpisodes?.(listInput, listContext);
+      expect(countCalls(calls, "api.anidb.net:9001")).toBe(2);
+    });
+  });
+
+  test("a second listing reuses seeded official metadata instead of refetching it", async () => {
+    await withStubbedRuntime(OFFICIAL_XML, async (calls) => {
+      await anidbProviderModule.listEpisodes?.(listInput, listContext);
+      const episodes = await anidbProviderModule.listEpisodes?.(listInput, listContext);
+      expect(countCalls(calls, "api.anidb.net:9001")).toBe(1);
+      expect(episodes?.[0]?.name).toBe("The Beginning");
+    });
+  });
+});

--- a/packages/providers/test/anidb-episode-metadata-cost.test.ts
+++ b/packages/providers/test/anidb-episode-metadata-cost.test.ts
@@ -4,6 +4,7 @@ import type { ProviderRuntimeContext } from "@kunai/types";
 
 import { anidbProviderModule, clearAnidbCachesForTest } from "../src/anidb/direct";
 import { clearAnimeMetadataCacheForTest } from "../src/shared/anime-metadata";
+import { isOfficialAnidbApi } from "./helpers/anidb-urls";
 
 // What this file protects: AniDB's own metadata is one request for a whole
 // series, while Jikan pages 100 episodes at a time under a rate limit. Paying
@@ -50,7 +51,7 @@ function stubAnidbFetch(officialBody: string): string[] {
       );
     }
     if (url.includes("/anime/plain-show-700")) return new Response(ANIDB_PAGE, { status: 200 });
-    if (url.includes("api.anidb.net:9001")) return new Response(officialBody, { status: 200 });
+    if (isOfficialAnidbApi(url)) return new Response(officialBody, { status: 200 });
     if (url.includes("graphql.anilist.co")) {
       return new Response(
         JSON.stringify({

--- a/packages/providers/test/anidb-official-xml-text.test.ts
+++ b/packages/providers/test/anidb-official-xml-text.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseAnidbOfficialEpisodeMetadata } from "../src/anidb/client";
+
+// Official AniDB summaries are markup that lands in terminal output: episode
+// titles in the picker, synopses in the rail. The browse scraper already closed
+// this class of hole; the XML parser reuses the same pipeline instead of its
+// own tag strip, and these are the cases that separate the two.
+
+const ESC = String.fromCharCode(0x1b);
+const BEL = String.fromCharCode(0x07);
+
+const wrap = (title: string, summary = "") =>
+  `<anime id="1"><episode id="1"><epno type="1">1</epno>` +
+  `<title xml:lang="en">${title}</title><summary>${summary}</summary>` +
+  `</episode></anime>`;
+
+describe("anidb official xml text", () => {
+  test("never decodes an entity into a live control character", () => {
+    // A provider needs no raw ESC byte to smuggle one: `&#27;` is plain ASCII
+    // in the response, and a decoder that mints it hands the terminal cursor
+    // moves, screen clears, and OSC 52 clipboard writes.
+    const parsed = parseAnidbOfficialEpisodeMetadata(wrap("Boom&#27;[2J&#7;"));
+    const title = parsed.get(1)?.title ?? "";
+    expect(title).not.toContain(ESC);
+    expect(title).not.toContain(BEL);
+    expect(title).toContain("&#27;");
+  });
+
+  test("strips a script span that survives a single tag pass", () => {
+    const parsed = parseAnidbOfficialEpisodeMetadata(
+      wrap("Ep", "<<script>script>alert(1)</script>tail"),
+    );
+    const synopsis = parsed.get(1)?.synopsis ?? "";
+    expect(synopsis.toLowerCase()).not.toContain("<script");
+    expect(synopsis).not.toContain("alert(1)");
+  });
+
+  test("decodes each entity exactly once", () => {
+    const parsed = parseAnidbOfficialEpisodeMetadata(wrap("Tom &amp;amp; Jerry"));
+    expect(parsed.get(1)?.title).toBe("Tom &amp; Jerry");
+  });
+
+  test("keeps only regular episodes, so specials never enter the playable sequence", () => {
+    const parsed = parseAnidbOfficialEpisodeMetadata(
+      `<anime id="1">
+         <episode id="1"><epno type="1">1</epno><title xml:lang="en">Regular</title></episode>
+         <episode id="2"><epno type="2">1</epno><title xml:lang="en">Special</title></episode>
+       </anime>`,
+    );
+    expect([...parsed.values()].map((entry) => entry.title)).toEqual(["Regular"]);
+  });
+});

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../src/anidb/direct";
 import { anidbManifest, ANIDB_PROVIDER_ID } from "../src/anidb/manifest";
 import { clearAnimeMetadataCacheForTest } from "../src/shared/anime-metadata";
+import { isOfficialAnidbApi } from "./helpers/anidb-urls";
 
 const fixture = (name: string) =>
   Bun.file(new URL(`./fixtures/anidb/${name}`, import.meta.url)).text();
@@ -614,7 +615,7 @@ describe("anidb episode metadata", () => {
             { status: 200 },
           );
         }
-        if (url.includes("api.anidb.net:9001")) {
+        if (isOfficialAnidbApi(url)) {
           return new Response(
             `<?xml version="1.0"?>
               <anime id="9876">

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -16,6 +16,7 @@ import {
   searchAnidb,
 } from "../src/anidb/direct";
 import { anidbManifest, ANIDB_PROVIDER_ID } from "../src/anidb/manifest";
+import { clearAnimeMetadataCacheForTest } from "../src/shared/anime-metadata";
 
 const fixture = (name: string) =>
   Bun.file(new URL(`./fixtures/anidb/${name}`, import.meta.url)).text();
@@ -319,6 +320,29 @@ describe("anidb search delegation", () => {
       Bun.which = originalWhich;
     }
   });
+
+  test("does not claim audio or subtitle availability before an episode probe", async () => {
+    const originalWhich = Bun.which;
+    const originalFetch = globalThis.fetch;
+    try {
+      Bun.which = ((_cmd: string) => null) as typeof Bun.which;
+      globalThis.fetch = (async () =>
+        new Response('<a href="/anime/show-1" title="Show"><article></article></a>', {
+          status: 200,
+        })) as unknown as typeof fetch;
+
+      const search = anidbProviderModule.search;
+      if (!search) throw new Error("AniDB search is not configured");
+      const result = await search({ query: "Show" }, { now: () => new Date().toISOString() });
+
+      expect(result?.[0]?.availableAudioModes).toBeUndefined();
+      expect(result?.[0]?.subtitleAvailability).toBeUndefined();
+      expect(result?.[0]?.languageEvidence).toBeUndefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+      Bun.which = originalWhich;
+    }
+  });
 });
 
 describe("anidb direct resolve season routing", () => {
@@ -539,6 +563,136 @@ describe("anidb direct resolve season routing", () => {
 
     expect(result.status).toBe("resolved");
     expect(result.externalIds?.malId).toBe("99999");
+  });
+
+  test("does not fall back to Japanese when a requested dub is unavailable", async () => {
+    const result = await resolveWithStub(
+      {
+        title: { id: "plain-show-700", kind: "anime", title: "Plain Show" },
+        episode: { season: 1, episode: 1 },
+        mediaKind: "anime",
+        preferredAudioLanguage: "en",
+        intent: "play",
+        allowedRuntimes: ["direct-http"],
+      } as Parameters<typeof anidbProviderModule.resolve>[0],
+      anidbFetchStub({ episodesByNumericId: { "700": [{ id: 70001, number: 1 }] } }),
+    );
+
+    expect(result.status).toBe("exhausted");
+    expect(result.failures[0]?.message).toContain("No AniDB streams");
+  });
+});
+
+describe("anidb episode metadata", () => {
+  test("enriches episode titles, air dates, and thumbnails from existing catalog ids", async () => {
+    clearAnidbCachesForTest();
+    clearAnimeMetadataCacheForTest();
+    const originalWhich = Bun.which;
+    const originalFetch = globalThis.fetch;
+
+    try {
+      Bun.which = ((_cmd: string) => null) as typeof Bun.which;
+      globalThis.fetch = (async (input: unknown) => {
+        const url = String(input);
+        if (url.includes("/api/frontend/anime/700/episodes")) {
+          return new Response(
+            JSON.stringify({
+              episodes: [
+                { id: 70001, number: 1 },
+                { id: 70002, number: 2 },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/anime/plain-show-700")) {
+          return new Response(
+            '<a href="https://myanimelist.net/anime/5678/Plain-Show">MAL</a>' +
+              '<a href="https://anilist.co/anime/1234">AniList</a>' +
+              '<a href="https://anidb.net/anime/9876">AniDB</a>' +
+              '<meta property="og:image" content="https://img.example/poster.jpg">',
+            { status: 200 },
+          );
+        }
+        if (url.includes("api.anidb.net:9001")) {
+          return new Response(
+            `<?xml version="1.0"?>
+              <anime id="9876">
+                <episode id="1"><epno type="1">2</epno><airdate>2020-01-09</airdate>
+                  <title xml:lang="en">Official Journey</title><summary>Official synopsis</summary>
+                </episode>
+                <episode id="2"><epno type="1">1</epno><airdate>2020-01-02</airdate>
+                  <title xml:lang="ja">公式の始まり</title><title xml:lang="x-jat">The Beginning</title>
+                </episode>
+                <episode id="3"><epno type="2">1</epno><title xml:lang="en">Special</title></episode>
+              </anime>`,
+            { status: 200 },
+          );
+        }
+        if (url.includes("graphql.anilist.co")) {
+          return new Response(
+            JSON.stringify({
+              data: {
+                Media: {
+                  streamingEpisodes: [
+                    { title: "The Beginning", thumbnail: "https://img.example/ep-1.jpg" },
+                    { title: "The Journey", thumbnail: "https://img.example/ep-2.jpg" },
+                  ],
+                },
+              },
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("api.jikan.moe")) {
+          return new Response(
+            JSON.stringify({
+              data: [
+                { mal_id: 1, title: "The Beginning", aired: "2020-01-02T00:00:00+00:00" },
+                { mal_id: 2, title: "The Journey", aired: "2020-01-09T00:00:00+00:00" },
+              ],
+              pagination: { has_next_page: false },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      }) as unknown as typeof fetch;
+
+      const episodes = await anidbProviderModule.listEpisodes?.(
+        {
+          title: {
+            id: "plain-show-700",
+            kind: "anime",
+            title: "Plain Show",
+          },
+          preferredAudioLanguage: "ja",
+        },
+        { now: () => new Date().toISOString(), signal: new AbortController().signal },
+      );
+
+      expect(episodes?.[0]).toMatchObject({
+        index: 1,
+        name: "The Beginning",
+        label: "Episode 1 · The Beginning",
+        release: { airDate: "2020-01-02" },
+        artwork: { thumbnailUrl: "https://img.example/ep-1.jpg" },
+      });
+      expect(episodes?.[1]).toMatchObject({
+        index: 2,
+        name: "Official Journey",
+        label: "Episode 2 · Official Journey",
+        release: { airDate: "2020-01-09" },
+        artwork: { thumbnailUrl: "https://img.example/ep-2.jpg" },
+        detail: "Official synopsis",
+      });
+      expect(episodes?.[0]?.externalIds).toEqual({ anilistId: "1234", malId: "5678" });
+    } finally {
+      globalThis.fetch = originalFetch;
+      Bun.which = originalWhich;
+      clearAnidbCachesForTest();
+      clearAnimeMetadataCacheForTest();
+    }
   });
 });
 

--- a/packages/providers/test/helpers/anidb-urls.ts
+++ b/packages/providers/test/helpers/anidb-urls.ts
@@ -1,0 +1,16 @@
+/**
+ * Host-and-port match for the official AniDB HTTP API.
+ *
+ * A `url.includes("api.anidb.net:9001")` stub matches any URL that merely
+ * contains that text, so a fetch to `evil.test/?x=api.anidb.net:9001` would be
+ * answered with the official-API fixture and the stub would quietly cover a
+ * request the provider never should have made.
+ */
+export function isOfficialAnidbApi(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname === "api.anidb.net" && parsed.port === "9001";
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## What this fixes

Two things that were wrong on the same screen — the post-play surface for an
anime episode — plus the work needed to make AniDB carry real episode metadata.

### 1. Post-play season progress (`fix(post-play)`)

Post-play showed `S01 · E08 of 200` next to `0 / 201 · 0%` for a series the
viewer was eight episodes into. Two independent faults:

- **`watchedEpisodes` was a pre-playback snapshot.** `PlaybackPhase` reads the
  title's history once, before the stream resolves, and the post-play menu was
  still reading that array afterwards — so the episode you just watched was
  never in it, and a first watch always read `0`. It also counted *rows*, which
  is the wrong question for a season bar: jumping straight to E08 is eight
  episodes deep, not "1 watched". It now reads history at post-play time and
  projects the furthest episode reached (`projectFurthestWatchedEpisode`, next
  to the existing `projectSeriesProgress`), never behind the episode just
  watched.
- **Two totals for one season.** The `of N` line took its total from the
  playable episode list, the progress bar from the catalog episode count. AniDB
  carries 200 of Gintama's 201 episodes, so the two disagreed on screen. One
  total now feeds both, and the playable list wins — a denominator you cannot
  reach is the wrong one to show next to a playable episode number.

Regression test reproduces the exact screen: with the old logic it reports
`watchedEpisodes: 0` / `totalEpisodes: 201`.

### 2. AniDB episode metadata (`feat(anidb)`)

AniDB listed bare `Episode N` rows — no title, synopsis, air date or still —
so every AniDB surface rendered placeholder text where AllManga and Miruro
render real episodes.

`anidb.app` carries no episode metadata of its own, but its anime page links
the official anidb.net AID. The provider now follows that cross-link, reads the
official XML episode list (regular episodes only, `epno type="1"`), and fills
titles, synopses and air dates from it; AniList/Jikan stay as the gap-filler
for stills and filler/recap flags, exactly as on the AllManga path.

It also stops the provider making claims it cannot support: search no longer
advertises dub for every title, sub streams are no longer labelled hardsub, and
a dub request no longer silently plays Japanese audio under a "dub" label.

### 3. Making it fast and quiet-failure-proof (`perf(anidb)`)

The first pass ran the full external metadata pass unconditionally — so a
provider that had just fetched 201 official titles in one request still paged
Jikan 100 episodes at a time, under a rate limit, in front of the picker.

- Official AniDB metadata is seeded into the shared episode-metadata cache; a
  second listing of the same show is free.
- The external pass is split: **AniList still runs** even when titles are
  complete (one request, and the only source of stills AniDB has), while the
  **paginated Jikan pass is skipped**, gated by the existing
  `shouldSkipExternalEpisodeMetadataEnrichment()` threshold AllManga uses.
- An official response carrying `<error>` (rate limit, ban, invalid client)
  arrives as HTTP 200 and parses to nothing. That empty map was being cached for
  30 days, suppressing every episode title for the show long after the block
  lifted. Error and empty reads are no longer cached.
- `signal ?? AbortSignal.timeout(ms)` silently drops the deadline whenever a
  caller passes a signal — which is always, in production. Replaced with a
  shared `createTimeoutSignal`, which AllManga and Rivestream each already had
  their own private copy of.
- The external-metadata merge loop was copy-pasted between AllManga and AniDB;
  it now lives once in `shared/anime-metadata`.

## Verification

| Gate | Result |
| --- | --- |
| `bun run typecheck --force` | pass (14/14) |
| `bun run test --force` | pass — 4551 unit, 156 integration, 352 provider, 96 core |
| `bun run lint` | 0 errors (3 pre-existing analytics-ingest warnings) |
| `bun run build` | pass |
| `bun run verify:doc-paths` | pass |
| `bun run test:live:anidb` | pass — stream resolved from `hls.anidb.app`, 3.7s |

Live, on Gintama (`gintama-1816`, 200 playable episodes): cold `listEpisodes`
4.4s with **200/200** titles, synopses, air dates and Crunchyroll stills; warm
1ms. Jikan not called.

## Known limitations (documented, not fixed here)

- **Stills are positional.** AniList `streamingEpisodes` is an ordered array
  with no episode numbers, so a still can drift when the stream catalog's
  numbering has gaps (`anidb.app` has no episode 2 for Gintama). Same trade-off
  AllManga and Miruro already make; a numbered source (TMDB episode images,
  Jikan `/pictures`) would remove the guesswork.
- **Official API client name.** The HTTP API is called with `client=anidb`,
  which answers today. AniDB's terms are strict about repeat traffic and it
  blocks by client name, so the provider treats it as a once-per-series read
  (one request, 30-day cache, never per episode or per playback). Registering a
  Kunai client name is the correct follow-up.

## Not in this PR

While investigating the same screenshot I found a rendering fault in the
post-play rail: stale cells from an earlier frame survive a repaint (a green
`urite` tail in a colour no current rail element uses, blank rows where the
badge and title should be). It is a repaint-integrity bug, not bad data, and it
needs a live capture to root-cause properly rather than a guessed fix.
