### PR TITLE
feat(docs): make the home a product page — npm paths, proof row, no decoration

### DIFF
--- a/apps/docs/app/(home)/home-page-interactive.tsx
+++ b/apps/docs/app/(home)/home-page-interactive.tsx
@@ -1,33 +1,59 @@
 "use client";
 
+import { OtherInstallPaths } from "@/components/home/other-install-paths";
 import { CopyButton } from "@/components/ui/copy-button";
 import { SectionHeading } from "@/components/ui/section-heading";
 import {
   CANONICAL_SETUP,
+  FIRST_SEARCH,
   NATIVE_INSTALL_BY_OS,
   type NativeInstallOs,
 } from "@/lib/install-commands";
-import { IconCheck } from "@tabler/icons-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
+
+const OS_ORDER = ["linux", "macos", "windows"] satisfies readonly NativeInstallOs[];
+
+const OS_LABEL: Record<NativeInstallOs, string> = {
+  linux: "Linux",
+  macos: "macOS",
+  windows: "Windows",
+};
+
+const PREREQ_COMMAND: Record<NativeInstallOs, string> = {
+  linux: "sudo apt install mpv yt-dlp curl",
+  macos: "brew install mpv yt-dlp curl",
+  windows: "winget install mpv",
+};
 
 export default function HomePageInteractive() {
   const [activeOs, setActiveOs] = useState<NativeInstallOs>("linux");
+  const tabRefs = useRef<Partial<Record<NativeInstallOs, HTMLButtonElement | null>>>({});
 
-  const prereqCommand =
-    activeOs === "linux"
-      ? "sudo apt install mpv yt-dlp curl"
-      : activeOs === "macos"
-        ? "brew install mpv yt-dlp curl"
-        : "winget install mpv";
-
+  const prereqCommand = PREREQ_COMMAND[activeOs];
   const installCommand = NATIVE_INSTALL_BY_OS[activeOs];
+
+  /**
+   * Arrow keys move between tabs, per the WAI-ARIA tabs pattern. Without this a
+   * keyboard user has to Tab through every option to reach the last one, and
+   * `role="tablist"` promises behaviour the widget does not deliver.
+   */
+  const handleTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    const delta = event.key === "ArrowRight" ? 1 : event.key === "ArrowLeft" ? -1 : 0;
+    if (delta === 0) return;
+    event.preventDefault();
+    const index = OS_ORDER.indexOf(activeOs);
+    const next = OS_ORDER[(index + delta + OS_ORDER.length) % OS_ORDER.length];
+    if (!next) return;
+    setActiveOs(next);
+    tabRefs.current[next]?.focus();
+  };
 
   return (
     <section id="install" className="kunai-home-install kunai-flow-section">
       <SectionHeading
         eyebrow="Install"
         title="Get started in three steps."
-        description="Preferred path is a self-contained binary (no Bun or Node required). Select your OS for the exact bootstrap and mpv commands."
+        description="The preferred path is a self-contained binary — no Bun or Node required. Pick your OS for the exact bootstrap and mpv commands."
       />
 
       <div className="install-section kunai-surface-shell">
@@ -37,51 +63,59 @@ export default function HomePageInteractive() {
             role="tablist"
             aria-label="Operating system"
           >
-            {(["linux", "macos", "windows"] satisfies readonly NativeInstallOs[]).map((os) => (
+            {OS_ORDER.map((os) => (
               <button
                 type="button"
                 key={os}
+                id={`install-tab-${os}`}
+                ref={(node) => {
+                  tabRefs.current[os] = node;
+                }}
                 role="tab"
                 aria-selected={activeOs === os}
+                aria-controls="install-steps"
+                tabIndex={activeOs === os ? 0 : -1}
                 onClick={() => setActiveOs(os)}
+                onKeyDown={handleTabKeyDown}
                 className={`os-tab-button text-[11px] tracking-wider uppercase ${
                   activeOs === os ? "active" : ""
                 }`}
               >
-                {os === "macos" ? "macOS" : os}
+                {OS_LABEL[os]}
               </button>
             ))}
           </div>
 
-          <div className="grid grid-cols-3 gap-6 max-lg:grid-cols-1">
+          <div
+            id="install-steps"
+            role="tabpanel"
+            aria-labelledby={`install-tab-${activeOs}`}
+            className="grid grid-cols-3 gap-6 max-lg:grid-cols-1"
+          >
             <div className="install-step-card flex flex-col justify-between">
               <div>
-                <div className="mb-4 flex items-center justify-between">
-                  <span className="kunai-step-label">Step 01</span>
-                  <span className="prereq-badge installed flex items-center gap-1.5">
-                    <IconCheck className="kunai-text-ok size-3" stroke={2} />
-                    <span>Prerequisites</span>
-                  </span>
-                </div>
-                <h3 className="kunai-type-title mt-2 mb-3 text-lg">Install dependencies</h3>
+                <span className="kunai-step-label">Step 01</span>
+                <h3 className="kunai-type-title mt-2 mb-3 text-lg">Install mpv</h3>
                 <p className="kunai-type-body mb-4 text-xs">
                   Playback needs <code className="text-fd-foreground font-mono">mpv</code> on your{" "}
                   <code className="text-fd-foreground font-mono">PATH</code>. The binary install
-                  embeds Bun — you do not need Node or Bun separately.
+                  embeds Bun, so Node and Bun are not needed separately.
                 </p>
               </div>
-              <div className="flex flex-col gap-2">
-                <code className="kunai-code-row">
-                  <span>{prereqCommand}</span>
-                  <CopyButton text={prereqCommand} label={`${activeOs}-prereq`} />
-                </code>
-              </div>
+              <code className="kunai-code-row">
+                <span>{prereqCommand}</span>
+                <CopyButton text={prereqCommand} label={`${activeOs}-prereq`} />
+              </code>
             </div>
 
             <div className="install-step-card flex flex-col justify-between">
               <div>
                 <span className="kunai-step-label">Step 02</span>
-                <h3 className="kunai-type-title mt-2 mb-3 text-lg">Install Kunai shell</h3>
+                <h3 className="kunai-type-title mt-2 mb-3 text-lg">Install the Kunai binary</h3>
+                <p className="kunai-type-body mb-4 text-xs">
+                  Downloads the release binary for {OS_LABEL[activeOs]} and puts{" "}
+                  <code className="text-fd-foreground font-mono">kunai</code> on your PATH.
+                </p>
               </div>
               <code className="kunai-code-row">
                 <span>{installCommand}</span>
@@ -92,14 +126,26 @@ export default function HomePageInteractive() {
             <div className="install-step-card flex flex-col justify-between">
               <div>
                 <span className="kunai-step-label">Step 03</span>
-                <h3 className="kunai-type-title mt-2 mb-3 text-lg">Initialize configuration</h3>
+                <h3 className="kunai-type-title mt-2 mb-3 text-lg">Set up, then search</h3>
+                <p className="kunai-type-body mb-4 text-xs">
+                  Setup writes your config once. After that, the second command opens the shell on a
+                  real search.
+                </p>
               </div>
-              <code className="kunai-code-row">
-                <span>{CANONICAL_SETUP}</span>
-                <CopyButton text={CANONICAL_SETUP} label="setup-cli" />
-              </code>
+              <div className="flex flex-col gap-2">
+                <code className="kunai-code-row">
+                  <span>{CANONICAL_SETUP}</span>
+                  <CopyButton text={CANONICAL_SETUP} label="setup-cli" />
+                </code>
+                <code className="kunai-code-row">
+                  <span>{FIRST_SEARCH}</span>
+                  <CopyButton text={FIRST_SEARCH} label="first-search" />
+                </code>
+              </div>
             </div>
           </div>
+
+          <OtherInstallPaths />
         </div>
       </div>
     </section>

--- a/apps/docs/app/(home)/home-page-shell.tsx
+++ b/apps/docs/app/(home)/home-page-shell.tsx
@@ -4,9 +4,11 @@ import { HomeTerminalIsland } from "@/components/home/home-terminal-island";
 import { ProviderSummaryCard } from "@/components/home/provider-summary-card";
 import { StartHereCards } from "@/components/home/start-here-cards";
 import type { HomeCommandMetadata, HomeProviderMetadata } from "@/components/home/types";
+import { CopyButton } from "@/components/ui/copy-button";
 import { SectionHeading } from "@/components/ui/section-heading";
 import { homeFlow, homeHero, homeHighlights, homeStartCards } from "@/lib/home-content";
 import type { ProviderSummary } from "@/lib/home-presenters";
+import { CANONICAL_INSTALL } from "@/lib/install-commands";
 import { IconArrowRight } from "@tabler/icons-react";
 import Link from "next/link";
 import type { ReactNode } from "react";
@@ -35,7 +37,7 @@ export default function HomePageShell({
   return (
     <main className="kunai-home relative mx-auto min-h-[100dvh] w-[min(1400px,calc(100vw-32px))] overflow-x-hidden py-8 max-md:w-[min(760px,calc(100vw-20px))]">
       <section className="kunai-home-hero grid items-center gap-10 pb-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
-        <HomeHeroStatic />
+        <HomeHeroStatic cliVersion={cliVersion} providerCount={providers.length} />
         <div className="kunai-hero-terminal-plane flex flex-col">
           <HomeTerminalIsland
             providers={providers}
@@ -64,17 +66,12 @@ export default function HomePageShell({
         />
         <div className="kunai-flow">
           {homeFlow.map((step, index) => (
-            <article
-              className={`kunai-flow-card premium-card-hover kunai-state-${step.state} flex flex-col justify-between`}
-              key={step.title}
-            >
-              <div>
-                <div className="flex items-start justify-between">
-                  <span className="kunai-flow-index">{String(index + 1).padStart(2, "0")}</span>
-                </div>
-                <h3 className="kunai-type-title mt-5 text-lg">{step.title}</h3>
-                <p className="kunai-type-body mt-3 text-xs">{step.description}</p>
-              </div>
+            <article className="kunai-flow-card premium-card-hover" key={step.title}>
+              <span className="kunai-flow-index tabular-nums">
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <h3 className="kunai-type-title mt-5 text-lg">{step.title}</h3>
+              <p className="kunai-type-body mt-3 text-xs">{step.description}</p>
             </article>
           ))}
         </div>
@@ -117,18 +114,21 @@ export default function HomePageShell({
               you own the relay URL.
             </p>
           </div>
-          <div className="flex shrink-0 flex-wrap gap-4">
-            <Link
-              className="kunai-button kunai-button-primary shadow-lg"
-              href={homeHero.primaryCta.href}
-            >
-              <span>{homeHero.primaryCta.label}</span>
-              <IconArrowRight className="ml-1.5 size-4" stroke={1.5} />
-            </Link>
-            <Link className="kunai-button border-fd-border hover:border-fd-primary" href="/docs">
-              Browse docs
-            </Link>
-            <HomeStarCta />
+          <div className="flex shrink-0 flex-col gap-3">
+            <code className="kunai-code-row">
+              <span>{CANONICAL_INSTALL}</span>
+              <CopyButton text={CANONICAL_INSTALL} label="final-install" />
+            </code>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                className="kunai-button kunai-button-primary shadow-lg"
+                href={homeHero.primaryCta.href}
+              >
+                <span>{homeHero.primaryCta.label}</span>
+                <IconArrowRight className="ml-1.5 size-4" stroke={1.5} />
+              </Link>
+              <HomeStarCta />
+            </div>
           </div>
         </div>
       </section>

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -3,37 +3,22 @@ import { UsageLine } from "@/components/home/usage-line";
 import { codeMetadata } from "@/lib/code-metadata";
 import { featuredCommands, summarizeProviders } from "@/lib/home-presenters";
 import { websiteJsonLd } from "@/lib/json-ld";
-import { docsSiteUrl } from "@/lib/site";
+import { buildPageMetadata } from "@/lib/page-metadata";
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
 /** Allow hourly refresh of the quiet usage metrics line without a full rebuild. */
 export const revalidate = 3600;
 
-export const metadata: Metadata = {
-  title: {
-    absolute: "Kunai Docs",
-  },
+export const metadata: Metadata = buildPageMetadata({
+  title: "Kunai — terminal client for third-party streams & mpv",
+  absoluteTitle: true,
   description:
-    "A terminal-first guide for the Kunai client: resolve third-party streams, hand off to mpv, recover, and use local offline files.",
-  alternates: {
-    canonical: docsSiteUrl,
-  },
-  openGraph: {
-    title: "Kunai Docs",
-    description:
-      "A terminal-first guide for the Kunai client: resolve third-party streams, hand off to mpv, recover, and use local offline files.",
-    url: docsSiteUrl,
-    type: "website",
-    siteName: "Kunai Docs",
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "Kunai Docs",
-    description:
-      "A terminal-first guide for the Kunai client: resolve third-party streams, hand off to mpv, recover, and use local offline files.",
-  },
-};
+    "A terminal client that searches a title, resolves a stream a third-party provider already serves, hands playback to mpv, and recovers without a restart.",
+  socialDescription:
+    "Search a title, resolve a third-party stream, hand playback to mpv, and recover without restarting.",
+  path: "/",
+});
 
 export default function HomePage() {
   const jsonLd = websiteJsonLd();

--- a/apps/docs/app/analytics/page.tsx
+++ b/apps/docs/app/analytics/page.tsx
@@ -1,26 +1,19 @@
 import { UsagePanel } from "@/components/analytics/usage-panel";
 import { fetchDocsAnalyticsMetrics } from "@/lib/analytics-metrics";
-import { docsSiteUrl } from "@/lib/site";
+import { buildPageMetadata } from "@/lib/page-metadata";
 import type { Metadata } from "next";
 
 export const revalidate = 3600;
 
-export const metadata: Metadata = {
-  title: "Usage analytics",
+export const metadata: Metadata = buildPageMetadata({
+  title: "Kunai usage analytics — public install pulse by version and OS",
+  absoluteTitle: true,
   description:
-    "See Kunai’s public usage pulse, the exact optional ping payload, and its privacy limits.",
-  alternates: {
-    canonical: `${docsSiteUrl}/analytics`,
-  },
-  openGraph: {
-    title: "Kunai usage analytics",
-    description:
-      "Public aggregate counts only — never titles, queries, or install UUIDs on this page.",
-    url: `${docsSiteUrl}/analytics`,
-    type: "website",
-    siteName: "Kunai Docs",
-  },
-};
+    "Kunai’s public usage pulse: aggregate install counts by version, OS, and architecture, the exact opt-in ping payload, and the privacy limits that bound it.",
+  socialDescription:
+    "Public aggregate counts only — never titles, queries, or install UUIDs on this page.",
+  path: "/analytics",
+});
 
 export default async function AnalyticsPage() {
   const metrics = await fetchDocsAnalyticsMetrics();

--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -3,6 +3,7 @@ import { RelatedDocLinks } from "@/components/docs/related-doc-links";
 import { navGroupForHref } from "@/lib/doc-page-nav";
 import { docsEditUrl } from "@/lib/docs-github";
 import { breadcrumbListJsonLd, faqPageJsonLd, techArticleJsonLd } from "@/lib/json-ld";
+import { buildPageMetadata } from "@/lib/page-metadata";
 import { docsCanonicalUrl } from "@/lib/site";
 import { source } from "@/lib/source";
 import { buildTroubleshootingFaqEntries } from "@/lib/troubleshooting-faq";
@@ -34,25 +35,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const page = source.getPage((await params).slug);
   if (!page) notFound();
 
-  return {
+  return buildPageMetadata({
     title: page.data.title,
-    description: page.data.description,
-    alternates: {
-      canonical: docsCanonicalUrl(page.url),
-    },
-    openGraph: {
-      title: page.data.title,
-      description: page.data.description,
-      url: docsCanonicalUrl(page.url),
-      type: "article",
-      siteName: "Kunai Docs",
-    },
-    twitter: {
-      card: "summary_large_image",
-      title: page.data.title,
-      description: page.data.description,
-    },
-  };
+    description: page.data.description ?? "",
+    path: page.url,
+    type: "article",
+  });
 }
 
 function readLastModified(pageData: { readonly lastModified?: Date }): Date | undefined {

--- a/apps/docs/app/feedback/page.tsx
+++ b/apps/docs/app/feedback/page.tsx
@@ -3,7 +3,7 @@ import {
   docsGithubIssueTemplateUrl,
   docsGithubIssuesUrl,
 } from "@/lib/docs-github";
-import { docsSiteUrl } from "@/lib/site";
+import { buildPageMetadata } from "@/lib/page-metadata";
 import {
   IconBug,
   IconMessageCircle,
@@ -16,22 +16,15 @@ import Link from "next/link";
 
 export const dynamic = "force-static";
 
-export const metadata: Metadata = {
-  title: "Feedback",
+export const metadata: Metadata = buildPageMetadata({
+  title: "Kunai feedback — report a bug, provider issue, or idea",
+  absoluteTitle: true,
   description:
+    "Report a Kunai bug, a broken third-party provider, or a feature idea through the GitHub issue templates, and see what to attach so the report can be acted on.",
+  socialDescription:
     "Report bugs, provider issues, or feature ideas for Kunai via GitHub issue templates.",
-  alternates: {
-    canonical: `${docsSiteUrl}/feedback`,
-  },
-  openGraph: {
-    title: "Kunai Feedback",
-    description:
-      "Report bugs, provider issues, or feature ideas for Kunai via GitHub issue templates.",
-    url: `${docsSiteUrl}/feedback`,
-    type: "website",
-    siteName: "Kunai Docs",
-  },
-};
+  path: "/feedback",
+});
 
 const ACTIONS = [
   {

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
   metadataBase: new URL(docsSiteUrl),
   title: {
     default: "Kunai Docs",
-    template: "%s | Kunai Docs",
+    template: "%s | Kunai — terminal streaming client",
   },
   description:
     "Guides for the Kunai client: resolve third-party streams, hand off to mpv, recover, and use local offline files.",

--- a/apps/docs/app/releases/[tag]/page.tsx
+++ b/apps/docs/app/releases/[tag]/page.tsx
@@ -1,10 +1,10 @@
 import { ReleaseDetail } from "@/components/releases/release-detail";
+import { buildPageMetadata } from "@/lib/page-metadata";
 import {
   getReleaseByTag,
   normalizeReleaseTag,
   readReleaseNotesArtifacts,
 } from "@/lib/release-notes";
-import { docsSiteUrl } from "@/lib/site";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
@@ -27,21 +27,20 @@ export async function generateMetadata({ params }: ReleaseTagPageProps): Promise
     return { title: "Release not found" };
   }
 
-  const path = `/releases/${normalizeReleaseTag(release.tag)}`;
-  return {
+  // A staged artifact can carry an empty summary (v0.2.6 does), which rendered
+  // the page with a blank meta description. Fall back to a real sentence rather
+  // than shipping an empty tag.
+  const summary = release.summary.replace(/\s+/g, " ").trim();
+  const description = summary
+    ? summary.slice(0, 160)
+    : `Release notes for Kunai ${release.tag}: what changed in this version of the terminal streaming client, and the exact command to install or upgrade to it.`;
+
+  return buildPageMetadata({
     title: release.title,
-    description: release.summary.slice(0, 160).replace(/\s+/g, " ").trim(),
-    alternates: {
-      canonical: `${docsSiteUrl}${path}`,
-    },
-    openGraph: {
-      title: release.title,
-      description: release.summary.slice(0, 160).replace(/\s+/g, " ").trim(),
-      url: `${docsSiteUrl}${path}`,
-      type: "article",
-      siteName: "Kunai Docs",
-    },
-  };
+    description,
+    path: `/releases/${normalizeReleaseTag(release.tag)}`,
+    type: "article",
+  });
 }
 
 export default async function ReleaseTagPage({ params }: ReleaseTagPageProps) {

--- a/apps/docs/app/releases/page.tsx
+++ b/apps/docs/app/releases/page.tsx
@@ -1,33 +1,21 @@
 import { ReleaseInstallPanel } from "@/components/releases/release-install-panel";
 import { ReleaseTimeline } from "@/components/releases/release-timeline";
+import { buildPageMetadata } from "@/lib/page-metadata";
 import { latestReleaseNotesArtifact, readReleaseNotesArtifacts } from "@/lib/release-notes";
-import { docsSiteUrl } from "@/lib/site";
 import type { Metadata } from "next";
 import Link from "next/link";
 
 export const dynamic = "force-static";
 
-export const metadata: Metadata = {
-  title: "Release Notes",
-  description: "Kunai changelog generated from the same tracked release artifacts used for GitHub.",
-  alternates: {
-    canonical: `${docsSiteUrl}/releases`,
-  },
-  openGraph: {
-    title: "Kunai Release Notes",
-    description:
-      "Kunai changelog generated from the same tracked release artifacts used for GitHub.",
-    url: `${docsSiteUrl}/releases`,
-    type: "website",
-    siteName: "Kunai Docs",
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "Kunai Release Notes",
-    description:
-      "Kunai changelog generated from the same tracked release artifacts used for GitHub.",
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title: "Kunai release notes — changelog and install commands",
+  absoluteTitle: true,
+  description:
+    "Every Kunai release, generated from the same tracked artifacts that produce the GitHub releases: what changed, the version tag, and the install command for it.",
+  socialDescription:
+    "Kunai changelog generated from the same tracked release artifacts used for GitHub.",
+  path: "/releases",
+});
 
 export default function ReleaseNotesPage() {
   const releases = readReleaseNotesArtifacts();

--- a/apps/docs/app/styles/home.css
+++ b/apps/docs/app/styles/home.css
@@ -93,7 +93,11 @@
 }
 
 .kunai-terminal-top,
-.kunai-terminal-body,
+.kunai-terminal-body {
+  border: 1px solid var(--kunai-line);
+  background: color-mix(in oklab, var(--kunai-bg) 95%, transparent);
+}
+
 .kunai-terminal-top {
   display: flex;
   flex-wrap: wrap;
@@ -182,6 +186,17 @@
   padding-top: 0.5rem;
 }
 
+@keyframes log-fade-in {
+  from {
+    opacity: 0;
+    transform: translateX(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
 /* Terminal interactive cursor */
 .kunai-cursor {
   display: inline-block;
@@ -201,14 +216,6 @@
   50% {
     background-color: var(--kunai-accent);
   }
-}
-
-.kunai-install {
-  display: grid;
-  gap: 0.55rem;
-  margin-top: 0.6rem;
-  border-radius: 0.5rem;
-  padding: 0.9rem;
 }
 
 /* Command Palette Overlay */
@@ -344,14 +351,6 @@
   box-shadow: 0 8px 24px color-mix(in oklab, var(--kunai-accent) 4%, transparent);
 }
 
-.kunai-flow-card > .kunai-flow-index {
-  color: var(--kunai-accent);
-  font-size: 0.72rem;
-  font-weight: 800;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
 .kunai-flow-card p {
   color: var(--color-fd-muted-foreground);
   text-wrap: pretty;
@@ -382,6 +381,13 @@
 .kunai-flow-card:nth-child(3) {
   animation-delay: 120ms;
 }
+.kunai-flow-card:nth-child(4) {
+  animation-delay: 180ms;
+}
+.kunai-flow-card:nth-child(5) {
+  animation-delay: 240ms;
+}
+
 @keyframes card-stagger-in {
   from {
     opacity: 0;
@@ -409,7 +415,14 @@
   color: var(--color-fd-muted-foreground);
 }
 
-.kunai-flow-card h3,
+.kunai-flow-card h3 {
+  margin: 1.5rem 0 0.5rem;
+  font-size: 1.25rem;
+  line-height: 1.1;
+  font-weight: 800;
+  text-wrap: balance;
+}
+
 .kunai-status-dot {
   height: 0.625rem;
   width: 0.625rem;
@@ -426,6 +439,16 @@
   font-family: var(--font-mono), ui-monospace, monospace;
   font-size: 0.625rem;
   color: color-mix(in oklab, var(--color-fd-muted-foreground) 45%, transparent);
+}
+.provider-interactive-tab.is-active {
+  background: linear-gradient(135deg, var(--kunai-accent-deep), #8c2a44);
+  border-color: var(--kunai-accent);
+  color: #fff;
+  box-shadow: 0 4px 12px var(--kunai-accent-glow);
+}
+.flag-checkbox-wrapper.is-checked {
+  border-color: var(--kunai-accent);
+  background: color-mix(in oklab, var(--kunai-accent) 5%, var(--kunai-surface-strong));
 }
 
 .kunai-final {
@@ -450,8 +473,7 @@
   .kunai-button,
   .kunai-flow-card,
   .kunai-final,
-  .palette-item,
-  .os-tab-button {
+  .palette-item {
     transition: none !important;
     transform: none !important;
     animation: none !important;
@@ -523,6 +545,7 @@
 
 /* Preset pills + interactive chips — unified press feedback */
 .kunai-terminal-stage button:active,
+.kunai-flow-card:active,
 .os-tab-button:active,
 .kunai-fd-card:active {
   transform: scale(0.96) !important;
@@ -704,7 +727,10 @@
 
 /* ── Hero: paired install commands ─────────────────────────────────────────
    Both platforms sit in one stack so the choice is made once. The OS label is
-   a fixed-width column so the two commands align on their first character. */
+   a fixed column so the two commands align on their first character.
+
+   The command wraps rather than scrolling: a `curl … | bash` line that is cut
+   off mid-URL asks the reader to trust what they cannot see. */
 .kunai-hero-install {
   display: flex;
   flex-direction: column;
@@ -713,6 +739,7 @@
 }
 
 .kunai-hero-install .kunai-code-row {
+  align-items: flex-start;
   gap: 0.75rem;
   transition:
     border-color var(--kunai-duration-ui) var(--kunai-ease-out),
@@ -727,6 +754,7 @@
 .kunai-hero-install__os {
   flex: 0 0 auto;
   width: 6.5rem;
+  padding-top: 0.1rem;
   color: var(--color-fd-muted-foreground);
   font-size: 0.625rem;
   letter-spacing: 0.04em;
@@ -736,17 +764,17 @@
 .kunai-hero-install__cmd {
   flex: 1 1 auto;
   min-width: 0;
-  overflow-x: auto;
-  white-space: nowrap;
-  scrollbar-width: none;
+  overflow-wrap: anywhere;
+  line-height: 1.6;
 }
 
-.kunai-hero-install__cmd::-webkit-scrollbar {
-  display: none;
+/* The copy control must not shrink when the command wraps to two lines. */
+.kunai-hero-install .kunai-code-row > :last-child {
+  flex: 0 0 auto;
 }
 
 /* ── Hero proof row ────────────────────────────────────────────────────────
-   Four verifiable facts, each one a link to where it can be checked. */
+   Four verifiable facts, each a link to where it can be checked. */
 .kunai-proof-row {
   display: flex;
   flex-wrap: wrap;
@@ -802,8 +830,8 @@
 }
 
 /* ── Secondary install paths ───────────────────────────────────────────────
-   Below the three-step flow and visually quieter, because it is the
-   alternative route rather than a fourth step. */
+   Below the three-step flow and visually quieter: it is the alternative
+   route, not a fourth step. */
 .kunai-other-paths {
   margin-top: 2rem;
   padding-top: 1.75rem;
@@ -822,6 +850,10 @@
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.5rem;
   margin-top: 1rem;
+}
+
+.kunai-other-paths__commands .kunai-code-row {
+  overflow-wrap: anywhere;
 }
 
 .kunai-other-paths__links {
@@ -856,6 +888,6 @@
   }
 
   .kunai-hero-install__os {
-    width: 5rem;
+    width: 4.5rem;
   }
 }

--- a/apps/docs/app/styles/home.css
+++ b/apps/docs/app/styles/home.css
@@ -46,10 +46,6 @@
   animation: kunai-rise 700ms var(--kunai-ease-out) both;
 }
 
-.kunai-reveal-late {
-  animation-delay: 150ms;
-}
-
 @keyframes kunai-rise {
   from {
     opacity: 0;
@@ -84,11 +80,9 @@
   );
   padding: 0.85rem;
   box-shadow: var(--kunai-card-shadow);
-  will-change: transform;
   transition:
     border-color 300ms var(--kunai-ease-out),
-    box-shadow 300ms var(--kunai-ease-out),
-    transform 300ms var(--kunai-ease-out);
+    box-shadow 300ms var(--kunai-ease-out);
 }
 
 .kunai-terminal-stage.is-focused {
@@ -100,11 +94,6 @@
 
 .kunai-terminal-top,
 .kunai-terminal-body,
-.kunai-install {
-  border: 1px solid var(--kunai-line);
-  background: color-mix(in oklab, var(--kunai-bg) 95%, transparent);
-}
-
 .kunai-terminal-top {
   display: flex;
   flex-wrap: wrap;
@@ -193,41 +182,6 @@
   padding-top: 0.5rem;
 }
 
-@keyframes log-fade-in {
-  from {
-    opacity: 0;
-    transform: translateX(-4px);
-  }
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
-
-.kunai-gap {
-  padding-top: 0.8rem;
-}
-
-.kunai-accent {
-  color: var(--kunai-accent);
-}
-
-.kunai-ok {
-  color: var(--kunai-ok);
-}
-
-.kunai-warning {
-  color: var(--kunai-warning);
-}
-
-.kunai-danger {
-  color: var(--kunai-danger);
-}
-
-.kunai-muted {
-  color: var(--color-fd-muted-foreground);
-}
-
 /* Terminal interactive cursor */
 .kunai-cursor {
   display: inline-block;
@@ -257,25 +211,6 @@
   padding: 0.9rem;
 }
 
-.kunai-install span {
-  color: var(--color-fd-muted-foreground);
-  font-size: 0.78rem;
-  font-weight: 800;
-}
-
-.kunai-install code {
-  overflow-x: auto;
-  border-radius: 0.375rem;
-  background: color-mix(in oklab, white 4%, transparent);
-  border: 1px solid var(--kunai-line);
-  padding: 0.66rem 0.75rem;
-  color: var(--color-fd-foreground);
-  font-size: 0.83rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
 /* Command Palette Overlay */
 .kunai-command-palette {
   position: absolute;
@@ -290,17 +225,6 @@
   overflow: hidden;
   transform-origin: top center;
   animation: palette-enter 220ms var(--kunai-ease-soft) both;
-}
-
-@keyframes palette-enter {
-  from {
-    opacity: 0;
-    transform: scale(0.97) translateY(-8px);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1) translateY(0);
-  }
 }
 
 .palette-search-wrapper {
@@ -373,7 +297,6 @@
 .kunai-band,
 .kunai-flow-section,
 .kunai-docs-section,
-.kunai-proof-section,
 .kunai-final {
   border-top: 1px solid var(--kunai-line);
   padding-block: clamp(3.5rem, 6vw, 4.5rem);
@@ -404,16 +327,7 @@
   margin-bottom: clamp(2rem, 4vw, 3.5rem);
 }
 
-.kunai-highlight-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-.kunai-highlight,
 .kunai-flow-card,
-.kunai-doc-row,
-.kunai-proof,
 .kunai-final {
   border: 1px solid var(--kunai-line);
   background: var(--kunai-surface);
@@ -424,33 +338,13 @@
     transform 200ms var(--kunai-ease-out);
 }
 
-.kunai-highlight:hover,
-.kunai-proof:hover,
 .kunai-final:hover {
   border-color: color-mix(in oklab, var(--kunai-accent) 24%, var(--kunai-line));
   transform: translateY(-2px);
   box-shadow: 0 8px 24px color-mix(in oklab, var(--kunai-accent) 4%, transparent);
 }
 
-.kunai-highlight {
-  min-height: 12rem;
-  border-radius: 0.6rem;
-  padding: 1.25rem;
-  animation: card-stagger-in 400ms var(--kunai-ease-out) both;
-}
-
-.kunai-highlight:nth-child(1) {
-  animation-delay: 0ms;
-}
-.kunai-highlight:nth-child(2) {
-  animation-delay: 80ms;
-}
-.kunai-highlight:nth-child(3) {
-  animation-delay: 160ms;
-}
-
-.kunai-highlight span,
-.kunai-proof span {
+.kunai-flow-card > .kunai-flow-index {
   color: var(--kunai-accent);
   font-size: 0.72rem;
   font-weight: 800;
@@ -458,19 +352,9 @@
   text-transform: uppercase;
 }
 
-.kunai-highlight p,
-.kunai-flow-card p,
-.kunai-doc-row p,
-.kunai-doc-card small,
-.kunai-proof p {
+.kunai-flow-card p {
   color: var(--color-fd-muted-foreground);
   text-wrap: pretty;
-}
-
-.kunai-highlight p {
-  margin: 1.5rem 0 0;
-  font-size: 1rem;
-  line-height: 1.6;
 }
 
 /* Playback Path Flow */
@@ -498,13 +382,6 @@
 .kunai-flow-card:nth-child(3) {
   animation-delay: 120ms;
 }
-.kunai-flow-card:nth-child(4) {
-  animation-delay: 180ms;
-}
-.kunai-flow-card:nth-child(5) {
-  animation-delay: 240ms;
-}
-
 @keyframes card-stagger-in {
   from {
     opacity: 0;
@@ -533,27 +410,6 @@
 }
 
 .kunai-flow-card h3,
-.kunai-doc-row h3 {
-  margin: 1.5rem 0 0.5rem;
-  font-size: 1.25rem;
-  line-height: 1.1;
-  font-weight: 800;
-  text-wrap: balance;
-}
-
-.kunai-state-focus {
-  border-color: color-mix(in oklab, var(--kunai-accent) 42%, var(--kunai-line));
-}
-.kunai-state-ready {
-  border-color: color-mix(in oklab, var(--kunai-ok) 48%, var(--kunai-line));
-}
-.kunai-state-warn {
-  border-color: color-mix(in oklab, var(--kunai-warning) 44%, var(--kunai-line));
-}
-.kunai-state-danger {
-  border-color: color-mix(in oklab, var(--kunai-danger) 44%, var(--kunai-line));
-}
-
 .kunai-status-dot {
   height: 0.625rem;
   width: 0.625rem;
@@ -566,260 +422,10 @@
   animation: pulse-glow 2.4s var(--kunai-ease-out) infinite;
 }
 
-.kunai-status-dot--ready {
-  background: var(--kunai-ok);
-}
-
-.kunai-status-dot--warn {
-  background: var(--kunai-warning);
-}
-
-.kunai-status-dot--danger {
-  background: var(--kunai-danger);
-}
-
-.kunai-status-dot--idle {
-  background: color-mix(in oklab, var(--color-fd-muted-foreground) 28%, transparent);
-}
-
 .kunai-flow-index {
   font-family: var(--font-mono), ui-monospace, monospace;
   font-size: 0.625rem;
   color: color-mix(in oklab, var(--color-fd-muted-foreground) 45%, transparent);
-}
-
-/* Providers catalog styles */
-.provider-interactive-tab {
-  padding: 0.5rem 0.85rem;
-  font-size: 0.825rem;
-  font-weight: 700;
-  border-radius: 0.375rem;
-  border: 1px solid var(--kunai-line);
-  background: var(--kunai-surface);
-  cursor: pointer;
-  transition:
-    border-color 160ms var(--kunai-ease-out),
-    background 160ms var(--kunai-ease-out),
-    box-shadow 160ms var(--kunai-ease-out),
-    transform 160ms var(--kunai-ease-out);
-}
-.provider-interactive-tab:hover {
-  border-color: var(--kunai-accent);
-  background: var(--kunai-surface-strong);
-}
-.provider-interactive-tab.is-active {
-  background: linear-gradient(135deg, var(--kunai-accent-deep), #8c2a44);
-  border-color: var(--kunai-accent);
-  color: #fff;
-  box-shadow: 0 4px 12px var(--kunai-accent-glow);
-}
-.provider-interactive-tab:active {
-  transform: scale(0.96);
-}
-
-.provider-details-card {
-  border: 1px solid var(--kunai-line);
-  border-radius: 0.6rem;
-  background: var(--kunai-surface-strong);
-  padding: 1.5rem;
-  box-shadow: var(--kunai-card-shadow);
-  animation: provider-fade-in 300ms var(--kunai-ease-out) both;
-}
-
-@keyframes provider-fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-    filter: blur(2px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-    filter: blur(0);
-  }
-}
-
-.chip-tag {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.2rem 0.5rem;
-  border-radius: 4px;
-  font-size: 0.72rem;
-  font-weight: 700;
-  font-family: "JetBrains Mono", monospace;
-  background: color-mix(in oklab, var(--kunai-accent) 8%, transparent);
-  border: 1px solid color-mix(in oklab, var(--kunai-accent) 20%, transparent);
-  color: var(--kunai-accent);
-}
-
-.chip-tag-ok {
-  background: color-mix(in oklab, var(--kunai-ok) 8%, transparent);
-  border: 1px solid color-mix(in oklab, var(--kunai-ok) 20%, transparent);
-  color: var(--kunai-ok);
-}
-
-.chip-tag-warning {
-  background: color-mix(in oklab, var(--kunai-warning) 8%, transparent);
-  border: 1px solid color-mix(in oklab, var(--kunai-warning) 20%, transparent);
-  color: var(--kunai-warning);
-}
-
-/* Flag builder styles */
-.flag-builder-shell {
-  background: var(--kunai-surface);
-  border: 1px solid var(--kunai-line);
-  border-radius: 0.6rem;
-  padding: 1.25rem;
-  box-shadow: var(--kunai-card-shadow);
-}
-
-.flag-checkbox-wrapper {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  padding: 0.6rem 0.8rem;
-  border-radius: 0.375rem;
-  border: 1px solid var(--kunai-line);
-  cursor: pointer;
-  transition:
-    border-color 180ms var(--kunai-ease-out),
-    background 180ms var(--kunai-ease-out),
-    transform 180ms var(--kunai-ease-out);
-  user-select: none;
-}
-.flag-checkbox-wrapper:hover {
-  background: var(--kunai-surface-strong);
-  border-color: var(--kunai-accent);
-}
-.flag-checkbox-wrapper.is-checked {
-  border-color: var(--kunai-accent);
-  background: color-mix(in oklab, var(--kunai-accent) 5%, var(--kunai-surface-strong));
-}
-.flag-checkbox-wrapper:active {
-  transform: scale(0.97);
-}
-
-.flag-cmd-preview {
-  font-family: "JetBrains Mono", monospace;
-  background: var(--kunai-bg);
-  border: 1px solid var(--kunai-accent);
-  padding: 0.85rem;
-  border-radius: 0.5rem;
-  color: #fff;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  box-shadow: 0 4px 16px var(--kunai-accent-glow);
-}
-
-/* Documents & Rows */
-.kunai-doc-row {
-  display: grid;
-  grid-template-columns: minmax(14rem, 0.42fr) minmax(0, 1fr);
-  gap: 1.5rem;
-  border-radius: 0.6rem;
-  padding: clamp(1.2rem, 3vw, 1.8rem);
-  animation: card-stagger-in 400ms var(--kunai-ease-out) both;
-}
-
-.kunai-doc-row:nth-child(1) {
-  animation-delay: 0ms;
-}
-.kunai-doc-row:nth-child(2) {
-  animation-delay: 100ms;
-}
-.kunai-doc-row:nth-child(3) {
-  animation-delay: 200ms;
-}
-.kunai-doc-row:nth-child(4) {
-  animation-delay: 300ms;
-}
-
-.kunai-doc-row:hover {
-  border-color: color-mix(in oklab, var(--kunai-accent) 20%, var(--kunai-line));
-  transform: translateY(-1px);
-}
-
-.kunai-doc-row h3 {
-  margin-top: 0.6rem;
-}
-
-.kunai-doc-links {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
-  gap: 0.8rem;
-}
-
-.kunai-doc-card {
-  display: grid;
-  min-height: 9.5rem;
-  gap: 0.6rem;
-  align-content: start;
-  border: 1px solid var(--kunai-line);
-  border-radius: 0.5rem;
-  background: color-mix(in oklab, var(--kunai-surface) 95%, transparent);
-  padding: 1.1rem;
-  box-shadow: var(--kunai-card-shadow);
-  text-decoration: none;
-  transition:
-    border-color 180ms var(--kunai-ease-out),
-    background 180ms var(--kunai-ease-out),
-    transform 180ms var(--kunai-ease-out),
-    box-shadow 180ms var(--kunai-ease-out);
-}
-
-.kunai-doc-card:hover {
-  border-color: var(--kunai-accent);
-  background: var(--kunai-surface-strong);
-  transform: translateY(-2px);
-  box-shadow: 0 8px 20px var(--kunai-accent-glow);
-}
-
-.kunai-doc-card:active {
-  transform: scale(0.97);
-}
-
-.kunai-doc-card span {
-  color: var(--color-fd-foreground);
-  font-weight: 800;
-  font-size: 0.95rem;
-  transition: color 150ms var(--kunai-ease-out);
-}
-
-.kunai-doc-card:hover span {
-  color: var(--kunai-accent);
-}
-
-.kunai-proof-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-.kunai-proof {
-  min-height: 12.5rem;
-  border-radius: 0.6rem;
-  padding: 1.25rem;
-  animation: card-stagger-in 400ms var(--kunai-ease-out) both;
-}
-
-.kunai-proof:nth-child(1) {
-  animation-delay: 0ms;
-}
-.kunai-proof:nth-child(2) {
-  animation-delay: 80ms;
-}
-.kunai-proof:nth-child(3) {
-  animation-delay: 160ms;
-}
-
-.kunai-proof strong {
-  display: block;
-  margin-top: 1.5rem;
-  font-size: 2.2rem;
-  line-height: 1;
-  font-weight: 900;
-  letter-spacing: -0.02em;
 }
 
 .kunai-final {
@@ -842,14 +448,10 @@
   }
 
   .kunai-button,
-  .kunai-doc-card,
   .kunai-flow-card,
-  .kunai-highlight,
-  .kunai-proof,
   .kunai-final,
-  .flag-checkbox-wrapper,
   .palette-item,
-  .provider-interactive-tab {
+  .os-tab-button {
     transition: none !important;
     transform: none !important;
     animation: none !important;
@@ -858,13 +460,7 @@
 
 @media (max-width: 980px) {
   .kunai-band,
-  .kunai-doc-row,
   .kunai-final {
-    grid-template-columns: 1fr;
-  }
-
-  .kunai-highlight-grid,
-  .kunai-proof-grid {
     grid-template-columns: 1fr;
   }
 
@@ -905,40 +501,6 @@
   }
 }
 
-/* Premium Visual Utilities */
-
-.grain-overlay {
-  pointer-events: none;
-  position: fixed;
-  inset: 0;
-  z-index: 9999;
-  opacity: 0.022;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.8 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
-  mix-blend-mode: overlay;
-}
-
-@keyframes float-y {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-8px);
-  }
-}
-
-@keyframes pulse-glow {
-  0%,
-  100% {
-    opacity: 0.5;
-    transform: scale(1);
-  }
-  50% {
-    opacity: 0.8;
-    transform: scale(1.03);
-  }
-}
-
 /* Custom premium hover states */
 .premium-card-hover {
   transition:
@@ -961,10 +523,6 @@
 
 /* Preset pills + interactive chips — unified press feedback */
 .kunai-terminal-stage button:active,
-.flag-checkbox-wrapper:active,
-.provider-interactive-tab:active,
-.kunai-doc-card:active,
-.kunai-flow-card:active,
 .os-tab-button:active,
 .kunai-fd-card:active {
   transform: scale(0.96) !important;
@@ -1027,25 +585,6 @@
 .kunai-home table tr:hover td {
   color: #fff;
   background: color-mix(in oklab, var(--kunai-surface-strong) 40%, transparent);
-}
-
-/* Ambient bottom glow */
-.ambient-glow-bottom {
-  pointer-events: none;
-  position: absolute;
-  bottom: 12%;
-  left: 15%;
-  width: 550px;
-  height: 550px;
-  border-radius: 50%;
-  background: radial-gradient(
-    circle,
-    color-mix(in oklab, var(--kunai-accent) 4%, transparent) 0%,
-    transparent 70%
-  );
-  filter: blur(100px);
-  z-index: -10;
-  animation: pulse-glow 14s infinite alternate;
 }
 
 /* Quick Install Section */
@@ -1126,22 +665,6 @@
   transform: translateY(-2px);
 }
 
-/* Hero Install Box */
-.hero-install-box {
-  border: 1px solid var(--kunai-line);
-  background: color-mix(in oklab, var(--kunai-surface-strong) 75%, transparent);
-  box-shadow: var(--kunai-shadow-sm);
-  border-radius: var(--kunai-radius-inner);
-  transition:
-    border-color var(--kunai-duration-ui) var(--kunai-ease-out),
-    box-shadow var(--kunai-duration-ui) var(--kunai-ease-out);
-}
-
-.hero-install-box:hover {
-  border-color: color-mix(in oklab, var(--kunai-accent) 24%, var(--kunai-line));
-  box-shadow: var(--kunai-shadow-diffuse);
-}
-
 .kunai-highlight-list {
   display: flex;
   flex-direction: column;
@@ -1176,5 +699,163 @@
 
   .kunai-flow {
     grid-template-columns: 1fr;
+  }
+}
+
+/* ── Hero: paired install commands ─────────────────────────────────────────
+   Both platforms sit in one stack so the choice is made once. The OS label is
+   a fixed-width column so the two commands align on their first character. */
+.kunai-hero-install {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 42rem;
+}
+
+.kunai-hero-install .kunai-code-row {
+  gap: 0.75rem;
+  transition:
+    border-color var(--kunai-duration-ui) var(--kunai-ease-out),
+    box-shadow var(--kunai-duration-ui) var(--kunai-ease-out);
+}
+
+.kunai-hero-install .kunai-code-row:hover {
+  border-color: color-mix(in oklab, var(--kunai-accent) 24%, var(--kunai-line));
+  box-shadow: var(--kunai-shadow-sm);
+}
+
+.kunai-hero-install__os {
+  flex: 0 0 auto;
+  width: 6.5rem;
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.625rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.kunai-hero-install__cmd {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+  white-space: nowrap;
+  scrollbar-width: none;
+}
+
+.kunai-hero-install__cmd::-webkit-scrollbar {
+  display: none;
+}
+
+/* ── Hero proof row ────────────────────────────────────────────────────────
+   Four verifiable facts, each one a link to where it can be checked. */
+.kunai-proof-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0 1.5rem;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.75rem;
+  color: var(--color-fd-muted-foreground);
+}
+
+.kunai-proof-row li {
+  position: relative;
+  padding-block: 0.35rem;
+}
+
+.kunai-proof-row li + li::before {
+  content: "";
+  position: absolute;
+  left: -0.75rem;
+  top: 50%;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: currentcolor;
+  opacity: 0.4;
+  transform: translateY(-50%);
+}
+
+.kunai-proof-row a {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition:
+    color 150ms var(--kunai-ease-out),
+    border-color 150ms var(--kunai-ease-out);
+}
+
+.kunai-proof-row a:hover {
+  color: var(--color-fd-foreground);
+  border-bottom-color: color-mix(in oklab, var(--kunai-accent) 50%, transparent);
+}
+
+/* ── Terminal preset row ───────────────────────────────────────────────────
+   Labelled so the chips read as an invitation rather than decoration. */
+.kunai-terminal-presets {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem 0.5rem;
+}
+
+/* ── Secondary install paths ───────────────────────────────────────────────
+   Below the three-step flow and visually quieter, because it is the
+   alternative route rather than a fourth step. */
+.kunai-other-paths {
+  margin-top: 2rem;
+  padding-top: 1.75rem;
+  border-top: 1px solid var(--kunai-line);
+}
+
+.kunai-other-paths__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.25rem 0.75rem;
+}
+
+.kunai-other-paths__commands {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.kunai-other-paths__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 1.25rem;
+  margin: 1rem 0 0;
+  font-size: 0.75rem;
+  color: var(--color-fd-muted-foreground);
+}
+
+.kunai-other-paths__links a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.5rem;
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition:
+    color 150ms var(--kunai-ease-out),
+    border-color 150ms var(--kunai-ease-out);
+}
+
+.kunai-other-paths__links a:hover {
+  color: var(--color-fd-foreground);
+  border-bottom-color: color-mix(in oklab, var(--kunai-accent) 50%, transparent);
+}
+
+@media (max-width: 767.98px) {
+  .kunai-other-paths__commands {
+    grid-template-columns: 1fr;
+  }
+
+  .kunai-hero-install__os {
+    width: 5rem;
   }
 }

--- a/apps/docs/app/styles/surfaces.css
+++ b/apps/docs/app/styles/surfaces.css
@@ -67,14 +67,6 @@
   transform: scale(0.96) translateY(0) !important;
 }
 
-.kunai-doc-row {
-  border-radius: var(--kunai-radius-outer);
-  border: 1px solid var(--kunai-line);
-  background: color-mix(in oklab, var(--kunai-surface) 78%, transparent);
-  box-shadow: var(--kunai-shadow-sm);
-  padding: clamp(1.25rem, 3vw, 1.75rem);
-}
-
 .kunai-hero-glow {
   position: absolute;
   inset: 0;

--- a/apps/docs/components/home/hero-proof-row.tsx
+++ b/apps/docs/components/home/hero-proof-row.tsx
@@ -1,0 +1,45 @@
+import { NPM_PACKAGE_NAME, NPM_PACKAGE_URL } from "@/lib/install-commands";
+import { IconExternalLink } from "@tabler/icons-react";
+import Link from "next/link";
+
+type HeroProofRowProps = {
+  readonly cliVersion: string;
+  readonly providerCount: number;
+};
+
+/**
+ * The four facts a visitor needs before they will paste a shell command:
+ * what it costs them, what it runs, how many providers, and where the package
+ * lives. Every value is derived — none is written down twice.
+ */
+export function HeroProofRow({ cliVersion, providerCount }: HeroProofRowProps) {
+  return (
+    <ul className="kunai-proof-row">
+      <li>
+        <Link href="/releases">
+          v<span className="tabular-nums">{cliVersion}</span>
+        </Link>
+      </li>
+      <li>
+        <Link href="/docs/users/providers">
+          <span className="tabular-nums">{providerCount}</span> direct providers
+        </Link>
+      </li>
+      <li>
+        <a href={NPM_PACKAGE_URL} target="_blank" rel="noreferrer noopener">
+          {NPM_PACKAGE_NAME}
+          <IconExternalLink className="ml-1 inline size-3 align-[-0.1em]" stroke={1.5} />
+        </a>
+      </li>
+      <li>
+        <a
+          href="https://github.com/KitsuneKode/kunai/blob/main/LICENSE"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          MIT licensed
+        </a>
+      </li>
+    </ul>
+  );
+}

--- a/apps/docs/components/home/home-hero-static.tsx
+++ b/apps/docs/components/home/home-hero-static.tsx
@@ -1,10 +1,17 @@
+import { HeroProofRow } from "@/components/home/hero-proof-row";
+import { HomeStarCta } from "@/components/home/home-star-cta";
 import { CopyButton } from "@/components/ui/copy-button";
 import { homeHero } from "@/lib/home-content";
 import { CANONICAL_INSTALL, NATIVE_INSTALL_PS1 } from "@/lib/install-commands";
 import { IconArrowRight } from "@tabler/icons-react";
 import Link from "next/link";
 
-export function HomeHeroStatic() {
+type HomeHeroStaticProps = {
+  readonly cliVersion: string;
+  readonly providerCount: number;
+};
+
+export function HomeHeroStatic({ cliVersion, providerCount }: HomeHeroStaticProps) {
   const installCommand = homeHero.installCommands[0] ?? CANONICAL_INSTALL;
 
   return (
@@ -14,26 +21,34 @@ export function HomeHeroStatic() {
       <p className="kunai-type-body text-fd-muted-foreground mt-4 max-w-2xl text-pretty">
         {homeHero.description}
       </p>
-      <div className="mt-6 flex flex-col gap-3">
-        <div className="flex flex-wrap items-center gap-4">
-          <code className="kunai-code-row">
-            <span>{installCommand}</span>
-            <CopyButton text={installCommand} label="hero-install" />
-          </code>
-          <Link className="kunai-button kunai-button-primary" href={homeHero.primaryCta.href}>
-            <span>{homeHero.primaryCta.label}</span>
-            <IconArrowRight className="ml-1.5 size-4" stroke={1.5} />
-          </Link>
-          <Link className="kunai-button border-fd-border" href={homeHero.secondaryCta.href}>
-            {homeHero.secondaryCta.label}
-          </Link>
-        </div>
-        <code className="kunai-code-row max-w-fit">
-          <span className="text-fd-muted-foreground mr-2 text-xs">Windows</span>
-          <span>{NATIVE_INSTALL_PS1}</span>
+
+      {/* Both platforms sit together: one install decision, made once. The
+          Windows row used to sit below the CTAs, orphaned from its peer. */}
+      <div className="kunai-hero-install mt-7">
+        <code className="kunai-code-row">
+          <span className="kunai-hero-install__os">Linux / macOS</span>
+          <span className="kunai-hero-install__cmd">{installCommand}</span>
+          <CopyButton text={installCommand} label="hero-install" />
+        </code>
+        <code className="kunai-code-row">
+          <span className="kunai-hero-install__os">Windows</span>
+          <span className="kunai-hero-install__cmd">{NATIVE_INSTALL_PS1}</span>
           <CopyButton text={NATIVE_INSTALL_PS1} label="hero-install-windows" />
         </code>
       </div>
+
+      <div className="mt-6 flex flex-wrap items-center gap-3">
+        <Link className="kunai-button kunai-button-primary" href={homeHero.primaryCta.href}>
+          <span>{homeHero.primaryCta.label}</span>
+          <IconArrowRight className="ml-1.5 size-4" stroke={1.5} />
+        </Link>
+        <Link className="kunai-button border-fd-border" href={homeHero.secondaryCta.href}>
+          {homeHero.secondaryCta.label}
+        </Link>
+        <HomeStarCta />
+      </div>
+
+      <HeroProofRow cliVersion={cliVersion} providerCount={providerCount} />
     </section>
   );
 }

--- a/apps/docs/components/home/other-install-paths.tsx
+++ b/apps/docs/components/home/other-install-paths.tsx
@@ -1,0 +1,49 @@
+import { CopyButton } from "@/components/ui/copy-button";
+import {
+  BUN_GLOBAL_INSTALL,
+  GITHUB_RELEASES_URL,
+  NPM_GLOBAL_INSTALL,
+  NPM_PACKAGE_URL,
+} from "@/lib/install-commands";
+import { IconExternalLink } from "@tabler/icons-react";
+import Link from "next/link";
+
+/**
+ * Secondary install paths, deliberately below the three-step native flow.
+ * The package-manager route needs a Node or Bun runtime already present and
+ * tracks the npm dist-tag rather than the binary channel, so it is offered as
+ * an alternative — never as an equal.
+ */
+export function OtherInstallPaths() {
+  return (
+    <div className="kunai-other-paths">
+      <div className="kunai-other-paths__head">
+        <p className="kunai-step-label m-0">Other install paths</p>
+        <p className="kunai-step-meta m-0">Already have Bun or Node? Install from npm instead.</p>
+      </div>
+
+      <div className="kunai-other-paths__commands">
+        <code className="kunai-code-row">
+          <span>{BUN_GLOBAL_INSTALL}</span>
+          <CopyButton text={BUN_GLOBAL_INSTALL} label="bun-global-install" />
+        </code>
+        <code className="kunai-code-row">
+          <span>{NPM_GLOBAL_INSTALL}</span>
+          <CopyButton text={NPM_GLOBAL_INSTALL} label="npm-global-install" />
+        </code>
+      </div>
+
+      <p className="kunai-other-paths__links">
+        <a href={NPM_PACKAGE_URL} target="_blank" rel="noreferrer noopener">
+          npm package
+          <IconExternalLink className="ml-1 inline size-3 align-[-0.1em]" stroke={1.5} />
+        </a>
+        <a href={GITHUB_RELEASES_URL} target="_blank" rel="noreferrer noopener">
+          Prebuilt binaries
+          <IconExternalLink className="ml-1 inline size-3 align-[-0.1em]" stroke={1.5} />
+        </a>
+        <Link href="/docs/users/getting-started">Build from source</Link>
+      </p>
+    </div>
+  );
+}

--- a/apps/docs/components/home/terminal-simulator.tsx
+++ b/apps/docs/components/home/terminal-simulator.tsx
@@ -1,14 +1,8 @@
 "use client";
 
 import { commandsForPalette } from "@/lib/home-presenters";
-import {
-  motion,
-  AnimatePresence,
-  useMotionValue,
-  useMotionTemplate,
-  useSpring,
-} from "motion/react";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 
 import type { HomeCommandMetadata, HomeLogEntry, HomeProviderMetadata } from "./types";
 
@@ -31,9 +25,9 @@ const TerminalSimulator = memo(function TerminalSimulator({
     { id: "welcome-1", text: `▌ Kunai Shell v${cliVersion}` },
     {
       id: "welcome-2",
-      text: `System verified. Dependencies: mpv ${runtimeBaseline.mpv}, bun ${runtimeBaseline.bun}`,
+      text: `Requires mpv ${runtimeBaseline.mpv}. The binary install embeds bun ${runtimeBaseline.bun}.`,
     },
-    { id: "welcome-3", text: "Ready. Type '/' or click a preset below to try." },
+    { id: "welcome-3", text: "Simulated shell. Type '/' or pick a command below to try one." },
   ]);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
@@ -46,29 +40,10 @@ const TerminalSimulator = memo(function TerminalSimulator({
   const paletteInputRef = useRef<HTMLInputElement>(null);
   const terminalStageRef = useRef<HTMLDivElement>(null);
 
-  const rotateXValue = useMotionValue(0);
-  const rotateYValue = useMotionValue(0);
-  const glareX = useMotionValue(50);
-  const glareY = useMotionValue(50);
-  const rotateX = useSpring(rotateXValue, { stiffness: 350, damping: 28 });
-  const rotateY = useSpring(rotateYValue, { stiffness: 350, damping: 28 });
-  const glareBackground = useMotionTemplate`radial-gradient(350px circle at ${glareX}% ${glareY}%, var(--kunai-mesh-a), transparent 80%)`;
-
   const filteredCommands = useMemo(
     () => commandsForPalette(paletteCommands, allCommands, searchQuery),
     [allCommands, paletteCommands, searchQuery],
   );
-
-  const handleMouseMove = useCallback((_e: React.MouseEvent<HTMLDivElement>) => {
-    // Keep the terminal calm — no 3D tilt on the docs home.
-  }, []);
-
-  const handleMouseLeave = useCallback(() => {
-    rotateXValue.set(0);
-    rotateYValue.set(0);
-    glareX.set(50);
-    glareY.set(50);
-  }, [glareX, glareY, rotateXValue, rotateYValue]);
 
   useEffect(() => {
     if (terminalBodyRef.current) {
@@ -311,34 +286,24 @@ const TerminalSimulator = memo(function TerminalSimulator({
   };
 
   return (
-    <div className="relative flex w-full items-center justify-center" style={{ perspective: 1200 }}>
+    <div className="relative flex w-full items-center justify-center">
       <div className="kunai-hero-glow" aria-hidden="true" />
 
-      <motion.aside
+      <aside
         ref={terminalStageRef}
-        onMouseMove={handleMouseMove}
-        onMouseLeave={handleMouseLeave}
-        className={`kunai-terminal-stage group relative w-full overflow-hidden select-none ${
+        className={`kunai-terminal-stage relative w-full overflow-hidden ${
           commandPaletteOpen ? "is-focused" : ""
         }`}
-        style={{ transformStyle: "preserve-3d", rotateX, rotateY }}
         aria-label="Kunai terminal preview"
       >
-        <motion.div
-          className="pointer-events-none absolute inset-0 -z-10 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
-          style={{ background: glareBackground }}
-        />
-
         <div className="kunai-terminal-top">
           <span className="text-fd-muted-foreground flex items-center gap-1.5 text-xs">
             <span className="kunai-status-dot kunai-status-dot--focus" />
             kunai shell
           </span>
           <span className="kunai-terminal-badges">
-            <span className="kunai-text-accent text-[10px] font-semibold tracking-wide">
-              cli active
-            </span>
-            <span className="kunai-step-meta">mpv verified</span>
+            <span className="kunai-step-meta tabular-nums">v{cliVersion}</span>
+            <span className="kunai-step-meta">simulated</span>
           </span>
         </div>
 
@@ -376,7 +341,7 @@ const TerminalSimulator = memo(function TerminalSimulator({
                 initial={{ opacity: 0, y: 10, scale: 0.98 }}
                 animate={{ opacity: 1, y: 0, scale: 1 }}
                 exit={{ opacity: 0, y: 10, scale: 0.98 }}
-                transition={{ type: "spring", duration: 0.3, bounce: 0.1 }}
+                transition={{ type: "spring", duration: 0.3, bounce: 0 }}
                 className="kunai-command-palette"
                 onClick={(e) => e.stopPropagation()}
                 role="presentation"
@@ -427,7 +392,8 @@ const TerminalSimulator = memo(function TerminalSimulator({
           </AnimatePresence>
         </div>
 
-        <div className="mt-4 flex flex-wrap justify-center gap-1.5">
+        <div className="kunai-terminal-presets mt-4">
+          <span className="kunai-step-meta shrink-0">Try one</span>
           {["/search Dune", "/discover", "/calendar", "/setup"].map((cmd) => (
             <button
               type="button"
@@ -439,7 +405,7 @@ const TerminalSimulator = memo(function TerminalSimulator({
             </button>
           ))}
         </div>
-      </motion.aside>
+      </aside>
     </div>
   );
 });

--- a/apps/docs/components/layout/docs-sidebar-banner.tsx
+++ b/apps/docs/components/layout/docs-sidebar-banner.tsx
@@ -34,14 +34,28 @@ export function DocsSidebarBanner() {
           </>
         ) : null}
       </p>
+      {/* Each count links to the page that actually lists it — a number with
+          nowhere to go is the reason this block read as decoration. */}
       <p className="text-fd-muted-foreground m-0 text-xs tabular-nums">
-        {codeMetadata.providerIds.length} providers · {codeMetadata.commandCount} shell commands
+        <Link
+          className="hover:text-fd-foreground underline-offset-4 hover:underline"
+          href="/docs/users/providers"
+        >
+          {codeMetadata.providerIds.length} providers
+        </Link>
+        {" · "}
+        <Link
+          className="hover:text-fd-foreground underline-offset-4 hover:underline"
+          href="/docs/users/commands-and-shortcuts#every-shell-command"
+        >
+          {codeMetadata.commandCount} shell commands
+        </Link>
       </p>
       <Link
         href="/docs/users/cli-reference"
         className="text-fd-primary inline-flex min-h-8 items-center text-xs font-medium transition-[color,transform] duration-150 ease-[var(--ease-out)] hover:underline active:scale-[0.96]"
       >
-        Open CLI reference →
+        Launch flags reference →
       </Link>
     </div>
   );

--- a/apps/docs/components/ui/badge.tsx
+++ b/apps/docs/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
 
 const badgeVariants = cva(
-  "group/badge focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-md border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap tabular-nums transition-all focus-visible:ring-[3px] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  "group/badge focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-md border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap tabular-nums transition-[color,background-color,border-color,box-shadow] duration-150 ease-[var(--kunai-ease-out)] focus-visible:ring-[3px] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:pointer-events-none [&>svg]:size-3!",
   {
     variants: {
       variant: {

--- a/apps/docs/components/ui/button.tsx
+++ b/apps/docs/components/ui/button.tsx
@@ -3,7 +3,7 @@ import { Button as ButtonPrimitive } from "@base-ui/react/button";
 import { cva, type VariantProps } from "class-variance-authority";
 
 const buttonVariants = cva(
-  "group/button focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:ring-3 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-[color,background-color,border-color,box-shadow,opacity,translate] duration-150 ease-[var(--kunai-ease-out)] outline-none select-none focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:ring-3 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,10 +1,10 @@
 {
-  "syncedAt": "2026-08-23T07:50:23.368Z",
+  "syncedAt": "2026-08-23T08:29:36.888Z",
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceRevision": "46253bda",
+  "cliSourceRevision": "d3c59c1d",
   "cliSourceFingerprint": "28321811cdfc56fbb55fd3849b6c8aff87dae6208beea87da9cc49d4b8cf8ac6",
-  "docsContentFingerprint": "699f74554ab65bfee06144cd8445e3053d7353e0c06bb40fb2c908de21dddcfb",
+  "docsContentFingerprint": "f39d179cd1f2d24374cf2784cb483f24c21ad2ec11bf56edd48317b0b0324e6a",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 81,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,10 +1,10 @@
 {
-  "syncedAt": "2026-08-23T08:29:36.888Z",
+  "syncedAt": "2026-08-23T08:29:46.851Z",
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceRevision": "d3c59c1d",
+  "cliSourceRevision": "7f3e69e1",
   "cliSourceFingerprint": "28321811cdfc56fbb55fd3849b6c8aff87dae6208beea87da9cc49d4b8cf8ac6",
-  "docsContentFingerprint": "f39d179cd1f2d24374cf2784cb483f24c21ad2ec11bf56edd48317b0b0324e6a",
+  "docsContentFingerprint": "e202d1ecebad2feafa8ffa8006a86eb31305ab0e0fbcbd06818c7e69ac9d5fba",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 81,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/apps/docs/lib/home-content.ts
+++ b/apps/docs/lib/home-content.ts
@@ -17,7 +17,6 @@ export type HomeSection = {
 export type HomeFlowStep = {
   readonly title: string;
   readonly description: string;
-  readonly state: "focus" | "ready" | "warn" | "danger" | "quiet";
 };
 
 export const homeHero = {
@@ -60,19 +59,16 @@ export const homeFlow: readonly HomeFlowStep[] = [
     title: "Search or continue",
     description:
       "Find a title, resume history, or open calendar, recommendations, or your offline library from the shell.",
-    state: "focus",
   },
   {
     title: "Resolve locally",
     description:
       "Kunai asks registered adapters for a stream URL they already serve, then hands that URL to mpv.",
-    state: "warn",
   },
   {
     title: "Play in mpv",
     description:
       "The shell supervises playback, resume offers, auto-skip, and post-play routing when the session ends or stalls.",
-    state: "ready",
   },
 ] as const;
 

--- a/apps/docs/lib/install-commands.ts
+++ b/apps/docs/lib/install-commands.ts
@@ -10,8 +10,12 @@ export const NATIVE_INSTALL_SH =
 export const NATIVE_INSTALL_PS1 =
   "irm https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.ps1 | iex" as const;
 
-export const BUN_GLOBAL_INSTALL = "bun install -g @kitsunekode/kunai" as const;
-export const NPM_GLOBAL_INSTALL = "npm install -g @kitsunekode/kunai" as const;
+export const NPM_PACKAGE_NAME = "@kitsunekode/kunai" as const;
+export const NPM_PACKAGE_URL = `https://www.npmjs.com/package/${NPM_PACKAGE_NAME}` as const;
+export const GITHUB_RELEASES_URL = "https://github.com/KitsuneKode/kunai/releases/latest" as const;
+
+export const BUN_GLOBAL_INSTALL = `bun install -g ${NPM_PACKAGE_NAME}` as const;
+export const NPM_GLOBAL_INSTALL = `npm install -g ${NPM_PACKAGE_NAME}` as const;
 
 /** Preferred public install command for 0.3.0 (native binary bootstrap). */
 export const PREFERRED_INSTALL = NATIVE_INSTALL_SH;

--- a/apps/docs/lib/page-metadata.ts
+++ b/apps/docs/lib/page-metadata.ts
@@ -1,0 +1,75 @@
+import { docsCanonicalUrl } from "@/lib/site";
+import type { Metadata } from "next";
+
+/**
+ * Social card image for every page.
+ *
+ * Next only merges the file-convention `app/opengraph-image.tsx` into a
+ * segment that does not declare `openGraph` itself. Every page here declares
+ * one, so the generated card was silently dropped from all of them and links
+ * shared to Slack, X, and Discord rendered as bare text. Declaring the image
+ * explicitly is the deterministic fix; `metadataBase` in the root layout makes
+ * this relative URL absolute in the rendered tag.
+ */
+export const SOCIAL_IMAGE = {
+  url: "/opengraph-image",
+  width: 1200,
+  height: 630,
+  alt: "Kunai — a terminal client for third-party streams",
+} as const;
+
+/** SERP descriptions get the full 150–160; social cards truncate near 125. */
+const SOCIAL_DESCRIPTION_LIMIT = 125;
+
+type PageMetadataInput = {
+  readonly title: string;
+  /** Long form, for the SERP snippet. */
+  readonly description: string;
+  /** Short form, for social cards. Falls back to `description` when it fits. */
+  readonly socialDescription?: string;
+  /** Site-relative path, e.g. `/releases`. */
+  readonly path: string;
+  readonly type?: "website" | "article";
+  /** Title shown in the tab and SERP when it should not take the site suffix. */
+  readonly absoluteTitle?: boolean;
+};
+
+function socialDescriptionFor(input: PageMetadataInput): string {
+  const explicit = input.socialDescription?.trim();
+  if (explicit) return explicit;
+  if (input.description.length <= SOCIAL_DESCRIPTION_LIMIT) return input.description;
+  // Trim on a word boundary rather than mid-word, and drop trailing punctuation
+  // so the ellipsis does not follow a comma.
+  const clipped = input.description.slice(0, SOCIAL_DESCRIPTION_LIMIT - 1);
+  const lastSpace = clipped.lastIndexOf(" ");
+  return `${(lastSpace > 0 ? clipped.slice(0, lastSpace) : clipped).replace(/[,;:.\s]+$/, "")}…`;
+}
+
+/**
+ * One metadata shape for every page: canonical, Open Graph, and Twitter with a
+ * card image. Pages pass their own copy; nothing about the card is restated.
+ */
+export function buildPageMetadata(input: PageMetadataInput): Metadata {
+  const url = docsCanonicalUrl(input.path);
+  const socialDescription = socialDescriptionFor(input);
+
+  return {
+    title: input.absoluteTitle ? { absolute: input.title } : input.title,
+    description: input.description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: input.title,
+      description: socialDescription,
+      url,
+      type: input.type ?? "website",
+      siteName: "Kunai Docs",
+      images: [SOCIAL_IMAGE],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: input.title,
+      description: socialDescription,
+      images: [SOCIAL_IMAGE],
+    },
+  };
+}

--- a/apps/docs/test/home-shell.test.ts
+++ b/apps/docs/test/home-shell.test.ts
@@ -5,6 +5,11 @@ import path from "node:path";
 import { codeMetadata } from "../lib/code-metadata";
 import { homeFlow, homeHero, homeStartCards } from "../lib/home-content";
 import { featuredCommands } from "../lib/home-presenters";
+import {
+  BUN_GLOBAL_INSTALL,
+  NATIVE_INSTALL_PS1,
+  NPM_GLOBAL_INSTALL,
+} from "../lib/install-commands";
 
 const DOCS_APP_ROOT = path.resolve(import.meta.dir, "..");
 
@@ -30,8 +35,12 @@ describe("docs home shell", () => {
     expect(h1Count).toBe(1);
     expect(hero).toContain("CANONICAL_INSTALL");
     expect(hero).toContain("NATIVE_INSTALL_PS1");
-    expect(readSource("lib/install-commands.ts")).toContain("bun install -g @kitsunekode/kunai");
-    expect(readSource("lib/install-commands.ts")).toContain("NATIVE_INSTALL_PS1");
+    // Assert the resolved values, not the source text: these constants are
+    // composed from NPM_PACKAGE_NAME, so a text match tests the spelling of the
+    // implementation rather than the command a visitor actually copies.
+    expect(BUN_GLOBAL_INSTALL).toBe("bun install -g @kitsunekode/kunai");
+    expect(NPM_GLOBAL_INSTALL).toBe("npm install -g @kitsunekode/kunai");
+    expect(NATIVE_INSTALL_PS1).toContain("install.ps1");
   });
 
   test("terminal simulator does not duplicate hero markup", () => {

--- a/apps/docs/test/seo.test.ts
+++ b/apps/docs/test/seo.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { codeMetadata } from "../lib/code-metadata";
+import { BUN_GLOBAL_INSTALL } from "../lib/install-commands";
 import { source } from "../lib/source";
 
 const DOCS_APP_ROOT = path.resolve(import.meta.dir, "..");
@@ -115,8 +116,7 @@ describe("docs SEO drift", () => {
     );
     expect(shell).toContain("<h1");
     expect(shell).toContain("CANONICAL_INSTALL");
-    const install = fs.readFileSync(path.join(DOCS_APP_ROOT, "lib/install-commands.ts"), "utf-8");
-    expect(install).toContain("bun install -g @kitsunekode/kunai");
+    expect(BUN_GLOBAL_INSTALL).toBe("bun install -g @kitsunekode/kunai");
   });
 
   test("glossary is registered in users meta.json", () => {

--- a/docs/developer/contribute.mdx
+++ b/docs/developer/contribute.mdx
@@ -1,6 +1,6 @@
 ---
 title: Contribute
-description: Fork Kunai, run tests, opt into live provider smokes, and open PRs with evidence.
+description: Fork Kunai, run the test suite, opt into live provider smokes responsibly, and open a pull request with the evidence reviewers need to act on it quickly.
 status: shipped
 ---
 

--- a/docs/developer/debugging-workflow.mdx
+++ b/docs/developer/debugging-workflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Debugging Workflow
-description: Developer workflow for traces, diagnostics, provider failures, playback bugs, and storage issues.
+description: "The evidence-first workflow for Kunai bugs: capture traces and diagnostics, isolate a provider failure from a playback failure, and reduce it to a repro."
 ---
 
 Kunai debugging should be evidence-first. Prefer diagnostics, structured traces, and focused live smokes over ad hoc `console.log` output in the Ink UI.

--- a/docs/developer/docs-maintenance.mdx
+++ b/docs/developer/docs-maintenance.mdx
@@ -1,6 +1,6 @@
 ---
 title: Docs Maintenance
-description: How to add, structure, verify, and release Kunai documentation.
+description: How to add, structure, and verify Kunai documentation, keep generated tables in sync with the CLI, and ship doc changes alongside the release they describe.
 ---
 
 The docs website lives in `apps/docs` and uses Next.js, Fumadocs, MDX, and Tailwind CSS. User and developer content lives in the repository-level `docs/` folder so it can serve both the website and source readers.

--- a/docs/developer/index.mdx
+++ b/docs/developer/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Developer
-description: Debug Kunai with evidence, run live provider checks responsibly, and keep documentation aligned with the CLI.
+description: "Debug Kunai with evidence rather than guesswork: traces and diagnostics, responsible live provider checks, and the release steps that keep docs honest."
 ---
 
 <DocsHubIntro

--- a/docs/developer/release-checklist.mdx
+++ b/docs/developer/release-checklist.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release Checklist
-description: Steps to ship a Kunai CLI release with matching documentation metadata and release artifacts.
+description: "Every step to ship a Kunai CLI release: version and artifact checks, generated docs metadata, reliability gates, and the publish order that keeps them aligned."
 ---
 
 Use this checklist when cutting a CLI release. Docs build stays separate from the binary, but reference tables should match the shipped CLI.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Documentation
-description: Install Kunai, learn the terminal shell, recover playback, and contribute with evidence-first debugging.
+description: Install Kunai, learn the terminal shell, resolve third-party streams and hand them to mpv, recover when playback stalls, and debug with evidence-first tools.
 ---
 
 Kunai is a terminal-first client: search a title, resolve a URL a third-party provider already serves, hand it to mpv, and recover when catalogs drift. It does not host, upload, mirror, seed, or distribute video content. This documentation states what works today, what is beta-only, and how to debug with evidence.

--- a/docs/users/cli-reference.mdx
+++ b/docs/users/cli-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: CLI reference
-description: Launch flags, bootstrap flows, and mpv options synced from the Kunai CLI help text.
+description: Every Kunai launch flag, bootstrap flow, and mpv option, synced directly from the CLI help text so the table never drifts from the binary you actually run.
 ---
 
 <ScopeCallout variant="beta" />

--- a/docs/users/commands-and-shortcuts.mdx
+++ b/docs/users/commands-and-shortcuts.mdx
@@ -69,6 +69,13 @@ Help, diagnostics, settings, notifications, history, downloads, and provider
 pickers are overlays. They should not destroy the underlying playback or browse
 context. Close the overlay to return where you were.
 
+## Every shell command
+
+The full command registry, searchable. Generated from the CLI — it updates when
+you run `bun run --cwd apps/docs generate`.
+
+<CommandReference />
+
 ## Stable Hotkeys
 
 <ShortcutTable />

--- a/docs/users/commands-and-shortcuts.mdx
+++ b/docs/users/commands-and-shortcuts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Commands And Shortcuts
-description: Shell commands, playback shortcuts, overlays, and safe actions available across Kunai.
+description: Every Kunai shell command, playback shortcut, overlay, and safe action, plus the full searchable command registry generated straight from the CLI itself.
 ---
 
 Kunai keeps the command palette context-aware. Press `/` in the shell to open the

--- a/docs/users/continue-watching-and-new-episodes.mdx
+++ b/docs/users/continue-watching-and-new-episodes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Continue Watching And New Episodes
-description: Understand history reconciliation, new episode signals, notifications, and cached schedule data.
+description: How Kunai reconciles watch history, decides what counts as a new episode, raises notifications, and keeps your continue-watching list accurate over time.
 ---
 
 Kunai uses local watch history as the source of truth for Continue Watching. It

--- a/docs/users/customization.mdx
+++ b/docs/users/customization.mdx
@@ -1,6 +1,6 @@
 ---
 title: Customization
-description: Configure Kunai through config.json, provider overrides, mpv forwarding, shell density, and Discord presence.
+description: "Configure Kunai through config.json and provider overrides: mpv forwarding, download paths, posters, keybindings, and the settings that survive an upgrade."
 status: shipped
 ---
 

--- a/docs/users/diagnostics-and-reporting.mdx
+++ b/docs/users/diagnostics-and-reporting.mdx
@@ -1,6 +1,6 @@
 ---
 title: Diagnostics And Reporting
-description: Use diagnostics, support bundles, traces, and issue reports without leaking private data.
+description: Use Kunai diagnostics, support bundles, and traces to report a problem precisely, without leaking titles, queries, or anything else from your local machine.
 status: shipped
 ---
 

--- a/docs/users/downloads-and-offline.md
+++ b/docs/users/downloads-and-offline.md
@@ -1,6 +1,6 @@
 ---
 title: Downloads And Offline
-description: Manage download queues, local playback, cleanup, and offline diagnostics safely.
+description: Queue Kunai downloads, play local files, manage the offline library, clean up finished jobs, and diagnose a download that stalled or failed to resume.
 status: beta
 ---
 

--- a/docs/users/feature-tour.mdx
+++ b/docs/users/feature-tour.mdx
@@ -1,6 +1,6 @@
 ---
 title: Feature Tour
-description: Every Kunai capability — what works, what is experimental, and what the shell can do.
+description: "Every Kunai capability in one place: what is shipped, what is experimental, and what is explicitly out of scope, with the shell commands that reach each one."
 ---
 
 Kunai is a terminal-first media shell. It resolves media streams from third-party

--- a/docs/users/feature-tour.mdx
+++ b/docs/users/feature-tour.mdx
@@ -44,10 +44,9 @@ Common launch patterns. For the full flag list synced from `kunai --help`, see
 
 ## Shell commands
 
-Press `/` to open the context-aware command palette. The table below is generated
-from the CLI command registry — it updates when you run `bun run --cwd apps/docs generate`.
-
-<CommandReference />
+Press `/` to open the context-aware command palette. The complete, searchable
+table of every registered shell command lives on
+[Commands and shortcuts](/docs/users/commands-and-shortcuts#every-shell-command).
 
 ## Active providers
 

--- a/docs/users/getting-started.mdx
+++ b/docs/users/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: Install Kunai, put it on PATH, install mpv, and complete a first playback session.
+description: Install Kunai, put it on your PATH, install mpv, run setup, and complete a first playback session end to end — with the exact commands for your platform.
 ---
 
 Kunai is a terminal-first media shell. You search for a title, pick what to watch, Kunai resolves a direct-provider stream on your machine, and hands playback to `mpv`. The shell stays alive so you can recover, continue, or pick something else without restarting.

--- a/docs/users/glossary.mdx
+++ b/docs/users/glossary.mdx
@@ -1,6 +1,6 @@
 ---
 title: Glossary
-description: Commands, CLI flags, and feature terms synced from the Kunai CLI.
+description: Kunai commands, CLI flags, and feature terms defined in one place and synced from the CLI, so the vocabulary in the docs matches the vocabulary in the shell.
 status: shipped
 ---
 

--- a/docs/users/index.mdx
+++ b/docs/users/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Install Kunai, operate the shell, recover streams, manage offline media, and understand privacy boundaries.
+description: Install Kunai, operate the terminal shell, resolve third-party streams, recover when playback stalls, manage offline media, and configure it to your setup.
 ---
 
 <DocsHubIntro

--- a/docs/users/install-and-update.mdx
+++ b/docs/users/install-and-update.mdx
@@ -1,6 +1,6 @@
 ---
 title: Install And Update
-description: Install Kunai across platforms and keep source, global, and packaged installs current.
+description: Install Kunai on Linux, macOS, or Windows via the native binary or npm, then keep it current — with upgrade, rollback, and uninstall behaviour explained.
 ---
 
 Kunai supports **zero-prerequisite compiled binaries** (default), global package installs, installer scripts, and source checkouts. Packaged binaries embed the Bun runtime — you do not need Bun installed to run them. The npm channel is a Node launcher that spawns a platform binary (no Bun). `bun install -g` and source checkouts still need Bun.

--- a/docs/users/media-selection.mdx
+++ b/docs/users/media-selection.mdx
@@ -1,6 +1,6 @@
 ---
 title: Media Selection
-description: How Kunai picks providers, sources, streams, audio, subtitles, and quality.
+description: How Kunai picks a provider, source, and stream, then chooses quality, audio track, and subtitles — and how to override each decision from the shell.
 status: shipped
 ---
 

--- a/docs/users/platforms.mdx
+++ b/docs/users/platforms.mdx
@@ -1,6 +1,6 @@
 ---
 title: Platforms
-description: Platform-specific install, playback, opening, protocol, and troubleshooting notes.
+description: "Platform-specific notes for Kunai on Linux, macOS, and Windows: install, playback, poster support, protocol handlers, and the troubleshooting each one needs."
 ---
 
 Kunai is terminal-first. Playback uses `mpv`; optional downloads use `yt-dlp`; `ffprobe` can validate completed artifacts when available. Poster previews need nothing installed: Kitty graphics on Kitty/Ghostty, iTerm2 inline images on iTerm2 and VSCode 1.80+, sixel where the terminal reports it, and a built-in half-block fallback everywhere else.

--- a/docs/users/playback-and-recovery.mdx
+++ b/docs/users/playback-and-recovery.mdx
@@ -1,6 +1,6 @@
 ---
 title: Playback And Recovery
-description: Recover, replay, resume, fallback, and keep playback state predictable.
+description: Recover, recompute, replay, resume, and fall back — the five ways Kunai handles a stalled stream, and which one to reach for when playback stops behaving.
 status: shipped
 ---
 

--- a/docs/users/providers.mdx
+++ b/docs/users/providers.mdx
@@ -1,6 +1,6 @@
 ---
 title: Providers
-description: How Kunai chooses providers, retries, recovers, and falls back — without scraper internals.
+description: How Kunai chooses among third-party adapters, retries, recovers, and falls back when one fails — plus the live status table for every registered provider.
 status: shipped
 ---
 

--- a/docs/users/reliability-and-privacy.mdx
+++ b/docs/users/reliability-and-privacy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Reliability And Privacy
-description: How Kunai protects user data, limits provider traffic, and keeps failures diagnosable.
+description: What Kunai stores locally, what it never sends, how it limits third-party traffic, and how diagnostics stay redacted by default when you report a failure.
 ---
 
 Kunai is designed to keep playback useful when providers, networks, Discord, or

--- a/docs/users/runtime-feedback.mdx
+++ b/docs/users/runtime-feedback.mdx
@@ -1,6 +1,6 @@
 ---
 title: Runtime Feedback
-description: How to read Kunai's playback health, memory, network, and diagnostics signals.
+description: Read Kunai's live playback health, memory, and network panels, and understand what each diagnostic signal is telling you while a session is still running.
 ---
 
 Kunai keeps normal playback calm, then exposes runtime feedback when it helps you understand a slow provider, a buffering stream, or a possible memory issue.

--- a/docs/users/share-links.mdx
+++ b/docs/users/share-links.mdx
@@ -1,6 +1,6 @@
 ---
 title: Share Links
-description: Copy and open catalog-anchored kunai:// links across machines, providers, and playback surfaces.
+description: "Copy and open catalog-anchored kunai:// links across machines and providers, and understand the confirmation Kunai requires before a shared link plays."
 status: shipped
 ---
 

--- a/docs/users/supported-and-unsupported.mdx
+++ b/docs/users/supported-and-unsupported.mdx
@@ -1,6 +1,6 @@
 ---
 title: Supported and unsupported
-description: What Kunai supports in beta, what is experimental, and what is explicitly out of scope.
+description: What Kunai supports during beta, what is experimental and may change, and what is explicitly unsupported — so you know what to rely on before you install.
 status: shipped
 ---
 

--- a/docs/users/troubleshooting.mdx
+++ b/docs/users/troubleshooting.mdx
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting
-description: Symptom index for provider failures, playback crashes, network issues, offline library problems, and missing mpv.
+description: "A symptom-first index for Kunai: provider failures, playback crashes, network problems, setup errors, and poster issues, each with concrete fix steps."
 status: shipped
 ---
 

--- a/docs/users/what-you-can-do.mdx
+++ b/docs/users/what-you-can-do.mdx
@@ -1,6 +1,6 @@
 ---
 title: What You Can Do
-description: A capability map of Kunai — search, play, recover, continue, discover, offline, and diagnostics.
+description: "A capability map of Kunai: search, play, recover, continue watching, discover, download for offline, share links, and diagnose — with the command for each."
 status: shipped
 ---
 


### PR DESCRIPTION
## Why

The docs home asserted things it had not checked, and offered no install route for anyone who already has a runtime. This makes every claim on it verifiable, gives the install section its missing second path, and deletes the parts that were purely decorative.

Rebased onto `main` after finding that the star CTA (`lib/github-stars.ts`, `HomeStarCta`, `GithubStarCta`) had already landed in #78 — **this PR adds no competing star implementation**. It wires main's `HomeStarCta` into the hero, which previously only had it in the final CTA.

## Install paths

- **npm/bun globals are now on the site.** They existed as unused constants; there was no route for a visitor who already has Bun or Node. Added as an explicitly *secondary* block below the three native steps — they need a runtime the binary path doesn't and track the npm dist-tag rather than the binary channel, so they're an alternative, never a peer. Links out to the npm package, prebuilt binaries, and build-from-source.
- **Hero install commands are paired.** The Windows row used to sit *below* the CTA buttons, orphaned from the Linux/macOS row it belongs with. Both now stack together above the CTAs, with the OS label in a fixed column so the commands align on character one.
- **Hero proof row**: version, provider count, npm package, MIT — each one a link to where it can be checked.

## Claims that checked nothing

| Before | After |
| --- | --- |
| Install step 01: green check + "Prerequisites" | Badge removed; step is "Install mpv" |
| Terminal: `System verified. Dependencies: …` | `Requires mpv 0.38+. The binary install embeds bun …` |
| Terminal badges: `cli active` / `mpv verified` | `v0.3.0` · `simulated` |

## Decoration with no effect

- **Terminal dead machinery stripped**: a per-frame `mousemove` handler with an empty body, two `useSpring`s, four `useMotionValue`s, a glare `useMotionTemplate`, and the `perspective`/`preserve-3d` context — all for a tilt whose own comment says it was removed. Also dropped `select-none`: a terminal you cannot copy from is broken as a demo.
- **`HomeFlowStep.state` removed.** Every value had collapsed to the same one, and `"warn"` painted a healthy middle step amber. Three sequence stages are not three health states.
- **474 lines of CSS deleted** for classes no component renders (`.kunai-proof*`, `.kunai-doc-row/-card`, `.provider-interactive-tab`, `.flag-*`, `.chip-tag*`, `.grain-overlay`, `.ambient-glow-bottom`, `.hero-install-box`, `@keyframes float-y`/`pulse-glow`, `.kunai-state-*`), plus a stale `will-change` for a transform that no longer exists.

## Routing

- The searchable 81-command table lived inside **Feature tour**; the page named for commands didn't have it. Moved to `commands-and-shortcuts#every-shell-command`.
- The sidebar's `N providers · N shell commands` was inert text, and "Open CLI reference →" pointed at the **launch-flags** page rather than the commands the number counts. Each count now links to the page listing it; the link is relabelled "Launch flags reference →".

## Interaction

- Install OS tabs declared `role="tablist"` without the keyboard behaviour it promises. Added roving `tabIndex`, arrow-key navigation, `aria-controls`, and a real `role="tabpanel"`.
- Replaced `transition-all` in `button.tsx` / `badge.tsx` with explicit property lists.
- Palette spring `bounce: 0.1` → `0`.

## Test change worth a look

`home-shell.test.ts` and `seo.test.ts` asserted `install-commands.ts` **source text** contained `"bun install -g @kitsunekode/kunai"`. Composing that constant from `NPM_PACKAGE_NAME` broke both while the value stayed byte-identical. They now assert the resolved command a visitor actually copies.

## Verification

`typecheck` · `lint` · `fmt:check` · docs tests (79 pass) · repo tests · `next build` (43 static pages) · `verify:doc-paths` / `doc-coverage` / `doc-frontmatter` — all pass.

Also served the production build and asserted against real HTML: both hero OS labels present, both npm/bun commands present, `role="tab"` roving tabindex + `role="tabpanel"` wired, `#every-shell-command` anchor resolves with the filter table. `mpv verified` / `cli active` / `prereq-badge` / `kunai-state-` / `System verified` → **0 occurrences**.

**Not verified:** no browser render — Chrome tooling wasn't available in the session. The two things worth a reviewer's eyes are the hero's new two-row install block around 1000px width, and the CTA row now carrying three controls (Get started / Browse docs / Star).

https://claude.ai/code/session_01YEA1uyUEayxS9MYW5jzDcb