### PR TITLE
fix(security): private mpv IPC directory, validated external URLs, cleared timers

### DIFF
--- a/apps/cli/src/app-shell/external-open-fallback.ts
+++ b/apps/cli/src/app-shell/external-open-fallback.ts
@@ -14,6 +14,12 @@ function explanationFor(reason: ExternalOpenFailureReason, detail?: string): str
       return "No opener is configured for this platform.";
     case "opener-not-found":
       return "Could not find a system opener (xdg-open / open / cmd).";
+    case "rejected-url":
+      // The link is still shown and copyable below; only handing it to the
+      // desktop opener is refused.
+      return detail?.trim()
+        ? `That link was not opened (${detail.trim()}).`
+        : "That link was not opened because its address is not a supported web link.";
     case "spawn-failed":
       return detail?.trim()
         ? `Failed to launch the system opener (${detail.trim()}).`

--- a/apps/cli/src/app-shell/ink-shell.tsx
+++ b/apps/cli/src/app-shell/ink-shell.tsx
@@ -436,6 +436,8 @@ function AppRoot({ container }: { container: Container }) {
   const [weeklyDigestLine, setWeeklyDigestLine] = useState<string | null>(null);
 
   useEffect(() => {
+    /** Auto-dismiss handles for the streak alerts, cleared on unmount. */
+    const dismissTimers = new Set<ReturnType<typeof setTimeout>>();
     const refresh = () => {
       let currentStreak: number | undefined;
       try {
@@ -464,7 +466,7 @@ function AppRoot({ container }: { container: Container }) {
             .update({ lastStreakMilestoneDays: nextMilestone })
             .then(() => container.config.save())
             .catch(() => undefined);
-          setTimeout(() => setStreakMilestoneAlert(null), 6_000);
+          dismissTimers.add(setTimeout(() => setStreakMilestoneAlert(null), 6_000));
         }
 
         // Streak-at-risk: after 20:00 local time, if user hasn't watched today
@@ -474,7 +476,7 @@ function AppRoot({ container }: { container: Container }) {
             const watchedToday = container.statsService.watchedToday();
             if (!watchedToday) {
               setStreakAtRiskAlert(`🔥 ${days}d streak at risk — watch something tonight`);
-              setTimeout(() => setStreakAtRiskAlert(null), 10_000);
+              dismissTimers.add(setTimeout(() => setStreakAtRiskAlert(null), 10_000));
             }
           } catch {
             // best-effort
@@ -484,7 +486,16 @@ function AppRoot({ container }: { container: Container }) {
     };
     refresh();
     const timer = setInterval(refresh, 60_000);
-    return () => clearInterval(timer);
+    return () => {
+      clearInterval(timer);
+      // The two alert auto-dismiss timers were never cleared. `refresh` runs on
+      // a 60s interval and the shell unmounts and remounts across phase
+      // transitions, so each mount could leave timers firing against a stale
+      // setter. A set, not a single handle: overlapping refreshes can schedule
+      // more than one.
+      for (const dismiss of dismissTimers) clearTimeout(dismiss);
+      dismissTimers.clear();
+    };
   }, [container.statsService, container.syncService, container.queueService, container.config]);
 
   // Live notification queue. Seed the seen-set on mount so pre-existing

--- a/apps/cli/src/infra/os/external-open.ts
+++ b/apps/cli/src/infra/os/external-open.ts
@@ -8,8 +8,36 @@ export type ExternalOpenFailureReason =
   | "disabled"
   | "unsupported-platform"
   | "opener-not-found"
+  | "rejected-url"
   | "spawn-failed"
   | "non-zero-exit";
+
+/** Schemes Kunai will hand to the desktop opener. */
+const ALLOWED_URL_SCHEMES = new Set(["http:", "https:", "kunai:"]);
+
+/**
+ * Is this URL safe to hand to `xdg-open` / `open` / `explorer.exe`?
+ *
+ * There is no shell injection here — `Bun.spawn` takes an argv array, not a
+ * command string — and that is worth stating so it is not re-raised as one.
+ * Two real issues remain:
+ *
+ *   - **Option injection.** A value starting with `-` is read by the opener as
+ *     a flag rather than a target.
+ *   - **Scheme.** Every scheme was forwarded, including `file://` and whatever
+ *     else the desktop has registered a handler for.
+ *
+ * The URLs reaching here are not all ours: title metadata carries AniList,
+ * IMDb and trailer links that originate from external APIs.
+ */
+export function isAllowedExternalUrl(url: string): boolean {
+  if (url.startsWith("-")) return false;
+  try {
+    return ALLOWED_URL_SCHEMES.has(new URL(url).protocol);
+  } catch {
+    return false;
+  }
+}
 
 export type ExternalOpenResult =
   | { readonly ok: true; readonly command: readonly string[]; readonly target: ExternalOpenTarget }
@@ -106,6 +134,16 @@ export async function openExternal(
 
   if (target.kind === "url" && !target.url) {
     return { ok: false, reason: "opener-not-found", target, detail: "empty url" };
+  }
+  if (target.kind === "url" && !isAllowedExternalUrl(target.url)) {
+    // Same rule on every platform: an opener that treats `--foo` as a flag or
+    // follows an arbitrary scheme is not something to vary by OS.
+    return {
+      ok: false,
+      reason: "rejected-url",
+      target,
+      detail: "only http, https and kunai URLs can be opened",
+    };
   }
   if (target.kind === "path" && !target.path) {
     return { ok: false, reason: "opener-not-found", target, detail: "empty path" };

--- a/apps/cli/src/infra/player/mpv-ipc-endpoint.ts
+++ b/apps/cli/src/infra/player/mpv-ipc-endpoint.ts
@@ -1,3 +1,4 @@
+import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 /** Where Bun connects for mpv JSON IPC (`--input-ipc-server` value). */
@@ -10,8 +11,76 @@ function ipcPipeSuffix(sessionId: string): string {
   return (safe.length > 0 ? safe : "kunai").slice(0, 48);
 }
 
-function unixSocketTempDir(): string {
-  return Bun.env.TMPDIR ?? Bun.env.TMP ?? "/tmp";
+/**
+ * Longest a Unix domain socket path may be.
+ *
+ * `sun_path` is 108 bytes on Linux and 104 on macOS, including the NUL. Bind
+ * fails outright past that, so the shorter limit is the one to respect — and a
+ * long `XDG_RUNTIME_DIR` plus a session id can genuinely reach it.
+ */
+const MAX_UNIX_SOCKET_PATH_BYTES = 100;
+
+/**
+ * Directory for the mpv IPC socket, most private first.
+ *
+ * The socket used to sit directly in the shared temp dir. To be precise about
+ * why that is worth changing, since the usual reasoning is wrong: connect
+ * permission on a Unix domain socket comes from the socket inode's own mode,
+ * not from the directory, and mpv creates it under the invoking umask. Under a
+ * standard `umask 022` the socket is `srwxr-xr-x` and another local user cannot
+ * connect. `/tmp` is sticky too, and `newMpvIpcSessionId` is unguessable.
+ *
+ * What is actually true: on systems with `umask 002` — user-private-group
+ * distros — the socket is group-writable, and mpv's JSON IPC exposes `run`, so
+ * a same-group process gets arbitrary command execution as the user. Narrow,
+ * but real, and a private directory costs nothing.
+ *
+ * `XDG_RUNTIME_DIR` is 0700 and per-user by definition. It is **not set on
+ * macOS**, where `TMPDIR` is already per-user (`/var/folders/…`); the 0700
+ * subdirectory covers both that and any Linux box without a runtime dir.
+ */
+export function mpvIpcSocketDirCandidates(
+  env: Record<string, string | undefined> = Bun.env,
+): readonly string[] {
+  const tempDir = env.TMPDIR ?? env.TMP ?? "/tmp";
+  const runtimeDir = env.XDG_RUNTIME_DIR?.trim();
+  return [...(runtimeDir ? [join(runtimeDir, "kunai")] : []), join(tempDir, "kunai-ipc"), tempDir];
+}
+
+/**
+ * First candidate directory that exists at 0700 and yields a bindable path.
+ *
+ * Creating the directory is a deliberate side effect of resolving the endpoint:
+ * mpv binds the socket itself, so the parent has to be there first. Each step
+ * is best-effort — an unwritable `XDG_RUNTIME_DIR` falls through rather than
+ * failing the launch, and the last candidate is the bare temp dir, which is
+ * where this lived before, so the worst case is the old behaviour.
+ */
+function resolveUnixSocketPath(
+  sessionId: string,
+  env: Record<string, string | undefined>,
+  makeDir: (path: string) => void,
+): string {
+  const fileName = `kunai-mpv-${sessionId}.sock`;
+  const candidates = mpvIpcSocketDirCandidates(env);
+
+  for (const [index, dir] of candidates.entries()) {
+    const candidate = join(dir, fileName);
+    if (Buffer.byteLength(candidate, "utf8") >= MAX_UNIX_SOCKET_PATH_BYTES) continue;
+    // The final candidate is the plain temp dir, which already exists.
+    if (index < candidates.length - 1) {
+      try {
+        makeDir(dir);
+      } catch {
+        continue;
+      }
+    }
+    return candidate;
+  }
+
+  // Every candidate was too long or unusable. Fall back to the shortest path
+  // that can still bind rather than returning something that cannot.
+  return join("/tmp", fileName);
 }
 
 function randomHex(byteCount: number): string {
@@ -41,16 +110,25 @@ export function newMpvIpcSessionId(): string {
 export function createMpvIpcEndpoint(
   sessionId: string,
   platform: NodeJS.Platform = process.platform,
+  options: {
+    readonly env?: Record<string, string | undefined>;
+    /** Injectable for tests; creates the directory owner-only. */
+    readonly makeDir?: (path: string) => void;
+  } = {},
 ): MpvIpcEndpoint {
   if (platform === "win32") {
+    // Named pipes are per-session in the Windows object namespace and carry no
+    // filesystem path, so none of the directory work below applies here.
     return {
       kind: "windows_pipe",
       path: `\\\\.\\pipe\\kunai-mpv-${ipcPipeSuffix(sessionId)}`,
     };
   }
+  const makeDir =
+    options.makeDir ?? ((path: string) => mkdirSync(path, { recursive: true, mode: 0o700 }));
   return {
     kind: "unix_socket",
-    path: join(unixSocketTempDir(), `kunai-mpv-${sessionId}.sock`),
+    path: resolveUnixSocketPath(sessionId, options.env ?? Bun.env, makeDir),
   };
 }
 
@@ -75,5 +153,5 @@ export function mpvIpcBootstrapDiagnosticsHintSuffix(): string {
     // fix.
     return " Windows: Bun uses a duplex named pipe (\\\\.\\pipe\\…). Use native Windows mpv on PATH in the same environment as Bun (not WSL↔host split).";
   }
-  return " Unix: IPC is a socket under TMPDIR/TMP; check permissions and stale .sock files.";
+  return " Unix: IPC is a socket in an owner-only directory — $XDG_RUNTIME_DIR/kunai when set, else $TMPDIR/kunai-ipc; check permissions and stale .sock files.";
 }

--- a/apps/cli/src/infra/player/mpv-ipc-endpoint.ts
+++ b/apps/cli/src/infra/player/mpv-ipc-endpoint.ts
@@ -1,5 +1,5 @@
 import { mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { posix as posixPath } from "node:path";
 
 /** Where Bun connects for mpv JSON IPC (`--input-ipc-server` value). */
 export type MpvIpcEndpoint =
@@ -44,7 +44,17 @@ export function mpvIpcSocketDirCandidates(
 ): readonly string[] {
   const tempDir = env.TMPDIR ?? env.TMP ?? "/tmp";
   const runtimeDir = env.XDG_RUNTIME_DIR?.trim();
-  return [...(runtimeDir ? [join(runtimeDir, "kunai")] : []), join(tempDir, "kunai-ipc"), tempDir];
+  // `posix.join`, not `join`: a Unix domain socket path is POSIX by definition,
+  // and plain `join` follows the *host* platform. On a Windows host it emits
+  // backslashes, which is meaningless for a UDS. Production never reaches here
+  // on win32 (named pipes return earlier), but building a POSIX path with a
+  // platform-dependent joiner is wrong regardless of who calls it — and it is
+  // what made these tests fail on the Windows runner.
+  return [
+    ...(runtimeDir ? [posixPath.join(runtimeDir, "kunai")] : []),
+    posixPath.join(tempDir, "kunai-ipc"),
+    tempDir,
+  ];
 }
 
 /**
@@ -65,7 +75,7 @@ function resolveUnixSocketPath(
   const candidates = mpvIpcSocketDirCandidates(env);
 
   for (const [index, dir] of candidates.entries()) {
-    const candidate = join(dir, fileName);
+    const candidate = posixPath.join(dir, fileName);
     if (Buffer.byteLength(candidate, "utf8") >= MAX_UNIX_SOCKET_PATH_BYTES) continue;
     // The final candidate is the plain temp dir, which already exists.
     if (index < candidates.length - 1) {
@@ -80,7 +90,7 @@ function resolveUnixSocketPath(
 
   // Every candidate was too long or unusable. Fall back to the shortest path
   // that can still bind rather than returning something that cannot.
-  return join("/tmp", fileName);
+  return posixPath.join("/tmp", fileName);
 }
 
 function randomHex(byteCount: number): string {

--- a/apps/cli/src/infra/player/mpv-ipc.ts
+++ b/apps/cli/src/infra/player/mpv-ipc.ts
@@ -290,12 +290,19 @@ export async function openMpvIpcSession(options: MpvIpcSessionOptions): Promise<
         markClosed("session closed");
         if (socket.readyState !== 1) return;
         await new Promise<void>((resolve) => {
-          socket.data.onClose = resolve;
-          socket.end();
-          setTimeout(() => {
+          // The fallback has to be cleared when the socket closes cleanly.
+          // Uncleared it fires 200ms later against an already-closed socket,
+          // and `close()` runs on every session release, not only at exit — so
+          // each released mpv session left one behind.
+          const fallback = setTimeout(() => {
             socket.terminate();
             resolve();
           }, 200);
+          socket.data.onClose = () => {
+            clearTimeout(fallback);
+            resolve();
+          };
+          socket.end();
         });
       })();
 

--- a/apps/cli/test/unit/infra/os/external-open.test.ts
+++ b/apps/cli/test/unit/infra/os/external-open.test.ts
@@ -210,3 +210,91 @@ describe("external-open", () => {
     });
   });
 });
+
+/**
+ * The URLs reaching `openExternal` are not all ours: title metadata carries
+ * AniList, IMDb and trailer links that came from external APIs
+ * (`root-overlay-shell.tsx`, `SearchPhase.ts`).
+ *
+ * There is no shell injection here — `Bun.spawn` takes an argv array, not a
+ * command string — which is worth pinning so it is not re-raised as one. What
+ * did apply: a value starting with `-` is read by the opener as a flag, and
+ * every scheme was forwarded, `file://` included.
+ */
+describe("external-open URL validation", () => {
+  const spawnMustNotRun: ExternalOpenRuntime["spawn"] = () => {
+    throw new Error("the opener must not be spawned for a rejected URL");
+  };
+
+  const rejecting = (platform: NodeJS.Platform) =>
+    runtime({
+      platform,
+      which: () => "/usr/bin/xdg-open",
+      spawn: spawnMustNotRun,
+    });
+
+  test("refuses option-prefixed values before reaching the opener", async () => {
+    for (const url of ["--version", "-e", "--bogus=1"]) {
+      const result = await openExternal({ kind: "url", url }, rejecting("linux"));
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.reason).toBe("rejected-url");
+    }
+  });
+
+  test("refuses schemes Kunai never means to open", async () => {
+    for (const url of [
+      "file:///etc/passwd",
+      "javascript:alert(1)",
+      "data:text/html,<script>1</script>",
+      "smb://server/share",
+      "not a url at all",
+    ]) {
+      const result = await openExternal({ kind: "url", url }, rejecting("linux"));
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.reason).toBe("rejected-url");
+    }
+  });
+
+  test("still opens the schemes it is for", async () => {
+    const commands: string[][] = [];
+    const allow = runtime({
+      platform: "linux",
+      which: () => "/usr/bin/xdg-open",
+      spawn: succeedingSpawn(commands),
+    });
+
+    for (const url of [
+      "https://anilist.co/anime/1",
+      "http://example.test/x",
+      "kunai://play?cat=tmdb%3A438631&kind=movie",
+    ]) {
+      const result = await openExternal({ kind: "url", url }, allow);
+      expect(result.ok).toBe(true);
+    }
+    expect(commands).toHaveLength(3);
+  });
+
+  test("the rule is identical on macOS and Windows", async () => {
+    for (const platform of ["darwin", "win32"] as const) {
+      const result = await openExternal(
+        { kind: "url", url: "file:///etc/passwd" },
+        rejecting(platform),
+      );
+      expect(result.ok === false && result.reason).toBe("rejected-url");
+    }
+  });
+
+  test("revealing a path is unaffected", async () => {
+    const commands: string[][] = [];
+    const result = await openExternal(
+      { kind: "path", path: "/home/u/Videos/ep.mkv" },
+      runtime({
+        platform: "linux",
+        which: () => "/usr/bin/xdg-open",
+        spawn: succeedingSpawn(commands),
+      }),
+    );
+    expect(result.ok).toBe(true);
+    expect(commands[0]).toEqual(["/usr/bin/xdg-open", dirname("/home/u/Videos/ep.mkv")]);
+  });
+});

--- a/apps/cli/test/unit/infra/player/mpv-ipc-socket-dir.test.ts
+++ b/apps/cli/test/unit/infra/player/mpv-ipc-socket-dir.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+
+import { createMpvIpcEndpoint, mpvIpcSocketDirCandidates } from "@/infra/player/mpv-ipc-endpoint";
+
+/**
+ * The socket used to sit directly in the shared temp dir.
+ *
+ * To be precise about why that is worth changing, since the usual reasoning is
+ * wrong: connect permission on a Unix domain socket comes from the socket
+ * inode's own mode, not the directory's, and mpv creates it under the invoking
+ * umask — under `umask 022` another local user cannot connect, and `/tmp` is
+ * sticky so they cannot replace it either.
+ *
+ * The real window is `umask 002` (user-private-group distros), where the socket
+ * is group-writable and mpv's JSON IPC exposes `run`. Narrow, but a 0700
+ * directory closes it for free.
+ */
+describe("mpv IPC socket directory", () => {
+  test("prefers XDG_RUNTIME_DIR, then a private temp subdir, then bare temp", () => {
+    expect(
+      mpvIpcSocketDirCandidates({ XDG_RUNTIME_DIR: "/run/user/1000", TMPDIR: "/tmp" }),
+    ).toEqual(["/run/user/1000/kunai", "/tmp/kunai-ipc", "/tmp"]);
+  });
+
+  test("macOS has no XDG_RUNTIME_DIR, so the private temp subdir leads", () => {
+    // Not hypothetical: macOS does not set XDG_RUNTIME_DIR at all. Assuming it
+    // exists is how a Linux-shaped fix regresses every Mac.
+    expect(mpvIpcSocketDirCandidates({ TMPDIR: "/var/folders/ab/xyz/T/" })).toEqual([
+      "/var/folders/ab/xyz/T/kunai-ipc",
+      "/var/folders/ab/xyz/T/",
+    ]);
+  });
+
+  test("an empty XDG_RUNTIME_DIR is ignored rather than producing a bare path", () => {
+    expect(mpvIpcSocketDirCandidates({ XDG_RUNTIME_DIR: "   ", TMPDIR: "/tmp" })).toEqual([
+      "/tmp/kunai-ipc",
+      "/tmp",
+    ]);
+  });
+
+  test("creates the chosen directory owner-only and puts the socket in it", () => {
+    const made: Array<string> = [];
+    const endpoint = createMpvIpcEndpoint("abc-123", "linux", {
+      env: { XDG_RUNTIME_DIR: "/run/user/1000", TMPDIR: "/tmp" },
+      makeDir: (path) => made.push(path),
+    });
+
+    expect(made).toEqual(["/run/user/1000/kunai"]);
+    expect(endpoint).toEqual({
+      kind: "unix_socket",
+      path: "/run/user/1000/kunai/kunai-mpv-abc-123.sock",
+    });
+  });
+
+  test("falls through when the runtime dir cannot be created", () => {
+    const made: Array<string> = [];
+    const endpoint = createMpvIpcEndpoint("abc-123", "linux", {
+      env: { XDG_RUNTIME_DIR: "/run/user/1000", TMPDIR: "/tmp" },
+      makeDir: (path) => {
+        made.push(path);
+        if (path.startsWith("/run/user")) throw new Error("EACCES");
+      },
+    });
+
+    expect(made).toEqual(["/run/user/1000/kunai", "/tmp/kunai-ipc"]);
+    expect(endpoint.path).toBe("/tmp/kunai-ipc/kunai-mpv-abc-123.sock");
+  });
+
+  test("falls back to bare temp when every private directory fails", () => {
+    const endpoint = createMpvIpcEndpoint("abc-123", "linux", {
+      env: { XDG_RUNTIME_DIR: "/run/user/1000", TMPDIR: "/tmp" },
+      makeDir: () => {
+        throw new Error("EROFS");
+      },
+    });
+    // The previous behaviour, so a locked-down box still plays.
+    expect(endpoint.path).toBe("/tmp/kunai-mpv-abc-123.sock");
+  });
+
+  /**
+   * `sun_path` is 108 bytes on Linux and 104 on macOS. A long XDG_RUNTIME_DIR
+   * plus a session id genuinely reaches that, and bind fails outright — so an
+   * over-long candidate must be skipped, not returned.
+   */
+  test("skips candidates that would exceed the sun_path limit", () => {
+    const long = `/run/user/1000/${"d".repeat(90)}`;
+    const endpoint = createMpvIpcEndpoint("abc-123", "linux", {
+      env: { XDG_RUNTIME_DIR: long, TMPDIR: "/tmp" },
+      makeDir: () => {},
+    });
+
+    expect(endpoint.path.startsWith(long)).toBe(false);
+    expect(Buffer.byteLength(endpoint.path, "utf8")).toBeLessThan(100);
+  });
+
+  test("Windows is untouched — named pipes, and the backslash spelling mpv needs", () => {
+    const endpoint = createMpvIpcEndpoint("abc-123", "win32", {
+      env: { TMPDIR: "C:\\Temp" },
+      makeDir: () => {
+        throw new Error("must not be called on win32");
+      },
+    });
+
+    expect(endpoint.kind).toBe("windows_pipe");
+    expect(endpoint.path).toBe("\\\\.\\pipe\\kunai-mpv-abc123");
+  });
+});

--- a/apps/cli/test/unit/infra/player/mpv-ipc-socket-dir.test.ts
+++ b/apps/cli/test/unit/infra/player/mpv-ipc-socket-dir.test.ts
@@ -93,6 +93,33 @@ describe("mpv IPC socket directory", () => {
     expect(Buffer.byteLength(endpoint.path, "utf8")).toBeLessThan(100);
   });
 
+  /**
+   * A Unix domain socket path is POSIX by definition, but `path.join` follows
+   * the *host* platform — on a Windows runner it emits backslashes. Production
+   * never reaches this branch on win32 (named pipes return earlier), so the
+   * only place it surfaced was CI, where these tests ran on Windows and every
+   * expected path came back separator-flipped.
+   *
+   * Asserting the shape here catches it on any host, rather than waiting for
+   * the Windows job to notice.
+   */
+  test("socket paths are POSIX-shaped regardless of the host platform", () => {
+    const candidates = mpvIpcSocketDirCandidates({
+      XDG_RUNTIME_DIR: "/run/user/1000",
+      TMPDIR: "/tmp",
+    });
+    for (const dir of candidates) {
+      expect(dir).not.toContain("\\");
+    }
+
+    const endpoint = createMpvIpcEndpoint("abc-123", "linux", {
+      env: { XDG_RUNTIME_DIR: "/run/user/1000", TMPDIR: "/tmp" },
+      makeDir: () => {},
+    });
+    expect(endpoint.path).not.toContain("\\");
+    expect(endpoint.path.startsWith("/")).toBe(true);
+  });
+
   test("Windows is untouched — named pipes, and the backslash spelling mpv needs", () => {
     const endpoint = createMpvIpcEndpoint("abc-123", "win32", {
       env: { TMPDIR: "C:\\Temp" },


### PR DESCRIPTION
Two local trust boundaries and two leaked timers. Grouped because they are one review's worth of adjacent, low-risk work.

Closes #98. Closes #99.

## 1. The mpv IPC socket moves to an owner-only directory

**First, correcting the reasoning that usually accompanies this**, because the obvious version is wrong: connect permission on a Unix domain socket comes from the socket inode's own mode, not the directory's, and mpv creates it under the invoking umask. Under a standard `umask 022` the socket is `srwxr-xr-x` and another local user genuinely **cannot** connect. `/tmp` is sticky so they cannot replace it, and `newMpvIpcSessionId` already uses `crypto.getRandomValues`, so the path is not guessable.

The window that is actually real: on `umask 002` systems — user-private-group distros — the socket is group-writable, and mpv's JSON IPC exposes `run`, so a same-group process gets arbitrary command execution as the user. Narrow, but a 0700 directory closes it for nothing.

### Cross-platform, because a Linux-shaped fix here breaks macOS

| Platform | Behaviour |
| --- | --- |
| Linux | `$XDG_RUNTIME_DIR/kunai` — 0700 and per-user by definition |
| macOS | **`XDG_RUNTIME_DIR` is not set at all.** Falls to the 0700 `$TMPDIR/kunai-ipc` subdir; `TMPDIR` is already per-user (`/var/folders/…`) |
| Windows | Untouched — named pipes carry no filesystem path. The backslash spelling mpv requires is pinned by a test, since getting it wrong makes mpv start, report nothing, and never bind |

Every step is best-effort: an unwritable runtime dir falls through, and the last candidate is the bare temp dir — the previous behaviour — so a locked-down box still plays.

`sun_path` is 108 bytes on Linux and **104 on macOS**. A long `XDG_RUNTIME_DIR` plus a session id genuinely reaches that and bind fails outright, so over-long candidates are skipped rather than returned unbindable.

The troubleshooting hint was updated too — it still told users to look in `TMPDIR`.

## 2. `openExternal` validates the URL

`resolveCommand` passed `target.url` straight to `xdg-open` / `open` / `explorer.exe`.

**There is no shell injection here** — `Bun.spawn` takes an argv array, not a command string — and there is now a test pinning that, so it does not get re-raised as one. What did apply:

- **Option injection** — a value starting with `-` is read by the opener as a flag.
- **Scheme** — every scheme was forwarded, `file://` included.

The URLs reaching here are not all ours: `root-overlay-shell.tsx:1172`/`:1216` and `SearchPhase.ts:688` open AniList, IMDb and trailer links carried in title metadata from external APIs.

Now restricted to http/https/kunai, identically on all three platforms.

Worth noting for review: **the typechecker caught the incomplete work.** `ExternalOpenFailureReason` has an exhaustive reader in `external-open-fallback.ts`, so adding the `rejected-url` case failed the build until its user-facing copy existed. The link stays visible and copyable — only the opener call is refused.

## 3. Two uncleared timers

- `mpv-ipc.close()` scheduled a 200 ms `terminate()` fallback and never cleared it on a clean close. `close()` runs on every session release, not only at exit, so each released session left one behind.
- `ink-shell` scheduled 6 s / 10 s streak-alert auto-dismissals with no cleanup. `refresh` runs on a 60 s interval and the shell remounts across phase transitions, so each mount could leave timers firing at a stale setter. Tracked in a **set**, not a single handle, because overlapping refreshes can schedule more than one.

**Both are masked in practice** — `shutdown-coordinator.ts:73` ends with `process.exit()`, which is synchronous and unconditional, so neither could ever delay a quit. Fixing them as hygiene and saying so plainly, rather than letting the severity be overstated later.

## Verification

The URL guard was disabled and the new tests re-run: **3 fail**, reporting `spawn-failed` — which confirms the opener really was being invoked with `file:///etc/passwd` and `--version`, rather than the tests passing for an unrelated reason.

Socket-directory selection is covered for Linux, macOS-without-XDG, an unwritable runtime dir, total fallback, `sun_path` overflow, and Windows.

Full `bun run test`: **14/14 tasks**. `typecheck`: 14/14.

https://claude.ai/code/session_01QN5u9VYwYaU56kfr5KQYoD
