### PR TITLE
fix(docs): stop committing provenance that changes on every regeneration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,8 @@ artifacts/
 # public and this directory holds proprietary source that must never be pushed.
 # Ignored (not merely untracked) so a stray `git add -A` cannot stage it.
 docs/installer-reference/
+
+# Provenance for the generated docs metadata: regenerated on every build, and
+# deliberately not committed — syncedAt and cliSourceRevision change every run,
+# so committing them made any two docs branches conflict on the same file.
+apps/docs/lib/generated-provenance.json

--- a/apps/docs/app/llms.txt/route.ts
+++ b/apps/docs/app/llms.txt/route.ts
@@ -1,4 +1,5 @@
 import { codeMetadata } from "@/lib/code-metadata";
+import { provenance } from "@/lib/provenance";
 import { publishedReleaseNotesArtifacts, releasePath } from "@/lib/release-notes";
 import { docsSiteUrl } from "@/lib/site";
 import { source } from "@/lib/source";
@@ -12,8 +13,8 @@ export async function GET() {
     "# Kunai Docs",
     "",
     `@doc-version: ${codeMetadata.cliVersion}`,
-    `@cli-source-revision: ${codeMetadata.cliSourceRevision}`,
-    `@synced-at: ${codeMetadata.syncedAt}`,
+    `@cli-source-revision: ${provenance.cliSourceRevision}`,
+    `@synced-at: ${provenance.syncedAt}`,
     "",
     "> Terminal-first guides for Kunai playback, recovery, offline use, and diagnostics.",
     "",

--- a/apps/docs/components/layout/docs-sidebar-banner.tsx
+++ b/apps/docs/components/layout/docs-sidebar-banner.tsx
@@ -1,10 +1,11 @@
 import { codeMetadata } from "@/lib/code-metadata";
+import { provenance } from "@/lib/provenance";
 import Link from "next/link";
 
 export function DocsSidebarBanner() {
   const revision =
-    codeMetadata.cliSourceRevision && codeMetadata.cliSourceRevision !== "unknown"
-      ? codeMetadata.cliSourceRevision
+    provenance.cliSourceRevision && provenance.cliSourceRevision !== "unknown"
+      ? provenance.cliSourceRevision
       : null;
   const commitUrl = revision ? `https://github.com/KitsuneKode/kunai/commit/${revision}` : null;
 

--- a/apps/docs/components/reference/synced-at.tsx
+++ b/apps/docs/components/reference/synced-at.tsx
@@ -1,8 +1,9 @@
 import { codeMetadata } from "@/lib/code-metadata";
+import { provenance } from "@/lib/provenance";
 import Link from "next/link";
 
 export function SyncedAt() {
-  const synced = new Date(codeMetadata.syncedAt);
+  const synced = new Date(provenance.syncedAt);
   const formatted = synced.toLocaleString("en-US", {
     dateStyle: "medium",
     timeStyle: "short",
@@ -13,8 +14,8 @@ export function SyncedAt() {
     <p className="text-fd-muted-foreground not-prose border-fd-border mt-10 border-t pt-4 text-xs leading-relaxed">
       Command and provider tables on this page are generated from the Kunai CLI (v
       {codeMetadata.version}) at {formatted} UTC
-      {codeMetadata.cliSourceRevision && codeMetadata.cliSourceRevision !== "unknown"
-        ? ` · source ${codeMetadata.cliSourceRevision}`
+      {provenance.cliSourceRevision && provenance.cliSourceRevision !== "unknown"
+        ? ` · source ${provenance.cliSourceRevision}`
         : null}
       . Run <code>bun run --cwd apps/docs generate</code> after registry changes.{" "}
       <Link href="/docs/developer/docs-maintenance" className="text-fd-primary hover:underline">

--- a/apps/docs/lib/code-metadata.ts
+++ b/apps/docs/lib/code-metadata.ts
@@ -48,10 +48,8 @@ export type PublicShortcutMetadata = {
 };
 
 export type CodeMetadata = {
-  readonly syncedAt: string;
   readonly version: string;
   readonly cliVersion: string;
-  readonly cliSourceRevision: string;
   readonly cliSourceFingerprint: string;
   readonly docsContentFingerprint: string;
   readonly featureStatusRevision: string;

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,8 +1,6 @@
 {
-  "syncedAt": "2026-08-23T09:02:43.569Z",
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceRevision": "fa725a13",
   "cliSourceFingerprint": "28321811cdfc56fbb55fd3849b6c8aff87dae6208beea87da9cc49d4b8cf8ac6",
   "docsContentFingerprint": "96f53137c036bc4de8363ce05097cd2ef7ba2ba567376fa9444ba1b0119e2248",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",

--- a/apps/docs/lib/provenance.ts
+++ b/apps/docs/lib/provenance.ts
@@ -1,0 +1,21 @@
+import provenanceJson from "./generated-provenance.json";
+
+/**
+ * When the generated metadata was last synced, and from which CLI revision.
+ *
+ * Deliberately separate from `generated-metadata.json` and gitignored. Both
+ * values move on every regeneration and every commit while saying nothing about
+ * whether the docs content changed, so committing them made any two branches
+ * that both ran `generate` conflict on the same file — which happened on four
+ * consecutive pull requests before this split.
+ *
+ * `bun run --cwd apps/docs generate` writes it, and that runs ahead of every
+ * build (locally, in CI, and in the Vercel build command), so the file is always
+ * present by the time anything imports it.
+ */
+export type Provenance = {
+  readonly syncedAt: string;
+  readonly cliSourceRevision: string;
+};
+
+export const provenance: Provenance = provenanceJson as Provenance;

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,7 +7,7 @@
     "generate": "bun run scripts/sync-code-metadata.ts && bun run scripts/sync-repo-content.ts && fumadocs-mdx",
     "dev": "bun run generate && next dev",
     "build:app": "NEXT_TELEMETRY_DISABLED=1 next build",
-    "build": "bun run build:app",
+    "build": "bun run generate && bun run build:app",
     "start": "next start",
     "typecheck:app": "bun tsc --noEmit",
     "typecheck": "bun run typecheck:app",

--- a/apps/docs/scripts/sync-code-metadata.ts
+++ b/apps/docs/scripts/sync-code-metadata.ts
@@ -69,22 +69,19 @@ function readExistingMetadata(filePath: string): Record<string, unknown> | null 
 }
 
 /**
- * The metadata's *content* identity, ignoring provenance stamps.
+ * The metadata's content identity.
  *
- * `syncedAt` and `cliSourceRevision` move on every regeneration and every
- * commit respectively, while saying nothing about whether the docs content
- * changed. Comparing them rewrote the file on every commit, so it sat
- * permanently modified in `git status` and added a two-line diff to unrelated
- * commits.
+ * Provenance (`syncedAt`, `cliSourceRevision`) used to live in this file and
+ * moved on every regeneration and every commit while saying nothing about
+ * whether the docs content changed. That guaranteed a conflict between any two
+ * branches that both regenerated, which is exactly what happened on four
+ * consecutive PRs. They now live in a gitignored sidecar, so this file changes
+ * only when its content does and the identity is simply the whole payload.
  *
- * Exported because `check-codegen-freshness.ts` must ask the identical
- * question. It previously kept its own copy that ignored BOTH fields while this
- * one ignored only `syncedAt` — so the writer rewrote for a change the checker
- * declared irrelevant. One definition, no drift.
+ * Exported because `check-codegen-freshness.ts` must ask the identical question.
  */
 export function metadataIdentity(value: Record<string, unknown>): string {
-  const { syncedAt: _syncedAt, cliSourceRevision: _cliSourceRevision, ...payload } = value;
-  return JSON.stringify(payload);
+  return JSON.stringify(value);
 }
 
 function extractString(content: string, prop: string): string | null {
@@ -374,10 +371,8 @@ export function buildMetadata(): Record<string, unknown> {
   const shortcuts = syncShortcuts();
 
   return {
-    syncedAt: new Date().toISOString(),
     version,
     cliVersion: version,
-    cliSourceRevision: resolveCliSourceRevision(ROOT_DIR),
     cliSourceFingerprint: computeCliSourceFingerprint(ROOT_DIR),
     docsContentFingerprint: computeDocsContentFingerprint(ROOT_DIR),
     featureStatusRevision: computeFeatureStatusRevision(ROOT_DIR),
@@ -400,13 +395,38 @@ function main() {
   const existing = readExistingMetadata(outputPath);
   if (existing && metadataIdentity(existing) === metadataIdentity(metadata)) {
     formatGeneratedFile(outputPath);
+    writeProvenance();
     console.log(`Metadata already up to date at: ${outputPath}`);
     return;
   }
 
   fs.writeFileSync(outputPath, JSON.stringify(metadata, null, 2), "utf-8");
   formatGeneratedFile(outputPath);
+  writeProvenance();
   console.log(`Successfully generated metadata at: ${outputPath}`);
+}
+
+/**
+ * When this ran and against which revision — written every time, never committed.
+ *
+ * Kept out of `generated-metadata.json` because both values change on every
+ * regeneration regardless of whether anything about the docs changed, so
+ * committing them made every pair of docs branches conflict on this file.
+ */
+function writeProvenance(): void {
+  const provenancePath = path.join(DOCS_LIB_DIR, "generated-provenance.json");
+  fs.writeFileSync(
+    provenancePath,
+    JSON.stringify(
+      {
+        syncedAt: new Date().toISOString(),
+        cliSourceRevision: resolveCliSourceRevision(ROOT_DIR),
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
 }
 
 if (import.meta.main) {

--- a/apps/docs/test/codegen-idempotence.test.ts
+++ b/apps/docs/test/codegen-idempotence.test.ts
@@ -1,0 +1,125 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+const DOCS_ROOT = path.resolve(import.meta.dir, "..");
+const LIB_DIR = path.join(DOCS_ROOT, "lib");
+
+/**
+ * Every generated file that is committed. The gitignored provenance sidecar is
+ * deliberately absent: it carries `syncedAt` and the CLI revision, which move
+ * on every run by design. That is the whole point of it being a sidecar.
+ */
+const COMMITTED_GENERATED_FILES = [
+  "generated-metadata.json",
+  "generated-mascot.json",
+  "generated-release-notes.json",
+  "generated-troubleshooting-faq.json",
+] as const;
+
+function snapshot(): Map<string, string> {
+  const files = new Map<string, string>();
+  for (const name of COMMITTED_GENERATED_FILES) {
+    const file = path.join(LIB_DIR, name);
+    files.set(name, fs.existsSync(file) ? fs.readFileSync(file, "utf-8") : "");
+  }
+  return files;
+}
+
+function runGenerate(): void {
+  const result = Bun.spawnSync(["bun", "run", "generate"], {
+    cwd: DOCS_ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, FORCE_COLOR: "0" },
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `generate exited ${result.exitCode}\n${result.stderr.toString()}\n${result.stdout.toString()}`,
+    );
+  }
+}
+
+/**
+ * Restore whatever was on disk when the test started.
+ *
+ * The test has to actually run the generator to observe its output, and a
+ * working tree with legitimately stale generated files would otherwise be
+ * silently rewritten by running the suite. Leave it exactly as found.
+ */
+const original = snapshot();
+
+afterAll(() => {
+  for (const [name, content] of original) {
+    const file = path.join(LIB_DIR, name);
+    if (content === "") continue;
+    fs.writeFileSync(file, content, "utf-8");
+  }
+});
+
+/**
+ * A committed generated file must be a pure function of committed inputs. If
+ * regenerating twice produces different bytes, it is not generated — it is a
+ * log, and every pair of branches that runs the generator will conflict on it.
+ *
+ * That is not hypothetical here. `generated-metadata.json` used to carry
+ * `syncedAt` (wall clock) and `cliSourceRevision` (git HEAD), so four
+ * consecutive PRs conflicted on this one file and each needed a manual
+ * regenerate to land — including, eventually, the PR that fixed it.
+ *
+ * `check-codegen-freshness.ts` asks a different question: *is the committed
+ * file up to date with its inputs?* This asks whether generating is
+ * deterministic at all. Both matter, and neither implies the other.
+ *
+ * Deliberately compares run N against run N+1 rather than against the committed
+ * bytes, so a merely stale checkout fails freshness — its own gate — instead of
+ * being misreported here as nondeterminism.
+ */
+test("generating twice in a row produces byte-identical committed files", () => {
+  runGenerate();
+  const first = snapshot();
+
+  runGenerate();
+  const second = snapshot();
+
+  for (const name of COMMITTED_GENERATED_FILES) {
+    const before = first.get(name) ?? "";
+    const after = second.get(name) ?? "";
+    if (before === after) continue;
+
+    // Name the drifting keys rather than dumping two large JSON blobs, since
+    // the failure is almost always one or two fields.
+    const drifted: string[] = [];
+    try {
+      const a = JSON.parse(before) as Record<string, unknown>;
+      const b = JSON.parse(after) as Record<string, unknown>;
+      for (const key of new Set([...Object.keys(a), ...Object.keys(b)])) {
+        if (JSON.stringify(a[key]) !== JSON.stringify(b[key])) {
+          drifted.push(`${key}: ${JSON.stringify(a[key])} -> ${JSON.stringify(b[key])}`);
+        }
+      }
+    } catch {
+      // Not JSON, or unparseable — fall through to the raw failure below.
+    }
+
+    throw new Error(
+      `${name} changed between two consecutive generate runs.\n` +
+        (drifted.length > 0 ? `Drifting keys:\n  ${drifted.join("\n  ")}\n\n` : "") +
+        "A committed generated file must not depend on the clock, the git revision, " +
+        "hostname, absolute paths, locale-dependent sorting, or iteration order. " +
+        "Move run-specific values into lib/generated-provenance.json, which is gitignored.",
+    );
+  }
+
+  expect(second).toEqual(first);
+});
+
+/** The sidecar is the escape hatch, so it must stay uncommitted. */
+test("the provenance sidecar is gitignored", () => {
+  const result = Bun.spawnSync(["git", "check-ignore", "apps/docs/lib/generated-provenance.json"], {
+    cwd: path.resolve(DOCS_ROOT, "../.."),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(result.exitCode).toBe(0);
+});

--- a/apps/docs/test/drift.test.ts
+++ b/apps/docs/test/drift.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
 
+import { provenance } from "@/lib/provenance";
+
 import { codeMetadata } from "../lib/code-metadata";
 import { docNavEntries } from "../lib/doc-navigation";
 import {
@@ -190,8 +192,10 @@ describe("docs codegen drift", () => {
   });
 
   test("cliSourceRevision is a short sha or unknown", () => {
-    expect(codeMetadata.cliSourceRevision.length).toBeGreaterThan(0);
-    expect(/^[0-9a-f]{7,12}$|unknown/.test(codeMetadata.cliSourceRevision)).toBe(true);
+    // Lives in the gitignored provenance sidecar, not the committed metadata:
+    // it moves on every commit and would otherwise conflict between branches.
+    expect(provenance.cliSourceRevision.length).toBeGreaterThan(0);
+    expect(/^[0-9a-f]{7,12}$|unknown/.test(provenance.cliSourceRevision)).toBe(true);
   });
 
   test("feature status has at least fifteen entries", () => {


### PR DESCRIPTION
Ends the merge-conflict class that hit **four consecutive PRs today** — #83, #85, #84, and #93 each conflicted on `apps/docs/lib/generated-metadata.json` and needed a manual regenerate to land.

## Cause

The file carried two fields that move on every regeneration regardless of content:

```json
"syncedAt": "2026-08-23T09:07:23.744Z",     // timestamp — changes every run
"cliSourceRevision": "c0d354c7",            // sha — changes every commit
```

So any two branches that ran `generate` produced different files and collided. The writer already knew these were noise — it excluded both when deciding *whether* to rewrite — it just still wrote them.

## Fix

They move to `lib/generated-provenance.json`, written on every generate and **gitignored**. The committed metadata is now stable: running `generate` twice in a row produces no diff.

`metadataIdentity` also loses its field-exclusion dance — with no churn in the file, identity is the whole payload, and `check-codegen-freshness.ts` keeps asking the identical question.

## Nothing user-visible is lost

`SyncedAt`, the docs sidebar banner, and `llms.txt` all read the same two values from the new module. The drift test still asserts the revision shape, now against provenance.

## One thing this caught

Deleting the sidecar and building — the state a fresh clone is in — failed with `Can't resolve './generated-provenance.json'`. `build` now runs `generate` first, matching what `dev` already did. Worth noting the fix deliberately avoids `fs` reads in `provenance.ts`: that is exactly the pattern #87 removed to stop Turbopack tracing the whole workspace.

## Verification

- `generate` twice → no diff on the committed file
- `check-codegen-freshness` → fresh
- docs build from a clean state → 43 static pages
- docs tests → 83 pass
- `lint`, `fmt`, `verify:doc-paths` → clean

https://claude.ai/code/session_01GssSecHjd7uJW5HFZMUVGu