### PR TITLE
feat(anidb): search-card posters and a real relaySafe gate

### DIFF
--- a/.docs/provider-dossiers/anidb-metadata-capabilities.md
+++ b/.docs/provider-dossiers/anidb-metadata-capabilities.md
@@ -199,10 +199,11 @@ The repository already has places for the missing data:
 7. **Keep drift fixtures current.** The provider tests now cover official XML,
    title-page crosswalks, episode JSON, language responses, and embed parsing.
    Keep volatile stream tokens out of committed fixtures.
-8. **Relay is metadata-only.** AniDB is registered for `/rpc/anidb` and the CLI
-   settings toggle. HLS ladder fetches go through the same curl fallback as
-   HTML/JSON so a missing RPC route cannot silently become a single `auto`
-   variant. Do not enable `videoFallback` until a `/stream/` handler exists.
+8. **Relay is metadata-only.** `createRelayFetchPort` and `handleRpcRequest` now
+   consult `manifest.relaySafe`. AllManga and Videasy declare `true` for metadata
+   RPC (the Settings toggle use case). Video URL rewrite is still unused:
+   `videoFallback` is persisted with no production reader and no `/stream/`
+   handler — do not enable it (roadmap K-04).
 
 ## Request Budget
 

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -608,6 +608,10 @@ used by search and resolve so they cannot drift apart:
 - Only anchors carrying result-card evidence (a `title`/`aria-label` attribute or nested card
   markup) become results, so nav, breadcrumb, related-rail and footer links cannot become
   `results[0]` and pin the wrong show.
+- Live cards also carry a poster `img`, a TV/Movie/ONA/… badge, and a star rating (`5.3`). Search
+  maps poster and rating onto `ProviderSearchResult`; a Movie badge becomes `type: "movie"`. The
+  card has no year — Kunai does not invent one. Placeholder `img` srcs (`placeholder.svg`) and
+  non-http(s) srcs are dropped. Relative posters resolve against `https://anidb.app/`.
 
 ### AniDB metadata and language evidence
 
@@ -644,8 +648,9 @@ The cost model matters as much as the data, because this runs in front of the ep
   after the block lifted.
 - AniDB is relay-registered (`/rpc/anidb`, settings toggle). Metadata HTML/JSON uses `context.fetch`
   with curl fallback. HLS ladder expansion uses the same path so a relay miss does not collapse
-  qualities to a silent `auto` row. Video remains direct from `hls.anidb.app` unless the user
-  enables video fallback (which is still unwired).
+  qualities to a silent `auto` row. Video remains direct from `hls.anidb.app`. `videoFallback` is
+  still parsed and persisted, but has no production reader and no `/stream/` handler — do not
+  enable it.
 
 ### AniDB season routing and episode numbering
 

--- a/.plans/021-provider-contract-enforcement.md
+++ b/.plans/021-provider-contract-enforcement.md
@@ -33,25 +33,18 @@ Land these in order. Each is independently shippable and independently revertabl
 
 ---
 
-### Stage 1 — Enforce `relaySafe` (S)
+### Stage 1 — Enforce `relaySafe` (S) — landed
 
-`packages/providers/src/allmanga/manifest.ts:49` and `videasy/manifest.ts:45` both
-declare `relaySafe: false`, and their metadata is relayed anyway. The only gate,
-`packages/relay/src/create-relay-fetch-port.ts:27`, asks `registry.isHostAllowed(...)`
-and never consults the flag. The server-side guard at `packages/relay/src/handler.ts:36`
-is `if (!provider.profile)`, which can never be true because `registry.ts:14` already
-skips profile-less modules — so `RelayErrorCode` value `"provider-not-relayable"` is
-unreachable.
+Semantics: **manifest-level `relaySafe` means metadata may traverse `/rpc/{id}`**.
+It is not permission to proxy media. `ProviderRuntimePort.relaySafe` stays a
+declaration for now.
 
-**Decide the semantics first.** There are two `relaySafe` fields — manifest-level
-(`packages/core/src/provider-manifest.ts:25`) and `ProviderRuntimePort.relaySafe`
-(`packages/types/src/index.ts:429`). Pick one meaning (suggested: manifest-level =
-"may traverse a relay at all") and document it on the type.
-
-**STOP and report** before flipping the gate on: enforcing it as written will _stop_
-relaying AllAnime metadata, which is the main relay use case today. The two manifests
-declaring `false` most likely want `true`. This is a maintainer decision, not an
-executor one.
+- `createRelayFetchPort` falls through to direct fetch when `manifest.relaySafe !== true`.
+- `handleRpcRequest` returns `provider-not-relayable` in that case, so the error
+  code is reachable.
+- AllManga and Videasy declare `relaySafe: true` because they are on the Settings
+  relay list and metadata relay is the product. YouTube stays `false`.
+- Video remains gated by the unused `videoFallback` flag (K-04) — do not add `/stream/`.
 
 ---
 

--- a/apps/cli/test/unit/architecture/contract-conformance.test.ts
+++ b/apps/cli/test/unit/architecture/contract-conformance.test.ts
@@ -258,9 +258,10 @@ describe("contract conformance", () => {
     ];
 
     // DEBT (2026-07-21): declared, wired to nothing.
-    // - rewriteStreamUrlForRelay: `providerRelay.videoFallback` is parsed, persisted
-    //   and shown in settings, but no caller rewrites the stream URL, so enabling it
-    //   is a placebo.
+    // - rewriteStreamUrlForRelay: `providerRelay.videoFallback` is parsed and
+    //   persisted, but Settings never shows it and no caller rewrites the stream
+    //   URL. Do not add a `/stream/` handler here (K-04). Enabling the flag is a
+    //   placebo.
     // - detectGeoBlockedProviderResponse: geo-blocking is the failure the relay
     //   exists for and nothing detects it; its allow-list also names "allmanga",
     //   which is the module name, not the provider id ("allanime").

--- a/packages/core/src/provider-manifest.ts
+++ b/packages/core/src/provider-manifest.ts
@@ -22,6 +22,11 @@ export interface CoreProviderManifest {
   readonly runtimePorts: readonly ProviderRuntimePort[];
   readonly cachePolicy: CachePolicy;
   readonly browserSafe: boolean;
+  /**
+   * When true, this provider's metadata HTTP may be sent through `/rpc/{id}`
+   * on a user-owned relay. Video URL rewrite is a separate, currently unused
+   * `videoFallback` flag — do not treat this as permission to proxy media.
+   */
   readonly relaySafe: boolean;
   readonly relayProfile?: RelayProfile;
   readonly status: ProviderManifestStatus;

--- a/packages/providers/src/allmanga/manifest.ts
+++ b/packages/providers/src/allmanga/manifest.ts
@@ -23,7 +23,7 @@ export const allanimeManifest = defineProviderManifest({
         "health-check",
       ],
       browserSafe: false,
-      relaySafe: false,
+      relaySafe: true,
       localOnly: true,
     },
   ],
@@ -46,7 +46,9 @@ export const allanimeManifest = defineProviderManifest({
     allowStale: true,
   },
   browserSafe: false,
-  relaySafe: false,
+  // Metadata RPC is the relay use case. Stream tokens stay IP-bound; that is
+  // `videoFallback`, which has no production reader and must stay off.
+  relaySafe: true,
   relayProfile: {
     upstreamHosts: [
       "api.mkissa.net",

--- a/packages/providers/src/anidb/browse-parser.ts
+++ b/packages/providers/src/anidb/browse-parser.ts
@@ -23,6 +23,10 @@ export interface AnidbSearchResult {
   readonly id: string;
   readonly title: string;
   readonly numericId: number;
+  readonly posterUrl?: string;
+  readonly rating?: number;
+  /** Present only when the card badge is Movie. Everything else stays a series. */
+  readonly kind?: "movie";
   readonly seasonEvidence: AnidbSeasonEvidence;
 }
 
@@ -74,7 +78,16 @@ export function parseAnidbBrowseHtml(html: string): readonly AnidbSearchResult[]
     const numericId = anidbNumericId(id);
     if (!title || numericId === null) continue;
     seen.add(id);
-    results.push({ id, title, numericId, seasonEvidence: parseAnidbSeasonEvidence(title) });
+    const card = extractAnidbCardFields(body, title);
+    results.push({
+      id,
+      title,
+      numericId,
+      ...(card.posterUrl ? { posterUrl: card.posterUrl } : {}),
+      ...(card.rating !== undefined ? { rating: card.rating } : {}),
+      ...(card.kind === "movie" ? { kind: "movie" as const } : {}),
+      seasonEvidence: parseAnidbSeasonEvidence(title),
+    });
   }
   return results;
 }
@@ -155,6 +168,44 @@ function extractAnidbTitle(attrs: string, body: string): string {
   return markupToPlainText(anchorTitle ?? imageAlt ?? stripScriptBlocks(body));
 }
 
+function extractAnidbCardFields(
+  body: string,
+  title: string,
+): {
+  readonly posterUrl?: string;
+  readonly rating?: number;
+  readonly kind?: "movie";
+} {
+  const remainder = stripTitleFromCardText(markupToPlainText(body), title);
+  const ratingMatch = remainder.match(/\b(10(?:\.0)?|[0-9]\.[0-9])\b/);
+  const rating = ratingMatch ? Number(ratingMatch[1]) : undefined;
+  return {
+    posterUrl: extractAnidbPosterUrl(body),
+    ...(rating !== undefined && Number.isFinite(rating) ? { rating } : {}),
+    ...(/\bmovie\b/i.test(remainder) ? { kind: "movie" as const } : {}),
+  };
+}
+
+function extractAnidbPosterUrl(body: string): string | undefined {
+  const raw = IMAGE_SRC_PATTERN.exec(body)?.[1];
+  if (!raw) return undefined;
+  try {
+    const parsed = new URL(decodeMarkupEntities(raw).trim(), "https://anidb.app/");
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return undefined;
+    if (parsed.pathname.toLowerCase().endsWith("placeholder.svg")) return undefined;
+    return parsed.href;
+  } catch {
+    return undefined;
+  }
+}
+
+function stripTitleFromCardText(plain: string, title: string): string {
+  const trimmed = title.trim();
+  if (!trimmed) return plain;
+  const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return plain.replace(new RegExp(escaped, "gi"), " ").replace(/\s+/g, " ").trim();
+}
+
 /**
  * Attribute patterns are precompiled and anchored on a start-or-whitespace
  * boundary. A `\b` boundary also matches after `-` and `:`, which would let
@@ -168,6 +219,7 @@ const ATTRIBUTE_PATTERNS = {
 } as const;
 
 const IMAGE_ALT_PATTERN = /<img\b[^>]*\salt\s*=\s*["']([^"']*)["']/i;
+const IMAGE_SRC_PATTERN = /<img\b[^>]*\ssrc\s*=\s*["']([^"']*)["']/i;
 
 function extractAttribute(
   attrs: string,

--- a/packages/providers/src/anidb/direct.ts
+++ b/packages/providers/src/anidb/direct.ts
@@ -222,9 +222,16 @@ export const anidbProviderModule: CoreProviderModule = {
     for (const result of results.slice(0, 40)) {
       mapped.push({
         id: result.id,
-        type: "series",
+        type: result.kind === "movie" ? "movie" : "series",
         title: result.title,
         metadataSource: "AniDB",
+        ...(result.posterUrl
+          ? {
+              posterPath: result.posterUrl,
+              artwork: { posterUrl: result.posterUrl, thumbnailUrl: result.posterUrl },
+            }
+          : {}),
+        ...(result.rating !== undefined ? { rating: result.rating } : {}),
         externalIds: {
           providerNativeIds: { [ANIDB_PROVIDER_ID]: result.id },
         },

--- a/packages/providers/src/anidb/manifest.ts
+++ b/packages/providers/src/anidb/manifest.ts
@@ -52,6 +52,6 @@ export const anidbManifest = defineProviderManifest({
     "Bun/fetch often gets Cloudflare 403 on anidb.app HTML/API; production path uses curl with a Chrome UA (dossier-proven).",
     "HLS media on hls.anidb.app usually works with native fetch after the embed URL is obtained. Ladder expansion uses the same curl fallback as metadata so a relay miss does not collapse to one auto row.",
     "Sub = Japanese audio (jpn embed); dub = English audio (eng embed) when the languages API exposes it. No independently addressable subtitle track has been observed — do not advertise hardsub.",
-    "Relay-safe for metadata RPC (/rpc/anidb). Video stays direct unless the user-owned relay implements /stream/ and videoFallback is on.",
+    "Relay-safe for metadata RPC (/rpc/anidb). Video stays direct: `videoFallback` is persisted but has no production reader and no `/stream/` handler.",
   ],
 });

--- a/packages/providers/src/videasy/manifest.ts
+++ b/packages/providers/src/videasy/manifest.ts
@@ -19,7 +19,7 @@ export const videasyManifest = defineProviderManifest({
       runtime: "direct-http",
       operations: ["resolve-stream", "resolve-subtitles", "health-check"],
       browserSafe: false,
-      relaySafe: false,
+      relaySafe: true,
       localOnly: true,
     },
   ],
@@ -42,7 +42,9 @@ export const videasyManifest = defineProviderManifest({
     allowStale: true,
   },
   browserSafe: false,
-  relaySafe: false,
+  // Catalog and route metadata may traverse /rpc/videasy. Stream URLs stay
+  // direct; videoFallback has no production reader.
+  relaySafe: true,
   relayProfile: {
     upstreamHosts: [
       "api.videasy.to",

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -69,6 +69,7 @@ describe("anidb browse parsing", () => {
         id: "onigiri-3942",
         title: "Onigiri & Friends",
         numericId: 3942,
+        posterUrl: "https://anidb.app/covers/3942.jpg",
         seasonEvidence: {
           seasonNumber: null,
           label: null,
@@ -84,6 +85,7 @@ describe("anidb browse parsing", () => {
         id: "solo-leveling-19413",
         title: "Solo Leveling",
         numericId: 19413,
+        posterUrl: "https://anidb.app/covers/19413.jpg",
         seasonEvidence: {
           seasonNumber: null,
           label: null,
@@ -153,6 +155,57 @@ describe("anidb browse parsing", () => {
     const results = parseAnidbBrowseHtml(await fixture("browse-with-page-chrome.html"));
     expect(results.map((result) => result.id)).toEqual(["onigiri-3942", "onigiri-tabetai-4501"]);
     expect(results[0]?.id).toBe("onigiri-3942");
+  });
+
+  test("keeps poster, rating, and Movie-vs-series from the live card without inventing a year", async () => {
+    const results = parseAnidbBrowseHtml(await fixture("browse-live-cards.html"));
+    expect(results).toEqual([
+      {
+        id: "onigiri-3942",
+        title: "Onigiri",
+        numericId: 3942,
+        posterUrl: "https://cdn.xlsbox.com/poster/small/1782735600/3942.jpg",
+        rating: 5.3,
+        seasonEvidence: {
+          seasonNumber: null,
+          label: null,
+          normalizedBaseTitle: "onigiri",
+        },
+      },
+      {
+        id: "a-silent-voice-movie-2187",
+        title: "A Silent Voice",
+        numericId: 2187,
+        posterUrl: "https://cdn.xlsbox.com/poster/small/1782735600/2187.jpg",
+        rating: 8.2,
+        kind: "movie",
+        seasonEvidence: {
+          seasonNumber: null,
+          label: null,
+          normalizedBaseTitle: "a silent voice",
+        },
+      },
+      {
+        id: "placeholder-only-9001",
+        title: "No Art Yet",
+        numericId: 9001,
+        seasonEvidence: {
+          seasonNumber: null,
+          label: null,
+          normalizedBaseTitle: "no art yet",
+        },
+      },
+    ]);
+  });
+
+  test("absolutizes a relative poster and ignores javascript src", () => {
+    const html = [
+      '<a href="/anime/onigiri-3942" title="Onigiri"><img src="/covers/3942.jpg" alt="Onigiri"></a>',
+      '<a href="/anime/hostile-2" title="Hostile"><img src="javascript:alert(1)" alt="Hostile"></a>',
+    ].join("");
+    const results = parseAnidbBrowseHtml(html);
+    expect(results[0]?.posterUrl).toBe("https://anidb.app/covers/3942.jpg");
+    expect(results[1]?.posterUrl).toBeUndefined();
   });
 
   test("strips script blocks behind every legal end-tag form", () => {
@@ -351,6 +404,39 @@ describe("anidb search delegation", () => {
       expect(result?.[0]?.availableAudioModes).toBeUndefined();
       expect(result?.[0]?.subtitleAvailability).toBeUndefined();
       expect(result?.[0]?.languageEvidence).toBeUndefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+      Bun.which = originalWhich;
+    }
+  });
+
+  test("search maps browse poster and rating onto the catalog result", async () => {
+    const originalWhich = Bun.which;
+    const originalFetch = globalThis.fetch;
+    try {
+      Bun.which = ((_cmd: string) => null) as typeof Bun.which;
+      globalThis.fetch = (async () =>
+        new Response(await fixture("browse-live-cards.html"), {
+          status: 200,
+        })) as unknown as typeof fetch;
+
+      const search = anidbProviderModule.search;
+      if (!search) throw new Error("AniDB search is not configured");
+      const result = await search({ query: "Onigiri" }, { now: () => new Date().toISOString() });
+      const onigiri = result?.find((row) => row.id === "onigiri-3942");
+      const movie = result?.find((row) => row.id === "a-silent-voice-movie-2187");
+
+      expect(onigiri).toMatchObject({
+        type: "series",
+        posterPath: "https://cdn.xlsbox.com/poster/small/1782735600/3942.jpg",
+        rating: 5.3,
+      });
+      expect(onigiri).not.toHaveProperty("year");
+      expect(onigiri?.artwork?.posterUrl).toBe(
+        "https://cdn.xlsbox.com/poster/small/1782735600/3942.jpg",
+      );
+      expect(movie?.type).toBe("movie");
+      expect(movie?.rating).toBe(8.2);
     } finally {
       globalThis.fetch = originalFetch;
       Bun.which = originalWhich;

--- a/packages/providers/test/fixtures/anidb/browse-live-cards.html
+++ b/packages/providers/test/fixtures/anidb/browse-live-cards.html
@@ -1,0 +1,36 @@
+<section class="anime-grid">
+  <a href="https://anidb.app/anime/onigiri-3942" class="anime-card group block" title="Onigiri">
+    <div class="bg-elevated relative overflow-hidden rounded-xl" style="aspect-ratio: 2/3">
+      <img
+        src="https://cdn.xlsbox.com/poster/small/1782735600/3942.jpg"
+        alt="Onigiri"
+        loading="lazy"
+      />
+      <div
+        class="pointer-events-none absolute top-1.5 right-1.5 left-1.5 flex items-start justify-between"
+      >
+        <span class="badge badge-orange text-[9px]">TV</span>
+        <span class="badge badge-gray flex items-center gap-0.5 text-[9px]">5.3</span>
+      </div>
+      <p class="text-xs font-semibold text-white">Onigiri</p>
+    </div>
+    <p class="text-faint mt-1.5 text-xs">Onigiri</p>
+  </a>
+  <a href="https://anidb.app/anime/a-silent-voice-movie-2187" title="A Silent Voice">
+    <div>
+      <img
+        src="https://cdn.xlsbox.com/poster/small/1782735600/2187.jpg"
+        alt="Wrong image-alt title"
+      />
+      <span>Movie</span>
+      <span>8.2</span>
+      <p>A Silent Voice</p>
+    </div>
+  </a>
+  <a href="https://anidb.app/anime/placeholder-only-9001" title="No Art Yet">
+    <div>
+      <img src="/img/placeholder.svg" alt="No Art Yet" />
+      <span>ONA</span>
+    </div>
+  </a>
+</section>

--- a/packages/relay/src/create-relay-fetch-port.ts
+++ b/packages/relay/src/create-relay-fetch-port.ts
@@ -24,6 +24,7 @@ export function createRelayFetchPort(options: RelayFetchPortOptions): RelayFetch
 
       const providerConfig = relay.providers?.[entry.providerId];
       if (providerConfig?.enabled === false) return fetchImpl(input, init);
+      if (entry.manifest.relaySafe !== true) return fetchImpl(input, init);
       if (!options.registry.isHostAllowed(entry.providerId, requestInfo.upstreamUrl, "metadata")) {
         return fetchImpl(input, init);
       }

--- a/packages/relay/src/handler.ts
+++ b/packages/relay/src/handler.ts
@@ -38,7 +38,7 @@ export async function handleRpcRequest(
   if (!provider) {
     return relayError("unknown-provider", options.providerId, "Unknown provider", 404);
   }
-  if (!provider.profile) {
+  if (!provider.profile || provider.manifest.relaySafe !== true) {
     return relayError(
       "provider-not-relayable",
       options.providerId,

--- a/packages/relay/test/handler.test.ts
+++ b/packages/relay/test/handler.test.ts
@@ -7,6 +7,7 @@ const registry = buildProviderRelayRegistry([
   {
     providerId: "allanime",
     manifest: {
+      relaySafe: true,
       relayProfile: {
         upstreamHosts: ["api.allanime.day"],
         maxRequestBodyBytes: 128,
@@ -17,8 +18,18 @@ const registry = buildProviderRelayRegistry([
   {
     providerId: "miruro",
     manifest: {
+      relaySafe: true,
       relayProfile: {
         upstreamHosts: ["miruro.bz"],
+      },
+    },
+  },
+  {
+    providerId: "videasy",
+    manifest: {
+      relaySafe: false,
+      relayProfile: {
+        upstreamHosts: ["api.videasy.to"],
       },
     },
   },
@@ -113,6 +124,7 @@ test("handleRpcRequest rejects unsafe upstream hosts before fetch", async () => 
     {
       providerId: "unsafe",
       manifest: {
+        relaySafe: true,
         relayProfile: {
           upstreamHosts: ["127.0.0.1"],
         },
@@ -225,6 +237,25 @@ test("handleRpcRequest enforces bearer token when configured", async () => {
   );
 
   expect(response.status).toBe(401);
+});
+
+test("handleRpcRequest refuses a provider whose manifest is not relay-safe", async () => {
+  const response = await handleRpcRequest(
+    rpcRequest({
+      method: "GET",
+      upstreamUrl: "https://api.videasy.to/api",
+    }),
+    {
+      providerId: "videasy",
+      registry,
+      async fetch() {
+        throw new Error("should not fetch");
+      },
+    },
+  );
+
+  expect(response.status).toBe(403);
+  expect(await response.json()).toMatchObject({ error: { code: "provider-not-relayable" } });
 });
 
 test("handleRpcRequest handles CORS preflight without upstream fetch", async () => {

--- a/packages/relay/test/relay-fetch-port.test.ts
+++ b/packages/relay/test/relay-fetch-port.test.ts
@@ -8,8 +8,18 @@ const registry = buildProviderRelayRegistry([
   {
     providerId: "allanime",
     manifest: {
+      relaySafe: true,
       relayProfile: {
         upstreamHosts: ["api.allanime.day"],
+      },
+    },
+  },
+  {
+    providerId: "videasy",
+    manifest: {
+      relaySafe: false,
+      relayProfile: {
+        upstreamHosts: ["api.videasy.to"],
       },
     },
   },
@@ -75,6 +85,23 @@ test("createRelayFetchPort falls back to direct when relay network fails", async
   const response = await port.fetch("https://api.allanime.day/api");
   expect(await response.json()).toEqual({ direct: true });
   expect(calls).toEqual(["https://relay.example/rpc/allanime", "https://api.allanime.day/api"]);
+});
+
+test("createRelayFetchPort stays on direct fetch when the manifest is not relay-safe", async () => {
+  const calls: string[] = [];
+  const port = createRelayFetchPort({
+    relayConfig: { baseUrl: "https://relay.example" },
+    registry,
+    providerId: "videasy",
+    async fetch(input) {
+      calls.push(String(input));
+      return Response.json({ direct: true });
+    },
+  });
+
+  const response = await port.fetch("https://api.videasy.to/api");
+  expect(await response.json()).toEqual({ direct: true });
+  expect(calls).toEqual(["https://api.videasy.to/api"]);
 });
 
 test("normalizeRelayBaseUrl accepts HTTPS and local HTTP only", () => {

--- a/packages/relay/test/resolve-relay-config.test.ts
+++ b/packages/relay/test/resolve-relay-config.test.ts
@@ -11,6 +11,7 @@ const registry = buildProviderRelayRegistry([
   {
     providerId: "allanime",
     manifest: {
+      relaySafe: true,
       relayProfile: {
         upstreamHosts: ["api.allanime.day"],
       },


### PR DESCRIPTION
## Summary
- AniDB search now maps the live browse card: poster, star rating, and Movie vs series. The card has no year, so none is invented. Placeholder/`javascript:` image srcs are dropped.
- `manifest.relaySafe` finally gates metadata RPC (`createRelayFetchPort` + `handleRpcRequest`). AllManga and Videasy declare `true` so the Settings relay toggle still works; YouTube stays `false`.
- `videoFallback` stays unused. No `/stream/` handler (roadmap K-04). Contract comment no longer claims Settings shows the flag.

Stacked on #70. Do not merge to main until #70 lands.

## Test plan
- [x] AniDB browse/search tests including live-shaped card fixture
- [x] Relay fetch-port and handler tests for `relaySafe: false`
- [x] `bun run typecheck` / `lint` / `verify:doc-paths`
- [ ] GitHub CI on this head