### PR TITLE
merge train: AniDB metadata/relay + review-fix train (#68, #69, #70, #71)

### DIFF
--- a/.changeset/principal-review-fixes.md
+++ b/.changeset/principal-review-fixes.md
@@ -1,0 +1,25 @@
+---
+"@kitsunekode/kunai": patch
+"@kunai/storage": patch
+---
+
+Security and honesty fixes from a full codebase review.
+
+- **Downloads:** provider stream URLs and headers are now guarded before
+  reaching yt-dlp (scheme check, leading-dash rejection, `--` terminator,
+  CRLF-stripped headers), closing an argv option-injection path the mpv lane
+  already blocked.
+- **Storage:** the data and cache SQLite files (plus `-wal`/`-shm`) are
+  chmod'd to owner-only on every open, matching config and token handling.
+- **CLI:** `--jump` help now says what the flag does (auto-pick the n-th
+  search result) and warns on invalid values; headless download failures and
+  rejected `--handoff-url` values exit nonzero.
+- **Playback:** one-shot mpv launches attach the full collected subtitle
+  inventory and report the real track count; prefetched and back-navigation
+  streams are re-resolved when blocked or older than five minutes instead of
+  replaying a possibly expired URL.
+- **AniSkip:** the TMDB→MAL fallback is refused beyond season 1 so
+  split-cour anime no longer risk wrong auto-skip windows.
+- **Docs/palette:** the command-honesty gate now counts the browse palette;
+  user docs stop promising `/sync`, `/random`, and `/surprise` as typed
+  commands; the keybindings doc's post-playback table matches the code.

--- a/.docs/keybindings.md
+++ b/.docs/keybindings.md
@@ -2,7 +2,7 @@
 title: Kunai CLI Keybindings
 description: Screen-by-screen keybinding map for the Kunai terminal shell.
 status: current
-lastReviewed: "2026-07-21"
+lastReviewed: "2026-08-18"
 ---
 
 # Kunai CLI Keybindings
@@ -115,26 +115,27 @@ mid-session". `l` carries the favourite toggle on those screens instead.
 
 ## Post-Playback
 
-| Key         | Action                                                             |
-| ----------- | ------------------------------------------------------------------ |
-| `/`         | Open command palette                                               |
-| `n`         | Next episode                                                       |
-| `p`         | Previous episode                                                   |
-| `c`         | Continue from saved point when resumable                           |
-| `r`         | Replay from start with mpv resume prompt available when applicable |
-| `e`         | Episode picker                                                     |
-| `k`         | Streams                                                            |
-| `o`         | Source                                                             |
-| `Shift+F`   | Fallback provider                                                  |
-| `/provider` | Provider picker                                                    |
-| `a`         | Toggle autoplay                                                    |
-| `d`         | Diagnostics                                                        |
-| `i`         | Recommendation pick actions, when the rail is visible              |
-| `1-3`       | Recommendation pick actions, when the rail is visible              |
-| `?`         | Help                                                               |
-| `s`         | Fresh search                                                       |
-| `q`         | Quit                                                               |
-| `Esc`       | Back to previous results                                           |
+| Key             | Action                                                                               |
+| --------------- | ------------------------------------------------------------------------------------ |
+| `/`             | Open command palette                                                                 |
+| `↑` / `k`       | Move selection up through the action list                                            |
+| `↓` / `j`       | Move selection down through the action list                                          |
+| `Enter`         | Run the highlighted action (or the first recommendation on series-complete)          |
+| `n`             | Continue / next — resume, next episode, next season, or queued head per footer label |
+| `r`             | Replay from start with mpv resume prompt available when applicable                   |
+| `e`             | Episode picker                                                                       |
+| `o`             | Source picker                                                                        |
+| `Shift+F`       | Fallback provider                                                                    |
+| `m`             | Title control menu                                                                   |
+| `h`             | History                                                                              |
+| `w`             | Watchlist (caught-up only)                                                           |
+| `d`             | Diagnostics                                                                          |
+| `1` / `2` / `3` | Play recommendation 1 / 2 / 3 when the rail is visible                               |
+| `!` / `@` / `#` | Open action menu for recommendation 1 / 2 / 3 when the rail is visible               |
+| `?`             | Help                                                                                 |
+| `s`             | Fresh search                                                                         |
+| `q`             | Quit                                                                                 |
+| `Esc`           | Back to previous results                                                             |
 
 ## Pickers
 
@@ -174,10 +175,10 @@ manual skip key can still offer finite known segments while autoskip is paused.
 
 ## Collision Notes
 
-| Key | Collision risk                                          | Decision                                                   |
-| --- | ------------------------------------------------------- | ---------------------------------------------------------- |
-| `g` | Settings in playback loading/resolving                  | Do not use for return/search                               |
-| `s` | Subtitles during active playback; search after playback | Keep contextual; use `Shift+S` for active return-to-search |
-| `r` | Recover during active playback; replay after playback   | Context is visible and acceptable                          |
-| `f` | Fallback in resolve/playback/post-playback              | Same intent across surfaces                                |
-| `e` | Episode picker in playback surfaces                     | Same intent across surfaces                                |
+| Key | Collision risk                                          | Decision                                                                             |
+| --- | ------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `g` | Settings in playback loading/resolving                  | Do not use for return/search                                                         |
+| `s` | Subtitles during active playback; search after playback | Keep contextual; use `Shift+S` for active return-to-search                           |
+| `r` | Recover during active playback; replay after playback   | Context is visible and acceptable                                                    |
+| `f` | Favourite while browsing; fallback elsewhere            | Bare `f` is browse-only; fallback is `Shift+F` in loading, player, and post-playback |
+| `e` | Episode picker in playback surfaces                     | Same intent across surfaces                                                          |

--- a/.docs/playback-timing-and-aniskip.md
+++ b/.docs/playback-timing-and-aniskip.md
@@ -57,6 +57,8 @@ Reference ecosystem: [synacktraa/ani-skip](https://github.com/synacktraa/ani-ski
 | Numeric                          | AniList, TMDB TV, or other     | Try ARM `anilist` → MAL; if missing, try ARM **TMDB → MAL** list (first entry; split cours caveat).                                                                   |
 | Opaque + non-AllAnime provider   | Unknown catalog                | Fall back: AniList **title search** (optional `seasonYear` from `title.year`) → ARM AniList → MAL.                                                                    |
 
+**TMDB → MAL fallback is season-1 only.** ARM returns the first mapping for a TMDB TV id, which is the season-1 MAL entry for split-cour shows. AniSkip episode numbers are season-relative, so using that mapping for season 2+ would apply the wrong show's skip windows. When the only remaining resolver is `resolveMALFromTheMovieDbId` and the requested season is known and greater than 1, Kunai skips AniSkip (`identity-missing`) rather than guess. Direct `externalIds.malId`, provider-native lookups, and the AniList ARM path are unaffected.
+
 **AniDB stamps MAL at resolve time.** The AniDB module's `resolve()` calls
 `fetchAnidbMalId()` (in `packages/providers/src/anidb/client.ts`, TTL 1 h cache,
 scrapes `myanimelist.net/anime/{id}` from the anidb.app anime page) when the input

--- a/.docs/provider-dossiers/anidb-metadata-capabilities.md
+++ b/.docs/provider-dossiers/anidb-metadata-capabilities.md
@@ -49,8 +49,10 @@ crosswalk.
 
 ### Live HTTP XML
 
-The following live request succeeded on 2026-08-18 using the registered
-`anidb` client name and returned the current XML shape for AID `17617`:
+The following live request succeeded on 2026-08-18 with the client name
+`anidb` (that the endpoint answered is the evidence here; this dossier makes no
+claim that the name is registered to this project) and returned the current XML
+shape for AID `17617`:
 
 [`httpapi?request=anime&...&aid=17617`](http://api.anidb.net:9001/httpapi?request=anime&client=anidb&clientver=1&protover=1&aid=17617)
 
@@ -197,3 +199,34 @@ The repository already has places for the missing data:
 7. **Keep drift fixtures current.** The provider tests now cover official XML,
    title-page crosswalks, episode JSON, language responses, and embed parsing.
    Keep volatile stream tokens out of committed fixtures.
+
+## Request Budget
+
+Official AniDB's terms are strict about repeat traffic and it answers abuse by
+blocking the client name, so the provider treats the official API as a
+once-per-series read:
+
+- One `request=anime` call per show, cached for 30 days in process and seeded
+  into the shared episode-metadata cache. Nothing here may run per episode or
+  per playback.
+- A response carrying `<error>` (rate limit, ban, invalid client values) arrives
+  as HTTP 200. It is never cached: caching what it parses to would suppress
+  every episode title for that show until the TTL expired, long after the block
+  lifted.
+- AniList is still called for stills even when titles are complete (one
+  request). Jikan, which pages 100 episodes at a time under a rate limit, is
+  skipped whenever official titles already cover the catalog.
+
+Measured on 2026-08-18 for Gintama (`gintama-1816`, 200 playable episodes):
+cold `listEpisodes` 4.4s with 200/200 titles, synopses, air dates, and stills;
+warm 1ms.
+
+## Known Limitation: Positional Stills
+
+AniList `streamingEpisodes` is an ordered array with no episode numbers, so
+stills are matched by position. When a stream catalog's numbering has gaps —
+`anidb.app` carries 200 of Gintama's 201 official episodes, with no `2` — a
+still can drift from its episode. The provider accepts this because the
+alternative is no stills at all, and it is the same trade-off AllManga and
+Miruro already make. A numbered still source (TMDB episode images, Jikan
+`/pictures`) would remove the guesswork.

--- a/.docs/provider-dossiers/anidb-metadata-capabilities.md
+++ b/.docs/provider-dossiers/anidb-metadata-capabilities.md
@@ -1,0 +1,199 @@
+---
+status: current
+lastReviewed: "2026-08-18"
+---
+
+# AniDB Metadata And API Capabilities
+
+> Agent-facing (L3). Research dossier for the active `anidb` provider. This is
+> not a claim that AniDB authorizes or operates the stream sources used by
+> `anidb.app`.
+
+## Executive Summary
+
+There are two different services in this repository's AniDB path:
+
+- **Official AniDB:** `anidb.net` and `api.anidb.net:9001`. The live HTTP API is
+  a rich anime catalog. It exposes anime titles, title languages/types, dates,
+  episode numbers/types, episode titles, air dates, lengths, summaries,
+  relations, external resources, and an anime-level poster filename.
+- **The active stream site:** `anidb.app`. Its current frontend exposes a
+  separate catalog identity, episode IDs, per-episode `eng`/`jpn` embed choices,
+  and an HLS player source. Its numeric IDs are not official AniDB AIDs.
+
+For example, the `anidb.app` page for Frieren uses slug ID `1663` and links to
+official AniDB AID `17617`. The active provider calls
+`/api/frontend/anime/1663/episodes`, not the official AniDB API for AID `17617`.
+Do not use the slug suffix as an AniDB database ID without an explicit
+crosswalk.
+
+## Capability Matrix
+
+| Capability                     | Official AniDB HTTP/XML                                                                                                                               | Current `anidb.app` behavior                                                                                                                                                                                                                                                       | Kunai `anidb` provider                                                                                      |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Anime title metadata           | **Yes.** `<type>`, episode count, start/end dates, description, ratings, creators, resources, and titles.                                             | **Yes, partial.** Page title, native/alternate title, synopsis, genres, runtime, ratings, and cross-links are rendered.                                                                                                                                                            | Search keeps one scraped result title only. It does not map official title variants or rich title metadata. |
+| Episode numbers                | **Yes.** `<epno type="1">` for regular episodes and other types for specials, openings/endings, previews, etc.                                        | **Yes, partial.** JSON returns `id`, `number`, `number2`, and `filler`.                                                                                                                                                                                                            | Keeps only positive `id`, `number`, and optional `filler`.                                                  |
+| Episode titles                 | **Yes.** Multiple localized `<title>` elements occur on each episode.                                                                                 | **Not in the observed episode JSON.**                                                                                                                                                                                                                                              | Official XML title, preferring English, is mapped; external metadata can fill a missing title.              |
+| Episode air dates              | **Yes.** `<airdate>YYYY-MM-DD</airdate>`.                                                                                                             | **Not in the observed episode JSON.**                                                                                                                                                                                                                                              | Official XML air date is mapped, with external metadata as fallback.                                        |
+| Episode length                 | **Yes.** `<length>` is present; live values are minute-scale integers such as `25` and `30`.                                                          | The title page displays a series runtime, but the episode-list JSON did not return per-episode length.                                                                                                                                                                             | Not currently surfaced by the shared episode contract.                                                      |
+| Episode synopsis               | **Yes.** `<summary>` may be present.                                                                                                                  | Not in the observed episode-list JSON.                                                                                                                                                                                                                                             | Official XML synopsis is mapped, with external metadata as fallback.                                        |
+| Episode thumbnails/images      | **No evidence in the official HTTP anime response.** The response has `<picture>` for the anime and characters, but no episode-level `<picture>`.     | No per-episode thumbnail field was observed. The player uses the anime poster as artwork.                                                                                                                                                                                          | AniList stills are used when available; otherwise the title-page poster is a truthful fallback.             |
+| Poster/artwork                 | **Yes, anime-level.** XML returns a filename such as `295082.jpg`; the official image CDN serves it. No backdrop field was observed.                  | Yes, but the page currently uses `cdn.xlsbox.com`, a separate image host.                                                                                                                                                                                                          | Title-page poster is carried into episode options; search/resolve do not invent a separate backdrop.        |
+| Relations                      | **Yes.** `<relatedanime>` includes typed relations such as `Sequel`; similar anime and recommendations are also present.                              | Not relied on for the active stream flow.                                                                                                                                                                                                                                          | Season routing searches title text; it does not consume official relation data.                             |
+| Language/title variants        | **Yes.** Anime and episode titles carry `xml:lang`; anime titles also carry types such as `main`, `official`, and `synonym`.                          | One primary title plus one alternate/native title is visible in the sampled page.                                                                                                                                                                                                  | No variant inventory; only the selected browse-card title is kept.                                          |
+| Dub/sub/audio catalog metadata | **Not in the verified anime XML.** No `audio`, `dub`, `sub`, or track fields were present. `resources` are external entity links, not audio evidence. | **Yes, as stream availability.** The frontend language endpoint returned `eng`/`English` and `jpn`/`Japanese` embed choices for the sample episode. This is provider runtime data, not official AniDB catalog metadata.                                                            | Maps exact `eng` to `dub` and exact `jpn` to `sub`; missing requested modes fail closed.                    |
+| Playable media streams         | **No.** The verified official anime XML contains catalog data and external resources, not media URLs or manifests.                                    | **Yes.** The returned embed page configures JW Player with an HLS `master.m3u8` source on `hls.anidb.app`.                                                                                                                                                                         | **Yes.** Extracts the embed's `file:` value and expands the HLS ladder into direct candidates.              |
+| Subtitle tracks                | **No official track URL was found.** The verified catalog XML has no subtitle-track fields.                                                           | **No independently addressable track was observed.** The current embed config contains JW Player captions styling but no `tracks` array or VTT/SRT URL. This does not prove that every title is hardsubbed; it proves only that no soft-track evidence was exposed in this sample. | Always returns `subtitles: []`; subtitle delivery remains unknown.                                          |
+
+## Official AniDB Evidence
+
+### Live HTTP XML
+
+The following live request succeeded on 2026-08-18 using the registered
+`anidb` client name and returned the current XML shape for AID `17617`:
+
+[`httpapi?request=anime&...&aid=17617`](http://api.anidb.net:9001/httpapi?request=anime&client=anidb&clientver=1&protover=1&aid=17617)
+
+Relevant fields in that response:
+
+- Anime-level fields: `<type>`, `<episodecount>`, `<startdate>`, `<enddate>`,
+  `<description>`, `<picture>`, `<resources>`, and `<titles>`.
+- Anime titles: `xml:lang` values include `ja`, `en`, `de`, `fr`, `pt-BR`,
+  `zh-Hans`, and others; title `type` values include `main`, `official`, and
+  `synonym`.
+- Relations: `<relatedanime><anime id="18886" type="Sequel">...` was present.
+- Regular episodes: each record has an episode ID, `<epno type="1">`,
+  `<length>`, `<airdate>`, localized titles, and sometimes `<summary>` and
+  external resources.
+- Non-regular entries are represented in the same catalog with other episode
+  number types, including `S` specials, `C` opening/ending content, and `T`
+  previews. A consumer must not flatten all entries into one regular-episode
+  sequence without preserving the `epno` type.
+- The live response includes `<picture>295082.jpg</picture>` for the anime and
+  many character pictures, but no episode picture element.
+
+The public HTTP endpoint is an anime request that embeds episode metadata. A
+direct probe of `request=episode` returned `error code=320 request type invalid`,
+and the same happened for `request=file`. This bounds the finding to the
+current public HTTP API endpoint: it is not evidence that no file metadata has
+ever existed in other AniDB interfaces, but it is evidence that the endpoint
+used here is not a media-file or subtitle delivery API.
+
+### Images
+
+For the `picture` filename returned by the official API, the current official
+image path is:
+
+- Legacy image URL: `https://img7.anidb.net/pics/anime/295082.jpg`
+- Current CDN target: `https://cdn.anidb.net/images/main/295082.jpg`
+
+The legacy URL currently redirects through the official AniDB image service to
+the CDN target, which returned `image/jpeg` and `200`. The XML gives a filename,
+not a full URL. No episode-image URL or current image-policy text could be
+retrieved from the official wiki in this environment.
+
+### Official Documentation And XSD Access
+
+Official documentation targets:
+
+- [AniDB HTTP API](https://wiki.anidb.net/w/HTTP_API)
+- [AniDB HTTP API definition](https://wiki.anidb.net/w/HTTP_API_Definition)
+- [AniDB official site](https://anidb.net/)
+
+The official wiki returned HTTP `403` for the API and image-policy pages during
+this research. The guessed legacy downloads
+`https://anidb.net/api/anime.xsd`, `episode.xsd`, and `file.xsd` returned `404`;
+`http://api.anidb.net:9001/httpapi.xsd` returned an AniDB API error rather than
+an XSD. Therefore this dossier cites the live XML response for field claims and
+does not claim a current downloadable XSD URL. Re-check the official wiki/XSD
+before implementing a strict schema validator.
+
+## Current `anidb.app` Evidence
+
+The following are live first-party pages for the host used by the repository's
+provider. They are cited as stream-site behavior, not as official AniDB API
+documentation:
+
+- [`anidb.app` home](https://anidb.app/) currently advertises HD playback,
+  adaptive quality, and sub/dub switching.
+- [Frieren title page](https://anidb.app/anime/frieren-beyond-journeys-end-1663)
+  renders a poster from `cdn.xlsbox.com`, shows `24m`, and links to official
+  AniDB AID `17617`, MAL, AniList, and Kitsu.
+- [`/api/frontend/anime/1663/episodes`](https://anidb.app/api/frontend/anime/1663/episodes)
+  returned records shaped like `{ id, number, number2, filler }` and no title,
+  air date, length, synopsis, or thumbnail fields.
+- [`/api/frontend/episode/3062/languages`](https://anidb.app/api/frontend/episode/3062/languages)
+  returned `eng`/`English` and `jpn`/`Japanese` with opaque `/embed/...` URLs.
+- The embed page returned by that endpoint configured JW Player with one HLS
+  `master.m3u8` source and the anime poster as `image`. Its config had captions
+  styling but no subtitle-track URL or `tracks` array. The source URL is
+  intentionally not copied here because it is a volatile media locator.
+
+## Repository Comparison
+
+### Active Provider Flow
+
+- `packages/providers/src/anidb/client.ts:18-21` sets the provider base to
+  `https://anidb.app`, not `anidb.net`.
+- `packages/providers/src/anidb/client.ts:116-125` searches scraped browse HTML.
+- `packages/providers/src/anidb/client.ts` retains episode ID, positive numeric
+  episode number, and filler from the stream catalog; the title-page crosswalk
+  and official XML parser provide episode titles, dates, and synopses separately.
+- `packages/providers/src/anidb/client.ts:189-223` retains language code/name
+  and the embed URL, but not a catalog audio-language model.
+- `packages/providers/src/anidb/client.ts:225-231` extracts a `file:` value
+  from the embed page; `:269-282` expands the HLS master into stream links.
+- `packages/providers/src/anidb/direct.ts` does not advertise unprobed audio
+  modes. Its episode list merges official AniDB XML with AniList/Jikan metadata,
+  populating episode names, detail/synopsis, release dates, external ids, and
+  artwork.
+- `packages/providers/src/anidb/direct.ts` returns direct HLS results, the
+  selected episode's release/artwork, external IDs, and an empty `subtitles`
+  array because no concrete track URL is exposed.
+- `packages/providers/src/anidb/manifest.ts:5-54` correctly declares an
+  anime-only direct HTTP stream provider. It does not declare catalog metadata
+  enrichment or subtitle-track support.
+- The module is production-wired by
+  `apps/cli/src/container/bootstrap-providers.ts:36-68`.
+
+### Relevant Contracts
+
+The repository already has places for the missing data:
+
+- `packages/types/src/index.ts:568-588` supports `nativeTitle`, `englishTitle`,
+  `altNames`, release/artwork, language evidence, and duration on search rows.
+- `packages/types/src/index.ts:605-615` supports episode `name`, release, and
+  artwork on episode options.
+- `packages/types/src/index.ts:211-223` supports provider subtitle candidates
+  with URL, language, format, and cache policy.
+- `packages/types/src/index.ts:286-295` supports resolve-level subtitles,
+  release, artwork, and external IDs.
+
+## Concrete Gaps And Next Steps
+
+1. **Keep identities separate.** Model official AniDB AID and the
+   `anidb.app` stream-site ID as different namespaces. The active provider now
+   follows the title page's explicit `anidb.net/anime/{aid}` cross-link rather
+   than treating `1663` as official AID `1663`.
+2. **Keep the metadata authority explicit.** Official AniDB XML is now the
+   primary episode metadata source; AniList/Jikan remain best-effort fallback
+   sources for thumbnails and fields absent from the official response.
+3. **Preserve official episode semantics.** The XML parser keeps only
+   `epno type="1"` records for the stream site's regular episode list, so
+   specials, openings/endings, and previews are not silently flattened into the
+   playable sequence. Current `anidb.app` JSON is insufficient for a full
+   non-regular catalog.
+4. **Fill contract fields only from evidence.** Official metadata can populate
+   title variants, episode names, air dates, lengths, release info, relations,
+   and poster artwork. It cannot justify stream audio or subtitle claims.
+5. **Downgrade audio/subtitle assertions.** Keep `eng`/`jpn` as per-episode
+   runtime availability from `anidb.app`; do not describe it as official AniDB
+   dub metadata. Keep `subtitles: []` unless a future live sample exposes a
+   concrete track URL or the media is independently proven hardsubbed.
+6. **Verify image terms before product use.** The official CDN path is
+   technically usable, but the current image policy was not retrievable here;
+   confirm attribution, caching, and redistribution terms before adding an
+   artwork cache.
+7. **Keep drift fixtures current.** The provider tests now cover official XML,
+   title-page crosswalks, episode JSON, language responses, and embed parsing.
+   Keep volatile stream tokens out of committed fixtures.

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -630,6 +630,19 @@ instead of pretending those fields came from `anidb.app`.
   metadata, but its AIDs must not be confused with the numeric ids in `anidb.app` URLs. See
   [the metadata capability dossier](./provider-dossiers/anidb-metadata-capabilities.md).
 
+The cost model matters as much as the data, because this runs in front of the episode picker:
+
+- Official AniDB XML is **one request for the whole series**, cached for a month and seeded into
+  the shared episode-metadata cache, so a second listing of the same show is free.
+- AniList runs even when every title is already known — it is a single request and the only source
+  of episode stills AniDB has.
+- Jikan is the expensive pass (100 episodes per page, strict rate limit) and is **skipped** when
+  official titles already cover the catalog, matching the AllManga path via
+  `shouldSkipExternalEpisodeMetadataEnrichment()`.
+- An official response that carries `<error>` (rate limit, ban, bad client credentials) is never
+  cached. Caching what it parses to would suppress every episode title for that show for a month
+  after the block lifted.
+
 ### AniDB season routing and episode numbering
 
 AniDB models each season as its own title, so `routeAnidbSeason()` in

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -609,6 +609,27 @@ used by search and resolve so they cannot drift apart:
   markup) become results, so nav, breadcrumb, related-rail and footer links cannot become
   `results[0]` and pin the wrong show.
 
+### AniDB metadata and language evidence
+
+The active `anidb.app` episode endpoint is a stream catalog, not a rich episode metadata catalog:
+it currently returns episode ids, numbers, and filler flags. `anidb.listEpisodes()` first follows
+the title page's explicit cross-link to the official AniDB AID and enriches from the official XML
+catalog. It then uses the existing shared AniList/Jikan path for still thumbnails and missing fields
+when the title identity carries an AniList or MAL id. This keeps the metadata authority explicit
+instead of pretending those fields came from `anidb.app`.
+
+- `anidb.app` language evidence is per episode: `jpn` is the sub/original embed and `eng` is the
+  dub embed when present. Search does not advertise both modes blindly; availability is confirmed
+  only by the episode languages response.
+- A missing requested language is an exhausted AniDB attempt. It must not fall back to the other
+  language and label the stream incorrectly.
+- The embed probe currently exposes an HLS source but no independently addressable subtitle track.
+  AniDB results keep `subtitles: []` and mark subtitle delivery unknown; `jpn` is not sufficient
+  evidence that captions are hardcoded.
+- Official AniDB XML is a separate catalog namespace. It can provide richer anime and episode
+  metadata, but its AIDs must not be confused with the numeric ids in `anidb.app` URLs. See
+  [the metadata capability dossier](./provider-dossiers/anidb-metadata-capabilities.md).
+
 ### AniDB season routing and episode numbering
 
 AniDB models each season as its own title, so `routeAnidbSeason()` in

--- a/apps/analytics-ingest/test/postgres-hardening.test.ts
+++ b/apps/analytics-ingest/test/postgres-hardening.test.ts
@@ -11,6 +11,7 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 
 // Side-effecting: honours NEON_FETCH_ENDPOINT. Must precede store construction.
+// oxlint-disable-next-line import/no-unassigned-import -- the side effect is the point
 import "../src/neon-fetch-endpoint";
 import { hashInstallId } from "../src/ingest";
 import { DEFAULT_ANALYTICS_LIMITS } from "../src/limits";

--- a/apps/cli/src/aniskip.ts
+++ b/apps/cli/src/aniskip.ts
@@ -4,6 +4,7 @@ import {
   classifyTimingThrownError,
   type PlaybackTimingSourceFetchResult,
 } from "@/infra/timing/PlaybackTimingSource";
+import { dbg } from "@/logger";
 import { fetchArmIdGraph } from "@/services/catalog/arm-client";
 import { fetchAnidbMalId } from "@kunai/providers";
 import type { ProviderExternalIds } from "@kunai/types";
@@ -105,11 +106,13 @@ async function resolveMalIdForAniSkip(opts: {
   externalIds?: ProviderExternalIds;
   titleName?: string;
   titleYear?: string;
+  /** TMDB season for the episode; gates ambiguous TMDB→MAL fallback when > 1. */
+  season?: number;
   /** `allanime` enables GraphQL `malId` lookup for opaque show ids (ani-skip `-s allanime`). */
   providerId?: string;
   signal?: AbortSignal;
 }): Promise<number | null> {
-  const { catalogTitleId, externalIds, titleName, titleYear, providerId, signal } = opts;
+  const { catalogTitleId, externalIds, titleName, titleYear, season, providerId, signal } = opts;
 
   const seasonYear = (() => {
     const y = titleYear ? Number.parseInt(titleYear, 10) : Number.NaN;
@@ -138,6 +141,7 @@ async function resolveMalIdForAniSkip(opts: {
   if (isNumericAniListId(catalogTitleId)) {
     const fromCatalogId = await resolveMALForSkipTiming({
       catalogId: catalogTitleId,
+      season,
       signal,
     });
     if (fromCatalogId) return fromCatalogId;
@@ -145,7 +149,7 @@ async function resolveMalIdForAniSkip(opts: {
 
   const nativeTmdbId = normalizeNumericId(externalIds?.tmdbId);
   if (nativeTmdbId) {
-    const fromNativeTmdb = await resolveMALFromTheMovieDbId(nativeTmdbId, signal);
+    const fromNativeTmdb = await resolveMALFromTheMovieDbId(nativeTmdbId, signal, season);
     if (fromNativeTmdb) return fromNativeTmdb;
   }
 
@@ -228,11 +232,25 @@ async function resolveMALFromAniListId(
   return malId;
 }
 
-/** TMDB TV id → MAL (first mapping; split cours may list multiple MAL entries). */
+/**
+ * TMDB TV id → MAL (first ARM mapping; split cours may list multiple MAL entries).
+ * Only trusted for season 1 — later seasons use a different MAL entry and episode
+ * numbers are season-relative, so callers must pass `season` and skip when > 1.
+ */
 async function resolveMALFromTheMovieDbId(
   tmdbId: string,
   signal?: AbortSignal,
+  season?: number,
 ): Promise<number | null> {
+  if (season !== undefined && season > 1) {
+    dbg("aniskip", "refused tmdb-mal fallback", {
+      tmdbId,
+      season,
+      reason: "tmdb-mal-mapping-ambiguous-for-season",
+    });
+    return null;
+  }
+
   const cacheKey = `tmdb:${tmdbId}`;
   if (malIdCache.has(cacheKey)) return malIdCache.get(cacheKey) ?? null;
 
@@ -248,15 +266,16 @@ async function resolveMALFromTheMovieDbId(
  */
 async function resolveMALForSkipTiming(opts: {
   catalogId: string;
+  season?: number;
   signal?: AbortSignal;
 }): Promise<number | null> {
-  const { catalogId, signal } = opts;
+  const { catalogId, season, signal } = opts;
   if (!isNumericAniListId(catalogId)) return null;
 
   const fromAnilist = await resolveMALFromAniListId(catalogId, signal);
   if (fromAnilist) return fromAnilist;
 
-  return await resolveMALFromTheMovieDbId(catalogId, signal);
+  return await resolveMALFromTheMovieDbId(catalogId, signal, season);
 }
 
 export function mapAniSkipTypeToTimingField(
@@ -302,6 +321,8 @@ export async function fetchAniSkipTimingMetadata(opts: {
   titleName?: string;
   /** Helps AniList `Media(search, seasonYear: …)` when the catalog id is not numeric. */
   titleYear?: string;
+  /** TMDB season for the episode; gates ambiguous TMDB→MAL fallback when > 1. */
+  season?: number;
   episode: number;
   episodeLength?: number;
   signal?: AbortSignal;
@@ -317,6 +338,7 @@ export async function fetchAniSkipTimingMetadataDetailed(opts: {
   externalIds?: ProviderExternalIds;
   titleName?: string;
   titleYear?: string;
+  season?: number;
   episode: number;
   episodeLength?: number;
   signal?: AbortSignal;
@@ -328,6 +350,7 @@ export async function fetchAniSkipTimingMetadataDetailed(opts: {
     externalIds,
     titleName,
     titleYear,
+    season,
     episode,
     episodeLength,
     signal,
@@ -342,6 +365,7 @@ export async function fetchAniSkipTimingMetadataDetailed(opts: {
       externalIds,
       titleName,
       titleYear,
+      season,
       providerId,
       signal,
     });

--- a/apps/cli/src/app/bootstrap/episode-info-from-catalog.ts
+++ b/apps/cli/src/app/bootstrap/episode-info-from-catalog.ts
@@ -16,7 +16,13 @@ export function episodeInfoFromSelection(args: {
       season,
       episode,
       name: match?.name ?? match?.label,
-      ...(match?.previewImageUrl ? { artwork: { thumbnailUrl: match.previewImageUrl } } : {}),
+      airDate: match?.airDate ?? match?.release?.airDate,
+      overview: match?.overview ?? match?.detail,
+      externalIds: match?.externalIds,
+      release: match?.release,
+      artwork:
+        match?.artwork ??
+        (match?.previewImageUrl ? { thumbnailUrl: match.previewImageUrl } : undefined),
     };
   }
 

--- a/apps/cli/src/app/playback/PlaybackPhase.ts
+++ b/apps/cli/src/app/playback/PlaybackPhase.ts
@@ -3474,6 +3474,7 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
             recommendationRail,
             historyRepository,
             diagnosticsService,
+            readWatchedEntries: () => historyRepository.listByTitleIdentity(historyTitleLookup),
             getMode: () => stateManager.getState().mode,
             getAutoplaySessionPaused: () => stateManager.getState().autoplaySessionPaused,
             getAutoskipSessionPaused: () => stateManager.getState().autoskipSessionPaused,

--- a/apps/cli/src/app/playback/PlaybackPhase.ts
+++ b/apps/cli/src/app/playback/PlaybackPhase.ts
@@ -130,6 +130,7 @@ import {
 } from "@/app/playback/policies/startup-stage-policy";
 import { createQueuePlaybackAttempt } from "@/app/playback/queue-playback-attempt";
 import {
+  isRecentPlaybackStreamFresh,
   recentPlaybackStreamKey,
   recentPlaybackStreamMatchesProvider,
   restoreRecentPlaybackStream,
@@ -1563,7 +1564,8 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
             const recent = recentEpisodeStreams.get(recentKey);
             if (
               recentPlaybackStreamMatchesProvider(recent, currentProvider.metadata.id) &&
-              recentStreamMatchesPreferred(recent, currentProvider.metadata.id, currentEpisode)
+              recentStreamMatchesPreferred(recent, currentProvider.metadata.id, currentEpisode) &&
+              isRecentPlaybackStreamFresh(recent)
             ) {
               const restored = restoreRecentPlaybackStream(recent);
               stream = restored.stream;

--- a/apps/cli/src/app/playback/playback-post-play-entry.ts
+++ b/apps/cli/src/app/playback/playback-post-play-entry.ts
@@ -39,6 +39,7 @@ export type CreatePostPlaybackMenuDepsInput = {
   readonly recommendationRail: PostPlaybackRecommendationRail;
   readonly historyRepository: Container["historyRepository"];
   readonly diagnosticsService: Container["diagnosticsService"];
+  readonly readWatchedEntries: PostPlaybackMenuDeps["readWatchedEntries"];
 
   readonly getMode: () => ShellMode;
   readonly getAutoplaySessionPaused: () => boolean;
@@ -110,6 +111,7 @@ export function createPostPlaybackMenuDeps(
     recommendationRail: input.recommendationRail,
     historyRepository: input.historyRepository,
     diagnosticsService: input.diagnosticsService,
+    readWatchedEntries: input.readWatchedEntries,
     getMode: input.getMode,
     getAutoplaySessionPaused: input.getAutoplaySessionPaused,
     getAutoskipSessionPaused: input.getAutoskipSessionPaused,

--- a/apps/cli/src/app/playback/recent-playback-stream.ts
+++ b/apps/cli/src/app/playback/recent-playback-stream.ts
@@ -1,5 +1,11 @@
+import {
+  isStreamTimestampFresh,
+  MAX_IN_MEMORY_STREAM_REPLAY_AGE_MS,
+} from "@/domain/playback/in-memory-stream-replay-policy";
 import type { EpisodeInfo, StreamInfo } from "@/domain/types";
 import type { LocalPlaybackSource } from "@/services/offline/local-playback-source";
+
+export { MAX_IN_MEMORY_STREAM_REPLAY_AGE_MS, isStreamTimestampFresh };
 
 export type RecentPlaybackStreamProvenance = "fresh" | "cache" | "prefetch" | "fallback" | "local";
 
@@ -44,4 +50,12 @@ export function recentPlaybackStreamMatchesProvider(
   if (!recent) return false;
   if (recent.resolvedProviderId !== effectiveProviderId) return false;
   return recent.selectedProviderId === effectiveProviderId || recent.provenance === "fallback";
+}
+
+export function isRecentPlaybackStreamFresh(
+  record: RecentPlaybackStreamRecord,
+  now: number = Date.now(),
+): boolean {
+  if (record.provenance === "local") return true;
+  return isStreamTimestampFresh(record.stream, now);
 }

--- a/apps/cli/src/app/playback/run-post-playback-menu.ts
+++ b/apps/cli/src/app/playback/run-post-playback-menu.ts
@@ -69,6 +69,7 @@ import {
 import type { PhaseResult } from "@/app/session/Phase";
 import type { Container } from "@/container";
 import { episodeThumbKey } from "@/domain/catalog/title-detail";
+import { projectFurthestWatchedEpisode } from "@/domain/continuation/watch-progress";
 import { resolveContentKind } from "@/domain/media/content-kind";
 import { toHistoryTimestamp } from "@/domain/playback/playback-history";
 import { didPlaybackEndNearNaturalEnd } from "@/domain/playback/playback-policy";
@@ -97,6 +98,12 @@ export type PostPlaybackMenuDeps = {
   readonly recommendationRail: PostPlaybackRecommendationRail;
   readonly historyRepository: Container["historyRepository"];
   readonly diagnosticsService: Container["diagnosticsService"];
+  /**
+   * Reads this title's history NOW. The iteration's `watchedEntries` snapshot is
+   * taken before the episode plays, so season progress read from it is always one
+   * episode stale — and reads 0 on a first watch.
+   */
+  readonly readWatchedEntries: () => readonly HistoryProgress[];
 
   readonly getMode: () => ShellMode;
   readonly getAutoplaySessionPaused: () => boolean;
@@ -421,13 +428,25 @@ export async function runPostPlaybackMenu(
             (option) => option.value === `${priorEpisode.season}:${priorEpisode.episode}`,
           )
         : undefined;
+      const postPlayTitleDetail = peekTitleDetail(title.id, title.type);
+      const isFilmStructure = title.type === "movie" || postPlayTitleDetail?.type === "movie";
       const episodesInCurrentSeason = iteration.shellEpisodePicker.options.filter((option) =>
         option.value.startsWith(`${currentEpisode.season}:`),
       ).length;
-      const watchedEpisodes = iteration.watchedEntries.filter((entry: HistoryProgress) =>
-        title.type === "series" ? entry.season === currentEpisode.season : true,
-      ).length;
-      const postPlayTitleDetail = peekTitleDetail(title.id, title.type);
+      // ONE season total for both the "E08 of N" line and the progress bar. The
+      // playable list wins over the catalog count: the two disagree often (a
+      // provider carrying 200 of a catalog's 201 episodes), and a denominator you
+      // cannot reach is the wrong one to show next to a playable episode number.
+      const seasonEpisodeTotal = isFilmStructure
+        ? undefined
+        : episodesInCurrentSeason || title.episodeCount;
+      // Furthest episode reached, read AFTER the episode played. The iteration
+      // snapshot predates this episode's history row, so it reads 0 on a first watch.
+      const watchedEpisodes = projectFurthestWatchedEpisode({
+        entries: deps.readWatchedEntries(),
+        ...(title.type === "series" ? { season: currentEpisode.season } : {}),
+        currentEpisode: currentEpisode.episode,
+      });
       const nextEpisodeThumbUrl =
         upcomingEpisode && postPlayTitleDetail?.artwork?.episodeThumbnails
           ? postPlayTitleDetail.artwork.episodeThumbnails[
@@ -472,11 +491,7 @@ export async function runPostPlaybackMenu(
             : { label: "Ready for next action", tone: "success" },
           footerMode: "minimal",
           postPlayState,
-          episodeLabel: buildPostPlayEpisodeLabel(
-            title,
-            currentEpisode,
-            episodesInCurrentSeason || undefined,
-          ),
+          episodeLabel: buildPostPlayEpisodeLabel(title, currentEpisode, seasonEpisodeTotal),
           nextEpisodeLabel: buildPostPlayNextEpisodeLabel(
             upcomingEpisode,
             nextEpisodePickerOption?.label,
@@ -489,16 +504,12 @@ export async function runPostPlaybackMenu(
           queueNextEntryId,
           nextEpisodeThumbUrl,
           previousEpisodeThumbUrl,
-          totalEpisodes:
-            title.type === "movie" || postPlayTitleDetail?.type === "movie"
-              ? undefined
-              : (title.episodeCount ?? iteration.shellEpisodePicker.options.length),
+          totalEpisodes: seasonEpisodeTotal,
           watchedEpisodes,
           currentSeason: currentEpisode.season,
           currentEpisode: currentEpisode.episode,
           contentKind: resolveContentKind(title, mode),
-          titleType:
-            title.type === "movie" || postPlayTitleDetail?.type === "movie" ? "movie" : title.type,
+          titleType: isFilmStructure ? "movie" : title.type,
           // Carry the session's captured video metadata so the post-play `video`
           // panel keeps channel/views/length facts that were shown during playback.
           videoMeta: container.stateManager.getState().videoMeta,

--- a/apps/cli/src/cli-args.ts
+++ b/apps/cli/src/cli-args.ts
@@ -63,7 +63,7 @@ DISPLAY
   -m, --minimal              Minimal chrome
   -z, --zen                  Zen mode (bare, ani-cli-style)
   -q, --quick                Quick layout
-      --jump <n>             Resume/seek to episode n
+      --jump <n>             Auto-pick the n-th search result (1-based, with -S)
 
 mpv
       --mpv-debug            Verbose mpv logging
@@ -342,6 +342,8 @@ export function parseCliArgs(argv: readonly string[]): CliArgs {
   const parsedJump = options.jump ? Number.parseInt(options.jump, 10) : Number.NaN;
   if (Number.isFinite(parsedJump) && parsedJump >= 1) {
     args.jump = parsedJump;
+  } else if (options.jump !== undefined) {
+    warnings.push("--jump expects a positive result index; ignoring");
   }
 
   args.debug = Boolean(options.debug || options.debugJson || options.debugSession);

--- a/apps/cli/src/domain/continuation/watch-progress.ts
+++ b/apps/cli/src/domain/continuation/watch-progress.ts
@@ -96,6 +96,40 @@ export function projectSeriesProgress(input: SeriesProgressInput): SeriesProgres
   };
 }
 
+export type FurthestWatchedEpisodeInput = {
+  /** History rows for one title. Rows outside `season` are ignored when it is set. */
+  readonly entries: readonly {
+    readonly season?: number | null;
+    readonly episode?: number | null;
+    readonly absoluteEpisode?: number | null;
+  }[];
+  /** Season to scope to. Omit for absolute/anime numbering, where every row counts. */
+  readonly season?: number;
+  /** Episode being watched right now; progress is never behind where you already are. */
+  readonly currentEpisode?: number;
+};
+
+/**
+ * How deep into the season the viewer has reached — the FURTHEST episode with
+ * history, not the number of history rows.
+ *
+ * Counting rows answers "how many episodes did you start from this machine",
+ * which is not what a season progress bar means: jumping straight to E08 is
+ * eight episodes deep, and a fresh row for the episode you just watched is not
+ * "1 of 201". `currentEpisode` keeps the bar honest during the very first watch,
+ * when the history row for it may not be written yet.
+ */
+export function projectFurthestWatchedEpisode(input: FurthestWatchedEpisodeInput): number {
+  const furthest = input.entries.reduce((deepest, entry) => {
+    if (input.season !== undefined && (entry.season ?? 1) !== input.season) return deepest;
+    const reached =
+      finitePositive(entry.absoluteEpisode ?? undefined) ??
+      finitePositive(entry.episode ?? undefined);
+    return reached && reached > deepest ? reached : deepest;
+  }, 0);
+  return Math.max(furthest, finitePositive(input.currentEpisode) ?? 0);
+}
+
 function finiteNonNegative(value: number | undefined): number | null {
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, value) : null;
 }

--- a/apps/cli/src/domain/playback/in-memory-stream-replay-policy.ts
+++ b/apps/cli/src/domain/playback/in-memory-stream-replay-policy.ts
@@ -1,0 +1,13 @@
+import type { StreamInfo } from "@/domain/types";
+
+/** Aligns with `stream-manifest` SQLite TTL and stream-health `playbackTrustMs`. */
+export const MAX_IN_MEMORY_STREAM_REPLAY_AGE_MS = 5 * 60_000;
+
+export function isStreamTimestampFresh(
+  stream: Pick<StreamInfo, "timestamp">,
+  now: number = Date.now(),
+): boolean {
+  const timestamp = stream.timestamp;
+  if (!timestamp || timestamp <= 0) return false;
+  return now - timestamp <= MAX_IN_MEMORY_STREAM_REPLAY_AGE_MS;
+}

--- a/apps/cli/src/domain/provider-relay-settings.ts
+++ b/apps/cli/src/domain/provider-relay-settings.ts
@@ -5,6 +5,7 @@ import {
 } from "@kunai/relay";
 
 export const RELAY_CAPABLE_PROVIDER_OPTIONS = [
+  { value: "anidb", label: "AniDB" },
   { value: "allanime", label: "AllAnime" },
   { value: "miruro", label: "Miruro" },
   { value: "videasy", label: "Videasy" },

--- a/apps/cli/src/domain/types.ts
+++ b/apps/cli/src/domain/types.ts
@@ -95,6 +95,11 @@ export interface EpisodePickerOption {
   readonly name?: string;
   readonly detail?: string;
   readonly previewImageUrl?: string;
+  readonly airDate?: string;
+  readonly overview?: string;
+  readonly externalIds?: ProviderExternalIds;
+  readonly release?: ProviderReleaseInfo;
+  readonly artwork?: ProviderArtworkInfo;
   /** Total episode count for the series, if known. Used to detect completion. */
   readonly totalEpisodeCount?: number;
 }

--- a/apps/cli/src/infra/timing/AniSkipTimingSource.ts
+++ b/apps/cli/src/infra/timing/AniSkipTimingSource.ts
@@ -42,6 +42,7 @@ export const AniSkipTimingSource: PlaybackTimingSource = {
       externalIds: title.externalIds,
       titleName: title.name,
       titleYear: title.year,
+      season: episode.season,
       episode: episode.episode ?? 1,
       signal,
       parentSignal: context?.parentSignal,

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -458,7 +458,8 @@ async function maybeRunDownloadMode(
     { container, signal: new AbortController().signal },
   );
   if (result.status === "error") {
-    console.log(`Download queue failed: ${result.error.message}`);
+    console.error(`Download queue failed: ${result.error.message}`);
+    process.exitCode = 1;
   } else if (result.status === "success" && result.value === "queued") {
     await container.downloadService.drainQueue(24 * 60 * 60 * 1000);
   }
@@ -660,6 +661,7 @@ export async function runCli(argv = process.argv.slice(2)): Promise<void> {
     const handoff = parseKunaiHandoffUrl(args.handoffUrl);
     if (!handoff) {
       console.error("Invalid kunai:// handoff URL. Refusing to run external action.");
+      process.exitCode = 1;
       return;
     }
     pendingShareLaunch = { action: handoff.action, ref: handoff.ref, trusted: false };

--- a/apps/cli/src/mpv.ts
+++ b/apps/cli/src/mpv.ts
@@ -353,7 +353,7 @@ async function launchMpvInner(
     emitPlaybackEvent({ type: "ipc-connected" });
     emitPlaybackEvent({ type: "opening-stream" });
     notifyPlayerReady();
-    const trackCount = opts.subtitle ? 1 : 0;
+    const trackCount = allowedLaunchSubtitleFiles(opts).length;
     if (trackCount > 0) {
       emitPlaybackEvent({ type: "subtitle-inventory-ready", trackCount });
       emitPlaybackEvent({ type: "subtitle-attached", trackCount });
@@ -552,10 +552,8 @@ export function buildMpvArgs(
     args.push("--tls-verify=no");
   }
 
-  if (opts.subtitle && isAllowedMpvUrl(opts.subtitle, opts.subtitleUrlKind ?? "remote")) {
-    args.push(`--sub-file=${opts.subtitle}`);
-  } else if (opts.subtitle) {
-    dbg("mpv", "subtitle-target-rejected", { delivery: "launch" });
+  for (const file of allowedLaunchSubtitleFiles(opts)) {
+    args.push(`--sub-file=${file}`);
   }
 
   const alang = toMpvLanguageToken(opts.audioPreference, {
@@ -698,6 +696,23 @@ export function collectLaunchSubtitleFiles(
     files.push(track.url);
   }
   return files;
+}
+
+function allowedLaunchSubtitleFiles(opts: {
+  subtitle: string | null;
+  subtitleUrlKind?: MpvUrlKind;
+  subtitleTracks?: readonly SubtitleTrack[];
+}): string[] {
+  const allowed: string[] = [];
+  for (const file of collectLaunchSubtitleFiles(opts.subtitle, opts.subtitleTracks)) {
+    const kind = file === opts.subtitle ? (opts.subtitleUrlKind ?? "remote") : "remote";
+    if (isAllowedMpvUrl(file, kind)) {
+      allowed.push(file);
+    } else {
+      dbg("mpv", "subtitle-target-rejected", { delivery: "launch" });
+    }
+  }
+  return allowed;
 }
 
 export function describeSubtitleTrackForMpv(

--- a/apps/cli/src/services/download/DownloadService.ts
+++ b/apps/cli/src/services/download/DownloadService.ts
@@ -13,6 +13,7 @@ import type {
 } from "@/domain/types";
 import { writeAtomicBytes } from "@/infra/fs/atomic-write";
 import type { Logger } from "@/infra/logger/Logger";
+import { isAllowedMpvUrl } from "@/infra/player/mpv-playback-url";
 import { runBackgroundTask } from "@/services/diagnostics/background-task";
 import type { DiagnosticsService } from "@/services/diagnostics/DiagnosticsService";
 import {
@@ -68,6 +69,29 @@ const STALLED_HEARTBEAT_MS = 90_000;
 const STDERR_MAX_BYTES = 64_000;
 const DEFAULT_ABORT_GRACE_MS = 2_500;
 const DEFAULT_INACTIVE_WAIT_MS = 5_000;
+const YTDLP_HEADER_CRLF_PATTERN = /[\r\n]/g;
+
+/** Sanitized yt-dlp argv tail: validated stream URL, scrubbed headers, `--` before positional URL. */
+export function buildYtDlpDownloadStreamArgs(
+  streamUrl: string,
+  tempPath: string,
+  headers: Record<string, string>,
+): string[] {
+  if (!isAllowedMpvUrl(streamUrl, "remote")) {
+    throw new Error("Refusing to download unsafe stream URL");
+  }
+  const args: string[] = [];
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value !== "string") continue;
+    const sanitizedKey = key.trim().replace(YTDLP_HEADER_CRLF_PATTERN, "");
+    const sanitizedValue = value.trim().replace(YTDLP_HEADER_CRLF_PATTERN, "");
+    if (sanitizedKey.length > 0 && sanitizedValue.length > 0) {
+      args.push("--add-header", `${sanitizedKey}: ${sanitizedValue}`);
+    }
+  }
+  args.push("-o", tempPath, "--", streamUrl);
+  return args;
+}
 
 export type DownloadEnqueueEligibility =
   | { readonly allowed: true }
@@ -886,14 +910,7 @@ export class DownloadService {
       }
     }
 
-    // Add headers
-    for (const [key, value] of Object.entries(job.headers)) {
-      if (value) {
-        args.push("--add-header", `${key}: ${value}`);
-      }
-    }
-
-    args.push("-o", job.tempPath, job.streamUrl);
+    args.push(...buildYtDlpDownloadStreamArgs(job.streamUrl, job.tempPath, job.headers));
 
     let lastProgressPersistAt = 0;
     let lastPersistedPercent = 0;
@@ -1645,6 +1662,12 @@ export function analyzeDownloadFailure(message: string): {
   }
   if (normalized.includes("cannot be downloaded")) {
     return { failureKind: "unsupported", retryable: false };
+  }
+  if (
+    normalized.includes("refusing to download unsafe stream url") ||
+    normalized.includes("refusing to load unsafe stream url")
+  ) {
+    return { failureKind: "unsafe-url", retryable: false };
   }
   if (normalized.includes("unsupported url") || normalized.includes("protocol not found")) {
     return { failureKind: "protocol", retryable: false };

--- a/apps/cli/src/services/playback/PlaybackResolveService.ts
+++ b/apps/cli/src/services/playback/PlaybackResolveService.ts
@@ -1,3 +1,4 @@
+import { isStreamTimestampFresh } from "@/domain/playback/in-memory-stream-replay-policy";
 import { describeProviderResolveProviderNote } from "@/domain/playback/provider-resolve-copy";
 import {
   createProviderAttemptTimeline,
@@ -280,13 +281,19 @@ export class PlaybackResolveService {
     const catalogIdentity = manifest ? resolveProviderCatalogIdentity(manifest) : undefined;
 
     if (input.prefetchedStream) {
-      return {
-        stream: input.prefetchedStream,
-        providerId: input.providerId,
-        attempts: [],
-        cacheStatus: "prefetched",
-        cacheProvenance: "prefetched",
-      };
+      const prefetched = input.prefetchedStream;
+      const blocked = isBlockedStreamUrl(prefetched.url, input.blockedStreamUrls);
+      const stale = !isStreamTimestampFresh(prefetched);
+      if (!blocked && !stale) {
+        return {
+          stream: prefetched,
+          providerId: input.providerId,
+          attempts: [],
+          cacheStatus: "prefetched",
+          cacheProvenance: "prefetched",
+        };
+      }
+      input.onEvent?.({ type: "cache-stale", providerId: input.providerId });
     }
 
     const cacheKey = this.buildCacheKey(input, input.providerId);

--- a/apps/cli/src/services/providers/ProviderRegistry.ts
+++ b/apps/cli/src/services/providers/ProviderRegistry.ts
@@ -133,6 +133,11 @@ export class ProviderRegistryImpl implements ProviderRegistry {
                 name: ep.name,
                 detail: ep.detail,
                 previewImageUrl: ep.artwork?.thumbnailUrl,
+                airDate: ep.release?.airDate,
+                overview: ep.detail,
+                externalIds: ep.externalIds,
+                release: ep.release,
+                artwork: ep.artwork,
                 totalEpisodeCount: ep.totalEpisodeCount,
               }));
             }

--- a/apps/cli/test/unit/aniskip.test.ts
+++ b/apps/cli/test/unit/aniskip.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, expect, test } from "bun:test";
 
-import { fetchAniSkipTimingMetadata, mapAniSkipTypeToTimingField } from "@/aniskip";
+import {
+  fetchAniSkipTimingMetadata,
+  fetchAniSkipTimingMetadataDetailed,
+  mapAniSkipTypeToTimingField,
+} from "@/aniskip";
 import { clearAnidbCachesForTest } from "@kunai/providers";
 
 const originalFetch = globalThis.fetch;
@@ -108,4 +112,94 @@ test("fetchAniSkipTimingMetadata resolves MAL id from AniDB show page for opaque
   });
   expect(anidbShowCall).toBeDefined();
   expect(calls.some((url) => url.includes("/32606/1?"))).toBe(true);
+});
+
+test("fetchAniSkipTimingMetadata refuses TMDB-only MAL resolution for season > 1", async () => {
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    calls.push(String(input));
+    return new Response("Not Found", { status: 404 });
+  }) as typeof fetch;
+
+  const detailed = await fetchAniSkipTimingMetadataDetailed({
+    anilistId: "opaque-catalog-id",
+    externalIds: { tmdbId: "13916" },
+    season: 2,
+    episode: 3,
+  });
+
+  expect(detailed.metadata).toBeNull();
+  expect(detailed.failureClass).toBe("identity-missing");
+  expect(calls.some((url) => url.includes("haglund.dev"))).toBe(false);
+  expect(calls.some((url) => url.includes("api.aniskip.com"))).toBe(false);
+});
+
+test("fetchAniSkipTimingMetadata resolves TMDB-only identity for season 1", async () => {
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    calls.push(url);
+    if (url.includes("arm.haglund.dev/api/v2/themoviedb")) {
+      return new Response(JSON.stringify([{ myanimelist: 1535, themoviedb: 13916 }]), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.includes("api.aniskip.com")) {
+      return new Response(
+        JSON.stringify({
+          found: true,
+          results: [{ skipType: "op", interval: { startTime: 5, endTime: 90 } }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response("Not Found", { status: 404 });
+  }) as typeof fetch;
+
+  const timing = await fetchAniSkipTimingMetadata({
+    anilistId: "opaque-catalog-id",
+    externalIds: { tmdbId: "13916" },
+    season: 1,
+    episode: 3,
+  });
+
+  expect(timing?.intro).toEqual([{ startMs: 5000, endMs: 90000 }]);
+  expect(calls.some((url) => url.includes("arm.haglund.dev/api/v2/themoviedb"))).toBe(true);
+  expect(calls.some((url) => url.includes("/1535/3?"))).toBe(true);
+});
+
+test("fetchAniSkipTimingMetadata AniList path is unaffected by season > 1", async () => {
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    calls.push(url);
+    if (url.includes("arm.haglund.dev/api/v2/ids")) {
+      return new Response(JSON.stringify({ myanimelist: 30013, anilist: 30013 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.includes("api.aniskip.com")) {
+      return new Response(
+        JSON.stringify({
+          found: true,
+          results: [{ skipType: "ed", interval: { startTime: 1200, endTime: 1320 } }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response("Not Found", { status: 404 });
+  }) as typeof fetch;
+
+  const timing = await fetchAniSkipTimingMetadata({
+    anilistId: "30013",
+    season: 2,
+    episode: 5,
+  });
+
+  expect(timing?.credits).toEqual([{ startMs: 1_200_000, endMs: 1_320_000 }]);
+  expect(calls.some((url) => url.includes("arm.haglund.dev/api/v2/themoviedb"))).toBe(false);
+  expect(calls.some((url) => url.includes("arm.haglund.dev/api/v2/ids"))).toBe(true);
+  expect(calls.some((url) => url.includes("/30013/5?"))).toBe(true);
 });

--- a/apps/cli/test/unit/aniskip.test.ts
+++ b/apps/cli/test/unit/aniskip.test.ts
@@ -10,6 +10,15 @@ import { clearAnidbCachesForTest } from "@kunai/providers";
 const originalFetch = globalThis.fetch;
 const originalWhich = Bun.which;
 
+/** Parsed hostname, or null for non-URL inputs — mock routing must never match on substrings. */
+function hostnameOf(url: string): string | null {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return null;
+  }
+}
+
 afterEach(() => {
   globalThis.fetch = originalFetch;
   Bun.which = originalWhich;
@@ -55,9 +64,12 @@ test("fetchAniSkipTimingMetadata uses provider-native MAL id before lookup fallb
   expect(timing?.intro).toEqual([{ startMs: 12000, endMs: 88000 }]);
   expect(calls).toHaveLength(1);
   expect(calls[0]).toContain("/32182/1?");
-  expect(calls.some((url) => url.includes("haglund.dev") || url.includes("anilist.co"))).toBe(
-    false,
-  );
+  expect(
+    calls.some((url) => {
+      const hostname = hostnameOf(url);
+      return hostname === "arm.haglund.dev" || hostname === "graphql.anilist.co";
+    }),
+  ).toBe(false);
 });
 
 test("fetchAniSkipTimingMetadata resolves MAL id from AniDB show page for opaque anidb catalog ids", async () => {
@@ -130,8 +142,8 @@ test("fetchAniSkipTimingMetadata refuses TMDB-only MAL resolution for season > 1
 
   expect(detailed.metadata).toBeNull();
   expect(detailed.failureClass).toBe("identity-missing");
-  expect(calls.some((url) => url.includes("haglund.dev"))).toBe(false);
-  expect(calls.some((url) => url.includes("api.aniskip.com"))).toBe(false);
+  expect(calls.some((url) => hostnameOf(url) === "arm.haglund.dev")).toBe(false);
+  expect(calls.some((url) => hostnameOf(url) === "api.aniskip.com")).toBe(false);
 });
 
 test("fetchAniSkipTimingMetadata resolves TMDB-only identity for season 1", async () => {
@@ -139,13 +151,14 @@ test("fetchAniSkipTimingMetadata resolves TMDB-only identity for season 1", asyn
   globalThis.fetch = (async (input: string | URL | Request) => {
     const url = String(input);
     calls.push(url);
-    if (url.includes("arm.haglund.dev/api/v2/themoviedb")) {
+    const hostname = hostnameOf(url);
+    if (hostname === "arm.haglund.dev" && url.includes("/api/v2/themoviedb")) {
       return new Response(JSON.stringify([{ myanimelist: 1535, themoviedb: 13916 }]), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
     }
-    if (url.includes("api.aniskip.com")) {
+    if (hostname === "api.aniskip.com") {
       return new Response(
         JSON.stringify({
           found: true,
@@ -165,7 +178,11 @@ test("fetchAniSkipTimingMetadata resolves TMDB-only identity for season 1", asyn
   });
 
   expect(timing?.intro).toEqual([{ startMs: 5000, endMs: 90000 }]);
-  expect(calls.some((url) => url.includes("arm.haglund.dev/api/v2/themoviedb"))).toBe(true);
+  expect(
+    calls.some(
+      (url) => hostnameOf(url) === "arm.haglund.dev" && url.includes("/api/v2/themoviedb"),
+    ),
+  ).toBe(true);
   expect(calls.some((url) => url.includes("/1535/3?"))).toBe(true);
 });
 
@@ -174,13 +191,14 @@ test("fetchAniSkipTimingMetadata AniList path is unaffected by season > 1", asyn
   globalThis.fetch = (async (input: string | URL | Request) => {
     const url = String(input);
     calls.push(url);
-    if (url.includes("arm.haglund.dev/api/v2/ids")) {
+    const hostname = hostnameOf(url);
+    if (hostname === "arm.haglund.dev" && url.includes("/api/v2/ids")) {
       return new Response(JSON.stringify({ myanimelist: 30013, anilist: 30013 }), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
     }
-    if (url.includes("api.aniskip.com")) {
+    if (hostname === "api.aniskip.com") {
       return new Response(
         JSON.stringify({
           found: true,
@@ -199,7 +217,13 @@ test("fetchAniSkipTimingMetadata AniList path is unaffected by season > 1", asyn
   });
 
   expect(timing?.credits).toEqual([{ startMs: 1_200_000, endMs: 1_320_000 }]);
-  expect(calls.some((url) => url.includes("arm.haglund.dev/api/v2/themoviedb"))).toBe(false);
-  expect(calls.some((url) => url.includes("arm.haglund.dev/api/v2/ids"))).toBe(true);
+  expect(
+    calls.some(
+      (url) => hostnameOf(url) === "arm.haglund.dev" && url.includes("/api/v2/themoviedb"),
+    ),
+  ).toBe(false);
+  expect(
+    calls.some((url) => hostnameOf(url) === "arm.haglund.dev" && url.includes("/api/v2/ids")),
+  ).toBe(true);
   expect(calls.some((url) => url.includes("/30013/5?"))).toBe(true);
 });

--- a/apps/cli/test/unit/app/episode-info-from-catalog.test.ts
+++ b/apps/cli/test/unit/app/episode-info-from-catalog.test.ts
@@ -11,9 +11,21 @@ describe("episodeInfoFromSelection", () => {
       episode: 2,
       isAnime: true,
       titleId: "anilist:21",
-      animeEpisodes: [{ index: 2, label: "Episode 2 · Cherry", name: "Cherry" }],
+      animeEpisodes: [
+        {
+          index: 2,
+          label: "Episode 2 · Cherry",
+          name: "Cherry",
+          detail: "A deterministic anime episode.",
+          release: { airDate: "2026-01-02" },
+          artwork: { thumbnailUrl: "https://img.example/episode-2.jpg" },
+        },
+      ],
     });
     expect(info.name).toBe("Cherry");
+    expect(info.overview).toBe("A deterministic anime episode.");
+    expect(info.airDate).toBe("2026-01-02");
+    expect(info.artwork?.thumbnailUrl).toBe("https://img.example/episode-2.jpg");
   });
 
   test("falls back to TMDB cache for series when warmed", async () => {

--- a/apps/cli/test/unit/app/playback/run-post-playback-menu.test.ts
+++ b/apps/cli/test/unit/app/playback/run-post-playback-menu.test.ts
@@ -107,6 +107,7 @@ function createDeps(overrides: Partial<PostPlaybackMenuDeps> = {}): TestDeps {
     historyRepository: {
       listByTitle: () => [],
     } as unknown as PostPlaybackMenuDeps["historyRepository"],
+    readWatchedEntries: () => [],
     diagnosticsService: {
       record: () => {},
     } as unknown as PostPlaybackMenuDeps["diagnosticsService"],
@@ -164,6 +165,60 @@ function createDeps(overrides: Partial<PostPlaybackMenuDeps> = {}): TestDeps {
 }
 
 describe("runPostPlaybackMenu", () => {
+  test("season progress reads history AFTER the episode played, and one total feeds both lines", async () => {
+    // Reproduces the post-play screen showing "E08 of 200" beside "0 / 201 · 0%":
+    // the count came from a pre-playback snapshot (empty on a first watch) and the
+    // two totals came from two different sources.
+    const run = createRun();
+    const iteration = createBaseIteration({
+      episodeAvailability: {
+        nextEpisode: { season: 1, episode: 9 },
+        previousEpisode: { season: 1, episode: 7 },
+        nextSeasonEpisode: null,
+        upcomingNext: null,
+        animeNextReleaseUnknown: false,
+        tmdbUnavailable: false,
+      },
+    });
+    // The picker is the playable list: 200 episodes, all in season 1.
+    const playableEpisodes = {
+      options: Array.from({ length: 200 }, (_, index) => ({
+        label: `Episode ${index + 1}`,
+        value: `1:${index + 1}`,
+      })),
+      subtitle: "",
+      initialIndex: 0,
+    };
+
+    let seenState: { totalEpisodes?: number; watchedEpisodes?: number; episodeLabel?: string } = {};
+    const deps = createDeps({
+      readWatchedEntries: () =>
+        [{ season: 1, episode: 8 }] as unknown as ReturnType<
+          PostPlaybackMenuDeps["readWatchedEntries"]
+        >,
+      openPlaybackShell: async (input) => {
+        seenState = input.state;
+        return "quit";
+      },
+    });
+
+    await runPostPlaybackMenu(
+      run,
+      {
+        ...iteration,
+        // Catalog says 201 episodes; the playable list carries 200.
+        title: { ...title, episodeCount: 201 },
+        currentEpisode: { season: 1, episode: 8 },
+        shellEpisodePicker: playableEpisodes,
+      },
+      deps,
+    );
+
+    expect(seenState.watchedEpisodes).toBe(8);
+    expect(seenState.totalEpisodes).toBe(200);
+    expect(seenState.episodeLabel).toContain("of 200");
+  });
+
   test("near-end auto-next uses stopAfterCurrentAtMenuEntry snapshot (B1)", async () => {
     let countdownOffered = false;
     const run = createRun();

--- a/apps/cli/test/unit/app/recent-playback-stream.test.ts
+++ b/apps/cli/test/unit/app/recent-playback-stream.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  isRecentPlaybackStreamFresh,
   recentPlaybackStreamKey,
   recentPlaybackStreamMatchesProvider,
   restoreRecentPlaybackStream,
   type RecentPlaybackStreamRecord,
 } from "@/app/playback/recent-playback-stream";
+import { MAX_IN_MEMORY_STREAM_REPLAY_AGE_MS } from "@/domain/playback/in-memory-stream-replay-policy";
+import type { StreamInfo } from "@/domain/types";
 
-const stream = { url: "https://example.test/stream.m3u8" } as never;
+const stream = { url: "https://example.test/stream.m3u8", headers: {} } as StreamInfo;
 
 describe("recent playback stream", () => {
   test("restores verified local provenance with its exact trust source", () => {
@@ -64,5 +67,44 @@ describe("recent playback stream", () => {
 
     expect(recentPlaybackStreamMatchesProvider(recent, "rivestream")).toBe(true);
     expect(recentPlaybackStreamMatchesProvider(recent, "vidking")).toBe(false);
+  });
+
+  test("isRecentPlaybackStreamFresh exempts local provenance regardless of age", () => {
+    const recent: RecentPlaybackStreamRecord = {
+      stream: { ...stream, timestamp: 0 },
+      selectedProviderId: "vidking",
+      resolvedProviderId: "vidking",
+      provenance: "local",
+      localPlaybackSource: {
+        kind: "local",
+        jobId: "job-1",
+        titleId: "title-1",
+        titleName: "Offline episode",
+        mediaKind: "series",
+        providerId: "vidking",
+        season: 1,
+        episode: 2,
+        filePath: "/media/episode-2.mkv",
+      },
+    };
+
+    expect(isRecentPlaybackStreamFresh(recent, 1_700_000_000_000)).toBe(true);
+  });
+
+  test("isRecentPlaybackStreamFresh rejects stale non-local streams", () => {
+    const now = 1_700_000_000_000;
+    const fresh: RecentPlaybackStreamRecord = {
+      stream: { ...stream, timestamp: now - 1_000 },
+      selectedProviderId: "vidking",
+      resolvedProviderId: "vidking",
+      provenance: "prefetch",
+    };
+    const stale: RecentPlaybackStreamRecord = {
+      ...fresh,
+      stream: { ...stream, timestamp: now - MAX_IN_MEMORY_STREAM_REPLAY_AGE_MS - 1 },
+    };
+
+    expect(isRecentPlaybackStreamFresh(fresh, now)).toBe(true);
+    expect(isRecentPlaybackStreamFresh(stale, now)).toBe(false);
   });
 });

--- a/apps/cli/test/unit/architecture/contract-conformance.test.ts
+++ b/apps/cli/test/unit/architecture/contract-conformance.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { KEYBINDINGS } from "@/app-shell/keybindings";
 import { resolveHelpScope } from "@/app-shell/root-shell-state";
+import { SEARCH_BROWSE_COMMAND_IDS } from "@/app-shell/search-browse-command-ids";
 import { COMMAND_CONTEXTS, COMMANDS } from "@/domain/session/command-registry";
 
 import {
@@ -57,18 +58,16 @@ function readerFilesFor(symbol: string, definedIn: readonly string[]): string[] 
 describe("contract conformance", () => {
   /**
    * A command the palette never offers is unreachable: `resolveCommands` only
-   * surfaces ids listed in a `COMMAND_CONTEXTS` entry, so a registered command
-   * missing from every context can never be typed, however complete its handler
-   * and aliases are.
+   * surfaces ids listed in a `COMMAND_CONTEXTS` entry or the browse command pool
+   * (`SEARCH_BROWSE_COMMAND_IDS`), so a registered command missing from every
+   * surface can never be typed, however complete its handler and aliases are.
    */
   test("every registered command is offered by at least one palette context", () => {
     // DEBT (2026-07-21): implemented + aliased, reachable from no palette surface.
     // `sync*` means the AniList/TMDB integration has no entry point at all.
     const KNOWN_UNREACHABLE_COMMANDS = new Set([
       "clear-history",
-      "details",
       "favorites",
-      "filters",
       "image-pane",
       "playlist-add",
       "queue-season",
@@ -78,10 +77,12 @@ describe("contract conformance", () => {
       "sync-connect-anilist",
       "sync-connect-tmdb",
       "sync-disconnect",
-      "trending",
     ]);
 
-    const offered = new Set<string>(Object.values(COMMAND_CONTEXTS).flat());
+    const offered = new Set<string>([
+      ...Object.values(COMMAND_CONTEXTS).flat(),
+      ...SEARCH_BROWSE_COMMAND_IDS,
+    ]);
     const unreachable = COMMANDS.map((command) => command.id)
       .filter((id) => !offered.has(id))
       .filter((id) => !KNOWN_UNREACHABLE_COMMANDS.has(id));
@@ -99,7 +100,10 @@ describe("contract conformance", () => {
    * debt above turned outward, where the user rather than an agent pays for it.
    */
   test("user-facing copy never instructs the user to run an unreachable command", () => {
-    const offered = new Set<string>(Object.values(COMMAND_CONTEXTS).flat());
+    const offered = new Set<string>([
+      ...Object.values(COMMAND_CONTEXTS).flat(),
+      ...SEARCH_BROWSE_COMMAND_IDS,
+    ]);
     const unreachableAlias = new Map<string, string>();
     for (const command of COMMANDS) {
       if (offered.has(command.id)) continue;
@@ -135,8 +139,6 @@ describe("contract conformance", () => {
     // each belongs to whoever wires that command up. Fixing one means deleting
     // its entry.
     const KNOWN_DEAD_INSTRUCTIONS = new Set<string>([
-      'apps/cli/src/app-shell/browse-shell.tsx: "/filters" -> filters',
-      'apps/cli/src/app-shell/browse-shell.tsx: "/trending" -> trending',
       'apps/cli/src/app-shell/details-panel.ts: "/playlist-add" -> playlist-add',
       'apps/cli/src/app-shell/settings/registry/discover.ts: "/random" -> random',
       'apps/cli/src/app-shell/settings/registry/discover.ts: "/surprise" -> surprise',
@@ -144,7 +146,6 @@ describe("contract conformance", () => {
       'apps/cli/src/app-shell/workflows/shell-workflows.ts: "/playlist-add" -> playlist-add',
       'apps/cli/src/app/discover/random-results.ts: "/random" -> random',
       'apps/cli/src/app/discover/random-results.ts: "/surprise" -> surprise',
-      'apps/cli/src/app/discover/random-results.ts: "/trending" -> trending',
     ]);
 
     expect(

--- a/apps/cli/test/unit/domain/continuation/watch-progress.test.ts
+++ b/apps/cli/test/unit/domain/continuation/watch-progress.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { projectSeriesProgress, projectWatchProgress } from "@/domain/continuation/watch-progress";
+import {
+  projectFurthestWatchedEpisode,
+  projectSeriesProgress,
+  projectWatchProgress,
+} from "@/domain/continuation/watch-progress";
 
 describe("watch progress projection", () => {
   test("clamps in-progress percentages to user-facing resume range", () => {
@@ -83,5 +87,54 @@ describe("series progress projection (distinct from episode progress)", () => {
     expect(series.percentage).toBeNull();
     expect(series.caughtUp).toBe(false);
     expect(series.seriesCompleted).toBe(false);
+  });
+});
+
+describe("furthest watched episode projection", () => {
+  const entry = (
+    season: number | undefined,
+    episode: number | undefined,
+    absoluteEpisode?: number,
+  ) => ({ season, episode, absoluteEpisode });
+
+  test("reports how far into the season the viewer has reached, not how many rows exist", () => {
+    // Jumping straight to E08 is 8 episodes deep, not one episode watched.
+    expect(
+      projectFurthestWatchedEpisode({
+        entries: [entry(1, 8)],
+        season: 1,
+      }),
+    ).toBe(8);
+  });
+
+  test("ignores entries from other seasons", () => {
+    expect(
+      projectFurthestWatchedEpisode({
+        entries: [entry(1, 8), entry(2, 12)],
+        season: 1,
+      }),
+    ).toBe(8);
+  });
+
+  test("keeps season-less rows when no season is scoped (anime absolute numbering)", () => {
+    expect(
+      projectFurthestWatchedEpisode({
+        entries: [entry(undefined, undefined, 40), entry(undefined, 12)],
+      }),
+    ).toBe(40);
+  });
+
+  test("never reports less than the episode currently being watched", () => {
+    expect(
+      projectFurthestWatchedEpisode({
+        entries: [entry(1, 3)],
+        season: 1,
+        currentEpisode: 8,
+      }),
+    ).toBe(8);
+  });
+
+  test("no history and no current episode is zero, not a guess", () => {
+    expect(projectFurthestWatchedEpisode({ entries: [] })).toBe(0);
   });
 });

--- a/apps/cli/test/unit/domain/playback/in-memory-stream-replay-policy.test.ts
+++ b/apps/cli/test/unit/domain/playback/in-memory-stream-replay-policy.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isStreamTimestampFresh,
+  MAX_IN_MEMORY_STREAM_REPLAY_AGE_MS,
+} from "@/domain/playback/in-memory-stream-replay-policy";
+
+describe("in-memory stream replay policy", () => {
+  test("accepts streams within the replay window", () => {
+    const now = 1_700_000_000_000;
+    expect(
+      isStreamTimestampFresh({ timestamp: now - MAX_IN_MEMORY_STREAM_REPLAY_AGE_MS }, now),
+    ).toBe(true);
+    expect(
+      isStreamTimestampFresh({ timestamp: now - MAX_IN_MEMORY_STREAM_REPLAY_AGE_MS - 1 }, now),
+    ).toBe(false);
+  });
+
+  test("rejects missing or zero timestamps", () => {
+    const now = 1_700_000_000_000;
+    expect(isStreamTimestampFresh({ timestamp: 0 }, now)).toBe(false);
+    expect(isStreamTimestampFresh({ timestamp: undefined as never }, now)).toBe(false);
+  });
+});

--- a/apps/cli/test/unit/infra/timing/timing-sources.test.ts
+++ b/apps/cli/test/unit/infra/timing/timing-sources.test.ts
@@ -132,3 +132,26 @@ test("AniSkipTimingSource reports identity-missing when MAL cannot be resolved",
   expect(detailed.metadata).toBeNull();
   expect(detailed.failureClass).toBe("identity-missing");
 });
+
+test("AniSkipTimingSource refuses TMDB-only identity for season > 1", async () => {
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    calls.push(String(input));
+    throw new Error("should not fetch without MAL");
+  }) as unknown as typeof fetch;
+
+  const detailed = await AniSkipTimingSource.fetchDetailed!({
+    title: {
+      id: "opaque-show",
+      type: "series",
+      name: "",
+      externalIds: { tmdbId: "13916" },
+    },
+    episode: { season: 2, episode: 1 },
+    context: { providerId: "unknown-provider" },
+  });
+
+  expect(detailed.metadata).toBeNull();
+  expect(detailed.failureClass).toBe("identity-missing");
+  expect(calls).toHaveLength(0);
+});

--- a/apps/cli/test/unit/main-args.test.ts
+++ b/apps/cli/test/unit/main-args.test.ts
@@ -12,6 +12,9 @@ test("buildCliHelpText describes canonical launch flags", () => {
   expect(help).toContain("Register the Linux-only kunai:// URL handler");
   expect(help).toContain("-y, --youtube");
   expect(help).toContain("--debug                Verbose redacted logging to ./logs.txt");
+  expect(help).toContain(
+    "--jump <n>             Auto-pick the n-th search result (1-based, with -S)",
+  );
   expect(help).toContain("kunai doctor");
   expect(help).toContain("kunai doctor --json");
   expect(help).toContain("kunai rollback");
@@ -146,6 +149,12 @@ test("parseArgs supports --jump <n> for hands-off first-result playback", () => 
   expect(args.jump).toBe(1);
 });
 
+test("parseArgs parses a positive --jump index", () => {
+  const args = parseArgs(["-S", "Dune", "--jump", "3"]);
+
+  expect(args.jump).toBe(3);
+});
+
 test("parseArgs supports -q / --quick as hands-off first-result", () => {
   const quickShort = parseArgs(["-S", "Dune", "-q"]);
   const quickLong = parseArgs(["-S", "Dune", "--quick"]);
@@ -156,15 +165,34 @@ test("parseArgs supports -q / --quick as hands-off first-result", () => {
 });
 
 test("parseArgs ignores invalid --jump values without crashing", () => {
-  const negative = parseArgs(["-S", "Dune", "--jump", "-1"]);
-  const zero = parseArgs(["-S", "Dune", "--jump", "0"]);
-  const missing = parseArgs(["-S", "Dune", "--jump"]);
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  console.warn = ((message: string) => warnings.push(message)) as typeof console.warn;
 
-  // Invalid --jump values fall back to "ask the user" — the field stays
-  // undefined so the bootstrap resolves the search to the browse surface.
-  expect(negative.jump).toBeUndefined();
-  expect(zero.jump).toBeUndefined();
-  expect(missing.jump).toBeUndefined();
+  try {
+    const negative = parseArgs(["-S", "Dune", "--jump", "-1"]);
+    warnings.length = 0;
+    const zero = parseArgs(["-S", "Dune", "--jump", "0"]);
+    warnings.length = 0;
+    const nonNumeric = parseArgs(["-S", "Dune", "--jump", "abc"]);
+    warnings.length = 0;
+    const missing = parseArgs(["-S", "Dune", "--jump"]);
+
+    expect(negative.jump).toBeUndefined();
+    expect(zero.jump).toBeUndefined();
+    expect(nonNumeric.jump).toBeUndefined();
+    expect(missing.jump).toBeUndefined();
+
+    warnings.length = 0;
+    parseArgs(["-S", "Dune", "--jump", "0"]);
+    expect(warnings.join("; ")).toContain("--jump expects a positive result index; ignoring");
+
+    warnings.length = 0;
+    parseArgs(["-S", "Dune", "--jump", "abc"]);
+    expect(warnings.join("; ")).toContain("--jump expects a positive result index; ignoring");
+  } finally {
+    console.warn = originalWarn;
+  }
 });
 
 test("parseArgs treats a bare argument as a search query", () => {

--- a/apps/cli/test/unit/mpv.test.ts
+++ b/apps/cli/test/unit/mpv.test.ts
@@ -32,13 +32,17 @@ test("buildMpvArgs whitelists HTTPS for local materialized HLS playlists", () =>
   );
 });
 
-test("buildMpvArgs attaches only the preferred subtitle during initial launch", () => {
+test("buildMpvArgs attaches full subtitle inventory during initial launch", () => {
   const args = buildMpvArgs(
     {
       url: "https://cdn.example/master.m3u8",
       headers: { referer: "https://www.vidking.net/", "user-agent": "Mozilla/5.0" },
       subtitle: "https://sub.example/en.srt",
-      subtitleTracks: [{ url: "https://sub.example/ar.srt", language: "ar" }],
+      subtitleTracks: [
+        { url: "https://sub.example/ar.srt", language: "ar" },
+        { url: "https://sub.example/fr.srt", language: "fr" },
+        { url: "https://sub.example/en.srt", language: "en" },
+      ],
       displayTitle: "Friends - S01E03",
     },
     "/tmp/kunai-test.sock",
@@ -58,6 +62,29 @@ test("buildMpvArgs attaches only the preferred subtitle during initial launch", 
   expect(args).toContain("--input-ipc-server=/tmp/kunai-test.sock");
   expect(args.filter((arg) => arg.startsWith("--sub-file="))).toEqual([
     "--sub-file=https://sub.example/en.srt",
+    "--sub-file=https://sub.example/ar.srt",
+    "--sub-file=https://sub.example/fr.srt",
+  ]);
+});
+
+test("buildMpvArgs rejects option-injection subtitle URLs from launch inventory", () => {
+  const args = buildMpvArgs(
+    {
+      url: "https://cdn.example/master.m3u8",
+      headers: {},
+      subtitle: "https://sub.example/en.srt",
+      subtitleTracks: [
+        { url: "--script=evil.lua", language: "evil" },
+        { url: "https://sub.example/ar.srt", language: "ar" },
+      ],
+      displayTitle: "Unsafe subtitle inventory",
+    },
+    null,
+  );
+
+  expect(args.filter((arg) => arg.startsWith("--sub-file="))).toEqual([
+    "--sub-file=https://sub.example/en.srt",
+    "--sub-file=https://sub.example/ar.srt",
   ]);
 });
 

--- a/apps/cli/test/unit/provider-relay-settings.test.ts
+++ b/apps/cli/test/unit/provider-relay-settings.test.ts
@@ -68,7 +68,7 @@ test("describeProviderRelayProviders counts direct overrides", () => {
       providers: { allanime: { enabled: false }, miruro: { enabled: false } },
     },
   };
-  expect(describeProviderRelayProviders(config)).toBe("3 on · 2 direct");
+  expect(describeProviderRelayProviders(config)).toBe("4 on · 2 direct");
 });
 
 test("isSafeProviderRelayBaseUrl accepts https and local http only", () => {

--- a/apps/cli/test/unit/services/download/download-service.test.ts
+++ b/apps/cli/test/unit/services/download/download-service.test.ts
@@ -232,6 +232,33 @@ describe("DownloadService", () => {
     });
   });
 
+  test("rejects a stream URL that begins with a dash without spawning yt-dlp", async () => {
+    const service = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      downloadPath: tempDir,
+    });
+
+    const job = await service.enqueue({
+      title: { id: "tmdb:1", type: "series", name: "Example" },
+      episode: { season: 1, episode: 1, name: "Episode 1" },
+      stream: { url: "--exec=touch /tmp/pwned", headers: {}, timestamp: 0 },
+      providerId: "vidking",
+    });
+    await service.processQueue();
+
+    expect(
+      spawnSpy.mock.calls.some(
+        (call: readonly unknown[]) =>
+          Array.isArray(call[0]) && (call[0] as readonly string[])[0] === "yt-dlp",
+      ),
+    ).toBe(false);
+    const reloaded = repo.get(job.id);
+    expect(reloaded?.status).toBe("failed");
+    expect(reloaded?.errorMessage).toContain("Refusing to download unsafe stream URL");
+  });
+
   test("rejects enqueue when downloads are disabled", async () => {
     const service = buildService({
       repo,

--- a/apps/cli/test/unit/services/download/yt-dlp-download-stream-args.test.ts
+++ b/apps/cli/test/unit/services/download/yt-dlp-download-stream-args.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildYtDlpDownloadStreamArgs } from "@/services/download/DownloadService";
+
+describe("buildYtDlpDownloadStreamArgs", () => {
+  test("rejects stream URLs that begin with a dash", () => {
+    expect(() =>
+      buildYtDlpDownloadStreamArgs("--exec=touch /tmp/pwned", "/tmp/out.mp4", {}),
+    ).toThrow("Refusing to download unsafe stream URL");
+  });
+
+  test("places -- immediately before a valid https stream URL", () => {
+    const streamUrl = "https://example.com/master.m3u8";
+    const args = buildYtDlpDownloadStreamArgs(streamUrl, "/tmp/out.mp4", {});
+    const terminatorIndex = args.indexOf("--");
+    expect(terminatorIndex).toBeGreaterThanOrEqual(0);
+    expect(args[terminatorIndex + 1]).toBe(streamUrl);
+    expect(args.slice(terminatorIndex + 2)).toEqual([]);
+  });
+
+  test("strips CRLF from header keys and values before --add-header", () => {
+    const args = buildYtDlpDownloadStreamArgs("https://example.com/v.mp4", "/tmp/out.mp4", {
+      Referer: "https://example.com\r\nX-Injected: evil",
+    });
+    const headerIndex = args.indexOf("--add-header");
+    expect(headerIndex).toBeGreaterThanOrEqual(0);
+    expect(args[headerIndex + 1]).toBe("Referer: https://example.comX-Injected: evil");
+    expect(args[headerIndex + 1]).not.toMatch(/[\r\n]/);
+  });
+
+  test("skips headers whose key or value is empty after sanitization", () => {
+    const args = buildYtDlpDownloadStreamArgs("https://example.com/v.mp4", "/tmp/out.mp4", {
+      "": "value",
+      Referer: "\r\n",
+      "User-Agent": "kunai",
+    });
+    expect(args.filter((arg) => arg === "--add-header")).toHaveLength(1);
+    const headerIndex = args.indexOf("--add-header");
+    expect(args[headerIndex + 1]).toBe("User-Agent: kunai");
+  });
+});

--- a/apps/cli/test/unit/services/playback/playback-resolve-service.test.ts
+++ b/apps/cli/test/unit/services/playback/playback-resolve-service.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 
+import { MAX_IN_MEMORY_STREAM_REPLAY_AGE_MS } from "@/domain/playback/in-memory-stream-replay-policy";
 import type { CacheStore } from "@/services/persistence/CacheStore";
 import { PlaybackResolveService } from "@/services/playback/PlaybackResolveService";
 import { StreamHealthService } from "@/services/playback/StreamHealthService";
@@ -2005,4 +2006,145 @@ test("PlaybackResolveService routes AniDB identity and absolute episode into the
   expect(input?.title.id).toBe("151807");
   expect(input?.title.anilistId).toBe("151807");
   expect(input?.episode).toEqual({ season: 2, episode: 1, absoluteEpisode: 13 });
+});
+
+test("PlaybackResolveService rejects blocked prefetched streams and falls through to resolve", async () => {
+  const blockedUrl = "https://cdn.example/prefetch-dead.m3u8";
+  const freshStreamUrl = "https://cdn.example/refetched-good.m3u8";
+  const cache = createMemoryCache(null);
+  const engine = createMockEngine({
+    result: {
+      status: "resolved",
+      providerId: "vidking" as ProviderId,
+      streams: [
+        {
+          id: "stream:vidking:fresh",
+          providerId: "vidking" as ProviderId,
+          url: freshStreamUrl,
+          protocol: "hls" as const,
+          confidence: 0.9,
+          cachePolicy: { ttlClass: "stream-manifest", scope: "local", keyParts: [] },
+        },
+      ],
+      subtitles: [],
+      trace: {
+        id: "trace:fresh",
+        startedAt: new Date().toISOString(),
+        title: { id: "12345", kind: "movie", title: "Test Movie" },
+        cacheHit: false,
+        steps: [],
+        failures: [],
+      },
+      failures: [],
+    },
+    providerId: "vidking" as ProviderId,
+    attempts: [{ providerId: "vidking" as ProviderId, result: undefined }],
+  });
+  const events: string[] = [];
+  const service = new PlaybackResolveService({ engine, cacheStore: cache });
+
+  const result = await service.resolve({
+    title,
+    episode: { season: 1, episode: 2 },
+    mode: "series",
+    providerId: "vidking",
+    audioPreference: "original",
+    subtitlePreference: "none",
+    signal: new AbortController().signal,
+    prefetchedStream: { ...stream, url: blockedUrl, timestamp: Date.now() },
+    blockedStreamUrls: [blockedUrl],
+    onEvent: (event) => events.push(event.type),
+  });
+
+  expect(events).toContain("cache-stale");
+  expect(result.cacheStatus).toBe("miss");
+  expect(result.stream?.url).toBe(freshStreamUrl);
+});
+
+test("PlaybackResolveService rejects stale prefetched streams and falls through to resolve", async () => {
+  const stalePrefetchedUrl = "https://cdn.example/prefetch-stale.m3u8";
+  const freshStreamUrl = "https://cdn.example/refetched-good.m3u8";
+  const cache = createMemoryCache(null);
+  const engine = createMockEngine({
+    result: {
+      status: "resolved",
+      providerId: "vidking" as ProviderId,
+      streams: [
+        {
+          id: "stream:vidking:fresh",
+          providerId: "vidking" as ProviderId,
+          url: freshStreamUrl,
+          protocol: "hls" as const,
+          confidence: 0.9,
+          cachePolicy: { ttlClass: "stream-manifest", scope: "local", keyParts: [] },
+        },
+      ],
+      subtitles: [],
+      trace: {
+        id: "trace:fresh",
+        startedAt: new Date().toISOString(),
+        title: { id: "12345", kind: "movie", title: "Test Movie" },
+        cacheHit: false,
+        steps: [],
+        failures: [],
+      },
+      failures: [],
+    },
+    providerId: "vidking" as ProviderId,
+    attempts: [{ providerId: "vidking" as ProviderId, result: undefined }],
+  });
+  const events: string[] = [];
+  const service = new PlaybackResolveService({ engine, cacheStore: cache });
+  const now = Date.now();
+
+  const result = await service.resolve({
+    title,
+    episode: { season: 1, episode: 2 },
+    mode: "series",
+    providerId: "vidking",
+    audioPreference: "original",
+    subtitlePreference: "none",
+    signal: new AbortController().signal,
+    prefetchedStream: {
+      ...stream,
+      url: stalePrefetchedUrl,
+      timestamp: now - MAX_IN_MEMORY_STREAM_REPLAY_AGE_MS - 1,
+    },
+    onEvent: (event) => events.push(event.type),
+  });
+
+  expect(events).toContain("cache-stale");
+  expect(result.cacheStatus).toBe("miss");
+  expect(result.stream?.url).toBe(freshStreamUrl);
+});
+
+test("PlaybackResolveService adopts fresh prefetched streams without provider resolve", async () => {
+  const prefetchedUrl = "https://cdn.example/prefetch-good.m3u8";
+  const cache = createMemoryCache(null);
+  let providerCalled = false;
+  const engine = createMockEngine(
+    { result: null, providerId: null, attempts: [] },
+    {
+      onResolveInput: () => {
+        providerCalled = true;
+      },
+    },
+  );
+  const service = new PlaybackResolveService({ engine, cacheStore: cache });
+
+  const result = await service.resolve({
+    title,
+    episode: { season: 1, episode: 2 },
+    mode: "series",
+    providerId: "vidking",
+    audioPreference: "original",
+    subtitlePreference: "none",
+    signal: new AbortController().signal,
+    prefetchedStream: { ...stream, url: prefetchedUrl, timestamp: Date.now() },
+  });
+
+  expect(providerCalled).toBe(false);
+  expect(result.cacheStatus).toBe("prefetched");
+  expect(result.cacheProvenance).toBe("prefetched");
+  expect(result.stream?.url).toBe(prefetchedUrl);
 });

--- a/apps/cli/test/unit/services/providers/provider-registry.test.ts
+++ b/apps/cli/test/unit/services/providers/provider-registry.test.ts
@@ -195,7 +195,17 @@ test("listEpisodes receives the full title identity and language preferences", a
     },
     async listEpisodes(input): Promise<ProviderEpisodeOption[]> {
       received = input as unknown as Record<string, unknown>;
-      return [{ index: 1, label: "Episode 1", totalEpisodeCount: 1 }];
+      return [
+        {
+          index: 1,
+          label: "Episode 1 · Pilot",
+          name: "Pilot",
+          detail: "The first episode",
+          release: { airDate: "2026-01-02" },
+          artwork: { thumbnailUrl: "https://img.example/episode-1.jpg" },
+          totalEpisodeCount: 1,
+        },
+      ];
     },
   };
 
@@ -207,7 +217,7 @@ test("listEpisodes receives the full title identity and language preferences", a
   } as unknown as ProviderEngine;
 
   const registry = new ProviderRegistryImpl(engine);
-  await registry.get("hooked")?.listEpisodes?.({
+  const episodes = await registry.get("hooked")?.listEpisodes?.({
     title: {
       id: "anilist:21",
       name: "One Piece",
@@ -223,4 +233,13 @@ test("listEpisodes receives the full title identity and language preferences", a
   expect(title.title).toBe("One Piece");
   expect((received as unknown as Record<string, unknown>).preferredAudioLanguage).toBe("dub");
   expect((received as unknown as Record<string, unknown>).preferredSubtitleLanguage).toBe("en");
+  expect(episodes?.[0]).toMatchObject({
+    name: "Pilot",
+    detail: "The first episode",
+    overview: "The first episode",
+    airDate: "2026-01-02",
+    release: { airDate: "2026-01-02" },
+    previewImageUrl: "https://img.example/episode-1.jpg",
+    artwork: { thumbnailUrl: "https://img.example/episode-1.jpg" },
+  });
 });

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,10 +1,10 @@
 {
-  "syncedAt": "2026-08-18T09:43:00.820Z",
+  "syncedAt": "2026-08-18T11:59:51.487Z",
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceRevision": "99c2c28b",
-  "cliSourceFingerprint": "0b65d1a676ffa988d3ada7fb4a6a7b5177ebd0ac02870904f2353b0b7f61d6c5",
-  "docsContentFingerprint": "483acbc973e88226ec894a6e57466689f87a24edf9a9f884610afcb6b5a0823a",
+  "cliSourceRevision": "2291d461",
+  "cliSourceFingerprint": "b57e364d9ec97498bd6a47345e2c92b07a2d124d867514ca44ded0d726f0d0ae",
+  "docsContentFingerprint": "9560b4c2ffe815810a356c4514330e4ca39b0536afefc6f34a3040ec3e8cfaec",
   "featureStatusRevision": "d4c1e1d0943d18f05bca1a12a5b0ff966754a588f12e4a86a03510d2bc424c1d",
   "commandCount": 81,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],
@@ -708,7 +708,7 @@
     {
       "short": "",
       "long": "--jump",
-      "description": "Resume/seek to episode n"
+      "description": "Auto-pick the n-th search result (1-based, with -S)"
     },
     {
       "short": "",

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,9 +1,9 @@
 {
-  "syncedAt": "2026-08-16T10:38:36.708Z",
+  "syncedAt": "2026-08-18T09:20:14.960Z",
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceRevision": "520c36c1",
-  "cliSourceFingerprint": "178d0832826823139f8b53f7988cb125e7b72b8d637e4e585bca7f7af6749d91",
+  "cliSourceRevision": "92ac3977",
+  "cliSourceFingerprint": "0b65d1a676ffa988d3ada7fb4a6a7b5177ebd0ac02870904f2353b0b7f61d6c5",
   "docsContentFingerprint": "3311367d534c1c9f29cde9ecf49f75ed0f7069979b2a014b488101e3e2ad87e9",
   "featureStatusRevision": "d4c1e1d0943d18f05bca1a12a5b0ff966754a588f12e4a86a03510d2bc424c1d",
   "commandCount": 81,
@@ -93,7 +93,8 @@
         "Mp4 (mp4upload scrape)",
         "Luf-Mp4",
         "Ak. Filemoon is gone.",
-        "2026-08: mkissa crypto requires buildId=81 + /client-crypto/v1/bootstrap (x-aa-boot). ani-cli v5 moved primary to anidb.app."
+        "2026-08: mkissa crypto requires buildId=119 (rotated from 81) + /client-crypto/v1/bootstrap (x-aa-boot)",
+        "7-day epochs. ani-cli v5 moved primary to anidb.app."
       ]
     },
     {
@@ -111,9 +112,7 @@
         "Primary hosts: www.miruro.bz",
         "www.miruro.ru. Bare miruro.bz/.ru are 301 redirects to www. and still CF-block at the pipe path; miruro.com serves a different app shell with no /api/secure/pipe; miruro.tv/.to are TLS-dead — all stay off the resolve list.",
         "Uses Miruro pipe API with XOR/gzip decryption key 71951034f8fbcf53d89db52ceb3dc22c.",
-        "Still not the default anime auto-fallback (AniDB is the default",
-        "AllAnime the fallback); Miruro is available for manual pick when curl/http2 path works.",
-        "May hit Cloudflare rate limits if called too frequently."
+        "Not in the automatic anime lane: `animeProviderPriority` is `[anidb"
       ]
     },
     {

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,9 +1,9 @@
 {
-  "syncedAt": "2026-08-18T09:43:00.820Z",
+  "syncedAt": "2026-08-18T10:57:56.286Z",
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceRevision": "99c2c28b",
-  "cliSourceFingerprint": "0b65d1a676ffa988d3ada7fb4a6a7b5177ebd0ac02870904f2353b0b7f61d6c5",
+  "cliSourceRevision": "2291d461",
+  "cliSourceFingerprint": "563c7f4bd69fea33fca72398350e0da049f70c653bd04bd2c4409b41d9a764cb",
   "docsContentFingerprint": "483acbc973e88226ec894a6e57466689f87a24edf9a9f884610afcb6b5a0823a",
   "featureStatusRevision": "d4c1e1d0943d18f05bca1a12a5b0ff966754a588f12e4a86a03510d2bc424c1d",
   "commandCount": 81,
@@ -68,6 +68,8 @@
         "Parity with ani-cli v5.0 (2026-08-01): browse search",
         "/api/frontend anime episodes + episode languages",
         "embed → HLS master.",
+        "Episode metadata follows the explicit anidb.app → official anidb.net AID cross-link",
+        "then reads official XML; AniList/Jikan fill missing fields and still artwork.",
         "Bun/fetch often gets Cloudflare 403 on anidb.app HTML/API; production path uses curl with a Chrome UA (dossier-proven).",
         "HLS media on hls.anidb.app usually works with native fetch after the embed URL is obtained.",
         "Sub = Japanese audio (jpn embed); dub = English audio (eng embed) when the languages API exposes it."

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,9 +1,9 @@
 {
-  "syncedAt": "2026-08-18T09:20:14.960Z",
+  "syncedAt": "2026-08-18T09:48:12.014Z",
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceRevision": "92ac3977",
-  "cliSourceFingerprint": "0b65d1a676ffa988d3ada7fb4a6a7b5177ebd0ac02870904f2353b0b7f61d6c5",
+  "cliSourceRevision": "4c0d2839",
+  "cliSourceFingerprint": "5aefbd00ff1678a77db02086a899294bd24b78c38a1ce45bd8cbb65eb4e4f4f8",
   "docsContentFingerprint": "3311367d534c1c9f29cde9ecf49f75ed0f7069979b2a014b488101e3e2ad87e9",
   "featureStatusRevision": "d4c1e1d0943d18f05bca1a12a5b0ff966754a588f12e4a86a03510d2bc424c1d",
   "commandCount": 81,
@@ -68,6 +68,8 @@
         "Parity with ani-cli v5.0 (2026-08-01): browse search",
         "/api/frontend anime episodes + episode languages",
         "embed → HLS master.",
+        "Episode metadata follows the explicit anidb.app → official anidb.net AID cross-link",
+        "then reads official XML; AniList/Jikan fill missing fields and still artwork.",
         "Bun/fetch often gets Cloudflare 403 on anidb.app HTML/API; production path uses curl with a Chrome UA (dossier-proven).",
         "HLS media on hls.anidb.app usually works with native fetch after the embed URL is obtained.",
         "Sub = Japanese audio (jpn embed); dub = English audio (eng embed) when the languages API exposes it."

--- a/apps/relay-server/src/provider-registry.ts
+++ b/apps/relay-server/src/provider-registry.ts
@@ -1,5 +1,6 @@
 import {
   allmangaProviderModule,
+  anidbProviderModule,
   miruroProviderModule,
   rivestreamProviderModule,
   videasyProviderModule,
@@ -12,6 +13,7 @@ export const relayProviderModules = [
   vidlinkProviderModule,
   rivestreamProviderModule,
   allmangaProviderModule,
+  anidbProviderModule,
   miruroProviderModule,
 ] as const;
 

--- a/docs/users/commands-and-shortcuts.mdx
+++ b/docs/users/commands-and-shortcuts.mdx
@@ -41,8 +41,9 @@ deliberately reduced public reference generated from the keybinding registry.
 - `/share` copies a catalog-anchored `kunai://` play link to the clipboard.
 - `/watch` parses a `kunai://` URL from the clipboard and launches playback.
 
-Advanced or experimental commands such as `/stats`, `/sync`, `/random`, and `/surprise`
-remain available by typing them directly even when they are not on the default browse palette.
+`/stats` is on the default browse palette. Tracker sync is experimental and lives under
+`/settings` → Sync. Random and surprise picks use the `kunai --random` launch flag or the
+browse shuffle key — they are not typed slash commands today.
 
 ## Playback Commands
 

--- a/packages/providers/src/allmanga/api-client.ts
+++ b/packages/providers/src/allmanga/api-client.ts
@@ -8,6 +8,7 @@ import {
   enrichEpisodeOptionsWithAnimeMetadata,
   fetchAnimeEpisodeMetadataByNumber,
   getSeededEpisodeMetadata,
+  mergeExternalEpisodeMetadataInto,
   parseAllMangaEpisodeNumber,
   seedEpisodeMetadataFromProvider,
   shouldSkipExternalEpisodeMetadataEnrichment,
@@ -15,6 +16,7 @@ import {
 } from "../shared/anime-metadata";
 import { expandHlsMasterPlaylist } from "../shared/hls-ladder";
 import { TTLCache } from "../shared/provider-cache";
+import { createTimeoutSignal } from "../shared/timeout-signal";
 import {
   ALLMANGA_BUILD_ID,
   ALLMANGA_CRYPTO_MATERIAL_TTL_MS,
@@ -493,27 +495,6 @@ export function clearAllMangaProviderCachesForTest(): void {
   retrySleep = (ms, signal) => sleepAbortable(ms, signal);
 }
 
-type AbortSignalConstructorWithAny = typeof AbortSignal & {
-  readonly any?: (signals: readonly AbortSignal[]) => AbortSignal;
-};
-
-function createTimeoutSignal(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
-  const timeoutSignal = AbortSignal.timeout(timeoutMs);
-  if (!signal) return timeoutSignal;
-  const abortSignal = AbortSignal as AbortSignalConstructorWithAny;
-  if (abortSignal.any) return abortSignal.any([signal, timeoutSignal]);
-
-  const controller = new AbortController();
-  const abort = (source: AbortSignal) => {
-    if (!controller.signal.aborted) controller.abort(source.reason);
-  };
-  if (signal.aborted) abort(signal);
-  if (timeoutSignal.aborted) abort(timeoutSignal);
-  signal.addEventListener("abort", () => abort(signal), { once: true });
-  timeoutSignal.addEventListener("abort", () => abort(timeoutSignal), { once: true });
-  return controller.signal;
-}
-
 export async function loadAvailableEpisodesDetail(
   context: ProviderRuntimeContext,
   apiUrl: string,
@@ -901,23 +882,7 @@ export async function fetchAllMangaEpisodeCatalog(opts: {
   if (!anilistId && !malId) return baseEpisodes;
 
   const externalMetadata = await fetchAnimeEpisodeMetadataByNumber({ anilistId, malId }, signal);
-  for (const [number, meta] of externalMetadata) {
-    const existing = metadata.get(number);
-    if (!existing) {
-      metadata.set(number, meta);
-      continue;
-    }
-    metadata.set(number, {
-      number,
-      title: existing.title ?? meta.title,
-      synopsis: existing.synopsis ?? meta.synopsis,
-      airDate: existing.airDate ?? meta.airDate,
-      thumbnail: existing.thumbnail ?? meta.thumbnail,
-      isFiller: existing.isFiller ?? meta.isFiller,
-      isRecap: existing.isRecap ?? meta.isRecap,
-      source: "merged",
-    });
-  }
+  mergeExternalEpisodeMetadataInto(metadata, externalMetadata);
 
   if (metadata.size === 0) return baseEpisodes;
 

--- a/packages/providers/src/anidb/browse-parser.ts
+++ b/packages/providers/src/anidb/browse-parser.ts
@@ -1,3 +1,5 @@
+import { decodeMarkupEntities, markupToPlainText, stripScriptBlocks } from "../shared/markup-text";
+
 /**
  * Pure AniDB browse-markup parsing.
  *
@@ -38,7 +40,7 @@ export function anidbNumericId(showId: string): number | null {
 }
 
 export function parseAnidbSeasonEvidence(title: string): AnidbSeasonEvidence {
-  const normalizedTitle = decodeHtmlEntities(title).replace(/\s+/g, " ").trim();
+  const normalizedTitle = decodeMarkupEntities(title).replace(/\s+/g, " ").trim();
   const match =
     /\bseason\s+(\d+)\b/i.exec(normalizedTitle) ??
     /\b(\d+)(?:st|nd|rd|th)\s+season\b/i.exec(normalizedTitle) ??
@@ -141,7 +143,7 @@ function hasNestedElement(body: string): boolean {
 }
 
 function parseAnidbShowIdFromHref(href: string | undefined): string | null {
-  const decoded = decodeHtmlEntities(href ?? "").trim();
+  const decoded = decodeMarkupEntities(href ?? "").trim();
   const match = /^(?:(?:https?:)?\/\/anidb\.app)?\/anime\/([^/?#]+)(?:[/?#].*)?$/i.exec(decoded);
   const id = (match?.[1] ?? "").trim();
   return looksLikeAnidbShowId(id) ? id : null;
@@ -150,30 +152,7 @@ function parseAnidbShowIdFromHref(href: string | undefined): string | null {
 function extractAnidbTitle(attrs: string, body: string): string {
   const anchorTitle = extractAttribute(attrs, "title") ?? extractAttribute(attrs, "aria-label");
   const imageAlt = IMAGE_ALT_PATTERN.exec(body)?.[1];
-  const nestedText = stripTags(stripScriptBlocks(body));
-  const decoded = decodeHtmlEntities(anchorTitle ?? imageAlt ?? nestedText);
-  // A raw ESC/BEL byte in the response body is the other half of the entity
-  // vector closed in decodeCodePoint(); `\s` matches neither, so without this
-  // they would survive into terminal output.
-  return stripControlCharacters(decoded).replace(/\s+/g, " ").trim();
-}
-
-/**
- * Drops C0/C1 controls but keeps tab/LF/CR, which the whitespace collapse below
- * turns into a single space -- stripping them outright would weld "Foo\nBar"
- * into "FooBar". Written as a code-point scan rather than a regex: a character
- * class of raw control characters is exactly what `no-control-regex` forbids,
- * and the scan reuses the same predicate the entity decoder checks.
- */
-function stripControlCharacters(value: string): string {
-  let out = "";
-  for (const character of value) {
-    const codePoint = character.codePointAt(0) ?? 0;
-    const isCollapsibleWhitespace = codePoint === 0x09 || codePoint === 0x0a || codePoint === 0x0d;
-    if (isControlCodePoint(codePoint) && !isCollapsibleWhitespace) continue;
-    out += character;
-  }
-  return out;
+  return markupToPlainText(anchorTitle ?? imageAlt ?? stripScriptBlocks(body));
 }
 
 /**
@@ -190,125 +169,12 @@ const ATTRIBUTE_PATTERNS = {
 
 const IMAGE_ALT_PATTERN = /<img\b[^>]*\salt\s*=\s*["']([^"']*)["']/i;
 
-/**
- * Removes `<script>…</script>` spans by scanning, not by regex.
- *
- * `/<script\b[\s\S]*?<\/script(?:[\s/][^>]*)?>/` is polynomial: the lazy body
- * advances one character at a time and each position re-scans `[^>]*` to the end,
- * so input repeating `</script\t` with no `>` degrades quadratically. This runs on
- * fetched provider markup, so that is a denial-of-service vector, not a nicety.
- *
- * Tag-name boundaries follow HTML: a name ends at whitespace, `/`, or `>`, and the
- * rest of an end tag is ignored — `</script>`, `</script >`, `</script\t\n bar>`
- * and `</script/>` all close, `</scriptfoo>` does not. An unterminated `<script`
- * drops the remainder: leaving it would put raw script source in a title.
- */
-function stripScriptBlocks(body: string): string {
-  const lowered = body.toLowerCase();
-  let out = "";
-  let cursor = 0;
-  for (;;) {
-    const open = indexOfTag(lowered, "<script", cursor);
-    if (open === -1) return out + body.slice(cursor);
-    const openEnd = body.indexOf(">", open);
-    if (openEnd === -1) return `${out + body.slice(cursor, open)} `;
-    const close = indexOfTag(lowered, "</script", openEnd + 1);
-    if (close === -1) return `${out + body.slice(cursor, open)} `;
-    const closeEnd = body.indexOf(">", close);
-    if (closeEnd === -1) return `${out + body.slice(cursor, open)} `;
-    out += `${body.slice(cursor, open)} `;
-    cursor = closeEnd + 1;
-  }
-}
-
-/**
- * Replaces `/<[^>]+>/g` for the same reason as stripScriptBlocks: on a body of
- * many `<` with no `>`, every `<` restarts a scan to end of input. Here the
- * failing `indexOf(">")` can happen at most once, because it returns
- * immediately, so the walk stays linear.
- *
- * Faithful to the regex it replaces: a tag needs at least one character between
- * the brackets, so a literal `<>` is text, and an unclosed `<` keeps the rest of
- * the string as text rather than discarding it.
- */
-function stripTags(value: string): string {
-  let out = "";
-  let cursor = 0;
-  for (;;) {
-    const open = value.indexOf("<", cursor);
-    if (open === -1) return out + value.slice(cursor);
-    const close = value.indexOf(">", open + 1);
-    if (close === -1) return out + value.slice(cursor);
-    if (close === open + 1) {
-      out += value.slice(cursor, close + 1);
-      cursor = close + 1;
-      continue;
-    }
-    out += `${value.slice(cursor, open)} `;
-    cursor = close + 1;
-  }
-}
-
-/** `indexOf` for a tag whose name ends at the match — not `<scriptfoo>`. */
-function indexOfTag(lowered: string, tag: string, from: number): number {
-  for (
-    let index = lowered.indexOf(tag, from);
-    index !== -1;
-    index = lowered.indexOf(tag, index + 1)
-  ) {
-    const next = lowered.charCodeAt(index + tag.length);
-    // whitespace, `/`, `>`, or end of input all terminate the tag name.
-    if (Number.isNaN(next) || next === 0x2f || next === 0x3e || next <= 0x20) return index;
-  }
-  return -1;
-}
-
 function extractAttribute(
   attrs: string,
   name: keyof typeof ATTRIBUTE_PATTERNS,
 ): string | undefined {
   const value = ATTRIBUTE_PATTERNS[name].exec(attrs)?.[1];
   return value?.trim() ? value : undefined;
-}
-
-const HTML_ENTITY_PATTERN = /&(?:#x([0-9a-f]+)|#(\d+)|(amp|lt|gt|quot|apos));/gi;
-
-const NAMED_ENTITIES: Record<string, string> = {
-  amp: "&",
-  lt: "<",
-  gt: ">",
-  quot: '"',
-  apos: "'",
-};
-
-function decodeCodePoint(raw: string, codePoint: number): string {
-  // Reject out-of-range values and the lone-surrogate block, which would
-  // otherwise produce an ill-formed title string.
-  if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) return raw;
-  if (codePoint >= 0xd800 && codePoint <= 0xdfff) return raw;
-  // Refuse to manufacture control characters. `&#27;` is plain ASCII in the
-  // response body, so a provider needs no raw ESC byte to smuggle one -- the
-  // decoder would mint it. These titles are printed straight to a terminal,
-  // where ESC drives cursor movement, screen clears, and OSC 52 clipboard
-  // writes. C0 (0x00-0x1f, 0x7f) and C1 (0x80-0x9f) are left as inert text.
-  if (isControlCodePoint(codePoint)) return raw;
-  return String.fromCodePoint(codePoint);
-}
-
-function isControlCodePoint(codePoint: number): boolean {
-  return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
-}
-
-/** Single pass, so `&amp;lt;` decodes to the literal `&lt;` and never to `<`. */
-function decodeHtmlEntities(value: string): string {
-  return value.replace(
-    HTML_ENTITY_PATTERN,
-    (raw: string, hex?: string, decimal?: string, named?: string) => {
-      if (hex !== undefined) return decodeCodePoint(raw, Number.parseInt(hex, 16));
-      if (decimal !== undefined) return decodeCodePoint(raw, Number.parseInt(decimal, 10));
-      return NAMED_ENTITIES[named?.toLowerCase() ?? ""] ?? raw;
-    },
-  );
 }
 
 function normalizeTitle(value: string): string {

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -3,6 +3,7 @@ import type { ProviderRuntimeContext } from "@kunai/types";
 import type { AnimeEpisodeMetadata } from "../shared/anime-metadata";
 import { curlCipherArgs, resolveCurlCandidate } from "../shared/curl-impersonate";
 import { expandHlsMasterPlaylist } from "../shared/hls-ladder";
+import { markupToPlainText } from "../shared/markup-text";
 import { TTLCache } from "../shared/provider-cache";
 import { createTimeoutSignal } from "../shared/timeout-signal";
 import { anidbNumericId, parseAnidbBrowseHtml, type AnidbSearchResult } from "./browse-parser";
@@ -246,7 +247,7 @@ export async function fetchAnidbOfficialEpisodeMetadata(
   }
 }
 
-function parseAnidbOfficialEpisodeMetadata(xml: string): Map<number, AnimeEpisodeMetadata> {
+export function parseAnidbOfficialEpisodeMetadata(xml: string): Map<number, AnimeEpisodeMetadata> {
   const metadata = new Map<number, AnimeEpisodeMetadata>();
   const episodePattern = /<episode\b[^>]*>([\s\S]*?)<\/episode>/gi;
   let match: RegExpExecArray | null;
@@ -301,34 +302,11 @@ function readXmlAttribute(attributes: string, name: string): string | undefined 
 }
 
 function normalizeXmlText(value: string): string {
-  return decodeXmlEntities(value.replace(/<[^>]+>/g, ""))
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function decodeXmlEntities(value: string): string {
-  return value.replace(
-    /&(?:#x([0-9a-f]+)|#(\d+)|(amp|lt|gt|quot|apos));/gi,
-    (raw, hex?: string, decimal?: string, named?: string) => {
-      if (hex !== undefined) return decodeXmlCodePoint(raw, Number.parseInt(hex, 16));
-      if (decimal !== undefined) return decodeXmlCodePoint(raw, Number.parseInt(decimal, 10));
-      return (
-        { amp: "&", lt: "<", gt: ">", quot: '"', apos: "'" }[named?.toLowerCase() ?? ""] ?? raw
-      );
-    },
-  );
-}
-
-function decodeXmlCodePoint(raw: string, codePoint: number): string {
-  if (
-    !Number.isInteger(codePoint) ||
-    codePoint < 0 ||
-    codePoint > 0x10ffff ||
-    (codePoint >= 0xd800 && codePoint <= 0xdfff)
-  ) {
-    return raw;
-  }
-  return String.fromCodePoint(codePoint);
+  // Official summaries carry markup and numeric entities, and land straight in
+  // terminal output. `markupToPlainText` is the same hardened path the browse
+  // scraper uses: script spans first, then tags, entities decoded once, and no
+  // decoded control character — `&#27;` must never become a live ESC byte.
+  return markupToPlainText(value);
 }
 
 function readMetaContent(html: string, property: string): string | undefined {

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -1,5 +1,6 @@
 import type { ProviderRuntimeContext } from "@kunai/types";
 
+import type { AnimeEpisodeMetadata } from "../shared/anime-metadata";
 import { curlCipherArgs, resolveCurlCandidate } from "../shared/curl-impersonate";
 import { expandHlsMasterPlaylist } from "../shared/hls-ladder";
 import { TTLCache } from "../shared/provider-cache";
@@ -23,6 +24,19 @@ export const ANIDB_USER_AGENT =
 const episodeCache = new TTLCache<string, readonly AnidbEpisodeEntry[]>(1_800_000);
 const languageCache = new TTLCache<string, readonly AnidbLanguageEntry[]>(300_000);
 const malCache = new TTLCache<string, number | null>(3_600_000);
+const externalIdsCache = new TTLCache<
+  string,
+  {
+    readonly malId: number | null;
+    readonly anilistId: string | null;
+    readonly officialAid: number | null;
+    readonly posterUrl: string | null;
+  }
+>(3_600_000);
+const officialEpisodeMetadataCache = new TTLCache<
+  string,
+  ReadonlyMap<number, AnimeEpisodeMetadata>
+>(30 * 24 * 60 * 60 * 1000);
 
 export type AnidbEpisodeEntry = {
   readonly id: number;
@@ -39,6 +53,7 @@ export type AnidbLanguageEntry = {
 export type AnidbStreamLink = {
   readonly url: string;
   readonly quality: string;
+  readonly audioMode: "sub" | "dub";
   readonly referer: string;
   readonly protocol: "hls";
   readonly container: "m3u8";
@@ -63,8 +78,29 @@ export function resolveAnidbCurl(
  */
 export async function anidbFetchText(
   url: string,
-  options: { readonly signal?: AbortSignal; readonly maxTimeSec?: number } = {},
+  options: {
+    readonly context?: ProviderRuntimeContext;
+    readonly signal?: AbortSignal;
+    readonly maxTimeSec?: number;
+  } = {},
 ): Promise<string> {
+  if (options.context?.fetch) {
+    try {
+      const response = await options.context.fetch.fetch(url, {
+        headers: { "User-Agent": ANIDB_USER_AGENT, Referer: ANIDB_REFERER },
+        signal: options.signal ?? AbortSignal.timeout(15_000),
+      });
+      if (response.ok) {
+        const text = await response.text();
+        if (!/just a moment/i.test(text)) {
+          return text;
+        }
+      }
+    } catch {
+      // Fallback to local curl/impersonate
+    }
+  }
+
   const curl = resolveAnidbCurl();
   if (!curl) {
     const response = await fetch(url, {
@@ -116,11 +152,13 @@ export async function anidbFetchText(
 export async function searchAnidb(
   query: string,
   signal?: AbortSignal,
+  context?: ProviderRuntimeContext,
 ): Promise<readonly AnidbSearchResult[]> {
   const trimmed = query.trim();
   if (!trimmed) return [];
   const page = await anidbFetchText(`${ANIDB_BASE}/browse?q=${encodeURIComponent(trimmed)}`, {
     signal,
+    context,
   });
   return parseAnidbBrowseHtml(page);
 }
@@ -128,6 +166,7 @@ export async function searchAnidb(
 export async function fetchAnidbMalId(
   showId: string,
   signal?: AbortSignal,
+  context?: ProviderRuntimeContext,
 ): Promise<number | undefined> {
   // `null` is "this page has no MAL link", which is a real answer worth caching.
   // A cache miss is `undefined`, so the two must not share a representation or
@@ -135,25 +174,191 @@ export async function fetchAnidbMalId(
   const cached = malCache.get(showId);
   if (cached !== undefined) return cached ?? undefined;
 
+  const ids = await fetchAnidbExternalIds(showId, signal, context);
+  if (!ids) return undefined;
+  const result = ids?.malId ?? null;
+  malCache.set(showId, result);
+  return result ?? undefined;
+}
+
+export type AnidbExternalIds = {
+  readonly malId?: number;
+  readonly anilistId?: string;
+  readonly officialAid?: number;
+  readonly posterUrl?: string;
+};
+
+export async function fetchAnidbExternalIds(
+  showId: string,
+  signal?: AbortSignal,
+  context?: ProviderRuntimeContext,
+): Promise<AnidbExternalIds | undefined> {
+  const cached = externalIdsCache.get(showId);
+  if (cached) {
+    return {
+      malId: cached.malId ?? undefined,
+      anilistId: cached.anilistId ?? undefined,
+      officialAid: cached.officialAid ?? undefined,
+      posterUrl: cached.posterUrl ?? undefined,
+    };
+  }
+
   try {
     const page = await anidbFetchText(`${ANIDB_BASE}/anime/${encodeURIComponent(showId)}`, {
       signal,
+      context,
     });
     const mal = /https:\/\/myanimelist\.net\/anime\/(\d+)/.exec(page)?.[1];
-    const parsed = mal ? Number(mal) : NaN;
-    const result = Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-    malCache.set(showId, result);
-    return result ?? undefined;
+    const parsedMal = mal ? Number(mal) : NaN;
+    const malId = Number.isFinite(parsedMal) && parsedMal > 0 ? parsedMal : null;
+    const anilistId = /https:\/\/anilist\.co\/anime\/(\d+)/.exec(page)?.[1] ?? null;
+    const official = /https:\/\/anidb\.net\/anime\/(\d+)/.exec(page)?.[1];
+    const parsedOfficial = official ? Number(official) : NaN;
+    const officialAid =
+      Number.isFinite(parsedOfficial) && parsedOfficial > 0 ? parsedOfficial : null;
+    const posterUrl = readMetaContent(page, "og:image") ?? null;
+    externalIdsCache.set(showId, { malId, anilistId, officialAid, posterUrl });
+    return {
+      malId: malId ?? undefined,
+      anilistId: anilistId ?? undefined,
+      officialAid: officialAid ?? undefined,
+      posterUrl: posterUrl ?? undefined,
+    };
   } catch {
-    // A transport failure says nothing about the show. Caching it would let one
-    // Cloudflare block or dropped connection suppress auto-skip for an hour.
+    // A transport failure says nothing about the show. Do not cache it or let a
+    // Cloudflare block suppress metadata and auto-skip for the full TTL.
     return undefined;
   }
+}
+
+export async function fetchAnidbOfficialEpisodeMetadata(
+  officialAid: number,
+  signal?: AbortSignal,
+): Promise<ReadonlyMap<number, AnimeEpisodeMetadata>> {
+  const cacheKey = String(officialAid);
+  const cached = officialEpisodeMetadataCache.get(cacheKey);
+  if (cached) return new Map(cached);
+
+  try {
+    const response = await fetch(
+      `http://api.anidb.net:9001/httpapi?request=anime&client=anidb&clientver=1&protover=1&aid=${officialAid}`,
+      {
+        headers: { Accept: "text/xml", "User-Agent": ANIDB_USER_AGENT },
+        signal: signal ?? AbortSignal.timeout(15_000),
+      },
+    );
+    if (!response.ok) return new Map();
+    const xml = await response.text();
+    const metadata = parseAnidbOfficialEpisodeMetadata(xml);
+    officialEpisodeMetadataCache.set(cacheKey, metadata);
+    return new Map(metadata);
+  } catch {
+    return new Map();
+  }
+}
+
+function parseAnidbOfficialEpisodeMetadata(xml: string): Map<number, AnimeEpisodeMetadata> {
+  const metadata = new Map<number, AnimeEpisodeMetadata>();
+  const episodePattern = /<episode\b[^>]*>([\s\S]*?)<\/episode>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = episodePattern.exec(xml)) !== null) {
+    const block = match[1] ?? "";
+    const epno = readXmlElement(block, "epno");
+    if (readXmlAttribute(epno.attributes, "type") !== "1") continue;
+    const number = Number(epno.value);
+    if (!Number.isInteger(number) || number < 1) continue;
+
+    const title = readPreferredAnidbEpisodeTitle(block);
+    const synopsis = readXmlElement(block, "summary").value;
+    const airDate = readXmlElement(block, "airdate").value;
+    metadata.set(number, {
+      number,
+      title: title || undefined,
+      synopsis: synopsis || undefined,
+      airDate: airDate || undefined,
+      source: "anidb",
+    });
+  }
+  return metadata;
+}
+
+function readPreferredAnidbEpisodeTitle(block: string): string {
+  const titles = [...block.matchAll(/<title\b([^>]*)>([\s\S]*?)<\/title>/gi)].map((match) => ({
+    language: readXmlAttribute(match[1] ?? "", "xml:lang"),
+    value: normalizeXmlText(match[2] ?? ""),
+  }));
+  return (
+    titles.find((title) => title.language === "en")?.value ??
+    titles.find((title) => title.language === "x-jat")?.value ??
+    titles[0]?.value ??
+    ""
+  );
+}
+
+function readXmlElement(
+  block: string,
+  name: string,
+): { readonly attributes: string; readonly value: string } {
+  const match = new RegExp(`<${name}\\b([^>]*)>([\\s\\S]*?)</${name}>`, "i").exec(block);
+  return {
+    attributes: match?.[1] ?? "",
+    value: normalizeXmlText(match?.[2] ?? ""),
+  };
+}
+
+function readXmlAttribute(attributes: string, name: string): string | undefined {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`${escapedName}\\s*=\\s*["']([^"']*)["']`, "i").exec(attributes)?.[1];
+}
+
+function normalizeXmlText(value: string): string {
+  return decodeXmlEntities(value.replace(/<[^>]+>/g, ""))
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function decodeXmlEntities(value: string): string {
+  return value.replace(
+    /&(?:#x([0-9a-f]+)|#(\d+)|(amp|lt|gt|quot|apos));/gi,
+    (raw, hex?: string, decimal?: string, named?: string) => {
+      if (hex !== undefined) return decodeXmlCodePoint(raw, Number.parseInt(hex, 16));
+      if (decimal !== undefined) return decodeXmlCodePoint(raw, Number.parseInt(decimal, 10));
+      return (
+        { amp: "&", lt: "<", gt: ">", quot: '"', apos: "'" }[named?.toLowerCase() ?? ""] ?? raw
+      );
+    },
+  );
+}
+
+function decodeXmlCodePoint(raw: string, codePoint: number): string {
+  if (
+    !Number.isInteger(codePoint) ||
+    codePoint < 0 ||
+    codePoint > 0x10ffff ||
+    (codePoint >= 0xd800 && codePoint <= 0xdfff)
+  ) {
+    return raw;
+  }
+  return String.fromCodePoint(codePoint);
+}
+
+function readMetaContent(html: string, property: string): string | undefined {
+  const escaped = property.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const propertyFirst = new RegExp(
+    `<meta\\b[^>]*property=["']${escaped}["'][^>]*content=["']([^"']+)["']`,
+    "i",
+  );
+  const contentFirst = new RegExp(
+    `<meta\\b[^>]*content=["']([^"']+)["'][^>]*property=["']${escaped}["']`,
+    "i",
+  );
+  return propertyFirst.exec(html)?.[1] ?? contentFirst.exec(html)?.[1];
 }
 
 export async function fetchAnidbEpisodes(
   showId: string,
   signal?: AbortSignal,
+  context?: ProviderRuntimeContext,
 ): Promise<readonly AnidbEpisodeEntry[]> {
   const numericId = anidbNumericId(showId);
   if (!numericId) return [];
@@ -161,7 +366,7 @@ export async function fetchAnidbEpisodes(
   if (cached) return cached;
 
   const url = `${ANIDB_BASE}/api/frontend/anime/${numericId}/episodes`;
-  const text = await anidbFetchText(url, { signal });
+  const text = await anidbFetchText(url, { signal, context });
   let parsed: { episodes?: readonly Record<string, unknown>[] };
   try {
     parsed = JSON.parse(text) as { episodes?: readonly Record<string, unknown>[] };
@@ -189,13 +394,14 @@ export async function fetchAnidbEpisodes(
 export async function fetchAnidbLanguages(
   episodeId: number,
   signal?: AbortSignal,
+  context?: ProviderRuntimeContext,
 ): Promise<readonly AnidbLanguageEntry[]> {
   const cacheKey = String(episodeId);
   const cached = languageCache.get(cacheKey);
   if (cached) return cached;
 
   const url = `${ANIDB_BASE}/api/frontend/episode/${episodeId}/languages`;
-  const text = await anidbFetchText(url, { signal });
+  const text = await anidbFetchText(url, { signal, context });
   let parsed: { languages?: readonly Record<string, unknown>[] };
   try {
     parsed = JSON.parse(text) as { languages?: readonly Record<string, unknown>[] };
@@ -225,8 +431,9 @@ export async function fetchAnidbLanguages(
 export async function fetchAnidbMasterUrl(
   embedUrl: string,
   signal?: AbortSignal,
+  context?: ProviderRuntimeContext,
 ): Promise<string | null> {
-  const page = await anidbFetchText(embedUrl, { signal });
+  const page = await anidbFetchText(embedUrl, { signal, context });
   const match = /file:\s*'([^']+)'/.exec(page);
   return match?.[1]?.trim() || null;
 }
@@ -238,20 +445,18 @@ export async function resolveAnidbEpisodeStreams(options: {
   readonly audioMode: "sub" | "dub";
   readonly signal?: AbortSignal;
 }): Promise<readonly AnidbStreamLink[]> {
-  const episodes = await fetchAnidbEpisodes(options.showId, options.signal);
+  const episodes = await fetchAnidbEpisodes(options.showId, options.signal, options.context);
   const episode = episodes.find((entry) => entry.number === options.episodeNumber);
   if (!episode) return [];
 
-  const languages = await fetchAnidbLanguages(episode.id, options.signal);
+  const languages = await fetchAnidbLanguages(episode.id, options.signal, options.context);
   const preferredCode = options.audioMode === "dub" ? "eng" : "jpn";
-  const fallbackCode = options.audioMode === "dub" ? "jpn" : "eng";
-  const language =
-    languages.find((entry) => entry.code === preferredCode) ??
-    languages.find((entry) => entry.code === fallbackCode) ??
-    languages[0];
+  // Do not silently play the other language and label it as the requested mode.
+  // The caller can then fall back to another provider or let the user switch.
+  const language = languages.find((entry) => entry.code === preferredCode);
   if (!language) return [];
 
-  const masterUrl = await fetchAnidbMasterUrl(language.embedUrl, options.signal);
+  const masterUrl = await fetchAnidbMasterUrl(language.embedUrl, options.signal, options.context);
   if (!masterUrl) return [];
 
   const fetchPort =
@@ -276,6 +481,7 @@ export async function resolveAnidbEpisodeStreams(options: {
   return variants.map((variant) => ({
     url: variant.url,
     quality: variant.qualityLabel,
+    audioMode: options.audioMode,
     referer: ANIDB_REFERER,
     protocol: "hls" as const,
     container: "m3u8" as const,
@@ -286,4 +492,6 @@ export function clearAnidbCachesForTest(): void {
   episodeCache.clear();
   languageCache.clear();
   malCache.clear();
+  externalIdsCache.clear();
+  officialEpisodeMetadataCache.clear();
 }

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -1,5 +1,6 @@
 import type { ProviderRuntimeContext } from "@kunai/types";
 
+import type { AnimeEpisodeMetadata } from "../shared/anime-metadata";
 import { curlCipherArgs, resolveCurlCandidate } from "../shared/curl-impersonate";
 import { expandHlsMasterPlaylist } from "../shared/hls-ladder";
 import { TTLCache } from "../shared/provider-cache";
@@ -23,6 +24,19 @@ export const ANIDB_USER_AGENT =
 const episodeCache = new TTLCache<string, readonly AnidbEpisodeEntry[]>(1_800_000);
 const languageCache = new TTLCache<string, readonly AnidbLanguageEntry[]>(300_000);
 const malCache = new TTLCache<string, number | null>(3_600_000);
+const externalIdsCache = new TTLCache<
+  string,
+  {
+    readonly malId: number | null;
+    readonly anilistId: string | null;
+    readonly officialAid: number | null;
+    readonly posterUrl: string | null;
+  }
+>(3_600_000);
+const officialEpisodeMetadataCache = new TTLCache<
+  string,
+  ReadonlyMap<number, AnimeEpisodeMetadata>
+>(30 * 24 * 60 * 60 * 1000);
 
 export type AnidbEpisodeEntry = {
   readonly id: number;
@@ -39,6 +53,7 @@ export type AnidbLanguageEntry = {
 export type AnidbStreamLink = {
   readonly url: string;
   readonly quality: string;
+  readonly audioMode: "sub" | "dub";
   readonly referer: string;
   readonly protocol: "hls";
   readonly container: "m3u8";
@@ -135,20 +150,183 @@ export async function fetchAnidbMalId(
   const cached = malCache.get(showId);
   if (cached !== undefined) return cached ?? undefined;
 
+  const ids = await fetchAnidbExternalIds(showId, signal);
+  if (!ids) return undefined;
+  const result = ids?.malId ?? null;
+  malCache.set(showId, result);
+  return result ?? undefined;
+}
+
+export type AnidbExternalIds = {
+  readonly malId?: number;
+  readonly anilistId?: string;
+  readonly officialAid?: number;
+  readonly posterUrl?: string;
+};
+
+export async function fetchAnidbExternalIds(
+  showId: string,
+  signal?: AbortSignal,
+): Promise<AnidbExternalIds | undefined> {
+  const cached = externalIdsCache.get(showId);
+  if (cached) {
+    return {
+      malId: cached.malId ?? undefined,
+      anilistId: cached.anilistId ?? undefined,
+      officialAid: cached.officialAid ?? undefined,
+      posterUrl: cached.posterUrl ?? undefined,
+    };
+  }
+
   try {
     const page = await anidbFetchText(`${ANIDB_BASE}/anime/${encodeURIComponent(showId)}`, {
       signal,
     });
     const mal = /https:\/\/myanimelist\.net\/anime\/(\d+)/.exec(page)?.[1];
-    const parsed = mal ? Number(mal) : NaN;
-    const result = Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-    malCache.set(showId, result);
-    return result ?? undefined;
+    const parsedMal = mal ? Number(mal) : NaN;
+    const malId = Number.isFinite(parsedMal) && parsedMal > 0 ? parsedMal : null;
+    const anilistId = /https:\/\/anilist\.co\/anime\/(\d+)/.exec(page)?.[1] ?? null;
+    const official = /https:\/\/anidb\.net\/anime\/(\d+)/.exec(page)?.[1];
+    const parsedOfficial = official ? Number(official) : NaN;
+    const officialAid =
+      Number.isFinite(parsedOfficial) && parsedOfficial > 0 ? parsedOfficial : null;
+    const posterUrl = readMetaContent(page, "og:image") ?? null;
+    externalIdsCache.set(showId, { malId, anilistId, officialAid, posterUrl });
+    return {
+      malId: malId ?? undefined,
+      anilistId: anilistId ?? undefined,
+      officialAid: officialAid ?? undefined,
+      posterUrl: posterUrl ?? undefined,
+    };
   } catch {
-    // A transport failure says nothing about the show. Caching it would let one
-    // Cloudflare block or dropped connection suppress auto-skip for an hour.
+    // A transport failure says nothing about the show. Do not cache it or let a
+    // Cloudflare block suppress metadata and auto-skip for the full TTL.
     return undefined;
   }
+}
+
+export async function fetchAnidbOfficialEpisodeMetadata(
+  officialAid: number,
+  signal?: AbortSignal,
+): Promise<ReadonlyMap<number, AnimeEpisodeMetadata>> {
+  const cacheKey = String(officialAid);
+  const cached = officialEpisodeMetadataCache.get(cacheKey);
+  if (cached) return new Map(cached);
+
+  try {
+    const response = await fetch(
+      `http://api.anidb.net:9001/httpapi?request=anime&client=anidb&clientver=1&protover=1&aid=${officialAid}`,
+      {
+        headers: { Accept: "text/xml", "User-Agent": ANIDB_USER_AGENT },
+        signal: signal ?? AbortSignal.timeout(15_000),
+      },
+    );
+    if (!response.ok) return new Map();
+    const xml = await response.text();
+    const metadata = parseAnidbOfficialEpisodeMetadata(xml);
+    officialEpisodeMetadataCache.set(cacheKey, metadata);
+    return new Map(metadata);
+  } catch {
+    return new Map();
+  }
+}
+
+function parseAnidbOfficialEpisodeMetadata(xml: string): Map<number, AnimeEpisodeMetadata> {
+  const metadata = new Map<number, AnimeEpisodeMetadata>();
+  const episodePattern = /<episode\b[^>]*>([\s\S]*?)<\/episode>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = episodePattern.exec(xml)) !== null) {
+    const block = match[1] ?? "";
+    const epno = readXmlElement(block, "epno");
+    if (readXmlAttribute(epno.attributes, "type") !== "1") continue;
+    const number = Number(epno.value);
+    if (!Number.isInteger(number) || number < 1) continue;
+
+    const title = readPreferredAnidbEpisodeTitle(block);
+    const synopsis = readXmlElement(block, "summary").value;
+    const airDate = readXmlElement(block, "airdate").value;
+    metadata.set(number, {
+      number,
+      title: title || undefined,
+      synopsis: synopsis || undefined,
+      airDate: airDate || undefined,
+      source: "anidb",
+    });
+  }
+  return metadata;
+}
+
+function readPreferredAnidbEpisodeTitle(block: string): string {
+  const titles = [...block.matchAll(/<title\b([^>]*)>([\s\S]*?)<\/title>/gi)].map((match) => ({
+    language: readXmlAttribute(match[1] ?? "", "xml:lang"),
+    value: normalizeXmlText(match[2] ?? ""),
+  }));
+  return (
+    titles.find((title) => title.language === "en")?.value ??
+    titles.find((title) => title.language === "x-jat")?.value ??
+    titles[0]?.value ??
+    ""
+  );
+}
+
+function readXmlElement(
+  block: string,
+  name: string,
+): { readonly attributes: string; readonly value: string } {
+  const match = new RegExp(`<${name}\\b([^>]*)>([\\s\\S]*?)</${name}>`, "i").exec(block);
+  return {
+    attributes: match?.[1] ?? "",
+    value: normalizeXmlText(match?.[2] ?? ""),
+  };
+}
+
+function readXmlAttribute(attributes: string, name: string): string | undefined {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`${escapedName}\\s*=\\s*["']([^"']*)["']`, "i").exec(attributes)?.[1];
+}
+
+function normalizeXmlText(value: string): string {
+  return decodeXmlEntities(value.replace(/<[^>]+>/g, ""))
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function decodeXmlEntities(value: string): string {
+  return value.replace(
+    /&(?:#x([0-9a-f]+)|#(\d+)|(amp|lt|gt|quot|apos));/gi,
+    (raw, hex?: string, decimal?: string, named?: string) => {
+      if (hex !== undefined) return decodeXmlCodePoint(raw, Number.parseInt(hex, 16));
+      if (decimal !== undefined) return decodeXmlCodePoint(raw, Number.parseInt(decimal, 10));
+      return (
+        { amp: "&", lt: "<", gt: ">", quot: '"', apos: "'" }[named?.toLowerCase() ?? ""] ?? raw
+      );
+    },
+  );
+}
+
+function decodeXmlCodePoint(raw: string, codePoint: number): string {
+  if (
+    !Number.isInteger(codePoint) ||
+    codePoint < 0 ||
+    codePoint > 0x10ffff ||
+    (codePoint >= 0xd800 && codePoint <= 0xdfff)
+  ) {
+    return raw;
+  }
+  return String.fromCodePoint(codePoint);
+}
+
+function readMetaContent(html: string, property: string): string | undefined {
+  const escaped = property.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const propertyFirst = new RegExp(
+    `<meta\\b[^>]*property=["']${escaped}["'][^>]*content=["']([^"']+)["']`,
+    "i",
+  );
+  const contentFirst = new RegExp(
+    `<meta\\b[^>]*content=["']([^"']+)["'][^>]*property=["']${escaped}["']`,
+    "i",
+  );
+  return propertyFirst.exec(html)?.[1] ?? contentFirst.exec(html)?.[1];
 }
 
 export async function fetchAnidbEpisodes(
@@ -244,11 +422,9 @@ export async function resolveAnidbEpisodeStreams(options: {
 
   const languages = await fetchAnidbLanguages(episode.id, options.signal);
   const preferredCode = options.audioMode === "dub" ? "eng" : "jpn";
-  const fallbackCode = options.audioMode === "dub" ? "jpn" : "eng";
-  const language =
-    languages.find((entry) => entry.code === preferredCode) ??
-    languages.find((entry) => entry.code === fallbackCode) ??
-    languages[0];
+  // Do not silently play the other language and label it as the requested mode.
+  // The caller can then fall back to another provider or let the user switch.
+  const language = languages.find((entry) => entry.code === preferredCode);
   if (!language) return [];
 
   const masterUrl = await fetchAnidbMasterUrl(language.embedUrl, options.signal);
@@ -276,6 +452,7 @@ export async function resolveAnidbEpisodeStreams(options: {
   return variants.map((variant) => ({
     url: variant.url,
     quality: variant.qualityLabel,
+    audioMode: options.audioMode,
     referer: ANIDB_REFERER,
     protocol: "hls" as const,
     container: "m3u8" as const,
@@ -286,4 +463,6 @@ export function clearAnidbCachesForTest(): void {
   episodeCache.clear();
   languageCache.clear();
   malCache.clear();
+  externalIdsCache.clear();
+  officialEpisodeMetadataCache.clear();
 }

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -4,6 +4,7 @@ import type { AnimeEpisodeMetadata } from "../shared/anime-metadata";
 import { curlCipherArgs, resolveCurlCandidate } from "../shared/curl-impersonate";
 import { expandHlsMasterPlaylist } from "../shared/hls-ladder";
 import { TTLCache } from "../shared/provider-cache";
+import { createTimeoutSignal } from "../shared/timeout-signal";
 import { anidbNumericId, parseAnidbBrowseHtml, type AnidbSearchResult } from "./browse-parser";
 
 export {
@@ -18,6 +19,14 @@ export {
 
 export const ANIDB_BASE = "https://anidb.app";
 export const ANIDB_REFERER = "https://anidb.app/";
+/**
+ * Official AniDB HTTP API. Read-only, one request per series, cached for a
+ * month: AniDB's terms are strict about repeat traffic and it answers abuse by
+ * banning the client name, so nothing here may run per episode or per playback.
+ */
+export const ANIDB_HTTP_API = "http://api.anidb.net:9001/httpapi";
+export const ANIDB_HTTP_API_CLIENT = "anidb";
+export const ANIDB_HTTP_API_CLIENT_VERSION = "1";
 export const ANIDB_USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
@@ -215,15 +224,21 @@ export async function fetchAnidbOfficialEpisodeMetadata(
 
   try {
     const response = await fetch(
-      `http://api.anidb.net:9001/httpapi?request=anime&client=anidb&clientver=1&protover=1&aid=${officialAid}`,
+      `${ANIDB_HTTP_API}?request=anime&client=${ANIDB_HTTP_API_CLIENT}&clientver=${ANIDB_HTTP_API_CLIENT_VERSION}&protover=1&aid=${officialAid}`,
       {
         headers: { Accept: "text/xml", "User-Agent": ANIDB_USER_AGENT },
-        signal: signal ?? AbortSignal.timeout(15_000),
+        signal: createTimeoutSignal(signal, 15_000),
       },
     );
     if (!response.ok) return new Map();
     const xml = await response.text();
+    // AniDB answers rate limits, bans, and bad client credentials with HTTP 200
+    // and an <error> body. Caching what that parses to (nothing) would suppress
+    // every episode title for this show for the full TTL, long after the block
+    // lifted — so an empty read stays uncached and simply retries next time.
+    if (/<error\b/i.test(xml)) return new Map();
     const metadata = parseAnidbOfficialEpisodeMetadata(xml);
+    if (metadata.size === 0) return new Map();
     officialEpisodeMetadataCache.set(cacheKey, metadata);
     return new Map(metadata);
   } catch {

--- a/packages/providers/src/anidb/direct.ts
+++ b/packages/providers/src/anidb/direct.ts
@@ -17,8 +17,13 @@ import type {
 
 import { resolveAnimeAudioIntent } from "../shared/anime-audio-intent";
 import {
+  anidbEpisodeMetadataCacheKey,
   enrichEpisodeOptionsWithAnimeMetadata,
   fetchAnimeEpisodeMetadataByNumber,
+  mergeExternalEpisodeMetadataInto,
+  mergeSeededEpisodeMetadataInto,
+  seedEpisodeMetadataFromProvider,
+  shouldSkipExternalEpisodeMetadataEnrichment,
   type AnimeEpisodeMetadata,
 } from "../shared/anime-metadata";
 import {
@@ -231,42 +236,40 @@ export const anidbProviderModule: CoreProviderModule = {
     if (!showId) return null;
     const episodes = await fetchAnidbEpisodes(showId, context.signal);
     if (episodes.length === 0) return [];
+
     const suppliedMalId = input.title.externalIds?.malId ?? input.title.malId;
     const suppliedAnilistId = input.title.externalIds?.anilistId ?? input.title.anilistId;
     const pageIds = await fetchAnidbExternalIds(showId, context.signal);
     const malId = suppliedMalId?.trim() ? suppliedMalId : pageIds?.malId;
     const anilistId = suppliedAnilistId ?? pageIds?.anilistId;
     const metadataMalId = malId === undefined ? undefined : String(malId);
+
+    // Official AniDB is the title/synopsis/air-date authority for this provider
+    // and answers in one request for the whole series, so it runs first and its
+    // values win. Seeded so a second listing (or the same show under another
+    // surface) does not pay for it again.
+    const metadataCacheKey = anidbEpisodeMetadataCacheKey(showId);
     const metadata = new Map<number, AnimeEpisodeMetadata>();
-    if (pageIds?.officialAid) {
-      for (const [number, meta] of await fetchAnidbOfficialEpisodeMetadata(
-        pageIds.officialAid,
-        context.signal,
-      )) {
-        metadata.set(number, meta);
-      }
+    mergeSeededEpisodeMetadataInto(metadata, metadataCacheKey);
+    if (metadata.size === 0 && pageIds?.officialAid) {
+      const official = await fetchAnidbOfficialEpisodeMetadata(pageIds.officialAid, context.signal);
+      for (const [number, meta] of official) metadata.set(number, meta);
+      seedEpisodeMetadataFromProvider(metadataCacheKey, [...official.values()]);
     }
-    const externalMetadata = await fetchAnimeEpisodeMetadataByNumber(
-      { anilistId, malId: metadataMalId },
-      context.signal,
-    );
-    for (const [number, meta] of externalMetadata) {
-      const existing = metadata.get(number);
-      metadata.set(
-        number,
-        existing
-          ? {
-              ...existing,
-              title: existing.title ?? meta.title,
-              synopsis: existing.synopsis ?? meta.synopsis,
-              airDate: existing.airDate ?? meta.airDate,
-              thumbnail: existing.thumbnail ?? meta.thumbnail,
-              isFiller: existing.isFiller ?? meta.isFiller,
-              isRecap: existing.isRecap ?? meta.isRecap,
-              source: "merged",
-            }
-          : meta,
+
+    // AniDB publishes no episode stills, so AniList still runs for artwork even
+    // when every title is already known — but the paginated, rate-limited Jikan
+    // pass is skipped, which is the slow half.
+    if (anilistId || metadataMalId) {
+      const pass = shouldSkipExternalEpisodeMetadataEnrichment(metadata, episodes.length)
+        ? "artwork"
+        : "full";
+      const externalMetadata = await fetchAnimeEpisodeMetadataByNumber(
+        { anilistId, malId: metadataMalId },
+        context.signal,
+        pass,
       );
+      mergeExternalEpisodeMetadataInto(metadata, externalMetadata);
     }
 
     const baseEpisodes = episodes.map(
@@ -275,6 +278,8 @@ export const anidbProviderModule: CoreProviderModule = {
         label: `Episode ${episode.number}`,
         detail: episode.filler ? "Filler" : undefined,
         totalEpisodeCount: episodes.length,
+        // Series poster as the still fallback: an empty art slot reads as a
+        // broken row, and AniDB has no per-episode image of its own.
         artwork: pageIds?.posterUrl ? { thumbnailUrl: pageIds.posterUrl } : undefined,
         externalIds: {
           anilistId,

--- a/packages/providers/src/anidb/direct.ts
+++ b/packages/providers/src/anidb/direct.ts
@@ -8,6 +8,7 @@ import type {
   ProviderEpisodeOption,
   ProviderFailure,
   ProviderResolveInput,
+  ProviderRuntimeContext,
   ProviderSearchResult,
   ProviderSourceCandidate,
   ProviderTraceEvent,
@@ -16,6 +17,11 @@ import type {
 } from "@kunai/types";
 
 import { resolveAnimeAudioIntent } from "../shared/anime-audio-intent";
+import {
+  enrichEpisodeOptionsWithAnimeMetadata,
+  fetchAnimeEpisodeMetadataByNumber,
+  type AnimeEpisodeMetadata,
+} from "../shared/anime-metadata";
 import {
   animeQualityFields,
   formatAnimeSourceArchetype,
@@ -30,6 +36,8 @@ import {
   anidbNumericId,
   chooseAnidbSearchMatch,
   fetchAnidbEpisodes,
+  fetchAnidbExternalIds,
+  fetchAnidbOfficialEpisodeMetadata,
   fetchAnidbMalId,
   looksLikeAnidbShowId,
   parseAnidbSeasonEvidence,
@@ -46,6 +54,8 @@ export {
   anidbNumericId,
   chooseAnidbSearchMatch,
   clearAnidbCachesForTest,
+  fetchAnidbExternalIds,
+  fetchAnidbOfficialEpisodeMetadata,
   fetchAnidbMalId,
   looksLikeAnidbShowId,
   parseAnidbBrowseHtml,
@@ -76,13 +86,14 @@ function directAnidbShowFromInput(input: {
 async function resolveAnidbShow(
   input: { readonly title: ProviderResolveInput["title"] },
   signal?: AbortSignal,
+  context?: ProviderRuntimeContext,
 ): Promise<AnidbSearchResult | null> {
   const direct = directAnidbShowFromInput(input);
   if (direct) return direct;
 
   const query = input.title.title?.trim() ?? "";
   if (!query) return null;
-  return chooseAnidbSearchMatch(query, await searchAnidb(query, signal));
+  return chooseAnidbSearchMatch(query, await searchAnidb(query, signal, context));
 }
 
 function buildStreamHeaders(referer: string): Record<string, string> {
@@ -116,6 +127,17 @@ function buildAnidbSourceInventory(
           sourceId,
           confidence: 0.85,
         },
+        ...(audioMode === "sub"
+          ? [
+              {
+                role: "hardsub" as const,
+                normalizedLanguage: "en",
+                nativeLabel: "hardsub",
+                sourceId,
+                confidence: 0.85,
+              },
+            ]
+          : []),
       ],
       sourceEvidence: [
         {
@@ -132,19 +154,22 @@ function buildAnidbSourceInventory(
 
 function linksToCandidates(
   links: readonly AnidbStreamLink[],
-  audioMode: "sub" | "dub",
   cachePolicy: ReturnType<typeof createProviderCachePolicy>,
 ): {
   readonly streams: StreamCandidate[];
   readonly variants: ProviderVariantCandidate[];
   readonly sourceId: string;
 } {
+  const audioMode = links[0]?.audioMode ?? "sub";
   const sourceId = `source:${ANIDB_PROVIDER_ID}:${audioMode}`;
   const streams: StreamCandidate[] = [];
   const variants: ProviderVariantCandidate[] = [];
+  const hardSubLanguage = audioMode === "sub" ? "en" : undefined;
+  const subtitleDelivery = audioMode === "sub" ? ("hardcoded" as const) : undefined;
+  const subtitleLanguages = audioMode === "sub" ? ["en"] : undefined;
   const sourceDetail = formatAnimeSourceDetail({
     audio: audioMode,
-    subtitleMode: audioMode === "sub" ? "hard" : "unknown",
+    subtitleMode: audioMode === "sub" ? "hard" : undefined,
   });
   const archetype = formatAnimeSourceArchetype({
     audio: audioMode,
@@ -167,14 +192,35 @@ function linksToCandidates(
       qualityLabel: quality.qualityLabel,
       qualityRank: quality.qualityRank,
       presentation: audioMode,
+      hardSubLanguage,
+      subtitleDelivery,
+      subtitleLanguages,
       audioLanguages: audioMode === "dub" ? ["en"] : ["ja"],
-      hardSubLanguage: audioMode === "sub" ? "en" : undefined,
-      subtitleDelivery: audioMode === "sub" ? "hardcoded" : undefined,
       flavorArchetype: archetype,
       flavorLabel: audioMode === "dub" ? "Dub" : "Sub",
       serverName: "anidb",
       confidence: 0.9,
       cachePolicy,
+      languageEvidence: [
+        {
+          role: "audio",
+          normalizedLanguage: audioMode === "dub" ? "en" : "ja",
+          nativeLabel: audioMode,
+          sourceId,
+          confidence: 0.85,
+        },
+        ...(audioMode === "sub"
+          ? [
+              {
+                role: "hardsub" as const,
+                normalizedLanguage: "en",
+                nativeLabel: "hardsub",
+                sourceId,
+                confidence: 0.85,
+              },
+            ]
+          : []),
+      ],
       metadata: {
         audioMode,
         sourceDetail,
@@ -203,7 +249,7 @@ export const anidbProviderModule: CoreProviderModule = {
   manifest: anidbManifest,
 
   async search(input, context) {
-    const results = await searchAnidb(input.query, context.signal);
+    const results = await searchAnidb(input.query, context.signal, context);
     const mapped: ProviderSearchResult[] = [];
     for (const result of results.slice(0, 40)) {
       mapped.push({
@@ -211,41 +257,73 @@ export const anidbProviderModule: CoreProviderModule = {
         type: "series",
         title: result.title,
         metadataSource: "AniDB",
-        availableAudioModes: ["sub", "dub"],
-        subtitleAvailability: "hardsub",
         externalIds: {
           providerNativeIds: { [ANIDB_PROVIDER_ID]: result.id },
         },
-        languageEvidence: [
-          {
-            role: "audio",
-            normalizedLanguage: "ja",
-            nativeLabel: "sub",
-            confidence: 0.8,
-          },
-        ],
       });
     }
     return mapped;
   },
 
   async listEpisodes(input, context) {
-    const showId = (await resolveAnidbShow(input, context.signal))?.id;
+    const showId = (await resolveAnidbShow(input, context.signal, context))?.id;
     if (!showId) return null;
-    const episodes = await fetchAnidbEpisodes(showId, context.signal);
+    const episodes = await fetchAnidbEpisodes(showId, context.signal, context);
     if (episodes.length === 0) return [];
-    const malId = await fetchAnidbMalId(showId, context.signal);
-    return episodes.map(
+    const suppliedMalId = input.title.externalIds?.malId ?? input.title.malId;
+    const suppliedAnilistId = input.title.externalIds?.anilistId ?? input.title.anilistId;
+    const pageIds = await fetchAnidbExternalIds(showId, context.signal, context);
+    const malId = suppliedMalId?.trim() ? suppliedMalId : pageIds?.malId;
+    const anilistId = suppliedAnilistId ?? pageIds?.anilistId;
+    const metadataMalId = malId === undefined ? undefined : String(malId);
+    const metadata = new Map<number, AnimeEpisodeMetadata>();
+    if (pageIds?.officialAid) {
+      for (const [number, meta] of await fetchAnidbOfficialEpisodeMetadata(
+        pageIds.officialAid,
+        context.signal,
+      )) {
+        metadata.set(number, meta);
+      }
+    }
+    const externalMetadata = await fetchAnimeEpisodeMetadataByNumber(
+      { anilistId, malId: metadataMalId },
+      context.signal,
+    );
+    for (const [number, meta] of externalMetadata) {
+      const existing = metadata.get(number);
+      metadata.set(
+        number,
+        existing
+          ? {
+              ...existing,
+              title: existing.title ?? meta.title,
+              synopsis: existing.synopsis ?? meta.synopsis,
+              airDate: existing.airDate ?? meta.airDate,
+              thumbnail: existing.thumbnail ?? meta.thumbnail,
+              isFiller: existing.isFiller ?? meta.isFiller,
+              isRecap: existing.isRecap ?? meta.isRecap,
+              source: "merged",
+            }
+          : meta,
+      );
+    }
+
+    const baseEpisodes = episodes.map(
       (episode): ProviderEpisodeOption => ({
         index: episode.number,
         label: `Episode ${episode.number}`,
         detail: episode.filler ? "Filler" : undefined,
         totalEpisodeCount: episodes.length,
+        artwork: pageIds?.posterUrl ? { thumbnailUrl: pageIds.posterUrl } : undefined,
         externalIds: {
+          anilistId,
           malId: malId ? String(malId) : undefined,
         },
       }),
     );
+    return metadata.size > 0
+      ? enrichEpisodeOptionsWithAnimeMetadata(baseEpisodes, metadata)
+      : baseEpisodes;
   },
 
   async resolve(input, context) {
@@ -264,7 +342,7 @@ export const anidbProviderModule: CoreProviderModule = {
       });
     }
 
-    const baseShow = await resolveAnidbShow(input, context.signal);
+    const baseShow = await resolveAnidbShow(input, context.signal, context);
     if (!baseShow) {
       return createExhaustedResult(input, context, ANIDB_PROVIDER_ID, {
         code: "unsupported-title",
@@ -276,8 +354,8 @@ export const anidbProviderModule: CoreProviderModule = {
     const route = await routeAnidbSeason({
       base: baseShow,
       episode: input.episode,
-      search: searchAnidb,
-      episodes: fetchAnidbEpisodes,
+      search: (query, signal) => searchAnidb(query, signal, context),
+      episodes: (showId, signal) => fetchAnidbEpisodes(showId, signal, context),
       signal: context.signal,
     });
     if (!route) {
@@ -308,7 +386,7 @@ export const anidbProviderModule: CoreProviderModule = {
     const malIdPromise =
       existingMalId !== undefined && existingMalId !== ""
         ? Promise.resolve(String(existingMalId))
-        : fetchAnidbMalId(showId, context.signal).then(
+        : fetchAnidbMalId(showId, context.signal, context).then(
             (id) => (id !== undefined ? String(id) : undefined),
             () => undefined,
           );
@@ -353,7 +431,7 @@ export const anidbProviderModule: CoreProviderModule = {
         });
       }
 
-      const { streams, variants, sourceId } = linksToCandidates(links, audioMode, cachePolicy);
+      const { streams, variants, sourceId } = linksToCandidates(links, cachePolicy);
       const selection = selectReadyStream(streams, {
         startupPriority: input.startupPriority,
         qualityPreference: input.qualityPreference,
@@ -387,6 +465,8 @@ export const anidbProviderModule: CoreProviderModule = {
         streams,
         variants,
         subtitles: [],
+        release: input.episode?.release,
+        artwork: input.episode?.artwork,
         externalIds: {
           anilistId: input.title.externalIds?.anilistId ?? input.title.anilistId,
           malId,

--- a/packages/providers/src/anidb/direct.ts
+++ b/packages/providers/src/anidb/direct.ts
@@ -17,6 +17,11 @@ import type {
 
 import { resolveAnimeAudioIntent } from "../shared/anime-audio-intent";
 import {
+  enrichEpisodeOptionsWithAnimeMetadata,
+  fetchAnimeEpisodeMetadataByNumber,
+  type AnimeEpisodeMetadata,
+} from "../shared/anime-metadata";
+import {
   animeQualityFields,
   formatAnimeSourceArchetype,
   formatAnimeSourceDetail,
@@ -30,6 +35,8 @@ import {
   anidbNumericId,
   chooseAnidbSearchMatch,
   fetchAnidbEpisodes,
+  fetchAnidbExternalIds,
+  fetchAnidbOfficialEpisodeMetadata,
   fetchAnidbMalId,
   looksLikeAnidbShowId,
   parseAnidbSeasonEvidence,
@@ -46,6 +53,8 @@ export {
   anidbNumericId,
   chooseAnidbSearchMatch,
   clearAnidbCachesForTest,
+  fetchAnidbExternalIds,
+  fetchAnidbOfficialEpisodeMetadata,
   fetchAnidbMalId,
   looksLikeAnidbShowId,
   parseAnidbBrowseHtml,
@@ -132,19 +141,19 @@ function buildAnidbSourceInventory(
 
 function linksToCandidates(
   links: readonly AnidbStreamLink[],
-  audioMode: "sub" | "dub",
   cachePolicy: ReturnType<typeof createProviderCachePolicy>,
 ): {
   readonly streams: StreamCandidate[];
   readonly variants: ProviderVariantCandidate[];
   readonly sourceId: string;
 } {
+  const audioMode = links[0]?.audioMode ?? "sub";
   const sourceId = `source:${ANIDB_PROVIDER_ID}:${audioMode}`;
   const streams: StreamCandidate[] = [];
   const variants: ProviderVariantCandidate[] = [];
   const sourceDetail = formatAnimeSourceDetail({
     audio: audioMode,
-    subtitleMode: audioMode === "sub" ? "hard" : "unknown",
+    subtitleMode: "unknown",
   });
   const archetype = formatAnimeSourceArchetype({
     audio: audioMode,
@@ -168,8 +177,6 @@ function linksToCandidates(
       qualityRank: quality.qualityRank,
       presentation: audioMode,
       audioLanguages: audioMode === "dub" ? ["en"] : ["ja"],
-      hardSubLanguage: audioMode === "sub" ? "en" : undefined,
-      subtitleDelivery: audioMode === "sub" ? "hardcoded" : undefined,
       flavorArchetype: archetype,
       flavorLabel: audioMode === "dub" ? "Dub" : "Sub",
       serverName: "anidb",
@@ -211,19 +218,9 @@ export const anidbProviderModule: CoreProviderModule = {
         type: "series",
         title: result.title,
         metadataSource: "AniDB",
-        availableAudioModes: ["sub", "dub"],
-        subtitleAvailability: "hardsub",
         externalIds: {
           providerNativeIds: { [ANIDB_PROVIDER_ID]: result.id },
         },
-        languageEvidence: [
-          {
-            role: "audio",
-            normalizedLanguage: "ja",
-            nativeLabel: "sub",
-            confidence: 0.8,
-          },
-        ],
       });
     }
     return mapped;
@@ -234,18 +231,60 @@ export const anidbProviderModule: CoreProviderModule = {
     if (!showId) return null;
     const episodes = await fetchAnidbEpisodes(showId, context.signal);
     if (episodes.length === 0) return [];
-    const malId = await fetchAnidbMalId(showId, context.signal);
-    return episodes.map(
+    const suppliedMalId = input.title.externalIds?.malId ?? input.title.malId;
+    const suppliedAnilistId = input.title.externalIds?.anilistId ?? input.title.anilistId;
+    const pageIds = await fetchAnidbExternalIds(showId, context.signal);
+    const malId = suppliedMalId?.trim() ? suppliedMalId : pageIds?.malId;
+    const anilistId = suppliedAnilistId ?? pageIds?.anilistId;
+    const metadataMalId = malId === undefined ? undefined : String(malId);
+    const metadata = new Map<number, AnimeEpisodeMetadata>();
+    if (pageIds?.officialAid) {
+      for (const [number, meta] of await fetchAnidbOfficialEpisodeMetadata(
+        pageIds.officialAid,
+        context.signal,
+      )) {
+        metadata.set(number, meta);
+      }
+    }
+    const externalMetadata = await fetchAnimeEpisodeMetadataByNumber(
+      { anilistId, malId: metadataMalId },
+      context.signal,
+    );
+    for (const [number, meta] of externalMetadata) {
+      const existing = metadata.get(number);
+      metadata.set(
+        number,
+        existing
+          ? {
+              ...existing,
+              title: existing.title ?? meta.title,
+              synopsis: existing.synopsis ?? meta.synopsis,
+              airDate: existing.airDate ?? meta.airDate,
+              thumbnail: existing.thumbnail ?? meta.thumbnail,
+              isFiller: existing.isFiller ?? meta.isFiller,
+              isRecap: existing.isRecap ?? meta.isRecap,
+              source: "merged",
+            }
+          : meta,
+      );
+    }
+
+    const baseEpisodes = episodes.map(
       (episode): ProviderEpisodeOption => ({
         index: episode.number,
         label: `Episode ${episode.number}`,
         detail: episode.filler ? "Filler" : undefined,
         totalEpisodeCount: episodes.length,
+        artwork: pageIds?.posterUrl ? { thumbnailUrl: pageIds.posterUrl } : undefined,
         externalIds: {
+          anilistId,
           malId: malId ? String(malId) : undefined,
         },
       }),
     );
+    return metadata.size > 0
+      ? enrichEpisodeOptionsWithAnimeMetadata(baseEpisodes, metadata)
+      : baseEpisodes;
   },
 
   async resolve(input, context) {
@@ -353,7 +392,7 @@ export const anidbProviderModule: CoreProviderModule = {
         });
       }
 
-      const { streams, variants, sourceId } = linksToCandidates(links, audioMode, cachePolicy);
+      const { streams, variants, sourceId } = linksToCandidates(links, cachePolicy);
       const selection = selectReadyStream(streams, {
         startupPriority: input.startupPriority,
         qualityPreference: input.qualityPreference,
@@ -387,6 +426,8 @@ export const anidbProviderModule: CoreProviderModule = {
         streams,
         variants,
         subtitles: [],
+        release: input.episode?.release,
+        artwork: input.episode?.artwork,
         externalIds: {
           anilistId: input.title.externalIds?.anilistId ?? input.title.anilistId,
           malId,

--- a/packages/providers/src/anidb/manifest.ts
+++ b/packages/providers/src/anidb/manifest.ts
@@ -17,8 +17,8 @@ export const anidbManifest = defineProviderManifest({
       runtime: "direct-http",
       operations: ["search", "list-episodes", "resolve-stream", "health-check"],
       browserSafe: false,
-      relaySafe: false,
-      localOnly: true,
+      relaySafe: true,
+      localOnly: false,
     },
   ],
   cachePolicy: {
@@ -39,7 +39,7 @@ export const anidbManifest = defineProviderManifest({
     allowStale: true,
   },
   browserSafe: false,
-  relaySafe: false,
+  relaySafe: true,
   relayProfile: {
     upstreamHosts: ["anidb.app", "hls.anidb.app"],
     defaultHeaders: {
@@ -48,6 +48,7 @@ export const anidbManifest = defineProviderManifest({
   },
   notes: [
     "Parity with ani-cli v5.0 (2026-08-01): browse search, /api/frontend anime episodes + episode languages, embed → HLS master.",
+    "Episode metadata follows the explicit anidb.app → official anidb.net AID cross-link, then reads official XML; AniList/Jikan fill missing fields and still artwork.",
     "Bun/fetch often gets Cloudflare 403 on anidb.app HTML/API; production path uses curl with a Chrome UA (dossier-proven).",
     "HLS media on hls.anidb.app usually works with native fetch after the embed URL is obtained.",
     "Sub = Japanese audio (jpn embed); dub = English audio (eng embed) when the languages API exposes it.",

--- a/packages/providers/src/anidb/manifest.ts
+++ b/packages/providers/src/anidb/manifest.ts
@@ -48,6 +48,7 @@ export const anidbManifest = defineProviderManifest({
   },
   notes: [
     "Parity with ani-cli v5.0 (2026-08-01): browse search, /api/frontend anime episodes + episode languages, embed → HLS master.",
+    "Episode metadata follows the explicit anidb.app → official anidb.net AID cross-link, then reads official XML; AniList/Jikan fill missing fields and still artwork.",
     "Bun/fetch often gets Cloudflare 403 on anidb.app HTML/API; production path uses curl with a Chrome UA (dossier-proven).",
     "HLS media on hls.anidb.app usually works with native fetch after the embed URL is obtained.",
     "Sub = Japanese audio (jpn embed); dub = English audio (eng embed) when the languages API exposes it.",

--- a/packages/providers/src/rivestream/direct.ts
+++ b/packages/providers/src/rivestream/direct.ts
@@ -43,6 +43,7 @@ import {
 } from "../shared/source-inventory";
 import { selectReadyStream } from "../shared/startup-selection";
 import { normalizeIsoLanguageCode } from "../shared/subtitle-helpers";
+import { createTimeoutSignal } from "../shared/timeout-signal";
 import { rivestreamManifest, RIVESTREAM_PROVIDER_ID } from "./manifest";
 
 export { RIVESTREAM_PROVIDER_ID };
@@ -104,27 +105,6 @@ type RivestreamResolvedCandidate = {
   readonly variants: readonly ProviderVariantCandidate[];
   readonly subtitles: readonly SubtitleCandidate[];
 };
-
-type AbortSignalConstructorWithAny = typeof AbortSignal & {
-  readonly any?: (signals: readonly AbortSignal[]) => AbortSignal;
-};
-
-function createTimeoutSignal(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
-  const timeout = AbortSignal.timeout(timeoutMs);
-  if (!signal) return timeout;
-  const abortSignal = AbortSignal as AbortSignalConstructorWithAny;
-  if (abortSignal.any) return abortSignal.any([signal, timeout]);
-  // Manual combine fallback so the timeout is never dropped.
-  const controller = new AbortController();
-  const abortFrom = (source: AbortSignal) => {
-    if (!controller.signal.aborted) controller.abort(source.reason);
-  };
-  if (signal.aborted) abortFrom(signal);
-  else signal.addEventListener("abort", () => abortFrom(signal), { once: true });
-  if (timeout.aborted) abortFrom(timeout);
-  else timeout.addEventListener("abort", () => abortFrom(timeout), { once: true });
-  return controller.signal;
-}
 
 function getRivestreamRawSources(
   data: RivestreamSourceResponse["data"],

--- a/packages/providers/src/shared/anime-metadata.ts
+++ b/packages/providers/src/shared/anime-metadata.ts
@@ -1,6 +1,7 @@
 import type { ProviderEpisodeOption } from "@kunai/types";
 
 import { TTLCache } from "./provider-cache";
+import { createTimeoutSignal } from "./timeout-signal";
 
 export type AnimeEpisodeMetadataSource =
   | "anidb"
@@ -38,6 +39,10 @@ export function allMangaEpisodeMetadataCacheKey(showId: string, mode: "sub" | "d
 
 export function miruroEpisodeMetadataCacheKey(anilistId: string): string {
   return `miruro:${anilistId}`;
+}
+
+export function anidbEpisodeMetadataCacheKey(showId: string): string {
+  return `anidb:${showId}`;
 }
 
 export function seedEpisodeMetadataFromProvider(
@@ -117,8 +122,11 @@ type AniListStreamingEpisode = {
   readonly thumbnail?: string | null;
 };
 
-function metadataCacheKey(ids: { readonly anilistId?: string; readonly malId?: string }): string {
-  return `${ids.anilistId ?? ""}|${ids.malId ?? ""}`;
+function metadataCacheKey(
+  ids: { readonly anilistId?: string; readonly malId?: string },
+  pass: EpisodeMetadataPass,
+): string {
+  return `${ids.anilistId ?? ""}|${ids.malId ?? ""}|${pass}`;
 }
 
 function pickLongerTitle(
@@ -158,7 +166,7 @@ function mergeEpisodeMetadata(
 async function fetchJson<T>(url: string, signal?: AbortSignal): Promise<T | null> {
   try {
     const response = await fetch(url, {
-      signal: signal ?? AbortSignal.timeout(20_000),
+      signal: createTimeoutSignal(signal, 20_000),
       headers: { Accept: "application/json" },
     });
     if (!response.ok) return null;
@@ -209,7 +217,7 @@ async function fetchAniListStreamingEpisodes(
   try {
     const response = await fetch(ANILIST_GRAPHQL, {
       method: "POST",
-      signal: signal ?? AbortSignal.timeout(20_000),
+      signal: createTimeoutSignal(signal, 20_000),
       headers: { "Content-Type": "application/json", Accept: "application/json" },
       body: JSON.stringify({
         query: `query ($id: Int) {
@@ -268,6 +276,17 @@ export function mergeMiruroPipeEpisodeMetadata(
   }
 }
 
+/**
+ * Which external passes a caller still needs.
+ *
+ * "artwork" is the cheap half: one AniList call for stills. "full" adds the
+ * Jikan episode list, which pages 100 at a time under a strict rate limit —
+ * worth it for a bare catalog, pure latency for a provider that already knows
+ * every episode title. Callers decide with
+ * `shouldSkipExternalEpisodeMetadataEnrichment`.
+ */
+export type EpisodeMetadataPass = "full" | "artwork";
+
 /** Fetch episode titles/synopses/stills keyed by absolute episode number.
  *
  * @deprecated Prefer provider-native episode metadata (Miruro pipe, AllManga
@@ -278,9 +297,13 @@ export function mergeMiruroPipeEpisodeMetadata(
 export async function fetchAnimeEpisodeMetadataByNumber(
   ids: { readonly anilistId?: string; readonly malId?: string },
   signal?: AbortSignal,
+  pass: EpisodeMetadataPass = "full",
 ): Promise<Map<number, AnimeEpisodeMetadata>> {
-  const cacheKey = metadataCacheKey(ids);
-  const cached = metadataCache.get(cacheKey);
+  // A completed full pass already contains everything the artwork pass would
+  // fetch, so it answers both; the reverse is not true.
+  const cached =
+    metadataCache.get(metadataCacheKey(ids, "full")) ??
+    (pass === "artwork" ? metadataCache.get(metadataCacheKey(ids, "artwork")) : undefined);
   if (cached) return new Map(cached);
 
   const merged = new Map<number, AnimeEpisodeMetadata>();
@@ -293,15 +316,43 @@ export async function fetchAnimeEpisodeMetadataByNumber(
     }
   }
 
-  if (Number.isFinite(malId) && malId > 0) {
+  if (pass === "full" && Number.isFinite(malId) && malId > 0) {
     const jikanEpisodes = await fetchJikanEpisodes(malId, signal);
     for (const [number, meta] of jikanEpisodes) {
       mergeEpisodeMetadata(merged, number, meta);
     }
   }
 
-  metadataCache.set(cacheKey, merged);
+  metadataCache.set(metadataCacheKey(ids, pass), merged);
   return merged;
+}
+
+/**
+ * Fill gaps in `target` from an external source. Provider-native values win
+ * field by field: the provider knows its own catalog, the external source is
+ * only there for what the provider does not carry.
+ */
+export function mergeExternalEpisodeMetadataInto(
+  target: Map<number, AnimeEpisodeMetadata>,
+  external: ReadonlyMap<number, AnimeEpisodeMetadata>,
+): void {
+  for (const [number, meta] of external) {
+    const existing = target.get(number);
+    if (!existing) {
+      target.set(number, meta);
+      continue;
+    }
+    target.set(number, {
+      number,
+      title: existing.title ?? meta.title,
+      synopsis: existing.synopsis ?? meta.synopsis,
+      airDate: existing.airDate ?? meta.airDate,
+      thumbnail: existing.thumbnail ?? meta.thumbnail,
+      isFiller: existing.isFiller ?? meta.isFiller,
+      isRecap: existing.isRecap ?? meta.isRecap,
+      source: "merged",
+    });
+  }
 }
 
 export function parseAllMangaEpisodeNumber(episode: ProviderEpisodeOption): number {

--- a/packages/providers/src/shared/anime-metadata.ts
+++ b/packages/providers/src/shared/anime-metadata.ts
@@ -2,7 +2,13 @@ import type { ProviderEpisodeOption } from "@kunai/types";
 
 import { TTLCache } from "./provider-cache";
 
-export type AnimeEpisodeMetadataSource = "anilist" | "jikan" | "miruro" | "allmanga" | "merged";
+export type AnimeEpisodeMetadataSource =
+  | "anidb"
+  | "anilist"
+  | "jikan"
+  | "miruro"
+  | "allmanga"
+  | "merged";
 
 export type AnimeEpisodeMetadata = {
   readonly number: number;

--- a/packages/providers/src/shared/markup-text.ts
+++ b/packages/providers/src/shared/markup-text.ts
@@ -1,0 +1,163 @@
+// =============================================================================
+// markup-text.ts — turning fetched provider markup into text that is safe to
+// print to a terminal.
+//
+// Every helper here exists because the naive one-liner is wrong in a way that
+// only shows up on hostile or malformed input: a regex that degrades to
+// quadratic time, a tag strip that leaves `<script` behind, an entity decoder
+// that mints a raw ESC byte into a string headed for stdout. Scraped HTML and
+// scraped XML have the same problem, so they share one implementation.
+// =============================================================================
+
+/**
+ * Removes `<script>…</script>` spans by scanning, not by regex.
+ *
+ * `/<script\b[\s\S]*?<\/script(?:[\s/][^>]*)?>/` is polynomial: the lazy body
+ * advances one character at a time and each position re-scans `[^>]*` to the end,
+ * so input repeating `</script\t` with no `>` degrades quadratically. This runs on
+ * fetched provider markup, so that is a denial-of-service vector, not a nicety.
+ *
+ * Tag-name boundaries follow HTML: a name ends at whitespace, `/`, or `>`, and the
+ * rest of an end tag is ignored — `</script>`, `</script >`, `</script\t\n bar>`
+ * and `</script/>` all close, `</scriptfoo>` does not. An unterminated `<script`
+ * drops the remainder: leaving it would put raw script source in a title.
+ */
+export function stripScriptBlocks(body: string): string {
+  const lowered = body.toLowerCase();
+  let out = "";
+  let cursor = 0;
+  for (;;) {
+    const open = indexOfTag(lowered, "<script", cursor);
+    if (open === -1) return out + body.slice(cursor);
+    const openEnd = body.indexOf(">", open);
+    if (openEnd === -1) return `${out + body.slice(cursor, open)} `;
+    const close = indexOfTag(lowered, "</script", openEnd + 1);
+    if (close === -1) return `${out + body.slice(cursor, open)} `;
+    const closeEnd = body.indexOf(">", close);
+    if (closeEnd === -1) return `${out + body.slice(cursor, open)} `;
+    out += `${body.slice(cursor, open)} `;
+    cursor = closeEnd + 1;
+  }
+}
+
+/**
+ * Replaces `/<[^>]+>/g` for the same reason as stripScriptBlocks: on a body of
+ * many `<` with no `>`, every `<` restarts a scan to end of input. Here the
+ * failing `indexOf(">")` can happen at most once, because it returns
+ * immediately, so the walk stays linear.
+ *
+ * Faithful to the regex it replaces: a tag needs at least one character between
+ * the brackets, so a literal `<>` is text, and an unclosed `<` keeps the rest of
+ * the string as text rather than discarding it.
+ *
+ * Run it after `stripScriptBlocks`, never instead of it: one pass over
+ * `<<script>script>alert(1)</script>` leaves a live `<script` behind.
+ */
+export function stripTags(value: string): string {
+  let out = "";
+  let cursor = 0;
+  for (;;) {
+    const open = value.indexOf("<", cursor);
+    if (open === -1) return out + value.slice(cursor);
+    const close = value.indexOf(">", open + 1);
+    if (close === -1) return out + value.slice(cursor);
+    if (close === open + 1) {
+      out += value.slice(cursor, close + 1);
+      cursor = close + 1;
+      continue;
+    }
+    out += `${value.slice(cursor, open)} `;
+    cursor = close + 1;
+  }
+}
+
+/** `indexOf` for a tag whose name ends at the match — not `<scriptfoo>`. */
+function indexOfTag(lowered: string, tag: string, from: number): number {
+  for (
+    let index = lowered.indexOf(tag, from);
+    index !== -1;
+    index = lowered.indexOf(tag, index + 1)
+  ) {
+    const next = lowered.charCodeAt(index + tag.length);
+    // whitespace, `/`, `>`, or end of input all terminate the tag name.
+    if (Number.isNaN(next) || next === 0x2f || next === 0x3e || next <= 0x20) return index;
+  }
+  return -1;
+}
+
+/**
+ * Drops C0/C1 controls but keeps tab/LF/CR, which a whitespace collapse then
+ * turns into a single space -- stripping them outright would weld "Foo\nBar"
+ * into "FooBar". Written as a code-point scan rather than a regex: a character
+ * class of raw control characters is exactly what `no-control-regex` forbids,
+ * and the scan reuses the same predicate the entity decoder checks.
+ */
+export function stripControlCharacters(value: string): string {
+  let out = "";
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    const isCollapsibleWhitespace = codePoint === 0x09 || codePoint === 0x0a || codePoint === 0x0d;
+    if (isControlCodePoint(codePoint) && !isCollapsibleWhitespace) continue;
+    out += character;
+  }
+  return out;
+}
+
+const HTML_ENTITY_PATTERN = /&(?:#x([0-9a-f]+)|#(\d+)|(amp|lt|gt|quot|apos));/gi;
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+};
+
+function decodeCodePoint(raw: string, codePoint: number): string {
+  // Reject out-of-range values and the lone-surrogate block, which would
+  // otherwise produce an ill-formed title string.
+  if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) return raw;
+  if (codePoint >= 0xd800 && codePoint <= 0xdfff) return raw;
+  // Refuse to manufacture control characters. `&#27;` is plain ASCII in the
+  // response body, so a provider needs no raw ESC byte to smuggle one -- the
+  // decoder would mint it. These titles are printed straight to a terminal,
+  // where ESC drives cursor movement, screen clears, and OSC 52 clipboard
+  // writes. C0 (0x00-0x1f, 0x7f) and C1 (0x80-0x9f) are left as inert text.
+  if (isControlCodePoint(codePoint)) return raw;
+  return String.fromCodePoint(codePoint);
+}
+
+function isControlCodePoint(codePoint: number): boolean {
+  return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+}
+
+/**
+ * Single pass, so `&amp;lt;` decodes to the literal `&lt;` and never to `<`.
+ *
+ * The five named entities are the XML predefined set, which is also the subset
+ * that matters in scraped HTML titles, so HTML and XML share this decoder.
+ */
+export function decodeMarkupEntities(value: string): string {
+  return value.replace(
+    HTML_ENTITY_PATTERN,
+    (raw: string, hex?: string, decimal?: string, named?: string) => {
+      if (hex !== undefined) return decodeCodePoint(raw, Number.parseInt(hex, 16));
+      if (decimal !== undefined) return decodeCodePoint(raw, Number.parseInt(decimal, 10));
+      return NAMED_ENTITIES[named?.toLowerCase() ?? ""] ?? raw;
+    },
+  );
+}
+
+/**
+ * The whole pipeline for one field of scraped markup: no scripts, no tags, no
+ * smuggled control characters, entities decoded exactly once, whitespace
+ * collapsed. Anything printed to the terminal from a provider response should
+ * come through here.
+ */
+export function markupToPlainText(value: string): string {
+  const decoded = decodeMarkupEntities(stripTags(stripScriptBlocks(value)));
+  // A raw ESC/BEL byte in the response body is the other half of the entity
+  // vector closed in decodeCodePoint(); `\s` matches neither, so without this
+  // they would survive into terminal output.
+  return stripControlCharacters(decoded).replace(/\s+/g, " ").trim();
+}

--- a/packages/providers/src/shared/timeout-signal.ts
+++ b/packages/providers/src/shared/timeout-signal.ts
@@ -1,0 +1,31 @@
+type AbortSignalConstructorWithAny = typeof AbortSignal & {
+  readonly any?: (signals: readonly AbortSignal[]) => AbortSignal;
+};
+
+/**
+ * Combine a caller's cancellation with a per-request deadline.
+ *
+ * `signal ?? AbortSignal.timeout(ms)` reads like it does this and does not: a
+ * caller that passes a signal silently loses the deadline, so one hung upstream
+ * holds the whole resolve open until something else gives up. Always combine.
+ */
+export function createTimeoutSignal(
+  signal: AbortSignal | undefined,
+  timeoutMs: number,
+): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  if (!signal) return timeoutSignal;
+  const abortSignal = AbortSignal as AbortSignalConstructorWithAny;
+  if (abortSignal.any) return abortSignal.any([signal, timeoutSignal]);
+
+  // Manual combine fallback so the timeout is never dropped.
+  const controller = new AbortController();
+  const abort = (source: AbortSignal) => {
+    if (!controller.signal.aborted) controller.abort(source.reason);
+  };
+  if (signal.aborted) abort(signal);
+  if (timeoutSignal.aborted) abort(timeoutSignal);
+  signal.addEventListener("abort", () => abort(signal), { once: true });
+  timeoutSignal.addEventListener("abort", () => abort(timeoutSignal), { once: true });
+  return controller.signal;
+}

--- a/packages/providers/test/anidb-episode-metadata-cost.test.ts
+++ b/packages/providers/test/anidb-episode-metadata-cost.test.ts
@@ -4,7 +4,7 @@ import type { ProviderRuntimeContext } from "@kunai/types";
 
 import { anidbProviderModule, clearAnidbCachesForTest } from "../src/anidb/direct";
 import { clearAnimeMetadataCacheForTest } from "../src/shared/anime-metadata";
-import { isOfficialAnidbApi } from "./helpers/anidb-urls";
+import { isOfficialAnidbApi, urlHasHostname } from "./helpers/anidb-urls";
 
 // What this file protects: AniDB's own metadata is one request for a whole
 // series, while Jikan pages 100 episodes at a time under a rate limit. Paying
@@ -52,7 +52,7 @@ function stubAnidbFetch(officialBody: string): string[] {
     }
     if (url.includes("/anime/plain-show-700")) return new Response(ANIDB_PAGE, { status: 200 });
     if (isOfficialAnidbApi(url)) return new Response(officialBody, { status: 200 });
-    if (url.includes("graphql.anilist.co")) {
+    if (urlHasHostname(url, "graphql.anilist.co")) {
       return new Response(
         JSON.stringify({
           data: {
@@ -67,7 +67,7 @@ function stubAnidbFetch(officialBody: string): string[] {
         { status: 200 },
       );
     }
-    if (url.includes("api.jikan.moe")) {
+    if (urlHasHostname(url, "api.jikan.moe")) {
       return new Response(
         JSON.stringify({
           data: [
@@ -104,8 +104,11 @@ async function withStubbedRuntime<T>(
   }
 }
 
-const countCalls = (calls: readonly string[], host: string) =>
-  calls.filter((url) => url.includes(host)).length;
+const countHostCalls = (calls: readonly string[], hostname: string) =>
+  calls.filter((url) => urlHasHostname(url, hostname)).length;
+
+const countOfficialAnidbApiCalls = (calls: readonly string[]) =>
+  calls.filter(isOfficialAnidbApi).length;
 
 describe("anidb episode metadata cost", () => {
   test("skips the paginated Jikan pass when official AniDB already titles every episode", async () => {
@@ -113,9 +116,9 @@ describe("anidb episode metadata cost", () => {
       const episodes = await anidbProviderModule.listEpisodes?.(listInput, listContext);
 
       expect(episodes?.map((episode) => episode.name)).toEqual(["The Beginning", "The Journey"]);
-      expect(countCalls(calls, "api.jikan.moe")).toBe(0);
+      expect(countHostCalls(calls, "api.jikan.moe")).toBe(0);
       // AniList still runs: one request, and the only source of episode stills.
-      expect(countCalls(calls, "graphql.anilist.co")).toBe(1);
+      expect(countHostCalls(calls, "graphql.anilist.co")).toBe(1);
       expect(episodes?.[0]?.artwork?.thumbnailUrl).toBe("https://img.example/ep-1.jpg");
     });
   });
@@ -123,7 +126,7 @@ describe("anidb episode metadata cost", () => {
   test("falls back to the full external pass when official metadata is unavailable", async () => {
     await withStubbedRuntime(OFFICIAL_ERROR, async (calls) => {
       const episodes = await anidbProviderModule.listEpisodes?.(listInput, listContext);
-      expect(countCalls(calls, "api.jikan.moe")).toBe(1);
+      expect(countHostCalls(calls, "api.jikan.moe")).toBe(1);
       // Filler is a Jikan-only signal, so its presence proves the pass ran and
       // its answer reached the option, not just that a request was made.
       expect(episodes?.[0]?.label).toContain("Filler");
@@ -133,13 +136,13 @@ describe("anidb episode metadata cost", () => {
   test("an error answer is never cached as 'this show has no episode metadata'", async () => {
     await withStubbedRuntime(OFFICIAL_ERROR, async (calls) => {
       await anidbProviderModule.listEpisodes?.(listInput, listContext);
-      expect(countCalls(calls, "api.anidb.net:9001")).toBe(1);
+      expect(countOfficialAnidbApiCalls(calls)).toBe(1);
 
       // Only the shared external cache is dropped; the official-metadata cache
       // must not be holding an empty answer from the failed read.
       clearAnimeMetadataCacheForTest();
       await anidbProviderModule.listEpisodes?.(listInput, listContext);
-      expect(countCalls(calls, "api.anidb.net:9001")).toBe(2);
+      expect(countOfficialAnidbApiCalls(calls)).toBe(2);
     });
   });
 
@@ -147,7 +150,7 @@ describe("anidb episode metadata cost", () => {
     await withStubbedRuntime(OFFICIAL_XML, async (calls) => {
       await anidbProviderModule.listEpisodes?.(listInput, listContext);
       const episodes = await anidbProviderModule.listEpisodes?.(listInput, listContext);
-      expect(countCalls(calls, "api.anidb.net:9001")).toBe(1);
+      expect(countOfficialAnidbApiCalls(calls)).toBe(1);
       expect(episodes?.[0]?.name).toBe("The Beginning");
     });
   });

--- a/packages/providers/test/anidb-episode-metadata-cost.test.ts
+++ b/packages/providers/test/anidb-episode-metadata-cost.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ProviderRuntimeContext } from "@kunai/types";
+
+import { anidbProviderModule, clearAnidbCachesForTest } from "../src/anidb/direct";
+import { clearAnimeMetadataCacheForTest } from "../src/shared/anime-metadata";
+
+// What this file protects: AniDB's own metadata is one request for a whole
+// series, while Jikan pages 100 episodes at a time under a rate limit. Paying
+// for Jikan when every title is already known is pure latency in front of the
+// episode picker, and it is invisible in a correctness-only test — both passes
+// produce the same titles.
+
+const ANIDB_PAGE =
+  '<a href="https://myanimelist.net/anime/5678/Plain-Show">MAL</a>' +
+  '<a href="https://anilist.co/anime/1234">AniList</a>' +
+  '<a href="https://anidb.net/anime/9876">AniDB</a>' +
+  '<meta property="og:image" content="https://img.example/poster.jpg">';
+
+const OFFICIAL_XML = `<?xml version="1.0"?>
+  <anime id="9876">
+    <episode id="1"><epno type="1">1</epno><airdate>2020-01-02</airdate>
+      <title xml:lang="en">The Beginning</title></episode>
+    <episode id="2"><epno type="1">2</epno><airdate>2020-01-09</airdate>
+      <title xml:lang="en">The Journey</title></episode>
+  </anime>`;
+
+const OFFICIAL_ERROR = "<error code='500'>Client Values Missing or Invalid</error>";
+
+const listInput = {
+  title: { id: "plain-show-700", kind: "anime" as const, title: "Plain Show" },
+  preferredAudioLanguage: "ja",
+};
+const listContext = { now: () => new Date().toISOString() } as ProviderRuntimeContext;
+
+function stubAnidbFetch(officialBody: string): string[] {
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: unknown) => {
+    const url = String(input);
+    calls.push(url);
+    if (url.includes("/api/frontend/anime/700/episodes")) {
+      return new Response(
+        JSON.stringify({
+          episodes: [
+            { id: 70001, number: 1 },
+            { id: 70002, number: 2 },
+          ],
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.includes("/anime/plain-show-700")) return new Response(ANIDB_PAGE, { status: 200 });
+    if (url.includes("api.anidb.net:9001")) return new Response(officialBody, { status: 200 });
+    if (url.includes("graphql.anilist.co")) {
+      return new Response(
+        JSON.stringify({
+          data: {
+            Media: {
+              streamingEpisodes: [
+                { title: "The Beginning", thumbnail: "https://img.example/ep-1.jpg" },
+                { title: "The Journey", thumbnail: "https://img.example/ep-2.jpg" },
+              ],
+            },
+          },
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.includes("api.jikan.moe")) {
+      return new Response(
+        JSON.stringify({
+          data: [
+            { mal_id: 1, title: "The Beginning", aired: "2020-01-02T00:00:00+00:00", filler: true },
+          ],
+          pagination: { has_next_page: false },
+        }),
+        { status: 200 },
+      );
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+async function withStubbedRuntime<T>(
+  officialBody: string,
+  run: (calls: string[]) => Promise<T>,
+): Promise<T> {
+  const originalWhich = Bun.which;
+  const originalFetch = globalThis.fetch;
+  clearAnidbCachesForTest();
+  clearAnimeMetadataCacheForTest();
+  // Force the fetch path; the production path shells out to curl-impersonate.
+  Bun.which = ((_command: string) => null) as typeof Bun.which;
+  const calls = stubAnidbFetch(officialBody);
+  try {
+    return await run(calls);
+  } finally {
+    globalThis.fetch = originalFetch;
+    Bun.which = originalWhich;
+    clearAnidbCachesForTest();
+    clearAnimeMetadataCacheForTest();
+  }
+}
+
+const countCalls = (calls: readonly string[], host: string) =>
+  calls.filter((url) => url.includes(host)).length;
+
+describe("anidb episode metadata cost", () => {
+  test("skips the paginated Jikan pass when official AniDB already titles every episode", async () => {
+    await withStubbedRuntime(OFFICIAL_XML, async (calls) => {
+      const episodes = await anidbProviderModule.listEpisodes?.(listInput, listContext);
+
+      expect(episodes?.map((episode) => episode.name)).toEqual(["The Beginning", "The Journey"]);
+      expect(countCalls(calls, "api.jikan.moe")).toBe(0);
+      // AniList still runs: one request, and the only source of episode stills.
+      expect(countCalls(calls, "graphql.anilist.co")).toBe(1);
+      expect(episodes?.[0]?.artwork?.thumbnailUrl).toBe("https://img.example/ep-1.jpg");
+    });
+  });
+
+  test("falls back to the full external pass when official metadata is unavailable", async () => {
+    await withStubbedRuntime(OFFICIAL_ERROR, async (calls) => {
+      const episodes = await anidbProviderModule.listEpisodes?.(listInput, listContext);
+      expect(countCalls(calls, "api.jikan.moe")).toBe(1);
+      // Filler is a Jikan-only signal, so its presence proves the pass ran and
+      // its answer reached the option, not just that a request was made.
+      expect(episodes?.[0]?.label).toContain("Filler");
+    });
+  });
+
+  test("an error answer is never cached as 'this show has no episode metadata'", async () => {
+    await withStubbedRuntime(OFFICIAL_ERROR, async (calls) => {
+      await anidbProviderModule.listEpisodes?.(listInput, listContext);
+      expect(countCalls(calls, "api.anidb.net:9001")).toBe(1);
+
+      // Only the shared external cache is dropped; the official-metadata cache
+      // must not be holding an empty answer from the failed read.
+      clearAnimeMetadataCacheForTest();
+      await anidbProviderModule.listEpisodes?.(listInput, listContext);
+      expect(countCalls(calls, "api.anidb.net:9001")).toBe(2);
+    });
+  });
+
+  test("a second listing reuses seeded official metadata instead of refetching it", async () => {
+    await withStubbedRuntime(OFFICIAL_XML, async (calls) => {
+      await anidbProviderModule.listEpisodes?.(listInput, listContext);
+      const episodes = await anidbProviderModule.listEpisodes?.(listInput, listContext);
+      expect(countCalls(calls, "api.anidb.net:9001")).toBe(1);
+      expect(episodes?.[0]?.name).toBe("The Beginning");
+    });
+  });
+});

--- a/packages/providers/test/anidb-episode-metadata-cost.test.ts
+++ b/packages/providers/test/anidb-episode-metadata-cost.test.ts
@@ -4,6 +4,7 @@ import type { ProviderRuntimeContext } from "@kunai/types";
 
 import { anidbProviderModule, clearAnidbCachesForTest } from "../src/anidb/direct";
 import { clearAnimeMetadataCacheForTest } from "../src/shared/anime-metadata";
+import { isOfficialAnidbApi } from "./helpers/anidb-urls";
 
 // What this file protects: AniDB's own metadata is one request for a whole
 // series, while Jikan pages 100 episodes at a time under a rate limit. Paying
@@ -50,7 +51,7 @@ function stubAnidbFetch(officialBody: string): string[] {
       );
     }
     if (url.includes("/anime/plain-show-700")) return new Response(ANIDB_PAGE, { status: 200 });
-    if (url.includes("api.anidb.net:9001")) return new Response(officialBody, { status: 200 });
+    if (isOfficialAnidbApi(url)) return new Response(officialBody, { status: 200 });
     if (url.includes("graphql.anilist.co")) {
       return new Response(
         JSON.stringify({

--- a/packages/providers/test/anidb-official-xml-text.test.ts
+++ b/packages/providers/test/anidb-official-xml-text.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseAnidbOfficialEpisodeMetadata } from "../src/anidb/client";
+
+// Official AniDB summaries are markup that lands in terminal output: episode
+// titles in the picker, synopses in the rail. The browse scraper already closed
+// this class of hole; the XML parser reuses the same pipeline instead of its
+// own tag strip, and these are the cases that separate the two.
+
+const ESC = String.fromCharCode(0x1b);
+const BEL = String.fromCharCode(0x07);
+
+const wrap = (title: string, summary = "") =>
+  `<anime id="1"><episode id="1"><epno type="1">1</epno>` +
+  `<title xml:lang="en">${title}</title><summary>${summary}</summary>` +
+  `</episode></anime>`;
+
+describe("anidb official xml text", () => {
+  test("never decodes an entity into a live control character", () => {
+    // A provider needs no raw ESC byte to smuggle one: `&#27;` is plain ASCII
+    // in the response, and a decoder that mints it hands the terminal cursor
+    // moves, screen clears, and OSC 52 clipboard writes.
+    const parsed = parseAnidbOfficialEpisodeMetadata(wrap("Boom&#27;[2J&#7;"));
+    const title = parsed.get(1)?.title ?? "";
+    expect(title).not.toContain(ESC);
+    expect(title).not.toContain(BEL);
+    expect(title).toContain("&#27;");
+  });
+
+  test("strips a script span that survives a single tag pass", () => {
+    const parsed = parseAnidbOfficialEpisodeMetadata(
+      wrap("Ep", "<<script>script>alert(1)</script>tail"),
+    );
+    const synopsis = parsed.get(1)?.synopsis ?? "";
+    expect(synopsis.toLowerCase()).not.toContain("<script");
+    expect(synopsis).not.toContain("alert(1)");
+  });
+
+  test("decodes each entity exactly once", () => {
+    const parsed = parseAnidbOfficialEpisodeMetadata(wrap("Tom &amp;amp; Jerry"));
+    expect(parsed.get(1)?.title).toBe("Tom &amp; Jerry");
+  });
+
+  test("keeps only regular episodes, so specials never enter the playable sequence", () => {
+    const parsed = parseAnidbOfficialEpisodeMetadata(
+      `<anime id="1">
+         <episode id="1"><epno type="1">1</epno><title xml:lang="en">Regular</title></episode>
+         <episode id="2"><epno type="2">1</epno><title xml:lang="en">Special</title></episode>
+       </anime>`,
+    );
+    expect([...parsed.values()].map((entry) => entry.title)).toEqual(["Regular"]);
+  });
+});

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -17,10 +17,22 @@ import {
 } from "../src/anidb/direct";
 import { anidbManifest, ANIDB_PROVIDER_ID } from "../src/anidb/manifest";
 import { clearAnimeMetadataCacheForTest } from "../src/shared/anime-metadata";
-import { isOfficialAnidbApi } from "./helpers/anidb-urls";
+import { isOfficialAnidbApi, urlHasHostname } from "./helpers/anidb-urls";
 
 const fixture = (name: string) =>
   Bun.file(new URL(`./fixtures/anidb/${name}`, import.meta.url)).text();
+
+describe("anidb fetch stub URL match", () => {
+  test("official API match is host and port, not a substring spoof", () => {
+    expect(isOfficialAnidbApi("http://api.anidb.net:9001/httpapi")).toBe(true);
+    expect(isOfficialAnidbApi("https://evil.test/?x=api.anidb.net:9001")).toBe(false);
+    expect(isOfficialAnidbApi("http://api.anidb.net.evil.test:9001/httpapi")).toBe(false);
+    expect(urlHasHostname("https://graphql.anilist.co/api", "graphql.anilist.co")).toBe(true);
+    expect(urlHasHostname("https://evil.test/?x=graphql.anilist.co", "graphql.anilist.co")).toBe(
+      false,
+    );
+  });
+});
 
 describe("anidb id helpers", () => {
   test("accepts slug-numeric show ids", () => {
@@ -658,7 +670,7 @@ describe("anidb episode metadata", () => {
             { status: 200 },
           );
         }
-        if (url.includes("graphql.anilist.co")) {
+        if (urlHasHostname(url, "graphql.anilist.co")) {
           return new Response(
             JSON.stringify({
               data: {
@@ -673,7 +685,7 @@ describe("anidb episode metadata", () => {
             { status: 200 },
           );
         }
-        if (url.includes("api.jikan.moe")) {
+        if (urlHasHostname(url, "api.jikan.moe")) {
           return new Response(
             JSON.stringify({
               data: [

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -16,6 +16,7 @@ import {
   searchAnidb,
 } from "../src/anidb/direct";
 import { anidbManifest, ANIDB_PROVIDER_ID } from "../src/anidb/manifest";
+import { clearAnimeMetadataCacheForTest } from "../src/shared/anime-metadata";
 
 const fixture = (name: string) =>
   Bun.file(new URL(`./fixtures/anidb/${name}`, import.meta.url)).text();
@@ -319,6 +320,29 @@ describe("anidb search delegation", () => {
       Bun.which = originalWhich;
     }
   });
+
+  test("does not claim audio or subtitle availability before an episode probe", async () => {
+    const originalWhich = Bun.which;
+    const originalFetch = globalThis.fetch;
+    try {
+      Bun.which = ((_cmd: string) => null) as typeof Bun.which;
+      globalThis.fetch = (async () =>
+        new Response('<a href="/anime/show-1" title="Show"><article></article></a>', {
+          status: 200,
+        })) as unknown as typeof fetch;
+
+      const search = anidbProviderModule.search;
+      if (!search) throw new Error("AniDB search is not configured");
+      const result = await search({ query: "Show" }, { now: () => new Date().toISOString() });
+
+      expect(result?.[0]?.availableAudioModes).toBeUndefined();
+      expect(result?.[0]?.subtitleAvailability).toBeUndefined();
+      expect(result?.[0]?.languageEvidence).toBeUndefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+      Bun.which = originalWhich;
+    }
+  });
 });
 
 describe("anidb direct resolve season routing", () => {
@@ -539,6 +563,169 @@ describe("anidb direct resolve season routing", () => {
 
     expect(result.status).toBe("resolved");
     expect(result.externalIds?.malId).toBe("99999");
+  });
+
+  test("does not fall back to Japanese when a requested dub is unavailable", async () => {
+    const result = await resolveWithStub(
+      {
+        title: { id: "plain-show-700", kind: "anime", title: "Plain Show" },
+        episode: { season: 1, episode: 1 },
+        mediaKind: "anime",
+        preferredAudioLanguage: "en",
+        intent: "play",
+        allowedRuntimes: ["direct-http"],
+      } as Parameters<typeof anidbProviderModule.resolve>[0],
+      anidbFetchStub({ episodesByNumericId: { "700": [{ id: 70001, number: 1 }] } }),
+    );
+
+    expect(result.status).toBe("exhausted");
+    expect(result.failures[0]?.message).toContain("No AniDB streams");
+  });
+
+  test("advertises English hardsub metadata for Japanese sub streams", async () => {
+    const result = await resolveWithStub(
+      {
+        title: { id: "plain-show-700", kind: "anime", title: "Plain Show" },
+        episode: { season: 1, episode: 1 },
+        mediaKind: "anime",
+        preferredAudioLanguage: "ja",
+        intent: "play",
+        allowedRuntimes: ["direct-http"],
+      } as Parameters<typeof anidbProviderModule.resolve>[0],
+      anidbFetchStub({ episodesByNumericId: { "700": [{ id: 70001, number: 1 }] } }),
+    );
+
+    expect(result.status).toBe("resolved");
+    if (result.status !== "resolved") throw new Error("expected resolved result");
+    const stream = result.streams[0];
+    expect(stream?.hardSubLanguage).toBe("en");
+    expect(stream?.subtitleDelivery).toBe("hardcoded");
+    expect(stream?.subtitleLanguages).toEqual(["en"]);
+    expect(stream?.languageEvidence).toContainEqual(
+      expect.objectContaining({
+        role: "hardsub",
+        normalizedLanguage: "en",
+      }),
+    );
+    expect(result.sources?.[0]?.languageEvidence).toContainEqual(
+      expect.objectContaining({
+        role: "hardsub",
+        normalizedLanguage: "en",
+      }),
+    );
+  });
+});
+
+describe("anidb episode metadata", () => {
+  test("enriches episode titles, air dates, and thumbnails from existing catalog ids", async () => {
+    clearAnidbCachesForTest();
+    clearAnimeMetadataCacheForTest();
+    const originalWhich = Bun.which;
+    const originalFetch = globalThis.fetch;
+
+    try {
+      Bun.which = ((_cmd: string) => null) as typeof Bun.which;
+      globalThis.fetch = (async (input: unknown) => {
+        const url = String(input);
+        if (url.includes("/api/frontend/anime/700/episodes")) {
+          return new Response(
+            JSON.stringify({
+              episodes: [
+                { id: 70001, number: 1 },
+                { id: 70002, number: 2 },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/anime/plain-show-700")) {
+          return new Response(
+            '<a href="https://myanimelist.net/anime/5678/Plain-Show">MAL</a>' +
+              '<a href="https://anilist.co/anime/1234">AniList</a>' +
+              '<a href="https://anidb.net/anime/9876">AniDB</a>' +
+              '<meta property="og:image" content="https://img.example/poster.jpg">',
+            { status: 200 },
+          );
+        }
+        if (url.includes("api.anidb.net:9001")) {
+          return new Response(
+            `<?xml version="1.0"?>
+              <anime id="9876">
+                <episode id="1"><epno type="1">2</epno><airdate>2020-01-09</airdate>
+                  <title xml:lang="en">Official Journey</title><summary>Official synopsis</summary>
+                </episode>
+                <episode id="2"><epno type="1">1</epno><airdate>2020-01-02</airdate>
+                  <title xml:lang="ja">公式の始まり</title><title xml:lang="x-jat">The Beginning</title>
+                </episode>
+                <episode id="3"><epno type="2">1</epno><title xml:lang="en">Special</title></episode>
+              </anime>`,
+            { status: 200 },
+          );
+        }
+        if (url.includes("graphql.anilist.co")) {
+          return new Response(
+            JSON.stringify({
+              data: {
+                Media: {
+                  streamingEpisodes: [
+                    { title: "The Beginning", thumbnail: "https://img.example/ep-1.jpg" },
+                    { title: "The Journey", thumbnail: "https://img.example/ep-2.jpg" },
+                  ],
+                },
+              },
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("api.jikan.moe")) {
+          return new Response(
+            JSON.stringify({
+              data: [
+                { mal_id: 1, title: "The Beginning", aired: "2020-01-02T00:00:00+00:00" },
+                { mal_id: 2, title: "The Journey", aired: "2020-01-09T00:00:00+00:00" },
+              ],
+              pagination: { has_next_page: false },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      }) as unknown as typeof fetch;
+
+      const episodes = await anidbProviderModule.listEpisodes?.(
+        {
+          title: {
+            id: "plain-show-700",
+            kind: "anime",
+            title: "Plain Show",
+          },
+          preferredAudioLanguage: "ja",
+        },
+        { now: () => new Date().toISOString(), signal: new AbortController().signal },
+      );
+
+      expect(episodes?.[0]).toMatchObject({
+        index: 1,
+        name: "The Beginning",
+        label: "Episode 1 · The Beginning",
+        release: { airDate: "2020-01-02" },
+        artwork: { thumbnailUrl: "https://img.example/ep-1.jpg" },
+      });
+      expect(episodes?.[1]).toMatchObject({
+        index: 2,
+        name: "Official Journey",
+        label: "Episode 2 · Official Journey",
+        release: { airDate: "2020-01-09" },
+        artwork: { thumbnailUrl: "https://img.example/ep-2.jpg" },
+        detail: "Official synopsis",
+      });
+      expect(episodes?.[0]?.externalIds).toEqual({ anilistId: "1234", malId: "5678" });
+    } finally {
+      globalThis.fetch = originalFetch;
+      Bun.which = originalWhich;
+      clearAnidbCachesForTest();
+      clearAnimeMetadataCacheForTest();
+    }
   });
 });
 

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../src/anidb/direct";
 import { anidbManifest, ANIDB_PROVIDER_ID } from "../src/anidb/manifest";
 import { clearAnimeMetadataCacheForTest } from "../src/shared/anime-metadata";
+import { isOfficialAnidbApi } from "./helpers/anidb-urls";
 
 const fixture = (name: string) =>
   Bun.file(new URL(`./fixtures/anidb/${name}`, import.meta.url)).text();
@@ -614,7 +615,7 @@ describe("anidb episode metadata", () => {
             { status: 200 },
           );
         }
-        if (url.includes("api.anidb.net:9001")) {
+        if (isOfficialAnidbApi(url)) {
           return new Response(
             `<?xml version="1.0"?>
               <anime id="9876">

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -16,6 +16,7 @@ import {
   searchAnidb,
 } from "../src/anidb/direct";
 import { anidbManifest, ANIDB_PROVIDER_ID } from "../src/anidb/manifest";
+import { clearAnimeMetadataCacheForTest } from "../src/shared/anime-metadata";
 
 const fixture = (name: string) =>
   Bun.file(new URL(`./fixtures/anidb/${name}`, import.meta.url)).text();
@@ -319,6 +320,29 @@ describe("anidb search delegation", () => {
       Bun.which = originalWhich;
     }
   });
+
+  test("does not claim audio or subtitle availability before an episode probe", async () => {
+    const originalWhich = Bun.which;
+    const originalFetch = globalThis.fetch;
+    try {
+      Bun.which = ((_cmd: string) => null) as typeof Bun.which;
+      globalThis.fetch = (async () =>
+        new Response('<a href="/anime/show-1" title="Show"><article></article></a>', {
+          status: 200,
+        })) as unknown as typeof fetch;
+
+      const search = anidbProviderModule.search;
+      if (!search) throw new Error("AniDB search is not configured");
+      const result = await search({ query: "Show" }, { now: () => new Date().toISOString() });
+
+      expect(result?.[0]?.availableAudioModes).toBeUndefined();
+      expect(result?.[0]?.subtitleAvailability).toBeUndefined();
+      expect(result?.[0]?.languageEvidence).toBeUndefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+      Bun.which = originalWhich;
+    }
+  });
 });
 
 describe("anidb direct resolve season routing", () => {
@@ -539,6 +563,136 @@ describe("anidb direct resolve season routing", () => {
 
     expect(result.status).toBe("resolved");
     expect(result.externalIds?.malId).toBe("99999");
+  });
+
+  test("does not fall back to Japanese when a requested dub is unavailable", async () => {
+    const result = await resolveWithStub(
+      {
+        title: { id: "plain-show-700", kind: "anime", title: "Plain Show" },
+        episode: { season: 1, episode: 1 },
+        mediaKind: "anime",
+        preferredAudioLanguage: "en",
+        intent: "play",
+        allowedRuntimes: ["direct-http"],
+      } as Parameters<typeof anidbProviderModule.resolve>[0],
+      anidbFetchStub({ episodesByNumericId: { "700": [{ id: 70001, number: 1 }] } }),
+    );
+
+    expect(result.status).toBe("exhausted");
+    expect(result.failures[0]?.message).toContain("No AniDB streams");
+  });
+});
+
+describe("anidb episode metadata", () => {
+  test("enriches episode titles, air dates, and thumbnails from existing catalog ids", async () => {
+    clearAnidbCachesForTest();
+    clearAnimeMetadataCacheForTest();
+    const originalWhich = Bun.which;
+    const originalFetch = globalThis.fetch;
+
+    try {
+      Bun.which = ((_cmd: string) => null) as typeof Bun.which;
+      globalThis.fetch = (async (input: unknown) => {
+        const url = String(input);
+        if (url.includes("/api/frontend/anime/700/episodes")) {
+          return new Response(
+            JSON.stringify({
+              episodes: [
+                { id: 70001, number: 1 },
+                { id: 70002, number: 2 },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/anime/plain-show-700")) {
+          return new Response(
+            '<a href="https://myanimelist.net/anime/5678/Plain-Show">MAL</a>' +
+              '<a href="https://anilist.co/anime/1234">AniList</a>' +
+              '<a href="https://anidb.net/anime/9876">AniDB</a>' +
+              '<meta property="og:image" content="https://img.example/poster.jpg">',
+            { status: 200 },
+          );
+        }
+        if (url.includes("api.anidb.net:9001")) {
+          return new Response(
+            `<?xml version="1.0"?>
+              <anime id="9876">
+                <episode id="1"><epno type="1">2</epno><airdate>2020-01-09</airdate>
+                  <title xml:lang="en">Official Journey</title><summary>Official synopsis</summary>
+                </episode>
+                <episode id="2"><epno type="1">1</epno><airdate>2020-01-02</airdate>
+                  <title xml:lang="ja">公式の始まり</title><title xml:lang="x-jat">The Beginning</title>
+                </episode>
+                <episode id="3"><epno type="2">1</epno><title xml:lang="en">Special</title></episode>
+              </anime>`,
+            { status: 200 },
+          );
+        }
+        if (url.includes("graphql.anilist.co")) {
+          return new Response(
+            JSON.stringify({
+              data: {
+                Media: {
+                  streamingEpisodes: [
+                    { title: "The Beginning", thumbnail: "https://img.example/ep-1.jpg" },
+                    { title: "The Journey", thumbnail: "https://img.example/ep-2.jpg" },
+                  ],
+                },
+              },
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("api.jikan.moe")) {
+          return new Response(
+            JSON.stringify({
+              data: [
+                { mal_id: 1, title: "The Beginning", aired: "2020-01-02T00:00:00+00:00" },
+                { mal_id: 2, title: "The Journey", aired: "2020-01-09T00:00:00+00:00" },
+              ],
+              pagination: { has_next_page: false },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      }) as unknown as typeof fetch;
+
+      const episodes = await anidbProviderModule.listEpisodes?.(
+        {
+          title: {
+            id: "plain-show-700",
+            kind: "anime",
+            title: "Plain Show",
+          },
+          preferredAudioLanguage: "ja",
+        },
+        { now: () => new Date().toISOString(), signal: new AbortController().signal },
+      );
+
+      expect(episodes?.[0]).toMatchObject({
+        index: 1,
+        name: "The Beginning",
+        label: "Episode 1 · The Beginning",
+        release: { airDate: "2020-01-02" },
+        artwork: { thumbnailUrl: "https://img.example/ep-1.jpg" },
+      });
+      expect(episodes?.[1]).toMatchObject({
+        index: 2,
+        name: "Official Journey",
+        label: "Episode 2 · Official Journey",
+        release: { airDate: "2020-01-09" },
+        artwork: { thumbnailUrl: "https://img.example/ep-2.jpg" },
+        detail: "Official synopsis",
+      });
+      expect(episodes?.[0]?.externalIds).toEqual({ anilistId: "1234", malId: "5678" });
+    } finally {
+      globalThis.fetch = originalFetch;
+      Bun.which = originalWhich;
+      clearAnidbCachesForTest();
+      clearAnimeMetadataCacheForTest();
+    }
   });
 });
 

--- a/packages/providers/test/helpers/anidb-urls.ts
+++ b/packages/providers/test/helpers/anidb-urls.ts
@@ -1,0 +1,16 @@
+/**
+ * Host-and-port match for the official AniDB HTTP API.
+ *
+ * A `url.includes("api.anidb.net:9001")` stub matches any URL that merely
+ * contains that text, so a fetch to `evil.test/?x=api.anidb.net:9001` would be
+ * answered with the official-API fixture and the stub would quietly cover a
+ * request the provider never should have made.
+ */
+export function isOfficialAnidbApi(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname === "api.anidb.net" && parsed.port === "9001";
+  } catch {
+    return false;
+  }
+}

--- a/packages/providers/test/helpers/anidb-urls.ts
+++ b/packages/providers/test/helpers/anidb-urls.ts
@@ -1,4 +1,20 @@
 /**
+ * Host match that does not treat a hostname as a substring of the whole URL.
+ *
+ * `url.includes("graphql.anilist.co")` is true for
+ * `https://evil.test/?x=graphql.anilist.co`, which would make a fetch stub
+ * answer the wrong fixture. CodeQL flags the substring form as
+ * `js/incomplete-url-substring-sanitization`.
+ */
+export function urlHasHostname(url: string, hostname: string): boolean {
+  try {
+    return new URL(url).hostname === hostname;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Host-and-port match for the official AniDB HTTP API.
  *
  * A `url.includes("api.anidb.net:9001")` stub matches any URL that merely

--- a/packages/storage/src/sqlite.ts
+++ b/packages/storage/src/sqlite.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { mkdirSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 
 export type KunaiDatabase = Database;
@@ -16,6 +16,26 @@ function ensureParentDirectory(path: string): void {
   const parent = dirname(path);
   if (parent === "." || parent === path) return;
   mkdirSync(parent, { recursive: true });
+}
+
+function bestEffortChmodOwnerOnly(dbPath: string): void {
+  if (dbPath === ":memory:" || dbPath.startsWith("file::memory:")) return;
+
+  try {
+    chmodSync(dbPath, 0o600);
+  } catch {
+    // Windows and exotic filesystems may reject chmod; opening must still succeed.
+  }
+
+  for (const suffix of ["-wal", "-shm"] as const) {
+    const sibling = `${dbPath}${suffix}`;
+    if (!existsSync(sibling)) continue;
+    try {
+      chmodSync(sibling, 0o600);
+    } catch {
+      // ignore
+    }
+  }
 }
 
 export interface OpenDatabaseOptions {
@@ -42,6 +62,8 @@ export function openKunaiDatabase(path: string, options: OpenDatabaseOptions = {
     if (options.wal !== false) {
       db.exec("PRAGMA journal_mode = WAL");
     }
+
+    bestEffortChmodOwnerOnly(path);
   }
 
   return db;

--- a/packages/storage/test/sqlite-permissions.test.ts
+++ b/packages/storage/test/sqlite-permissions.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { openKunaiDatabase } from "../src/sqlite";
+
+const dirs: string[] = [];
+const dbs: ReturnType<typeof openKunaiDatabase>[] = [];
+
+afterEach(() => {
+  Bun.gc(true);
+  for (const db of dbs.splice(0)) {
+    try {
+      (db as unknown as { clearQueryCache?: () => void }).clearQueryCache?.();
+      db.close(true);
+    } catch {
+      // already closed
+    }
+  }
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test.skipIf(process.platform === "win32")(
+  "openKunaiDatabase chmods the database to owner-only on POSIX",
+  () => {
+    const dir = mkdtempSync(join(tmpdir(), "kunai-sqlite-perms-"));
+    dirs.push(dir);
+    const dbPath = join(dir, "test.sqlite");
+
+    const db = openKunaiDatabase(dbPath);
+    dbs.push(db);
+    db.exec("PRAGMA user_version = 1");
+
+    expect(statSync(dbPath).mode & 0o777).toBe(0o600);
+  },
+);
+
+test.skipIf(process.platform === "win32")(
+  "openKunaiDatabase heals an existing 0644 database to 0600 on reopen",
+  () => {
+    const dir = mkdtempSync(join(tmpdir(), "kunai-sqlite-perms-heal-"));
+    dirs.push(dir);
+    const dbPath = join(dir, "test.sqlite");
+
+    const db1 = openKunaiDatabase(dbPath);
+    db1.close(true);
+
+    chmodSync(dbPath, 0o644);
+    expect(statSync(dbPath).mode & 0o777).toBe(0o644);
+
+    const db2 = openKunaiDatabase(dbPath);
+    dbs.push(db2);
+
+    expect(statSync(dbPath).mode & 0o777).toBe(0o600);
+  },
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

One mergeable stack containing every open PR, in dependency order, with the single cross-PR conflict resolved and all gates green. **Merge this with a merge commit (not squash)** — the constituent PRs all base on `main`, so landing this merge commit auto-marks #68, #69, #70, and #71 as merged in one go.

### Stack contents, bottom to top

1. **#68 — `chore(analytics-ingest)`**: silences the workspace's only lint warning (deliberate load-order-sensitive side-effect import in the postgres hardening suite). Independent, one file.
2. **#69 — AniDB episode metadata + post-play season progress**: carried inside #70's branch (its commits are ancestors of #70's head, verified with `git merge-base --is-ancestor`).
3. **#70 — `feat(anidb)` relay metadata without hardsub claims**: registers AniDB for metadata-only relay RPC and takes #69's episode-metadata honesty; video `/stream/` stays unwired.
4. **#71 — review-fix train**: download-lane yt-dlp guards, SQLite `0600`, `--jump`/exit-code honesty, one-shot subtitle inventory, in-memory stream replay bounds, AniSkip split-cour refusal, conformance browse-pool fix. Includes the CodeQL remediation below.

### CodeQL vulnerabilities fixed (was failing on #71)

CodeQL flagged 3 high-severity "incomplete URL substring sanitization" alerts in the new `apps/cli/test/unit/aniskip.test.ts` — mock-fetch routing matched hosts with `url.includes("api.aniskip.com")`, which also matches attacker-controlled URLs like `https://api.aniskip.com.evil.example`. The mock router and its assertions now parse each URL and compare exact hostnames (`new URL(url).hostname === "api.aniskip.com"`), the same shape #70 applied to the AniDB stubs in `packages/providers/test/helpers/anidb-urls.ts`. Pushed to #71's branch as `test(aniskip): route mock fetch by parsed hostname, not URL substrings`.

### Conflict resolution

The only conflict between #70 and #71 was `apps/docs/lib/generated-metadata.json` (both sides regenerate it). Resolved by re-running `apps/docs/scripts/sync-code-metadata.ts` against the merged source, so the committed file is generated output, not a hand-merge. `PlaybackPhase.ts` (touched by both #69 and #71) auto-merged cleanly — #71's change is one freshness guard on the recent-stream reuse path, #69's is the post-play progress read.

### Merge order if you prefer landing them individually

`#68` → `#70` (carries #69; merge #69 first if you want its history explicit) → `#71`, then this PR becomes redundant and can be closed.

## Checklist

- [x] Changeset added (`bun run changeset`) — #71's changeset rides along; #68 is non-release infra; #69/#70 changesets are whatever their author intended (none present on those branches)
- [x] `bun run guard` passes when `apps/cli/package.json`, changelogs, or `.changeset/**` changed
- [x] `bun run fmt && bun run lint && bun run test && bun run typecheck` passes locally (14/14 turbo test tasks; lint 0 warnings 0 errors; fmt clean on 1,527 files)
- [x] `bun run build` passes for feature, playback, provider, release, or packaging-sensitive changes
- [x] Live provider or Discord smokes were skipped intentionally — AniDB live behavior is #69/#70's authored scope; the review-fix train touches no provider crypto or Discord code

`bun run verify:doc-paths` also passes (48 docs, 1,930 source files, all paths resolve).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-215c3a35-6186-4bcd-aad5-4d2f8f1efef8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-215c3a35-6186-4bcd-aad5-4d2f8f1efef8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

