### PR TITLE
docs: correct the 0.3.0 privacy payload, macOS signing, and PATH behaviour

### DIFF
--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,10 +1,10 @@
 {
-  "syncedAt": "2026-08-22T05:14:20.206Z",
+  "syncedAt": "2026-08-23T07:50:23.368Z",
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceRevision": "be6cf06a",
+  "cliSourceRevision": "46253bda",
   "cliSourceFingerprint": "28321811cdfc56fbb55fd3849b6c8aff87dae6208beea87da9cc49d4b8cf8ac6",
-  "docsContentFingerprint": "24861572741b0e7dcd55774fb97a34a13d4c330f65d5596f0b9a6914913c444a",
+  "docsContentFingerprint": "699f74554ab65bfee06144cd8445e3053d7353e0c06bb40fb2c908de21dddcfb",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 81,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/docs/users/install-and-update.mdx
+++ b/docs/users/install-and-update.mdx
@@ -99,12 +99,61 @@ kunai
 </Tab>
 </Tabs>
 
+## PATH
+
+The installer puts `kunai` on your PATH for you. A script cannot change the
+shell that launched it, so it writes your shell startup file instead — the same
+thing rustup, bun, and Homebrew do — and prints one `source` line if you want
+the current terminal to pick it up without reopening.
+
+| Shell | File written |
+| --- | --- |
+| zsh | `~/.zshrc` |
+| bash | `~/.bashrc`, plus **one** login file (`~/.bash_profile`, else `~/.bash_login`, else `~/.profile`) |
+| fish | `~/.config/fish/conf.d/kunai.fish` |
+| anything else | `~/.profile` |
+| Windows | the persistent **User** `Path` environment variable |
+
+bash gets two files because `~/.bashrc` is read by interactive non-login shells
+and a login shell reads only the login file; writing exactly one of the login
+files keeps the line from being applied twice.
+
+The block is delimited and written once, so re-running the installer will not
+stack duplicates:
+
+```sh
+# >>> kunai installer >>>
+# <<< kunai installer <<<
+```
+
+**To opt out** — for managed environments, images, or a dotfile setup that owns
+PATH itself — use `--skip-path-update`. The installer then prints the directory
+to add and changes nothing.
+
+## Installer flags
+
+`install.sh` uses POSIX flags; `install.ps1` takes the same switches in
+PowerShell form. Either can be set by environment variable instead, which is
+what a Dockerfile or CI step usually wants.
+
+| `install.sh` | `install.ps1` | Environment | Effect |
+| --- | --- | --- | --- |
+| `--yes` | `-Yes` | `KUNAI_INSTALL_YES=1` | Accept every optional prompt. This is the **only** thing that answers on your behalf. |
+| `--skip-deps` | `-SkipDeps` | `KUNAI_SKIP_DEPS=1` | Never offer to install optional dependencies (`mpv`, `ffmpeg`). |
+| `--skip-path-update` | `-SkipPathUpdate` | `KUNAI_SKIP_PATH_UPDATE=1` | Leave PATH alone — see [PATH](#path). |
+
+Without a terminal — `curl … | bash` in CI, a container, or a sandbox — optional
+prompts are **skipped, not accepted**, and the installer says which step it
+skipped. Before 0.3.0 a missing terminal defaulted to yes and could run
+`sudo apt-get`/`pacman`/`dnf install` unattended.
+
 ## Unsigned binaries (beta)
 
 Release binaries are **not code-signed or notarized** today. That is intentional for beta:
 
 - **Windows:** SmartScreen may warn on first run. After download, `install.ps1` runs `Unblock-File` on the staged binary. You can also run `Unblock-File` manually on `kunai.exe`, or right-click → Properties → Unblock.
-- **macOS:** Gatekeeper may block unsigned binaries. Remove the quarantine attribute if needed: `xattr -dr com.apple.quarantine ~/.local/bin/kunai` (or your install path).
+- **macOS (Apple Silicon):** release binaries are cross-compiled on Linux, so they arrive **unsigned**, and arm64 macOS refuses to execute an unsigned Mach-O outright. The shell reports only `killed: 9` — no Gatekeeper dialog, and `xattr` does not help, because quarantine is not what failed. `install.sh` now ad-hoc signs the binary on your Mac (`codesign --force --sign -`); if `codesign` is unavailable it prints the exact command to run.
+- **macOS (Intel, or downloads outside the installer):** Gatekeeper quarantine can still block a manually downloaded binary. Clear it with `xattr -dr com.apple.quarantine ~/.local/bin/kunai` (or your install path).
 - **Linux:** No signing step; verify downloads against the `SHA256SUMS` file published on each GitHub Release.
 
 Production code signing and notarization are a post-beta goal, not a beta blocker.

--- a/docs/users/reliability-and-privacy.mdx
+++ b/docs/users/reliability-and-privacy.mdx
@@ -80,18 +80,26 @@ enable it, in a non-interactive terminal, or when `DO_NOT_TRACK=1` or `CI=true`.
 When on, Kunai sends at most one tiny ping per day:
 
 ```json
-{ "installId": "<uuid>", "version": "<semver>", "os": "<platform>", "arch": "<arch>", "ts": 0 }
+{ "installId": "<sha256-hex>", "version": "<semver>", "os": "<platform>", "arch": "<arch>", "ts": 0 }
 ```
 
+- `installId` on the wire is **`sha256` of your local install id**, not the id
+  itself. The id is generated on your machine, stored only in your config, and
+  never transmitted — so the value above is a 64-character hex digest, never a
+  UUID
 - Never titles, queries, providers, stream URLs, or file paths
 - Turning it off **deletes the install id from disk**. The id exists only while
   analytics is enabled
+- **Settings → General → Rotate install id** replaces the id with a fresh random
+  one while you stay opted in. Earlier pings cannot be linked to the new id. The
+  entry appears only while analytics is enabled, because disabling already
+  clears the id
 - `DO_NOT_TRACK=1` and `CI=true` block sends regardless of the setting. A value
   of `0`, `false`, or `no` does not block
 - Without an interactive terminal — piped or scripted output — analytics stays
   off, because the notice could not be shown
-- The ingest stores HMAC-hashed install ids with your platform, architecture,
-  and version, and never a raw UUID. It does not read your IP address at all
+- The ingest re-hashes that digest with an HMAC before storing it, alongside your
+  platform, architecture, and version. It does not read your IP address at all
 - Raw rows are deleted after 35 days. A permanent table keeps one hashed row per
   install with a first-seen date, which is what an exact lifetime count costs
 - Public docs show yesterday's active installs, a lifetime total, and version /

--- a/docs/users/troubleshooting.mdx
+++ b/docs/users/troubleshooting.mdx
@@ -263,7 +263,14 @@ More: [Share links](/docs/users/share-links).
 
 ## Installer and PATH issues
 
-**Symptoms:** `kunai: command not found`; wrong binary runs; upgrade/uninstall refuses ownership; install fails checksum or 404; unsigned binary blocked; rollback needed after a bad upgrade.
+**Symptoms:** `kunai: command not found`; wrong binary runs; upgrade/uninstall refuses ownership; install fails checksum or 404; unsigned binary blocked or `killed: 9` on Apple Silicon; rollback needed after a bad upgrade.
+
+<Callout title="Just installed?">
+  The installer writes your shell startup file, but it cannot change the
+  terminal that is already open. Open a new terminal, or run the `source` line
+  the installer printed. If you passed `--skip-path-update`, add the install
+  directory to PATH yourself.
+</Callout>
 
 ### What to try
 
@@ -305,7 +312,21 @@ More: [Share links](/docs/users/share-links).
    kunai rollback --to <version>
    ```
 
-6. **Unsigned binaries (beta):** Windows SmartScreen → `Unblock-File` on `kunai.exe`; macOS Gatekeeper → `xattr -dr com.apple.quarantine` on the install path; Linux → verify against `SHA256SUMS`. Details: [Unsigned binaries](/docs/users/install-and-update#unsigned-binaries-beta).
+6. **Unsigned binaries (beta):**
+
+   - **macOS on Apple Silicon, `killed: 9`:** the binary is unsigned, and arm64 macOS refuses to execute it. There is no Gatekeeper dialog and `xattr` will not fix it — quarantine is not what failed. Ad-hoc sign it:
+
+     ```sh
+     codesign --force --sign - ~/.local/bin/kunai
+     ```
+
+     `install.sh` does this for you; you only need it for a manual download.
+
+   - **macOS Gatekeeper quarantine** (Intel, or a binary downloaded outside the installer): `xattr -dr com.apple.quarantine` on the install path.
+   - **Windows SmartScreen:** `Unblock-File` on `kunai.exe`.
+   - **Linux:** verify against `SHA256SUMS`.
+
+   Details: [Unsigned binaries](/docs/users/install-and-update#unsigned-binaries-beta).
 
 7. **PATH shadowing:** put the intended install directory first (`~/.local/bin` on Unix, `%LOCALAPPDATA%\kunai\bin` on Windows). Remove or rename earlier shadowed copies. Re-check with `type -a` / `which -a` (bash), `whence -a` (zsh), or `Get-Command kunai -All` (PowerShell), then `kunai doctor`.
 


### PR DESCRIPTION
Five documentation defects, all describing behaviour 0.3.0 actually ships. Every claim below was checked against the code, not inferred.

## Wrong

**1. The analytics payload sample is not what we send.** `reliability-and-privacy.mdx` showed:

```json
{ "installId": "<uuid>", ... }
```

The wire carries `sha256(installId)` — see `usage-analytics-service.ts:158,239`. The id is minted locally and never transmitted. The following bullet compounded it ("the ingest stores HMAC-hashed install ids … never a raw UUID"), which reads as *the raw UUID arrives and is hashed server-side*.

This page's entire job is that privacy claim, and it was understating what we actually do.

**2. macOS advice pointed at the wrong failure.** Both `install-and-update.mdx` and `troubleshooting.mdx` said to clear Gatekeeper quarantine with `xattr -dr com.apple.quarantine`. The real Apple Silicon failure is an unsigned arm64 Mach-O: no dialog, no quarantine attribute, just `killed: 9` — and `xattr` does nothing for it. `install.sh:828` ad-hoc signs on the user's Mac. Quarantine guidance is kept, scoped to where it applies.

## Missing entirely

Zero matches across all 26 MDX pages:

**3. Installer flags.** `--skip-path-update`, `--yes`, `--skip-deps` had no page anywhere — with Windows switch and env-var equivalents.

**4. The installer writes your shell startup file.** It modifies user files (`install.sh:576` `path_rc_files`) and said so nowhere. Now documented per shell, including *why* bash gets two files and the `# >>> kunai installer >>>` idempotency markers.

**5. Rotate install id.** `general.ts:95`, gated on analytics being enabled.

Also records that a missing terminal now **skips** optional prompts instead of accepting them — the old behaviour could run `sudo apt-get`/`pacman`/`dnf` unattended.

Plus a "Just installed?" callout on the `command not found` path, which is the most common one-click failure: the profile is written, but the already-open shell hasn't read it.

## Verification

- `bun run verify:doc-paths` — 48 docs, 1943 source files, all resolve
- `bun run verify:doc-coverage` — clean
- `bun run lint` — 12/12
- `bun run build:app` in `apps/docs` — full build, all 24 doc routes prerender

Docs-only; no runtime code touched. `generated-metadata.json` moves because `docsContentFingerprint` tracks this content — it will conflict trivially with #83, and regenerating resolves it.

https://claude.ai/code/session_01GssSecHjd7uJW5HFZMUVGu