### PR TITLE
fix(relay): work on bytes, and anchor the CDN allowlist

### DIFF
--- a/apps/cli/src/infra/player/hls-relay.ts
+++ b/apps/cli/src/infra/player/hls-relay.ts
@@ -6,16 +6,18 @@ import type { Server } from "bun";
 import { normalizeStreamHttpHeaders } from "./mpv-stream-http-headers";
 
 /**
- * Allowlisted upstream CDNs, anchored to the registrable domain.
+ * Exact upstream CDN apexes. Their real subdomains are allowed; sibling TLDs
+ * and lookalike suffixes are not.
  *
  * These were `/\.uwucdn\./i` and `/\.owocdn\./i` — unanchored substring tests
  * against the hostname, so `evil.uwucdn.attacker.com` matched and the relay
- * would fetch it. `assertRelayUpstreamUrl` is the only gate on what this server
- * will request, and it is applied to attacker-influenceable input: the base64
- * path segments on `/p/` and `/s/`, and every URI rewritten out of a
- * provider-supplied playlist.
+ * would fetch it. A later registrable-domain-shaped regex still accepted any
+ * attacker-registrable TLD, such as `uwucdn.com`. `assertRelayUpstreamUrl` is
+ * the only gate on what this server will request, and it is applied to
+ * attacker-influenceable input: the base64 path segments on `/p/` and `/s/`,
+ * and every URI rewritten out of a provider-supplied playlist.
  */
-const CDN_PATTERNS = [/(?:^|\.)uwucdn\.[a-z]{2,}$/i, /(?:^|\.)owocdn\.[a-z]{2,}$/i] as const;
+const CDN_APEX_HOSTNAMES = ["uwucdn.top", "owocdn.top"] as const;
 
 /** `#EXTM3U`, as bytes — a playlist is identified without decoding the body. */
 const HLS_PLAYLIST_MAGIC = Buffer.from("#EXTM3U", "latin1");
@@ -63,7 +65,7 @@ export function streamNeedsHlsRelay(url: string): boolean {
 }
 
 export function isHlsRelayUpstreamHost(hostname: string): boolean {
-  return CDN_PATTERNS.some((p) => p.test(hostname));
+  return CDN_APEX_HOSTNAMES.some((apex) => hostname === apex || hostname.endsWith(`.${apex}`));
 }
 
 function assertRelayUpstreamUrl(url: string): URL {

--- a/apps/cli/src/infra/player/hls-relay.ts
+++ b/apps/cli/src/infra/player/hls-relay.ts
@@ -5,7 +5,33 @@ import type { Server } from "bun";
 
 import { normalizeStreamHttpHeaders } from "./mpv-stream-http-headers";
 
-const CDN_PATTERNS = [/\.uwucdn\./i, /\.owocdn\./i] as const;
+/**
+ * Allowlisted upstream CDNs, anchored to the registrable domain.
+ *
+ * These were `/\.uwucdn\./i` and `/\.owocdn\./i` — unanchored substring tests
+ * against the hostname, so `evil.uwucdn.attacker.com` matched and the relay
+ * would fetch it. `assertRelayUpstreamUrl` is the only gate on what this server
+ * will request, and it is applied to attacker-influenceable input: the base64
+ * path segments on `/p/` and `/s/`, and every URI rewritten out of a
+ * provider-supplied playlist.
+ */
+const CDN_PATTERNS = [/(?:^|\.)uwucdn\.[a-z]{2,}$/i, /(?:^|\.)owocdn\.[a-z]{2,}$/i] as const;
+
+/** `#EXTM3U`, as bytes — a playlist is identified without decoding the body. */
+const HLS_PLAYLIST_MAGIC = Buffer.from("#EXTM3U", "latin1");
+
+/**
+ * Is this response an HLS playlist?
+ *
+ * Both handlers used to answer this with `body.toString("utf-8").startsWith(…)`,
+ * which decodes the entire response to test seven bytes. For a binary MPEG-TS
+ * segment that is the worst case: the bytes are not valid UTF-8, so V8 builds a
+ * two-byte string and runs replacement-character substitution over several
+ * megabytes, every segment, to answer a question about the first seven.
+ */
+export function looksLikeHlsPlaylist(body: Buffer): boolean {
+  return body.subarray(0, HLS_PLAYLIST_MAGIC.length).equals(HLS_PLAYLIST_MAGIC);
+}
 /** Safety-net only; playback owns stop() for the real lifetime. */
 const IDLE_TIMEOUT_MS = 15 * 60_000;
 const CURL_META_MARKER = "__KUNAI_CURL_META__";
@@ -136,15 +162,24 @@ function curlFetch(
         reject(new Error(`curl exit ${code}: ${stderr.slice(0, 120)}`));
         return;
       }
-      const raw = buf.toString("binary");
-      const marker = `\n${CURL_META_MARKER}`;
-      const metaAt = raw.lastIndexOf(marker);
+      // Find the trailer in the bytes. This used to decode the whole response
+      // to a latin1 string, slice it, and re-encode the slice into a new
+      // Buffer — three full-size allocations per response, on a path that
+      // carries multi-megabyte video segments. `Buffer.lastIndexOf` and
+      // `subarray` do the same work with no copies at all: `subarray` is a view
+      // over the existing memory, not a duplicate.
+      const marker = Buffer.from(`\n${CURL_META_MARKER}`, "latin1");
+      const metaAt = buf.lastIndexOf(marker);
       if (metaAt === -1) {
         reject(new Error("curl response missing status trailer"));
         return;
       }
-      const body = Buffer.from(raw.slice(0, metaAt), "binary");
-      const metaLines = raw.slice(metaAt + marker.length).split("\n");
+      const body = buf.subarray(0, metaAt);
+      // Only the trailer becomes a string; it is a status code and a MIME type.
+      const metaLines = buf
+        .subarray(metaAt + marker.length)
+        .toString("utf-8")
+        .split("\n");
       const status = Number.parseInt(metaLines[0] ?? "0", 10);
       const contentType =
         (metaLines[1] ?? "application/octet-stream").split(";")[0]?.trim() ||
@@ -286,9 +321,12 @@ export function startHlsRelay(
             });
             return new Response(`upstream ${r.status}`, { status: r.status });
           }
-          const body = r.body.toString("utf-8");
-          if (body.startsWith("#EXTM3U")) {
-            const rewritten = rewriteHlsPlaylistForRelay(body, srcUrl, relayOrigin);
+          if (looksLikeHlsPlaylist(r.body)) {
+            const rewritten = rewriteHlsPlaylistForRelay(
+              r.body.toString("utf-8"),
+              srcUrl,
+              relayOrigin,
+            );
             return new Response(rewritten, {
               headers: { "Content-Type": "application/vnd.apple.mpegurl" },
             });
@@ -324,9 +362,14 @@ export function startHlsRelay(
               message: `upstream ${r.status}`,
             });
           }
-          const bodyText = r.body.toString("utf-8");
-          if (r.status === 200 && bodyText.startsWith("#EXTM3U")) {
-            const rewritten = rewriteHlsPlaylistForRelay(bodyText, srcUrl, relayOrigin);
+          // A variant playlist can arrive on the segment route when the URL did
+          // not look like a playlist, so the check stays — but on bytes.
+          if (r.status === 200 && looksLikeHlsPlaylist(r.body)) {
+            const rewritten = rewriteHlsPlaylistForRelay(
+              r.body.toString("utf-8"),
+              srcUrl,
+              relayOrigin,
+            );
             return new Response(rewritten, {
               headers: { "Content-Type": "application/vnd.apple.mpegurl" },
             });

--- a/apps/cli/test/unit/infra/player/hls-relay.test.ts
+++ b/apps/cli/test/unit/infra/player/hls-relay.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   fromB64Url,
+  looksLikeHlsPlaylist,
   rewriteHlsPlaylistForRelay,
   streamNeedsHlsRelay,
   toB64Url,
@@ -22,6 +23,86 @@ describe("hls-relay gating", () => {
       false,
     );
     expect(streamNeedsHlsRelay("not-a-url")).toBe(false);
+  });
+
+  /**
+   * The allowlist is the only gate on what the relay will fetch, and it is
+   * applied to attacker-influenceable input: base64 path segments on `/p/` and
+   * `/s/`, and every URI rewritten out of a provider-supplied playlist.
+   *
+   * The patterns were unanchored substring tests (`/\.uwucdn\./i`), so any host
+   * containing `.uwucdn.` as a label matched — an attacker-controlled domain
+   * turned the local relay into a fetcher for arbitrary external hosts.
+   */
+  test("the CDN allowlist is a domain suffix, not a substring", () => {
+    // Attacker-registrable domains that contain the allowlisted label.
+    expect(streamNeedsHlsRelay("https://evil.uwucdn.attacker.com/x.m3u8")).toBe(false);
+    expect(streamNeedsHlsRelay("https://uwucdn.evil.com/x.m3u8")).toBe(false);
+    expect(streamNeedsHlsRelay("https://owocdn.top.evil.net/x.m3u8")).toBe(false);
+    expect(streamNeedsHlsRelay("https://not-uwucdn.top.attacker.io/x.m3u8")).toBe(false);
+
+    // The real hosts still pass, on any TLD and at any subdomain depth.
+    expect(streamNeedsHlsRelay("https://uwucdn.top/x.m3u8")).toBe(true);
+    expect(streamNeedsHlsRelay("https://vault-06.uwucdn.top/x.m3u8")).toBe(true);
+    expect(streamNeedsHlsRelay("https://a.b.c.owocdn.top/x.m3u8")).toBe(true);
+  });
+
+  test("a hostless URL never matches", () => {
+    // `streamNeedsHlsRelay` answers "should this stream go through the relay",
+    // which is a host question — the scheme is enforced later and separately by
+    // `assertRelayUpstreamUrl`, which every fetch goes through and which
+    // rejects anything that is not http(s). Pinning the host contract here so
+    // the split stays deliberate rather than looking like a gap.
+    expect(streamNeedsHlsRelay("file:///etc/passwd")).toBe(false);
+    expect(streamNeedsHlsRelay("")).toBe(false);
+  });
+});
+
+/**
+ * Both handlers used to identify a playlist with
+ * `body.toString("utf-8").startsWith("#EXTM3U")` — decoding the entire
+ * response to test seven bytes. On a binary MPEG-TS segment that is the worst
+ * case: the bytes are not valid UTF-8, so V8 builds a two-byte string and runs
+ * replacement-character substitution over several megabytes, per segment.
+ *
+ * The byte comparison must answer identically for every case the string form
+ * did, which is what these pin.
+ */
+describe("hls-relay playlist detection on bytes", () => {
+  const utf8Says = (body: Buffer) => body.toString("utf-8").startsWith("#EXTM3U");
+
+  test("agrees with the old string check on playlists", () => {
+    for (const text of [
+      "#EXTM3U\n#EXT-X-VERSION:3\n",
+      "#EXTM3U",
+      "#EXTM3U\n",
+      "#EXTM3U\n#EXTINF:9.009,\nseg.ts\n",
+    ]) {
+      const body = Buffer.from(text, "utf-8");
+      expect(looksLikeHlsPlaylist(body)).toBe(true);
+      expect(looksLikeHlsPlaylist(body)).toBe(utf8Says(body));
+    }
+  });
+
+  test("agrees with the old string check on non-playlists", () => {
+    for (const text of ["#EXTM3", "", "EXTM3U", " #EXTM3U", "#EXT-X-VERSION:3"]) {
+      const body = Buffer.from(text, "utf-8");
+      expect(looksLikeHlsPlaylist(body)).toBe(false);
+      expect(looksLikeHlsPlaylist(body)).toBe(utf8Says(body));
+    }
+  });
+
+  test("a binary segment is not a playlist, and is never decoded to find out", () => {
+    // MPEG-TS: 0x47 sync byte, then bytes that are invalid UTF-8 sequences.
+    const segment = Buffer.from([0x47, 0x40, 0x11, 0x10, 0xff, 0xfe, 0x80, 0x81, 0x00, 0xc0]);
+    expect(looksLikeHlsPlaylist(segment)).toBe(false);
+    expect(looksLikeHlsPlaylist(segment)).toBe(utf8Says(segment));
+  });
+
+  test("a body shorter than the magic does not over-read", () => {
+    expect(looksLikeHlsPlaylist(Buffer.alloc(0))).toBe(false);
+    expect(looksLikeHlsPlaylist(Buffer.from([0x23]))).toBe(false);
+    expect(looksLikeHlsPlaylist(Buffer.from("#EXTM3", "latin1"))).toBe(false);
   });
 });
 

--- a/apps/cli/test/unit/infra/player/hls-relay.test.ts
+++ b/apps/cli/test/unit/infra/player/hls-relay.test.ts
@@ -30,21 +30,46 @@ describe("hls-relay gating", () => {
    * applied to attacker-influenceable input: base64 path segments on `/p/` and
    * `/s/`, and every URI rewritten out of a provider-supplied playlist.
    *
-   * The patterns were unanchored substring tests (`/\.uwucdn\./i`), so any host
-   * containing `.uwucdn.` as a label matched — an attacker-controlled domain
-   * turned the local relay into a fetcher for arbitrary external hosts.
+   * The original patterns were unanchored substring tests (`/\.uwucdn\./i`).
+   * Matching the registrable-looking shape is still insufficient: a wildcard
+   * TLD accepts attacker-owned `uwucdn.com`, `uwucdn.attacker`, and equivalent
+   * subdomains. Only the two observed `.top` apexes and their real subdomains
+   * belong to this local relay.
    */
-  test("the CDN allowlist is a domain suffix, not a substring", () => {
-    // Attacker-registrable domains that contain the allowlisted label.
-    expect(streamNeedsHlsRelay("https://evil.uwucdn.attacker.com/x.m3u8")).toBe(false);
-    expect(streamNeedsHlsRelay("https://uwucdn.evil.com/x.m3u8")).toBe(false);
-    expect(streamNeedsHlsRelay("https://owocdn.top.evil.net/x.m3u8")).toBe(false);
-    expect(streamNeedsHlsRelay("https://not-uwucdn.top.attacker.io/x.m3u8")).toBe(false);
+  test.each([
+    // Attacker-registrable TLDs and suffixes.
+    "https://uwucdn.com/x.m3u8",
+    "https://uwucdn.attacker/x.m3u8",
+    "https://vault.uwucdn.evil/x.m3u8",
+    "https://owocdn.xyz/x.m3u8",
+    "https://evil.uwucdn.attacker.com/x.m3u8",
+    "https://uwucdn.evil.com/x.m3u8",
+    "https://owocdn.top.evil.net/x.m3u8",
+    // Prefix and label-boundary tricks.
+    "https://not-uwucdn.top/x.m3u8",
+    "https://uwucdn-top.example/x.m3u8",
+    "https://eviluwucdn.top/x.m3u8",
+    // Unicode and its URL-parser punycode representation.
+    "https://uwucԁn.top/x.m3u8",
+    "https://xn--uwucn-1wf.top/x.m3u8",
+    // A trusted-looking userinfo or an explicit port cannot change the host.
+    "https://uwucdn.top@attacker.example/x.m3u8",
+    "https://owocdn.top:443@attacker.example/x.m3u8",
+    "https://vault.uwucdn.evil:8443/x.m3u8",
+  ] as const)("rejects non-allowlisted host %s", (url) => {
+    expect(streamNeedsHlsRelay(url)).toBe(false);
+  });
 
-    // The real hosts still pass, on any TLD and at any subdomain depth.
-    expect(streamNeedsHlsRelay("https://uwucdn.top/x.m3u8")).toBe(true);
-    expect(streamNeedsHlsRelay("https://vault-06.uwucdn.top/x.m3u8")).toBe(true);
-    expect(streamNeedsHlsRelay("https://a.b.c.owocdn.top/x.m3u8")).toBe(true);
+  test.each([
+    "https://uwucdn.top/x.m3u8",
+    "https://owocdn.top/x.m3u8",
+    "https://vault-06.uwucdn.top/x.m3u8",
+    "https://a.b.c.owocdn.top/x.m3u8",
+    // URL.hostname normalizes case and excludes the port before this check.
+    "https://VAULT-06.UWUCDN.TOP:8443/x.m3u8",
+    "https://OWOCDN.TOP:9443/x.m3u8",
+  ] as const)("accepts allowlisted host %s", (url) => {
+    expect(streamNeedsHlsRelay(url)).toBe(true);
   });
 
   test("a hostless URL never matches", () => {


### PR DESCRIPTION
Closes #96.

This PR fixes two adjacent defects in the local HLS relay without changing its routing contract.

## Byte-path performance

- Finds curl's status trailer with `Buffer.lastIndexOf` and keeps the body as a zero-copy `subarray` view.
- Detects `#EXTM3U` from the first seven bytes, decoding a body only after it is known to be a playlist.
- Avoids decoding multi-megabyte binary segments into UTF-8 strings on the CLI thread.

The original isolated 6 MiB/20-run measurement moved the per-segment check from 50.68 ms and roughly 60 MiB heap growth to effectively zero for both. The repair commit does not alter that byte-processing work.

## Exact CDN boundary

The first version correctly removed substring matching but still accepted arbitrary `uwucdn.<TLD>` and `owocdn.<TLD>` domains. The reviewed repair now accepts only:

- `uwucdn.top` and its true subdomains;
- `owocdn.top` and its true subdomains.

Other TLDs, suffix/prefix label tricks, userinfo/port-shaped lookalikes, and Unicode/punycode lookalikes are rejected. Scheme validation remains in `assertRelayUpstreamUrl`, the existing fetch boundary.

## Evidence

- Allowlist repair RED: 5 discriminating failures under the previous matcher.
- Focused HLS relay: 32 pass, 69 assertions.
- CLI unit: 4,641 pass, 0 fail.
- Repository tests: 14/14 tasks; CLI integration 145 pass, 24 explicit skips, 0 fail.
- Typecheck: 14/14; lint: 12/12 with one unrelated existing relay warning; format: 12/12; build: 10/10.
- Independent Standards/Spec review: CLEAN.

No release, deployment, or merge is performed by this PR update.
