### PR TITLE
fix(ci): give test:file the same timeout as the suites it is used to run

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -49,7 +49,7 @@
     "test": "bun run scripts/run-default-tests.ts",
     "test:coverage": "bun test test/unit test/integration --coverage",
     "test:coverage:report": "bun test test/unit test/integration --coverage --coverage-reporter=text",
-    "test:file": "bun test",
+    "test:file": "bun test --timeout=20000",
     "test:unit": "bun test test/unit --timeout=20000 --parallel",
     "test:future": "bun test --preload ./test/support/future-clock.preload.ts test/unit --timeout=20000",
     "test:integration": "bun test test/integration --timeout=20000",


### PR DESCRIPTION
Fixes the `Installer script lint` failure on main (`3cf31331`).

## Cause: two budgets for the same file

```jsonc
"test:unit":        "bun test test/unit --timeout=20000 --parallel",
"test:integration": "bun test test/integration --timeout=20000",
"test:file":        "bun test",        // ← no budget: bun defaults to 5000ms
```

`install-scripts-pwsh.test.ts` lives in `test/integration` and was written for the 20s budget. But CI runs it through `test:file`:

```yaml
bun run --cwd apps/cli test:file -- test/integration/install-scripts-pwsh.test.ts
```

So the same test got 20s under one script and 5s under another. `rejects lifecycle switches` spawns **two** pwsh processes and timed out at 5009ms.

Not flaky, and not slow code: locally the whole file finishes in ~11s with every test passing, and the CI agent runs it in ~31s — roughly 3x slower. The other single-file CI use (`npm-launcher.test.ts`) has the same exposure.

## Verified with pwsh actually installed

Previously these tests landed in the "1 skip" line locally and only ever ran in CI. With `powershell-bin` installed I ran the exact CI command:

```
bun run --cwd apps/cli test:file -- test/integration/install-scripts-pwsh.test.ts
26 pass · 1 skip · 0 fail · 11.75s
```

The remaining skip is legitimate — `install.ps1 PATH diagnostics` is gated on `process.platform === "win32"`.

Full `bun run test`: 14/14 tasks.

## Related

Third timing-budget CI failure this release, all the same shape — a test asserting how fast the machine is rather than what the code does. Tracked in #122 with a suggested sweep.