### PR TITLE
fix(queue,download): stop work-tracking state from surviving a failure

### DIFF
--- a/apps/cli/src/services/download/DownloadService.ts
+++ b/apps/cli/src/services/download/DownloadService.ts
@@ -544,11 +544,42 @@ export class DownloadService {
     // Claim synchronously (no await before this) so a concurrent worker's
     // selectEligibleQueuedJob skips this job until it is markRunning or released.
     this.claimedJobIds.add(next.id);
-    const storage = await this.evaluateStorageForPath(
-      next.outputPath,
-      next.id,
-      next.selectedQualityLabel,
-    );
+
+    // `evaluateStorageForPath` runs mkdir + statfs, which throw when the output
+    // path is unwritable, unmounted, or not a directory — an unplugged external
+    // drive or a dropped network share. That throw used to escape past the
+    // claim: `claimedJobIds` still held the id, `selectEligibleQueuedJob` skips
+    // claimed ids forever, and the job became unstartable for the rest of the
+    // session while still showing as queued. It also reached every
+    // `void processQueue()` call site as an unhandled rejection, which
+    // `main.ts` escalates to a fatal shutdown.
+    let storage: Awaited<ReturnType<DownloadService["evaluateStorageForPath"]>>;
+    try {
+      storage = await this.evaluateStorageForPath(
+        next.outputPath,
+        next.id,
+        next.selectedQualityLabel,
+      );
+    } catch (error) {
+      this.claimedJobIds.delete(next.id);
+      const detail = error instanceof Error ? error.message : String(error);
+      const retryAt = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+      this.deps.repo.pause(
+        next.id,
+        `Download paused because the download folder is unavailable: ${detail}`,
+        retryAt,
+        now,
+      );
+      this.deps.diagnostics?.record({
+        category: "download",
+        level: "warn",
+        operation: "download.path.unavailable",
+        message: "Download start failed because the output path could not be prepared",
+        context: { jobId: next.id, error: detail },
+      });
+      return null;
+    }
+
     if (!storage.allowed) {
       this.claimedJobIds.delete(next.id);
       const retryAt = new Date(Date.now() + 30 * 60 * 1000).toISOString();
@@ -570,13 +601,21 @@ export class DownloadService {
       });
       return null;
     }
-    if (!this.deps.repo.markRunning(next.id, now)) {
+    // Anything between the claim and the try/finally below must release the
+    // claim on the way out, or the job is stranded exactly as above.
+    let stopHeartbeat: () => void;
+    try {
+      if (!this.deps.repo.markRunning(next.id, now)) {
+        this.claimedJobIds.delete(next.id);
+        // Another process won the durable claim after our read. Its update makes
+        // this row ineligible, so continue with the next queued candidate.
+        return await this.processNextQueued();
+      }
+      stopHeartbeat = this.startHeartbeat(next.id);
+    } catch (error) {
       this.claimedJobIds.delete(next.id);
-      // Another process won the durable claim after our read. Its update makes
-      // this row ineligible, so continue with the next queued candidate.
-      return this.processNextQueued();
+      throw error;
     }
-    const stopHeartbeat = this.startHeartbeat(next.id);
 
     try {
       const downloaded = await this.executeYtDlpDownload(next);

--- a/apps/cli/test/unit/services/download/download-path-unavailable.test.ts
+++ b/apps/cli/test/unit/services/download/download-path-unavailable.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, expect, mock, spyOn, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { DownloadService } from "@/services/download/DownloadService";
+import type { ConfigService } from "@/services/persistence/ConfigService";
+import { DownloadJobsRepository, openKunaiDatabase, runMigrations } from "@kunai/storage";
+
+/**
+ * `processNextQueued` claims a job into the in-memory `claimedJobIds` set
+ * before it prepares the output directory. `evaluateStorageForPath` runs mkdir
+ * + statfs, which throw when the download folder is unwritable, unmounted, or
+ * not a directory — an unplugged external drive or a dropped network share.
+ *
+ * That throw escaped past the claim, with two consequences:
+ *   - `selectEligibleQueuedJob` skips claimed ids, and `claimedJobIds` is
+ *     process-lifetime state, so the job became unstartable until restart while
+ *     still displaying as queued.
+ *   - every caller is `void downloadService.processQueue()` with no `.catch()`,
+ *     so it surfaced as an unhandled rejection, which `main.ts` escalates to a
+ *     fatal shutdown.
+ *
+ * The unavailable path is simulated with a regular *file* where the download
+ * directory should be. `chmod` would be the obvious choice and is the wrong
+ * one: it is a no-op for root and effectively unenforced on Windows, so the
+ * test would quietly stop testing anything on two of three platforms.
+ */
+let tempDir: string;
+let db: ReturnType<typeof openKunaiDatabase>;
+let repo: DownloadJobsRepository;
+let whichSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "kunai-download-path-"));
+  db = openKunaiDatabase(join(tempDir, "data.sqlite"));
+  runMigrations(db, "data");
+  repo = new DownloadJobsRepository(db);
+  whichSpy = spyOn(Bun, "which");
+});
+
+afterEach(() => {
+  whichSpy.mockRestore();
+  db.close();
+  rmSync(tempDir, { recursive: true, force: true });
+  mock.restore();
+});
+
+function buildService(downloadPath: string): DownloadService {
+  return new DownloadService({
+    repo,
+    titleAliases: { upsertAliases() {} },
+    config: {
+      downloadsEnabled: true,
+      downloadPath,
+      offlineArtworkCacheEnabled: false,
+      offlineFreeSpaceReserveBytes: 0,
+      offlineUnknownEpisodeEstimateBytes: 1,
+    } as ConfigService,
+    ytDlpAvailable: true,
+    ffprobeAvailable: false,
+    logger: {
+      debug() {},
+      info() {},
+      warn() {},
+      error() {},
+      fatal() {},
+      child() {
+        return this;
+      },
+    },
+  });
+}
+
+test("an unavailable download folder does not strand the job or reject", async () => {
+  // Queue while the folder is healthy — `enqueue` prepares the directory too,
+  // so the failure has to arrive afterwards. That is also the real sequence:
+  // the drive is present when you queue and gone when the worker gets there.
+  const downloadRoot = join(tempDir, "downloads");
+  const service = buildService(downloadRoot);
+  const job = await service.enqueue({
+    title: { id: "tmdb:1", type: "series", name: "Frieren" },
+    episode: { season: 1, episode: 3, name: "Episode 3" },
+    providerId: "allanime",
+    mode: "anime",
+  });
+
+  // Now the drive goes away: replace the download root with a regular file, so
+  // mkdir(recursive) underneath it throws on Linux, macOS and Windows alike.
+  rmSync(downloadRoot, { recursive: true, force: true });
+  writeFileSync(downloadRoot, "not a directory");
+
+  // Must resolve, not reject: every call site is `void processQueue()`, so a
+  // rejection here reaches the unhandledRejection handler and kills the session.
+  const first = await service.processNextQueued();
+  expect(first).toBeNull();
+
+  // Deferred with a readable reason rather than left running or lost.
+  // `repo.pause` keeps status 'queued' and defers via next_retry_at, so the
+  // retry window is the signal here — not a 'paused' status.
+  const after = repo.get(job.id);
+  expect(after?.status).toBe("queued");
+  expect(after?.nextRetryAt).toBeDefined();
+  expect(after?.errorMessage).toContain("download folder is unavailable");
+
+  // Clear the retry window and prove a later pass still *selects* the job.
+  // This is the leak check: `claimedJobIds` is process-lifetime state and
+  // `selectEligibleQueuedJob` skips claimed ids, so before the fix this second
+  // pass could never reach the job again and it stayed queued forever with no
+  // retry window and no error.
+  repo.requeue(job.id, new Date().toISOString());
+  expect(repo.get(job.id)?.nextRetryAt).toBeUndefined();
+
+  const second = await service.processNextQueued();
+  expect(second).toBeNull();
+
+  const afterSecond = repo.get(job.id);
+  expect(afterSecond?.nextRetryAt).toBeDefined();
+  expect(afterSecond?.errorMessage).toContain("download folder is unavailable");
+});

--- a/packages/storage/src/repositories/queue.ts
+++ b/packages/storage/src/repositories/queue.ts
@@ -358,10 +358,23 @@ export class QueueRepository {
     this.db.query("DELETE FROM playlist_queue WHERE session_id = ?").run(sessionId);
   }
 
-  /** Persist an explicit ordering — assigns queue_position = index for each id in order. */
+  /**
+   * Persist an explicit ordering — assigns queue_position = index for each id in order.
+   *
+   * Transactional because `queue_position` is a total ordering across rows: a
+   * half-applied batch is not a stale queue, it is an invalid one, with
+   * duplicate or missing positions. The loop can be interrupted by a crash, the
+   * memory watchdog's SIGKILL, or the shutdown coordinator's force-exit
+   * deadline, so all-or-nothing is the only safe shape.
+   *
+   * Safe to call from inside another transaction — `restoreQueueSession` does.
+   * bun:sqlite nests via SAVEPOINT, so an outer rollback still undoes this.
+   */
   setQueuePositions(orderedIds: readonly string[]): void {
     const stmt = this.db.query("UPDATE playlist_queue SET queue_position = ? WHERE id = ?");
-    orderedIds.forEach((id, index) => stmt.run(index, id));
+    this.db.transaction(() => {
+      orderedIds.forEach((id, index) => stmt.run(index, id));
+    })();
   }
 
   clearPlayed(sessionId: string): void {

--- a/packages/storage/test/queue-reorder-atomicity.test.ts
+++ b/packages/storage/test/queue-reorder-atomicity.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, expect, test } from "bun:test";
+
+import { QueueRepository } from "../src/index";
+import type { KunaiDatabase } from "../src/sqlite";
+import { createTempStoreRegistry } from "./helpers/temp-store";
+
+const stores = createTempStoreRegistry();
+
+afterEach(() => {
+  stores.cleanup();
+});
+
+/**
+ * `queue_position` is a total ordering across rows, so a half-applied reorder
+ * is not a stale queue — it is an invalid one, with duplicate or missing
+ * positions. Anything that can interrupt the write loop leaves it that way: a
+ * crash, the memory watchdog's SIGKILL, or the shutdown coordinator's
+ * force-exit deadline.
+ *
+ * Interruption is simulated by failing one statement mid-batch, which is the
+ * only part of that scenario a unit test can reproduce deterministically.
+ */
+function failingDbAfter(
+  db: KunaiDatabase,
+  failOnRunNumber: number,
+): { db: KunaiDatabase; runs: () => number } {
+  let runs = 0;
+
+  // bun:sqlite's Database and Statement use private fields, so every method has
+  // to stay bound to the real object. Returning them through the proxy as the
+  // receiver fails with "Cannot access invalid private field".
+  const passThrough = (target: object, property: PropertyKey) => {
+    const value = Reflect.get(target, property, target) as unknown;
+    return typeof value === "function" ? value.bind(target) : value;
+  };
+
+  const proxy = new Proxy(db, {
+    get(target, property) {
+      if (property !== "query") return passThrough(target, property);
+      return (sql: string) => {
+        const statement = target.query(sql);
+        if (!sql.includes("SET queue_position")) return statement;
+        return new Proxy(statement, {
+          get(stmtTarget, stmtProperty) {
+            if (stmtProperty !== "run") return passThrough(stmtTarget, stmtProperty);
+            return (...args: unknown[]) => {
+              runs += 1;
+              if (runs === failOnRunNumber) {
+                throw new Error("simulated interruption mid-reorder");
+              }
+              return (stmtTarget.run as (...a: unknown[]) => unknown)(...args);
+            };
+          },
+        });
+      };
+    },
+  });
+  return { db: proxy as KunaiDatabase, runs: () => runs };
+}
+
+function seedQueue(db: KunaiDatabase): { repo: QueueRepository; ids: string[] } {
+  const repo = new QueueRepository(db);
+  repo.createQueueSession({
+    id: "session",
+    status: "active",
+    createdAt: "2026-08-23T09:00:00.000Z",
+    updatedAt: "2026-08-23T09:00:00.000Z",
+  });
+  const ids = ["a", "b", "c", "d"].map(
+    (title, index) =>
+      repo.enqueue({
+        title,
+        mediaKind: "anime",
+        titleId: `anilist:${title}`,
+        absoluteEpisode: 1,
+        queuePosition: index,
+        source: "manual",
+        sessionId: "session",
+      }).id,
+  );
+  return { repo, ids };
+}
+
+test("a reorder interrupted mid-batch leaves the original ordering, not a partial one", () => {
+  const store = stores.store("queue-reorder-atomicity", "data");
+  const { ids } = seedQueue(store);
+  const before = new QueueRepository(store)
+    .getAll("session")
+    .map((entry) => [entry.title, entry.queuePosition] as const);
+
+  // Reverse the queue, failing on the third of four writes.
+  const { db: flaky } = failingDbAfter(store, 3);
+  const flakyRepo = new QueueRepository(flaky);
+
+  expect(() => flakyRepo.setQueuePositions([...ids].reverse())).toThrow(
+    "simulated interruption mid-reorder",
+  );
+
+  const after = new QueueRepository(store)
+    .getAll("session")
+    .map((entry) => [entry.title, entry.queuePosition] as const);
+
+  // Without a transaction the first two writes commit and the queue is left
+  // with duplicate positions — d=0, c=1, and the untouched c/d rows still at
+  // 2 and 3.
+  expect(after).toEqual(before);
+
+  const positions = after.map(([, position]) => position);
+  expect(new Set(positions).size).toBe(positions.length);
+});
+
+test("a completed reorder still applies every position", () => {
+  const store = stores.store("queue-reorder-applies", "data");
+  const { repo, ids } = seedQueue(store);
+
+  repo.setQueuePositions([...ids].reverse());
+
+  expect(repo.getAll("session").map((entry) => entry.title)).toEqual(["d", "c", "b", "a"]);
+  expect(repo.getAll("session").map((entry) => entry.queuePosition)).toEqual([0, 1, 2, 3]);
+});


### PR DESCRIPTION
Two places where an interruption left work-tracking state that no later run could recover from.

Closes #97. Closes #116.

## 1. Queue reorder was not atomic

`setQueuePositions` (`packages/storage/src/repositories/queue.ts`) ran N unwrapped `UPDATE`s. `queue_position` is a **total ordering across rows**, so a half-applied batch is not a stale queue — it is an invalid one, with duplicate or missing positions.

This was the outlier, not a new pattern: every other multi-statement mutation in the package already wraps in `db.transaction` (`sync-outbox.ts` ×2, `resolve-trace.ts`, `history.ts`, `lists.ts` ×2, `diagnostic-events.ts`, `maintenance.ts`, and `queue.ts:461` in this very file).

`restoreQueueSession` calls `setQueuePositions` from *inside* its own transaction, so nesting had to be safe. Verified before relying on it — bun:sqlite nests via SAVEPOINT: a nested commit applies, and an outer rollback undoes the inner work.

## 2. An unavailable download folder stranded the job — and killed the session

`processNextQueued` claims a job into `claimedJobIds` before calling `evaluateStorageForPath`, which runs `mkdir` + `statfs`. Both throw when the output path is unwritable, unmounted, or not a directory — an unplugged external drive, a dropped network share. The throw escaped past the claim, and all three release sites sit after it (the `finally` opens later still).

This is worse than the leak it looks like:

- `selectEligibleQueuedJob` skips claimed ids and `claimedJobIds` is process-lifetime state, so the job was **unstartable until restart** while still displaying as queued.
- All **nine** call sites are `void downloadService.processQueue()` with no `.catch()`, so the throw surfaced as an unhandled rejection — which `main.ts:1133` escalates to a **fatal shutdown**. Unplugging a drive mid-session ended playback.

The storage evaluation is now guarded: the claim is released, the job is deferred with a readable reason, and a diagnostic is recorded, instead of the throw propagating. The `markRunning`/`startHeartbeat` region is wrapped too, so nothing between the claim and the existing `try`/`finally` can leak it.

## Verification

Both tests were run against the **unfixed** code before being trusted.

**Queue** — a reorder interrupted on write 3 of 4:

- without the transaction: the batch half-commits and `c` lands on `b`'s position — duplicate positions, exactly the corruption described
- with it: ordering is unchanged and positions stay unique
- removing the transaction again makes the test fail, so it is pinning the behaviour and not the shape of the code

**Download** — the test fails pre-fix with the exact `ENOTDIR: not a directory, mkdir …` that would have reached `unhandledRejection`.

Totals: storage package **142 pass**, download suites **160 pass**, full `bun run test` **14/14 tasks**, `typecheck` **14/14**.

## Cross-platform

The unavailable path is simulated with a regular **file** where the download directory should be, so `mkdir(recursive)` underneath it throws on Linux, macOS and Windows alike. `chmod 0o500` would have been the obvious choice and is the wrong one — it is a no-op for root and effectively unenforced on Windows, so the test would have quietly stopped testing anything on two of three platforms.

The test also queues while the folder is healthy and breaks it afterwards, because `enqueue` prepares the directory too. That is the real sequence anyway: the drive is present when you queue and gone when the worker gets there.

## Unrelated pre-existing failures, for the reviewer

Three tests fail on this machine and **also on clean `main`** — confirmed by stashing this work and re-running, so they are not introduced here:

- `Settings tab strip at narrow widths` (×2)
- `ErrorShell > panel width never changes across the frames of the fall`

Root cause found while investigating: they assert on raw string `.length` without stripping ANSI, so they fail whenever colour is forced. With `FORCE_COLOR=3` a 40-column strip measures 149; with `FORCE_COLOR=0` all pass. That is the same environment-dependent-assertion class as #95 and #104. Filed separately rather than folded in here.

https://claude.ai/code/session_01QN5u9VYwYaU56kfr5KQYoD
