### PR TITLE
Locate the post-play rail rendering fault in the write path

### DIFF
--- a/.docs/debugging-map.md
+++ b/.docs/debugging-map.md
@@ -116,6 +116,41 @@ Command behavior should route through the canonical command registry and shared
 picker/overlay surfaces. Avoid adding provider-specific or player-specific
 policy inside render-only shell components.
 
+### Rows missing or text welded together on screen (OPEN)
+
+Reported on the post-play rail: the `❀ anime` badge, the title row, and the
+`── synopsis ──` divider absent from the screen, with stray text fused onto fact
+values (`2006urite`, `★ 8.5tion`) in a colour no element on that surface uses.
+
+**Do not debug this in the model or the component.** That layer is ruled out and
+pinned by `apps/cli/test/unit/app-shell/media-panel-rail-frame.test.tsx`: the
+rendered frame carries every section, ends each fact value at the value, and
+emits no line wider than the rail it was given, at every rail width. A correct
+frame reaching a wrong screen means the fault is in the **write path**, so
+search there:
+
+- **Ink's frame diff.** Ink erases the previous frame by walking UP from where it
+  believes the cursor is, one erase-line per remembered row. That belief is only
+  valid while Ink is the sole writer.
+- **The two writers that are not Ink.** `sixel-overlay.ts` and
+  `image/kitty-transport.ts` write to `process.stdout` directly, at absolute
+  positions, scheduled independently of Ink's throttled frame.
+- **`clearRootContentTransitionFrame()`** in `apps/cli/src/app-shell/shell-screen-clear.ts`
+  writes a raw `ESC[2J ESC[H` on every root-content transition — playback →
+  post-play among them. It moves the cursor home behind Ink's back;
+  `apps/cli/test/unit/app-shell/ink-external-clear-desync.test.tsx` shows the
+  next frame still emitting a 12-row erase walk at a cursor that is no longer
+  there, so all 13 erases collapse onto row 1. Note the sibling
+  `clearShellScreen()` documents the opposite rule ("the raw ANSI clear is
+  intentionally omitted — Ink's reconciler handles repaint"); the two disagree.
+
+Root cause is **not yet established** and no fix should be guessed here: a wrong
+one is visible on every surface transition. What settles it is a byte-level
+capture of a real playback → post-play transition (drive the shell in a PTY at a
+fixed size, record raw stdout, and find which writer touches the rail rows
+between the two frames). The isolated-profile recipe for driving the real shell
+is in [features/privacy-and-storage.md](./features/privacy-and-storage.md).
+
 ## Windows-Specific Failure Modes
 
 Windows breaks in ways POSIX hides, and several of these presented as something

--- a/.docs/debugging-map.md
+++ b/.docs/debugging-map.md
@@ -129,27 +129,34 @@ emits no line wider than the rail it was given, at every rail width. A correct
 frame reaching a wrong screen means the fault is in the **write path**, so
 search there:
 
-- **Ink's frame diff.** Ink erases the previous frame by walking UP from where it
-  believes the cursor is, one erase-line per remembered row. That belief is only
-  valid while Ink is the sole writer.
-- **The two writers that are not Ink.** `sixel-overlay.ts` and
-  `image/kitty-transport.ts` write to `process.stdout` directly, at absolute
-  positions, scheduled independently of Ink's throttled frame.
-- **`clearRootContentTransitionFrame()`** in `apps/cli/src/app-shell/shell-screen-clear.ts`
-  writes a raw `ESC[2J ESC[H` on every root-content transition — playback →
-  post-play among them. It moves the cursor home behind Ink's back;
-  `apps/cli/test/unit/app-shell/ink-external-clear-desync.test.tsx` shows the
-  next frame still emitting a 12-row erase walk at a cursor that is no longer
-  there, so all 13 erases collapse onto row 1. Note the sibling
-  `clearShellScreen()` documents the opposite rule ("the raw ANSI clear is
-  intentionally omitted — Ink's reconciler handles repaint"); the two disagree.
+Ink erases the previous frame by walking UP from where it believes the cursor is,
+one erase-line per remembered row. That belief holds only while Ink is the sole
+writer to stdout, and three things in this app are not Ink.
 
-Root cause is **not yet established** and no fix should be guessed here: a wrong
-one is visible on every surface transition. What settles it is a byte-level
-capture of a real playback → post-play transition (drive the shell in a PTY at a
-fixed size, record raw stdout, and find which writer touches the rail rows
-between the two frames). The isolated-profile recipe for driving the real shell
-is in [features/privacy-and-storage.md](./features/privacy-and-storage.md).
+**Already eliminated — do not re-run these:**
+
+| Suspect | How it was ruled out |
+| --- | --- |
+| The model and the component | `media-panel-rail-frame.test.tsx` pins the rendered frame: every section present, each fact value ending at the value, no line wider than the rail, at all four rail widths. |
+| `clearRootContentTransitionFrame()` — the raw `ESC[2J ESC[H` on every root-content transition | Drove the real `mountRootContent` transition under a PTY and replayed the bytes through a terminal emulator. Screen was clean: header plus all four rows of the new surface, no stale cells. The `ESC[2J` blanks what the misaimed erase misses, and Ink re-synchronizes on the next frame. |
+| Ink frames interleaving into a chunked Kitty upload | The chunk loop in `image/kitty-transport.ts` yields to the event loop every 8 chunks, and the graphics protocol requires one transmission's chunks to be contiguous. Measured with both writers instrumented and Ink re-rendering on a 4 ms timer: **0 foreign writes** landed between the 14 chunks. Ink's 30 fps throttle is far slower than the yields. |
+
+Note while reading that code: `ink-external-clear-desync.test.tsx` still pins the
+desync itself (13 erase-line ops, 12 cursor-up ops, aimed at a cursor the clear
+already moved home), because it is real and load-bearing if anything ever stops
+the `ESC[2J` from landing. Its sibling `clearShellScreen()` documents the
+opposite rule — "the raw ANSI clear is intentionally omitted, Ink's reconciler
+handles repaint" — so the two disagree and one of them is wrong.
+
+**Still open:** `sixel-overlay.ts`, which writes at absolute positions on a
+`setTimeout(0)` — unthrottled, unlike Ink — and the interaction between the
+image renderer actually in use and the host terminal. Reproducing needs the
+reporter's environment: which renderer `detectImageCapability()` chose, and the
+terminal itself. The repro recipe that eliminated the two rows above is a PTY at
+a fixed size feeding raw bytes to a terminal emulator (`pyte`); it is worth
+rebuilding rather than guessing, because it shows the screen a viewer sees
+rather than the bytes a writer sent. Isolate the run per
+[features/privacy-and-storage.md](./features/privacy-and-storage.md).
 
 ## Windows-Specific Failure Modes
 

--- a/apps/cli/test/unit/app-shell/ink-external-clear-desync.test.tsx
+++ b/apps/cli/test/unit/app-shell/ink-external-clear-desync.test.tsx
@@ -48,6 +48,12 @@ async function renderThenExternallyClear(): Promise<string> {
     patchConsole: false,
     exitOnCtrlC: false,
     alternateScreen: true,
+    // Ink auto-detects CI and, when non-interactive, "disables ANSI erase
+    // sequences, cursor manipulation ... writing only the final frame at
+    // unmount" — which is the exact behaviour under test. Force the mode a
+    // real terminal gets so this measures the shell's write path, not the
+    // runner's environment.
+    interactive: true,
   });
   try {
     await Bun.sleep(80);

--- a/apps/cli/test/unit/app-shell/ink-external-clear-desync.test.tsx
+++ b/apps/cli/test/unit/app-shell/ink-external-clear-desync.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import { EventEmitter } from "node:events";
+
+import { Box, render, Text } from "ink";
+import React from "react";
+
+// Ink owns the screen buffer. It erases the previous frame by walking UP from
+// where it believes the cursor is — bottom of the last frame — using one
+// erase-line per remembered row. Any write that moves the cursor without Ink
+// knowing invalidates that belief, and the erase then lands somewhere else
+// entirely.
+//
+// `clearRootContentTransitionFrame()` does exactly that on every root-content
+// transition (playback → post-play among them): a raw `ESC[2J ESC[H` straight
+// to stdout. This test pins the consequence so the coupling is visible in CI
+// rather than rediscovered from a screenshot. See .docs/debugging-map.md.
+
+class RecordingStdout extends EventEmitter {
+  readonly isTTY = true;
+  readonly columns = 40;
+  readonly rows = 30;
+  written: string[] = [];
+  write(data: string) {
+    this.written.push(data);
+    return true;
+  }
+}
+
+const ESC = String.fromCharCode(0x1b);
+const CLEAR_SCREEN = `${ESC}[2J`;
+const HOME = `${ESC}[H`;
+
+const Frame = ({ rows }: { readonly rows: number }) => (
+  <Box flexDirection="column">
+    {Array.from({ length: rows }, (_, index) => (
+      // eslint-disable-next-line react/no-array-index-key -- fixed-length probe
+      <Text key={index}>{`row-${index}`}</Text>
+    ))}
+  </Box>
+);
+
+const countOf = (haystack: string, needle: string) => haystack.split(needle).length - 1;
+
+async function renderThenExternallyClear(): Promise<string> {
+  const stdout = new RecordingStdout();
+  const instance = render(<Frame rows={12} />, {
+    stdout: stdout as never,
+    patchConsole: false,
+    exitOnCtrlC: false,
+    alternateScreen: true,
+  });
+  try {
+    await Bun.sleep(80);
+    stdout.written = [];
+    // What the transition helper writes today, outside Ink's knowledge.
+    stdout.write(`${CLEAR_SCREEN}${HOME}`);
+    instance.rerender(<Frame rows={3} />);
+    await Bun.sleep(120);
+    return stdout.written.join("");
+  } finally {
+    instance.unmount();
+  }
+}
+
+describe("external screen clear vs Ink's erase bookkeeping", () => {
+  it("still aims a full 12-row erase at a cursor the clear already moved home", async () => {
+    const output = await renderThenExternallyClear();
+
+    // Ink erases the frame it remembers (12 rows), not the blank screen that
+    // actually exists: one erase-line per remembered row plus the closing one.
+    expect(countOf(output, `${ESC}[2K`)).toBe(13);
+    // Every cursor-up here is clamped at row 1, because the raw HOME already
+    // parked the cursor there — so all 13 erases collapse onto a single row.
+    expect(countOf(output, `${ESC}[1A`)).toBe(12);
+
+    // The new, shorter frame is what should be on screen afterwards.
+    expect(output).toContain("row-0");
+    expect(output).toContain("row-2");
+    expect(output).not.toContain("row-3");
+  });
+});

--- a/apps/cli/test/unit/app-shell/media-panel-rail-frame.test.tsx
+++ b/apps/cli/test/unit/app-shell/media-panel-rail-frame.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+
+import { buildMediaPanel } from "@/app-shell/media-panel-model";
+import { MediaPanel } from "@/app-shell/MediaPanel";
+import React from "react";
+
+import { captureFrame } from "../../harness/render-capture";
+
+// The post-play rail was reported rendering with rows missing (no ❀ badge, no
+// title, no synopsis divider) and stray text welded onto fact values —
+// "2006urite", "★ 8.5tion". That looks like a content bug and is not one: these
+// tests pin the rendered FRAME so the model/component layer stays ruled out and
+// the search stays on the write path (Ink's frame diff vs. the direct stdout
+// writes the poster overlays make). See .docs/debugging-map.md.
+
+const SYNOPSIS =
+  "The Amanto, aliens from outer space, have invaded Earth and taken over " +
+  "feudal Japan. As a result, a prohibition on swords has been established.";
+
+function railModel() {
+  return buildMediaPanel({
+    surface: "post-play",
+    contentKind: "anime",
+    titleType: "series",
+    title: "Gintama",
+    titleDetail: {
+      type: "series",
+      year: "2006",
+      score: 8.5,
+      studios: ["SUNRISE"],
+      status: "released",
+      synopsis: SYNOPSIS,
+      runtimeMinutes: 24,
+    } as never,
+    currentSeason: 1,
+    currentEpisode: 8,
+    nextEpisodeLabel: "S01 E09 — Fighting Should Be Done With Fists",
+    previousEpisodeLabel: "S01 E07 — Bring It On",
+    progress: { watched: 8, total: 200 },
+  });
+}
+
+/** The rail's own render width, mirroring post-play-shell's rail slice. */
+const RAIL_WIDTHS = [36, 34, 30, 28] as const;
+
+function railFrame(railWidth: number): string {
+  return captureFrame(
+    <MediaPanel model={railModel()} railWidth={railWidth} placementSlot="postplay-rail" />,
+    { columns: railWidth + 4, rows: 60 },
+  );
+}
+
+describe("post-play rail frame", () => {
+  it("renders every section the model carries", () => {
+    const frame = railFrame(36);
+    // The three rows reported missing from the screen.
+    expect(frame).toContain("❀ anime");
+    expect(frame).toContain("Gintama");
+    expect(frame).toContain("synopsis");
+    // Plus the sections that did survive, so a regression cannot pass by
+    // deleting the ones above.
+    expect(frame).toContain("details");
+    expect(frame).toContain("prev");
+    expect(frame).toContain("up next");
+  });
+
+  it("keeps fact values intact, with nothing welded onto them", () => {
+    const frame = railFrame(36);
+    const factLine = (label: string) =>
+      frame
+        .split("\n")
+        .find((line) => line.includes(label))
+        ?.trimEnd() ?? "";
+    // "2006urite" / "★ 8.5tion" is what the screen showed; the frame must end
+    // each value at the value.
+    expect(factLine("year")).toMatch(/year\s+2006$/u);
+    expect(factLine("score")).toMatch(/score\s+★ 8\.5$/u);
+    expect(factLine("studio")).toMatch(/studio\s+SUNRISE$/u);
+  });
+
+  it("never emits a line wider than the rail it was given", () => {
+    // A line wider than the rail would wrap in the terminal, and a wrapped line
+    // is a row Ink's erase bookkeeping does not know about — which would make
+    // this a content bug after all.
+    for (const railWidth of RAIL_WIDTHS) {
+      const overflowing = railFrame(railWidth)
+        .split("\n")
+        .filter((line) => line.length > railWidth);
+      expect({ railWidth, overflowing }).toEqual({ railWidth, overflowing: [] });
+    }
+  });
+});


### PR DESCRIPTION
## What this is

An investigation, not a fix — and deliberately so. It converts a "mystery
rendering glitch" into a located defect with the wrong layer permanently ruled
out, and stops short of guessing a remedy in a code path that is visible on
every surface transition.

## The report

The post-play rail rendered with rows missing — no `❀ anime` badge, no title
row, no `── synopsis ──` divider — and stray text welded onto fact values:
`year 2006urite`, `score ★ 8.5tion`, `aliens landed and conqueredhe`. The
`urite` tail was green, a colour nothing on that surface uses.

## What was ruled out

The model and the component. `media-panel-rail-frame.test.tsx` renders the real
`MediaPanel` from the real `buildMediaPanel()` with the reported data and pins
the frame:

- every section the model carries is present, including the three reported
  missing;
- each fact value ends at the value (`/year\s+2006$/`), so nothing is welded on;
- no line exceeds the rail width, at all four rail widths — a wrapped line would
  be a row Ink's erase bookkeeping does not know about, which would have made
  this a content bug after all.

The frame is correct. The screen is not. **The fault is in the write path.**

## What was found while narrowing it

Ink erases the previous frame by walking *up* from where it believes the cursor
is, emitting one erase-line per remembered row. That belief holds only while Ink
is the sole writer to stdout.

`clearRootContentTransitionFrame()` writes a raw `ESC[2J ESC[H` straight to
stdout on every root-content transition — playback → post-play among them.
`ink-external-clear-desync.test.tsx` drives real Ink against a recording stdout
and shows the consequence: the next frame still emits **13 erase-line ops and 12
cursor-up ops** aimed at a cursor the clear already parked at home, so every
erase collapses onto row 1.

Worth noting: its sibling two functions away, `clearShellScreen()`, documents the
opposite rule — *"the raw ANSI clear is intentionally omitted to avoid flicker —
Ink's reconciler handles repaint."* The two disagree with each other.

## Why no fix

The desync above is real but I could not show it is *this* bug: after the clear,
`2J` has already blanked the screen, so the misaimed erase is a no-op and Ink's
bookkeeping re-synchronizes on the following frame. Two other writers are
equally live suspects — `sixel-overlay.ts` and `image/kitty-transport.ts` both
write at absolute positions on a schedule independent of Ink's throttled frame.

Guessing between them would be a change to the repaint path of every surface in
the app, justified by a screenshot. `.docs/debugging-map.md` now carries the
evidence, the ruled-out layer, the three suspects, and the byte-level PTY
capture of a real playback → post-play transition that would settle it.

## Verification

| Gate | Result |
| --- | --- |
| `bun run typecheck --force` | pass (14/14) |
| `bun run test --force` | pass — 4562 unit, 156 integration, 356 provider, 96 core |
| `bun run lint` | 0 errors |
| `bun run verify:doc-paths` | pass |
