### PR TITLE
test: make two fake gates able to fail

### DIFF
--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -740,9 +740,13 @@ describe("install.sh consent without a terminal", () => {
       const args =
         process.platform === "darwin"
           ? ["-q", "/dev/null", "bash", probePath]
-          : ["-qfec", `bash ${probePath}`, "/dev/null"];
+          : ["-qfec", 'bash "$KUNAI_ASK_PROBE"', "/dev/null"];
       return spawnSync(scriptBin, args, {
         encoding: "utf8",
+        env: {
+          ...process.env,
+          ...(process.platform === "darwin" ? {} : { KUNAI_ASK_PROBE: probePath }),
+        },
         stdio: ["ignore", "pipe", "pipe"],
         timeout: 2_000,
       });
@@ -774,7 +778,30 @@ describe("install.sh consent without a terminal", () => {
     },
   );
 
-  test.skipIf(!scriptBin)("an explicit --yes is still consent", () => {
+  test.skipIf(!scriptBin)(
+    "requires script(1): TMPDIR shell metacharacters do not change the probe",
+    () => {
+      const parent = mkdtempSync(join(tmpdir(), "kunai-ask-parent-"));
+      const hostileTmpDir = join(parent, "has spaces; false #");
+      const originalTmpDir = process.env.TMPDIR;
+      mkdirSync(hostileTmpDir);
+      process.env.TMPDIR = hostileTmpDir;
+      try {
+        expect(tmpdir()).toBe(hostileTmpDir);
+        const result = runAskWithClosedPtyInput(0);
+        expect(result.error).toBeUndefined();
+        expect(result.signal).toBeNull();
+        expect(result.status).not.toBe(0);
+        expect(`${result.stdout}${result.stderr}`).toContain("No reply for: Install mpv?");
+      } finally {
+        if (originalTmpDir === undefined) delete process.env.TMPDIR;
+        else process.env.TMPDIR = originalTmpDir;
+        rmSync(parent, { recursive: true, force: true });
+      }
+    },
+  );
+
+  test.skipIf(!scriptBin)("requires script(1): an explicit --yes is still consent", () => {
     const result = runAskWithClosedPtyInput(1);
     expect(result.error).toBeUndefined();
     expect(result.signal).toBeNull();

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -711,7 +711,27 @@ describe("install.sh package activeVersion", () => {
  *     default, so a prompt nobody could answer became consent.
  */
 describe("install.sh consent without a terminal", () => {
-  function runAsk(yes: 0 | 1): { status: number | null; stderr: string } {
+  /**
+   * `setsid` is what actually removes the controlling terminal.
+   *
+   * `stdio: ["ignore", …]` closes stdin but leaves the child in the parent's
+   * session, so `</dev/tty` still opens whenever the developer runs the suite
+   * from a real terminal. This test used to rely on that closed stdin alone,
+   * which made it environment-dependent: green in CI (no controlling terminal,
+   * so the open fails and `ask` reports "No terminal for") and red under a
+   * developer's TTY (the open succeeds, `read` hits EOF, and `ask` reports
+   * "No reply for" instead). Both are correct refusals — the test was pinning
+   * whichever branch the environment happened to produce.
+   *
+   * macOS ships no `setsid` binary, so there the detach is unavailable and
+   * these skip loudly rather than passing for the wrong reason again.
+   */
+  const setsid = Bun.which("setsid");
+
+  function runAsk(
+    yes: 0 | 1,
+    options: { readonly detach: boolean },
+  ): { status: number | null; stderr: string } {
     const source = readFileSync(INSTALL_SH, "utf8");
     const fn = /^ask\(\) \{[\s\S]*?^\}/m.exec(source)?.[0];
     if (!fn) throw new Error("could not extract ask() from install.sh");
@@ -721,25 +741,50 @@ describe("install.sh consent without a terminal", () => {
       fn,
       `ask "Install mpv?" y`,
     ].join("\n");
-    // stdin closed and no controlling terminal — the `curl … | bash` in CI shape.
-    return spawnSync("bash", ["-c", script], {
+    const [command, args] =
+      options.detach && setsid
+        ? ([setsid, ["bash", "-c", script]] as const)
+        : (["bash", ["-c", script]] as const);
+    return spawnSync(command, args, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
+      // A regressed `ask` blocks on `read` forever; fail the test instead of
+      // stalling the suite.
+      timeout: 10_000,
     });
   }
 
-  test("declines rather than assuming yes, and says which step it skipped", () => {
-    const result = runAsk(0);
+  test.skipIf(!setsid)(
+    "with no controlling terminal, declines and says which step it skipped",
+    () => {
+      const result = runAsk(0, { detach: true });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("No terminal for: Install mpv?");
+      expect(result.stderr).toContain("--yes");
+      // bash's own redirect error would mean stderr is silenced after the failing
+      // open rather than before it.
+      expect(result.stderr).not.toContain("No such device");
+    },
+  );
+
+  /**
+   * The second trap, and the one the old setup silently exercised in a
+   * developer's terminal without asserting on it: a controlling terminal
+   * exists, so the `</dev/tty` open succeeds, but nothing can answer. The
+   * previous `read … || true` swallowed that failure and fell through to the
+   * `y` default, which is how a prompt nobody could answer ran `sudo apt-get
+   * install` unattended.
+   */
+  test("with a terminal but no answer, declines instead of defaulting to yes", () => {
+    const result = runAsk(0, { detach: false });
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("No terminal for: Install mpv?");
-    expect(result.stderr).toContain("--yes");
-    // bash's own redirect error would mean stderr is silenced after the failing
-    // open rather than before it.
-    expect(result.stderr).not.toContain("No such device");
+    // Either refusal is correct; which one depends on whether the runner has a
+    // controlling terminal. What must never happen is falling through to `y`.
+    expect(result.stderr).toMatch(/No (terminal|reply) for: Install mpv\?/);
   });
 
   test("an explicit --yes is still consent", () => {
-    expect(runAsk(1).status).toBe(0);
+    expect(runAsk(1, { detach: false }).status).toBe(0);
   });
 });
 

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -782,11 +782,12 @@ describe("install.sh consent without a terminal", () => {
     "requires script(1): TMPDIR shell metacharacters do not change the probe",
     () => {
       const parent = mkdtempSync(join(tmpdir(), "kunai-ask-parent-"));
-      const hostileTmpDir = join(parent, "has spaces; false #");
-      const originalTmpDir = process.env.TMPDIR;
-      mkdirSync(hostileTmpDir);
-      process.env.TMPDIR = hostileTmpDir;
+      let originalTmpDir: string | undefined;
       try {
+        const hostileTmpDir = join(parent, "has spaces; false #");
+        originalTmpDir = process.env.TMPDIR;
+        mkdirSync(hostileTmpDir);
+        process.env.TMPDIR = hostileTmpDir;
         expect(tmpdir()).toBe(hostileTmpDir);
         const result = runAskWithClosedPtyInput(0);
         expect(result.error).toBeUndefined();

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 
 import { getKunaiPaths } from "@kunai/storage";
@@ -711,80 +712,73 @@ describe("install.sh package activeVersion", () => {
  *     default, so a prompt nobody could answer became consent.
  */
 describe("install.sh consent without a terminal", () => {
-  /**
-   * `setsid` is what actually removes the controlling terminal.
-   *
-   * `stdio: ["ignore", …]` closes stdin but leaves the child in the parent's
-   * session, so `</dev/tty` still opens whenever the developer runs the suite
-   * from a real terminal. This test used to rely on that closed stdin alone,
-   * which made it environment-dependent: green in CI (no controlling terminal,
-   * so the open fails and `ask` reports "No terminal for") and red under a
-   * developer's TTY (the open succeeds, `read` hits EOF, and `ask` reports
-   * "No reply for" instead). Both are correct refusals — the test was pinning
-   * whichever branch the environment happened to produce.
-   *
-   * macOS ships no `setsid` binary, so there the detach is unavailable and
-   * these skip loudly rather than passing for the wrong reason again.
-   */
   const setsid = Bun.which("setsid");
+  const scriptBin = Bun.which("script");
 
-  function runAsk(
-    yes: 0 | 1,
-    options: { readonly detach: boolean },
-  ): { status: number | null; stderr: string } {
+  function askProbeSource(yes: 0 | 1): string {
     const source = readFileSync(INSTALL_SH, "utf8");
     const fn = /^ask\(\) \{[\s\S]*?^\}/m.exec(source)?.[0];
     if (!fn) throw new Error("could not extract ask() from install.sh");
-    const script = [
-      `warn() { echo "WARN: $*" >&2; }`,
-      `YES=${yes}`,
-      fn,
-      `ask "Install mpv?" y`,
-    ].join("\n");
-    const [command, args] =
-      options.detach && setsid
-        ? ([setsid, ["bash", "-c", script]] as const)
-        : (["bash", ["-c", script]] as const);
-    return spawnSync(command, args, {
+    return [`warn() { echo "WARN: $*" >&2; }`, `YES=${yes}`, fn, `ask "Install mpv?" y`].join("\n");
+  }
+
+  function runAskWithoutControllingTerminal(yes: 0 | 1) {
+    if (!setsid) throw new Error("setsid is unavailable");
+    return spawnSync(setsid, ["bash", "-c", askProbeSource(yes)], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
-      // A regressed `ask` blocks on `read` forever; fail the test instead of
-      // stalling the suite.
-      timeout: 10_000,
+      timeout: 2_000,
     });
   }
 
+  function runAskWithClosedPtyInput(yes: 0 | 1) {
+    if (!scriptBin) throw new Error("script(1) is unavailable");
+    const root = mkdtempSync(join(tmpdir(), "kunai-ask-"));
+    const probePath = join(root, "ask-probe.sh");
+    try {
+      writeFileSync(probePath, askProbeSource(yes), { mode: 0o700 });
+      const args =
+        process.platform === "darwin"
+          ? ["-q", "/dev/null", "bash", probePath]
+          : ["-qfec", `bash ${probePath}`, "/dev/null"];
+      return spawnSync(scriptBin, args, {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 2_000,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+
   test.skipIf(!setsid)(
-    "with no controlling terminal, declines and says which step it skipped",
+    "requires setsid: no controlling terminal declines and explains --yes",
     () => {
-      const result = runAsk(0, { detach: true });
+      const result = runAskWithoutControllingTerminal(0);
+      expect(result.error).toBeUndefined();
+      expect(result.signal).toBeNull();
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain("No terminal for: Install mpv?");
       expect(result.stderr).toContain("--yes");
-      // bash's own redirect error would mean stderr is silenced after the failing
-      // open rather than before it.
-      expect(result.stderr).not.toContain("No such device");
     },
   );
 
-  /**
-   * The second trap, and the one the old setup silently exercised in a
-   * developer's terminal without asserting on it: a controlling terminal
-   * exists, so the `</dev/tty` open succeeds, but nothing can answer. The
-   * previous `read … || true` swallowed that failure and fell through to the
-   * `y` default, which is how a prompt nobody could answer ran `sudo apt-get
-   * install` unattended.
-   */
-  test("with a terminal but no answer, declines instead of defaulting to yes", () => {
-    const result = runAsk(0, { detach: false });
-    expect(result.status).not.toBe(0);
-    // Either refusal is correct; which one depends on whether the runner has a
-    // controlling terminal. What must never happen is falling through to `y`.
-    expect(result.stderr).toMatch(/No (terminal|reply) for: Install mpv\?/);
-  });
+  test.skipIf(!scriptBin)(
+    "requires script(1): closed PTY input declines instead of defaulting to yes",
+    () => {
+      const result = runAskWithClosedPtyInput(0);
+      expect(result.error).toBeUndefined();
+      expect(result.signal).toBeNull();
+      expect(result.status).not.toBe(0);
+      expect(`${result.stdout}${result.stderr}`).toContain("No reply for: Install mpv?");
+    },
+  );
 
-  test("an explicit --yes is still consent", () => {
-    expect(runAsk(1, { detach: false }).status).toBe(0);
+  test.skipIf(!scriptBin)("an explicit --yes is still consent", () => {
+    const result = runAskWithClosedPtyInput(1);
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(0);
   });
 });
 

--- a/apps/cli/test/unit/architecture/filename-convention.test.ts
+++ b/apps/cli/test/unit/architecture/filename-convention.test.ts
@@ -11,8 +11,150 @@ function srcRelative(absolute: string): string {
   return toPosixPath(relative(CLI_SRC, absolute));
 }
 
-/** Existing PascalCase `.ts` files (migration allowlist — shrink when renaming). */
-const PASCAL_CASE_TS_ALLOWLIST = new Set<string>();
+/**
+ * Existing PascalCase `.ts` files — migration debt per
+ * `.docs/runtime-boundary-map.md`: new `.ts` logic modules must be kebab-case,
+ * and these are renamed only under the rename policy documented there.
+ *
+ * This list is deliberately **static and hand-maintained**, and may only ever
+ * shrink. It was previously populated by walking the same tree the test then
+ * checked, which made the assertion `A ⊆ A` — it could not fail, and silently
+ * adopted every new PascalCase file instead of rejecting it.
+ */
+const PASCAL_CASE_TS_ALLOWLIST = new Set<string>([
+  "app/playback/DownloadOnlyPhase.ts",
+  "app/playback/PlaybackPhase.ts",
+  "app/search/SearchPhase.ts",
+  "app/session/Phase.ts",
+  "app/session/SessionController.ts",
+  "domain/continuation/ContinuationEngine.ts",
+  "domain/lists/ListService.ts",
+  "domain/lists/StatsFormatter.ts",
+  "domain/lists/StatsService.ts",
+  "domain/lists/WatchGenreStats.ts",
+  "domain/offline/OfflineLibraryEngine.ts",
+  "domain/playback-source/SourceSelectionEngine.ts",
+  "domain/provider/ProviderAttemptTimeline.ts",
+  "domain/provider/ProviderFailureClassifier.ts",
+  "domain/queue/QueuePlanner.ts",
+  "domain/queue/QueueService.ts",
+  "domain/recovery/RecoveryPolicy.ts",
+  "domain/search/SearchIntent.ts",
+  "domain/search/SearchIntentEngine.ts",
+  "domain/search/SearchIntentParser.ts",
+  "domain/session/PickerModel.ts",
+  "domain/session/SessionState.ts",
+  "domain/session/SessionStateManager.ts",
+  "infra/logger/Logger.ts",
+  "infra/logger/StructuredLogger.ts",
+  "infra/player/PersistentMpvSession.ts",
+  "infra/player/PlaybackStatsSnapshot.ts",
+  "infra/player/PlayerControlService.ts",
+  "infra/player/PlayerControlServiceImpl.ts",
+  "infra/player/PlayerService.ts",
+  "infra/player/PlayerServiceImpl.ts",
+  "infra/shell/ShellService.ts",
+  "infra/shell/ShellServiceImpl.ts",
+  "infra/storage/FileStorage.ts",
+  "infra/storage/StorageService.ts",
+  "infra/timing/AniSkipTimingSource.ts",
+  "infra/timing/IntroDbTimingSource.ts",
+  "infra/timing/PlaybackTimingAggregator.ts",
+  "infra/timing/PlaybackTimingSource.ts",
+  "infra/tracer/Tracer.ts",
+  "infra/tracer/TracerImpl.ts",
+  "infra/work/WorkControlService.ts",
+  "infra/work/WorkControlServiceImpl.ts",
+  "services/attention/AttentionRefreshScheduler.ts",
+  "services/attention/AttentionRefreshWorker.ts",
+  "services/attention/FollowedTitleService.ts",
+  "services/attention/RefreshBudgetPolicy.ts",
+  "services/attention/ReleaseAvailabilityService.ts",
+  "services/background/BackgroundWorkScheduler.ts",
+  "services/catalog/CatalogDiscoveryService.ts",
+  "services/catalog/CatalogIdentityService.ts",
+  "services/catalog/CatalogScheduleService.ts",
+  "services/catalog/ResultEnrichmentService.ts",
+  "services/catalog/TimelineService.ts",
+  "services/catalog/TitleDetailService.ts",
+  "services/continuation/ContinuationProjectionService.ts",
+  "services/continuation/ContinueWatchingService.ts",
+  "services/diagnostics/DebugTraceReporter.ts",
+  "services/diagnostics/DiagnosticsBundleBuilder.ts",
+  "services/diagnostics/DiagnosticsService.ts",
+  "services/diagnostics/DiagnosticsServiceImpl.ts",
+  "services/diagnostics/DiagnosticsStore.ts",
+  "services/diagnostics/DiagnosticsStoreImpl.ts",
+  "services/diagnostics/DurableDiagnosticsSink.ts",
+  "services/diagnostics/IssueReportBuilder.ts",
+  "services/diagnostics/ResolveTraceSink.ts",
+  "services/download/DownloadFeature.ts",
+  "services/download/DownloadIntentService.ts",
+  "services/download/DownloadService.ts",
+  "services/download/StorageBudgetPolicy.ts",
+  "services/history-metadata/HistoryIdentityConsolidator.ts",
+  "services/history-metadata/HistoryIdentityEnrichBackfill.ts",
+  "services/history-metadata/HistoryMetadataHealer.ts",
+  "services/history-metadata/HistoryWatchLedgerBackfill.ts",
+  "services/media-actions/MediaActionRouter.ts",
+  "services/network/Connectivity.ts",
+  "services/network/NetworkStatus.ts",
+  "services/notifications/NotificationActionRouter.ts",
+  "services/notifications/NotificationEngine.ts",
+  "services/notifications/NotificationService.ts",
+  "services/offline/OfflineAssetService.ts",
+  "services/offline/OfflineLibraryService.ts",
+  "services/offline/OfflineMaintenanceService.ts",
+  "services/offline/OfflineRunwayService.ts",
+  "services/persistence/CacheStore.ts",
+  "services/persistence/ConfigService.ts",
+  "services/persistence/ConfigServiceImpl.ts",
+  "services/persistence/ConfigStore.ts",
+  "services/persistence/ConfigStoreImpl.ts",
+  "services/persistence/SqliteCacheStoreImpl.ts",
+  "services/persistence/StorageMaintenanceService.ts",
+  "services/persistence/SyncTokenStore.ts",
+  "services/playback/EpisodePlaybackSelectionService.ts",
+  "services/playback/MediaTrackService.ts",
+  "services/playback/PlaybackResolveCoordinator.ts",
+  "services/playback/PlaybackResolveService.ts",
+  "services/playback/PlaybackResolveWorkService.ts",
+  "services/playback/PlaybackSourceInventoryProjection.ts",
+  "services/playback/PlaybackSourceInventoryView.ts",
+  "services/playback/ProviderCandidatePlanner.ts",
+  "services/playback/ProviderEndpointHealthService.ts",
+  "services/playback/ProviderHealthEvidence.ts",
+  "services/playback/ResolveResultCommitPolicy.ts",
+  "services/playback/ResolveWorkLedger.ts",
+  "services/playback/SourceInventoryService.ts",
+  "services/playback/StreamHealthService.ts",
+  "services/playback/TitlePlaybackSourceService.ts",
+  "services/playback/TitleProviderHealthService.ts",
+  "services/playback/VideasyLazySourceProbeService.ts",
+  "services/playlists/DurablePlaylistService.ts",
+  "services/playlists/KunaiPlaylistFormat.ts",
+  "services/playlists/PlaylistProjectionService.ts",
+  "services/presence/PresenceService.ts",
+  "services/presence/PresenceServiceImpl.ts",
+  "services/providers/Provider.ts",
+  "services/providers/ProviderRegistry.ts",
+  "services/recommendations/RecommendationService.ts",
+  "services/recommendations/RecommendationServiceImpl.ts",
+  "services/release-reconciliation/ReleaseProgressWriter.ts",
+  "services/release-reconciliation/ReleaseReconciliationPlanner.ts",
+  "services/release-reconciliation/ReleaseReconciliationService.ts",
+  "services/search/SearchRegistry.ts",
+  "services/search/SearchRoutingService.ts",
+  "services/search/SearchService.ts",
+  "services/sync/AniListAdapter.ts",
+  "services/sync/SyncAdapter.ts",
+  "services/sync/SyncService.ts",
+  "services/sync/TmdbAdapter.ts",
+  "services/update/BinaryAutoUpdater.ts",
+  "services/update/UpdateService.ts",
+  "services/youtube/YoutubeRecommendationService.ts",
+  "services/ytdlp/YtDlpService.ts",
+]);
 
 /** Existing kebab-case `.tsx` files outside PascalCase / *-shell / *-ui naming (migration allowlist). */
 const TSX_NAMING_ALLOWLIST = new Set([
@@ -61,13 +203,6 @@ function walkTsFiles(directory: string, files: string[] = []): string[] {
     }
   }
   return files;
-}
-
-for (const file of walkTsFiles(CLI_SRC)) {
-  const name = basename(file, ".ts");
-  if (/^[A-Z]/.test(name) && !name.endsWith(".model")) {
-    PASCAL_CASE_TS_ALLOWLIST.add(file);
-  }
 }
 
 describe("filename conventions", () => {


### PR DESCRIPTION
Two policy tests were green without proving the preconditions named by their
contracts. This PR makes both gates falsifiable and deterministic.

Closes #104. Closes #95.

## Static filename-debt gate

`PASCAL_CASE_TS_ALLOWLIST` previously populated itself from the same tree the
test scanned, so a new PascalCase module was automatically adopted. It is now a
checked-in migration inventory containing exactly the 132 existing
non-`.model.ts` PascalCase modules. The inventory may only shrink.

Observed RED: adding the disposable
`apps/cli/src/domain/ZzzHonestGateProbe.ts` made the wrapper gate fail and name
`domain/ZzzHonestGateProbe.ts`. Removing the probe restored 4,610 pass / 0
fail. An independent inventory comparison found 132 allowlist entries, 132
current modules, and no missing, stale, or duplicate paths.

## Deterministic installer-consent gates

Closing child stdin does not remove a controlling terminal: `</dev/tty` can
still open when the suite is launched from a developer terminal. The repaired
harness creates both relevant preconditions explicitly:

- `setsid` creates a child with no controlling terminal and proves the prompt
  refuses with guidance to pass `--yes`;
- `script(1)` creates a disposable PTY whose input is closed and proves a
  terminal read failure refuses instead of accepting the default;
- explicit `--yes` remains covered as consent;
- every probe has a 2,000 ms deadline, and error/signal assertions prevent a
  timeout or crash from masquerading as a safe refusal;
- unavailable `setsid` or `script(1)` capabilities skip with the capability
  named in test output.

On Linux the `script -c` command is constant and receives the disposable probe
path only through a quoted child environment variable. A hostile `TMPDIR` path
containing spaces and shell metacharacters is covered, and every fixture is
removed in `finally`. Darwin uses BSD `script` argv directly.

Observed RED: temporarily restoring the historical
`read ... </dev/tty || true` behavior made the closed-PTY test fail because an
unanswered prompt returned success. The production guarded-read block was
restored immediately. `install.sh` is unchanged by this PR.

## Local verification

- `bun run typecheck` — 14/14 tasks
- `bun run lint` — 12/12 tasks, zero errors (one pre-existing relay test
  shadowing warning)
- `bun run fmt:check` — 26/26 tasks
- `bun run test` — 14/14 tasks; CLI integration 147 pass / 24 capability skips /
  0 fail
- `git diff origin/main...HEAD --check` — clean

Independent task reviews and the final Standards/Spec review were required
before the branch update. This PR remains unmerged pending release-train
approval.
