### PR TITLE
test: stop CI failures from depending on the machine that ran them

### DIFF
--- a/apps/cli/test/integration/completion-scripts.test.ts
+++ b/apps/cli/test/integration/completion-scripts.test.ts
@@ -6,6 +6,8 @@ import { join } from "node:path";
 
 import { COMPLETION_SHELLS, renderCompletionScript } from "@/services/completion/completion-script";
 
+import { removeTempDir } from "../support/remove-temp-dir";
+
 /**
  * Unit tests assert what the generated scripts *contain*. Only a real parser
  * catches a script that is syntactically broken — an unbalanced `case` arm or a
@@ -21,7 +23,7 @@ function writeScript(contents: string, extension: string): { path: string; clean
   const dir = mkdtempSync(join(tmpdir(), "kunai-completion-"));
   const path = join(dir, `kunai.${extension}`);
   writeFileSync(path, contents, "utf8");
-  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+  return { path, cleanup: () => removeTempDir(dir) };
 }
 
 const describeBash = shellAvailable("bash", ["-c", "exit 0"]) ? describe : describe.skip;

--- a/apps/cli/test/integration/helpers/compiled-binary-harness.ts
+++ b/apps/cli/test/integration/helpers/compiled-binary-harness.ts
@@ -11,6 +11,7 @@ import {
 import { getKunaiPaths, type KunaiPaths, type StoragePlatform } from "@kunai/storage";
 
 import { storageRootEnv } from "../../helpers/storage-env";
+import { removeTempDir } from "../../support/remove-temp-dir";
 
 const CLI_ROOT = resolve(import.meta.dirname, "../../..");
 const REPO_ROOT = resolve(CLI_ROOT, "../..");
@@ -112,7 +113,7 @@ exec ${JSON.stringify(GLIBC_BIN)} "$@"
     paths,
     env,
     evidencePath,
-    cleanup: () => rmSync(root, { recursive: true, force: true }),
+    cleanup: () => removeTempDir(root),
   };
 }
 

--- a/apps/cli/test/integration/helpers/installer-script-harness.ts
+++ b/apps/cli/test/integration/helpers/installer-script-harness.ts
@@ -2,6 +2,8 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 
+import { removeTempDir } from "../../support/remove-temp-dir";
+
 /**
  * Sandbox the directories install.ps1 resolves its defaults from.
  *
@@ -76,7 +78,7 @@ export function createInstallerSandbox(name: string) {
       // to the developer's real User PATH and then delete it during cleanup.
       KUNAI_SKIP_PATH_UPDATE: "1",
     } as NodeJS.ProcessEnv,
-    cleanup: () => rmSync(root, { recursive: true, force: true }),
+    cleanup: () => removeTempDir(root),
   };
 }
 

--- a/apps/cli/test/integration/helpers/readme-command-harness.ts
+++ b/apps/cli/test/integration/helpers/readme-command-harness.ts
@@ -28,6 +28,7 @@ import { getKunaiPaths, type KunaiPaths, type StoragePlatform } from "@kunai/sto
 
 import { buildPtyCommand } from "../../helpers/pty-command";
 import { storageRootEnv } from "../../helpers/storage-env";
+import { removeTempDir } from "../../support/remove-temp-dir";
 
 export type ReadmeCommandMode = "fixture-assets" | "published-assets";
 
@@ -155,7 +156,7 @@ export function prepareReadmeFixtureRelease(options: {
     root,
     assetName,
     version,
-    cleanup: () => rmSync(root, { recursive: true, force: true }),
+    cleanup: () => removeTempDir(root),
   };
 }
 
@@ -197,7 +198,7 @@ export function createIsolatedReadmeProfile(label = "readme"): IsolatedReadmePro
     cacheDir: paths.cacheDir,
     paths,
     env,
-    cleanup: () => rmSync(root, { recursive: true, force: true }),
+    cleanup: () => removeTempDir(root),
   };
 }
 

--- a/apps/cli/test/integration/npm-launcher.test.ts
+++ b/apps/cli/test/integration/npm-launcher.test.ts
@@ -13,6 +13,8 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { removeTempDir } from "../support/remove-temp-dir";
+
 /**
  * The npm `bin` launcher must run under plain Node.
  *
@@ -126,7 +128,7 @@ setTimeout(() => {}, 30000);
 });
 
 afterAll(() => {
-  if (workDir) rmSync(workDir, { recursive: true, force: true });
+  removeTempDir(workDir);
 });
 
 function runLauncher(args: readonly string[]) {
@@ -238,7 +240,7 @@ windowsNativeLauncherTest(
       expect(help.exitCode).toBe(0);
       expect(help.stdout.toString().trim()).not.toBe("");
     } finally {
-      rmSync(fixture.packageRoot, { recursive: true, force: true });
+      removeTempDir(fixture.packageRoot);
     }
   },
 );
@@ -305,7 +307,7 @@ nodeTest("reports an actionable error when the platform binary is missing", () =
   expect(stderr).toMatch(/install -g|add -g/);
   expect(stderr).toContain("install.sh");
 
-  rmSync(empty, { recursive: true, force: true });
+  removeTempDir(empty);
 });
 
 // Signal semantics are POSIX-only.

--- a/apps/cli/test/integration/process-shutdown.test.ts
+++ b/apps/cli/test/integration/process-shutdown.test.ts
@@ -9,6 +9,7 @@ import { getKunaiPaths, type KunaiPaths, type StoragePlatform } from "@kunai/sto
 import { describePosixOnly as describe } from "../helpers/platform-gates";
 import { buildPtyCommand } from "../helpers/pty-command";
 import { storageRootEnv } from "../helpers/storage-env";
+import { removeTempDir } from "../support/remove-temp-dir";
 
 // Real-process shutdown coverage: spawn the CLI against an isolated shadow
 // profile, deliver a signal, and assert the conventional exit status plus a
@@ -42,7 +43,7 @@ afterEach(() => {
     }
   }
   for (const dir of tempRoots.splice(0)) {
-    rmSync(dir, { recursive: true, force: true });
+    removeTempDir(dir);
   }
 });
 

--- a/apps/cli/test/integration/settings-analytics-consent.test.tsx
+++ b/apps/cli/test/integration/settings-analytics-consent.test.tsx
@@ -14,6 +14,7 @@ import { ConfigStoreImpl } from "@/services/persistence/ConfigStoreImpl";
 import React, { act } from "react";
 
 import { render } from "../harness/render-capture";
+import { waitUntil as sharedWaitUntil } from "../support/wait-until";
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -71,19 +72,34 @@ function createSettingsContainer(config: ConfigService): Container {
   } as unknown as Container;
 }
 
+/**
+ * Poll inside an `act()` boundary, with a budget that is not a bet on the host.
+ *
+ * This was a 100 x 10ms loop -- one second of wall clock for work that writes
+ * config to disk atomically. On a loaded Windows agent under `--parallel` that
+ * is not enough, and it failed as `message` rather than as anything about
+ * analytics. Scheduling shifts whenever unrelated tests are added elsewhere,
+ * which is exactly how it surfaced.
+ */
 async function waitUntil(predicate: () => boolean, message: string): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    if (predicate()) return;
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    });
-  }
-  throw new Error(message);
+  await sharedWaitUntil(predicate, {
+    label: message,
+    tick: async (ms) => {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, ms));
+      });
+    },
+  });
 }
 
+/**
+ * The settings save is debounced, so this waits out the debounce rather than
+ * polling a condition. Kept as a sleep for that reason, but sized above the
+ * debounce with headroom instead of sitting just past it.
+ */
 async function waitForDelayedSettingsSave(): Promise<void> {
   await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 700));
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
   });
 }
 

--- a/apps/cli/test/support/remove-temp-dir.ts
+++ b/apps/cli/test/support/remove-temp-dir.ts
@@ -1,0 +1,61 @@
+import { rmSync } from "node:fs";
+
+/**
+ * Remove a temp directory that a spawned process may still be holding open.
+ *
+ * POSIX unlinks a file with an open handle happily — the directory entry goes
+ * and the inode survives until the last descriptor closes. Windows refuses: an
+ * open handle locks the file, and `rmSync` returns `EBUSY` no matter how many
+ * times `force: true` is passed.
+ *
+ * Tests that spawn a child observe *process exit*, which is not the same event
+ * as the OS reclaiming that child's handles and can lag it by a few
+ * milliseconds. So teardown races a handle on its way out, and the suite fails
+ * in an `afterAll` — reported as `(fail) (unnamed)`, which reads like an
+ * unrelated failure and tells the reader nothing about the change under test.
+ *
+ * Deliberately **not** fixed by sleeping before the delete: a fixed wait is a
+ * bet on how fast the host is, which is the shape that makes these suites
+ * environment-dependent in the first place. This retries only while the OS is
+ * actually refusing, and returns the instant the delete succeeds.
+ *
+ * A leftover temp directory is not a test failure — the OS reclaims it — so a
+ * final refusal warns rather than throws.
+ */
+export function removeTempDir(
+  dir: string | undefined,
+  options: {
+    readonly attempts?: number;
+    /** Injectable so the retry path is testable off Windows, where EBUSY cannot occur. */
+    readonly rm?: (path: string) => void;
+    readonly onGiveUp?: (message: string) => void;
+  } = {},
+): void {
+  if (!dir) return;
+
+  const attempts = options.attempts ?? 20;
+  const rm = options.rm ?? ((path: string) => rmSync(path, { recursive: true, force: true }));
+  const onGiveUp = options.onGiveUp ?? ((message: string) => console.warn(message));
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      rm(dir);
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      // Only a held handle is worth retrying. Anything else is a real problem
+      // and should surface immediately rather than after a spin.
+      if (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY") {
+        return;
+      }
+      // Busy-wait briefly: this runs in teardown, and Atomics.wait on a fresh
+      // buffer is the only synchronous sleep available without making every
+      // caller async.
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
+    }
+  }
+
+  onGiveUp(
+    `removeTempDir: ${dir} is still locked after ${attempts} attempts; leaving it for the OS.`,
+  );
+}

--- a/apps/cli/test/support/rendered-width.ts
+++ b/apps/cli/test/support/rendered-width.ts
@@ -1,0 +1,69 @@
+/**
+ * How wide a rendered terminal line actually is.
+ *
+ * Ink emits SGR colour sequences inline, so `line.length` counts escape bytes
+ * as if they were glyphs. That makes any width assertion depend on whether
+ * colour happens to be enabled: with `FORCE_COLOR=3` a 40-column tab strip
+ * measured 149, and the same assertion passed at `FORCE_COLOR=0`. `FORCE_COLOR`
+ * is set in plenty of developer shells and CI images — and is exactly what you
+ * would set to exercise the colour paths — so the tests inverted depending on
+ * the environment rather than on the layout they exist to check.
+ *
+ * Terminals lay out in *display columns*, which is also not the same as
+ * character count: a combining mark occupies none, and a CJK ideograph
+ * occupies two.
+ */
+
+/**
+ * SGR and CSI sequences Ink can emit: colour, cursor movement, erase.
+ *
+ * Deliberately a local regex rather than the `ansi-regex` package — that is a
+ * transitive dependency of Ink, not one this workspace declares, so importing
+ * it would work today and break whenever Ink's tree changes.
+ */
+// eslint-disable-next-line no-control-regex
+const ANSI_PATTERN = /[][[\]()#;?]*(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]/g;
+
+/** Ranges a terminal renders two columns wide (East Asian Wide + Fullwidth). */
+const WIDE_RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0x1100, 0x115f], // Hangul Jamo
+  [0x2e80, 0x303e], // CJK radicals, Kangxi
+  [0x3041, 0x33ff], // Hiragana through CJK compatibility
+  [0x3400, 0x4dbf], // CJK Extension A
+  [0x4e00, 0x9fff], // CJK Unified Ideographs
+  [0xa000, 0xa4cf], // Yi
+  [0xac00, 0xd7a3], // Hangul syllables
+  [0xf900, 0xfaff], // CJK compatibility ideographs
+  [0xfe30, 0xfe6f], // CJK compatibility forms
+  [0xff00, 0xff60], // Fullwidth forms
+  [0xffe0, 0xffe6],
+  [0x1f300, 0x1f64f], // Emoji
+  [0x1f900, 0x1f9ff],
+  [0x20000, 0x3fffd], // CJK Extension B+
+];
+
+export function stripAnsi(value: string): string {
+  return value.replace(ANSI_PATTERN, "");
+}
+
+function codePointWidth(codePoint: number): number {
+  // Combining marks and zero-width joiners occupy no column.
+  if (codePoint === 0x200d) return 0;
+  if (codePoint >= 0x0300 && codePoint <= 0x036f) return 0;
+  if (codePoint >= 0xfe00 && codePoint <= 0xfe0f) return 0; // variation selectors
+  return WIDE_RANGES.some(([lo, hi]) => codePoint >= lo && codePoint <= hi) ? 2 : 1;
+}
+
+/** Display columns one line occupies, ignoring colour and trailing padding. */
+export function renderedWidth(line: string): number {
+  let width = 0;
+  for (const char of stripAnsi(line).trimEnd()) {
+    width += codePointWidth(char.codePointAt(0) ?? 0);
+  }
+  return width;
+}
+
+/** Widest line in a multi-line frame. */
+export function frameWidth(frame: string): number {
+  return Math.max(0, ...frame.split("\n").map(renderedWidth));
+}

--- a/apps/cli/test/support/wait-until.ts
+++ b/apps/cli/test/support/wait-until.ts
@@ -24,14 +24,24 @@
  */
 export async function waitUntil(
   predicate: () => boolean,
-  options: { readonly timeoutMs?: number; readonly label?: string } = {},
+  options: {
+    readonly timeoutMs?: number;
+    readonly label?: string;
+    /**
+     * How to yield between polls. Ink/React suites pass an `act()`-wrapped
+     * sleep, because state updates flushed outside an act boundary make React
+     * warn — and this repo's harness treats that warning as a defect.
+     */
+    readonly tick?: (ms: number) => Promise<void>;
+  } = {},
 ): Promise<void> {
   const timeoutMs = options.timeoutMs ?? 5_000;
+  const tick = options.tick ?? ((ms: number) => Bun.sleep(ms));
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
     if (predicate()) return;
-    await Bun.sleep(5);
+    await tick(5);
   }
 
   // One last check: the loop can exit on the deadline in the same tick the

--- a/apps/cli/test/support/wait-until.ts
+++ b/apps/cli/test/support/wait-until.ts
@@ -1,0 +1,46 @@
+/**
+ * Wait for a condition, with a budget generous enough not to assert machine speed.
+ *
+ * Hand-rolled poll loops kept re-appearing across these suites in three shapes,
+ * all of which make a test's result depend on the host rather than the code:
+ *
+ *   - a short bounded budget (`for (let i = 0; i < 100; i++) await Bun.sleep(10)`
+ *     — one second) that silently gives up and lets the assertion below it fail
+ *     with a misleading message;
+ *   - an **unbounded** `while (!condition) await Bun.sleep(1)`, which cannot
+ *     fail — it hangs until the runner's global timeout and reports as a
+ *     timeout rather than as the condition that never held;
+ *   - a fixed sleep standing in for synchronisation.
+ *
+ * The Windows agent is slower and, under `--parallel`, its scheduling shifts
+ * whenever unrelated tests are added elsewhere. That is how three
+ * `DownloadService` tests went red on a branch that touched no download code,
+ * and how a `SyncService` drain timed out on a documentation-only change.
+ *
+ * The predicate returns the instant it is true, so a large ceiling costs
+ * nothing when the code works. A genuinely broken condition still fails — just
+ * after a wait that no longer depends on the host, and with a message naming
+ * what was being waited for.
+ */
+export async function waitUntil(
+  predicate: () => boolean,
+  options: { readonly timeoutMs?: number; readonly label?: string } = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await Bun.sleep(5);
+  }
+
+  // One last check: the loop can exit on the deadline in the same tick the
+  // condition became true, and failing then would be its own flake.
+  if (predicate()) return;
+
+  throw new Error(
+    options.label
+      ? `waitUntil(${options.label}) timed out after ${timeoutMs}ms`
+      : `waitUntil timed out after ${timeoutMs}ms`,
+  );
+}

--- a/apps/cli/test/unit/app-shell/error-shell.test.tsx
+++ b/apps/cli/test/unit/app-shell/error-shell.test.tsx
@@ -4,6 +4,7 @@ import { ErrorShell } from "@/app-shell/root-status-shells";
 import React, { act } from "react";
 
 import { CAPTURE_WIDTHS, captureFrame, render } from "../../harness/render-capture";
+import { frameWidth, renderedWidth } from "../../support/rendered-width";
 
 /**
  * Let the petal-fall interval run for real, with its state updates flushed
@@ -30,10 +31,6 @@ const props = {
   onResolve: () => {},
   onRetry: () => {},
 };
-
-/** Longest line in the frame — the panel's outer width as actually rendered. */
-const frameWidth = (frame: string) =>
-  Math.max(...frame.split("\n").map((line) => [...line.trimEnd()].length));
 
 describe("ErrorShell", () => {
   test("renders the headline, scenario detail and waterfall", () => {
@@ -80,7 +77,9 @@ describe("ErrorShell", () => {
       const frame = captureFrame(<ErrorShell {...props} />, { columns });
       expect(frame).toContain("Playback failed");
       for (const line of frame.split("\n")) {
-        expect([...line.trimEnd()].length).toBeLessThanOrEqual(columns);
+        // Display columns, not character count — Ink's inline colour codes are
+        // not glyphs, and a wide glyph is not one column.
+        expect(renderedWidth(line)).toBeLessThanOrEqual(columns);
       }
     }
   });

--- a/apps/cli/test/unit/app-shell/settings-tab-strip-width.test.tsx
+++ b/apps/cli/test/unit/app-shell/settings-tab-strip-width.test.tsx
@@ -4,6 +4,7 @@ import { ClaudeTabRow } from "@/app-shell/primitives/ClaudeTabRow";
 import React from "react";
 
 import { render } from "../../harness/render-capture";
+import { renderedWidth } from "../../support/rendered-width";
 
 /** The real Settings sections, in order. */
 const SETTINGS_SECTIONS = [
@@ -44,7 +45,9 @@ describe("Settings tab strip at narrow widths", () => {
     const lines = stripAt(80, 0);
 
     expect(lines).toHaveLength(1);
-    expect(lines[0]?.length).toBeLessThanOrEqual(80);
+    // Display columns, not `.length`: Ink emits colour inline, so counting
+    // characters made this assertion depend on FORCE_COLOR rather than layout.
+    expect(renderedWidth(lines[0] ?? "")).toBeLessThanOrEqual(80);
   });
 
   test("shows the active section name in full at every position", () => {
@@ -64,7 +67,7 @@ describe("Settings tab strip at narrow widths", () => {
     for (const columns of [40, 50, 60, 70]) {
       const lines = stripAt(columns, 5);
       expect(lines).toHaveLength(1);
-      expect(lines[0]?.length).toBeLessThanOrEqual(columns);
+      expect(renderedWidth(lines[0] ?? "")).toBeLessThanOrEqual(columns);
     }
   });
 });

--- a/apps/cli/test/unit/infra/player/persistent-mpv-session-harness.test.ts
+++ b/apps/cli/test/unit/infra/player/persistent-mpv-session-harness.test.ts
@@ -6,6 +6,8 @@ import { LOCAL_HLS_DEMUXER_LAVF_OPTIONS } from "@/infra/player/mpv-stream-http-h
 import type { PersistentMpvSessionRuntime } from "@/infra/player/persistent-mpv-runtime";
 import { PersistentMpvSession } from "@/infra/player/PersistentMpvSession";
 
+import { waitUntil } from "../../../support/wait-until";
+
 type CapturedCallbacks = Parameters<PersistentMpvSessionRuntime["openIpcSession"]>[0];
 
 function createStream(overrides: Partial<StreamInfo> = {}): StreamInfo {
@@ -109,13 +111,15 @@ async function waitFor(predicate: () => boolean): Promise<void> {
   throw new Error("Timed out waiting for fake mpv lifecycle condition");
 }
 
-/** Bootstrap teardown does real filesystem work, so poll on timer ticks. */
+/**
+ * Bootstrap teardown does real filesystem work, so poll rather than sleep.
+ *
+ * The budget was 200ms, which is a bet on disk speed: the same work on a loaded
+ * Windows agent takes longer, and the failure surfaced as this generic message
+ * rather than as whatever was actually still pending.
+ */
 async function waitForSettled(predicate: () => boolean): Promise<void> {
-  for (let i = 0; i < 200; i++) {
-    if (predicate()) return;
-    await Bun.sleep(1);
-  }
-  throw new Error("Timed out waiting for mpv bootstrap teardown");
+  await waitUntil(predicate, { label: "mpv bootstrap teardown" });
 }
 
 describe("PersistentMpvSession single pending load owner", () => {

--- a/apps/cli/test/unit/services/download/download-service.test.ts
+++ b/apps/cli/test/unit/services/download/download-service.test.ts
@@ -7,6 +7,8 @@ import { DownloadEnqueueRejectedError, DownloadService } from "@/services/downlo
 import type { ConfigService } from "@/services/persistence/ConfigService";
 import { DownloadJobsRepository, openKunaiDatabase, runMigrations } from "@kunai/storage";
 
+import { waitUntil as sharedWaitUntil } from "../../../support/wait-until";
+
 const encoder = new TextEncoder();
 const originalFetch = globalThis.fetch;
 
@@ -1530,21 +1532,7 @@ function streamOf(text: string): ReadableStream<Uint8Array> {
   });
 }
 
-/**
- * Wait for a condition, with a budget generous enough not to assert machine speed.
- *
- * The old 250ms default was a bet on how fast the runner is, not on behaviour:
- * on a loaded Windows agent these download tests take seconds end to end, so
- * adding unrelated tests elsewhere reshuffled `--parallel` scheduling and tipped
- * three of them over. The predicate still returns the instant it is true, so a
- * larger ceiling costs nothing when the code works and a genuinely broken
- * condition still fails — just after a wait that no longer depends on the host.
- */
+/** Local signature kept so existing call sites read unchanged. */
 async function waitUntil(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (predicate()) return;
-    await Bun.sleep(5);
-  }
-  throw new Error(`waitUntil timed out after ${timeoutMs}ms`);
+  await sharedWaitUntil(predicate, { timeoutMs });
 }

--- a/apps/cli/test/unit/services/sync/anilist-adapter.test.ts
+++ b/apps/cli/test/unit/services/sync/anilist-adapter.test.ts
@@ -6,6 +6,8 @@ import type { SyncTokenStore } from "@/services/persistence/SyncTokenStore";
 import { AniListAdapter } from "@/services/sync/AniListAdapter";
 import type { TrackerOperation } from "@/services/sync/operations";
 
+import { waitUntil } from "../../../support/wait-until";
+
 const connectedTokenStore = {
   load: async () => ({ anilist: { accessToken: "token", userId: 42 } }),
 } as unknown as SyncTokenStore;
@@ -129,9 +131,7 @@ test("AniList Connect sends a non-empty attempt state to the browser", async () 
   const pending = adapter.connect({ signal: controller.signal });
 
   try {
-    for (let attempt = 0; attempt < 50 && opened.length === 0; attempt += 1) {
-      await Bun.sleep(5);
-    }
+    await waitUntil(() => opened.length > 0, { label: "authorize URL opened" });
     expect(opened).toHaveLength(1);
     expect(new URL(opened[0]!).searchParams.get("state")).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,

--- a/apps/cli/test/unit/services/sync/sync-drain.test.ts
+++ b/apps/cli/test/unit/services/sync/sync-drain.test.ts
@@ -21,6 +21,8 @@ import {
 import { openKunaiDatabase, runMigrations, SyncOutboxRepository } from "@kunai/storage";
 import type { HistoryProgress } from "@kunai/storage";
 
+import { waitUntil } from "../../../support/wait-until";
+
 const dirs: string[] = [];
 const openDatabases: { close(): void }[] = [];
 
@@ -147,9 +149,7 @@ describe("SyncService drain", () => {
 
     const first = await service.drain(25);
     expect(first.claimed).toBe(100);
-    for (let attempt = 0; attempt < 100 && repo.counts().pending > 0; attempt += 1) {
-      await Bun.sleep(10);
-    }
+    await waitUntil(() => repo.counts().pending === 0, { label: "outbox drained" });
 
     expect(anilist.calls).toHaveLength(103);
     expect(repo.counts().pending).toBe(0);
@@ -174,9 +174,7 @@ describe("SyncService drain", () => {
     }
 
     service.deliverSoon();
-    for (let attempt = 0; attempt < 100 && repo.counts().pending > 0; attempt += 1) {
-      await Bun.sleep(10);
-    }
+    await waitUntil(() => repo.counts().pending === 0, { label: "outbox drained" });
 
     expect(anilist.calls).toHaveLength(103);
     expect(repo.counts().pending).toBe(0);
@@ -207,7 +205,7 @@ describe("SyncService drain", () => {
       present: true,
     });
     service.deliverSoon();
-    while (anilist.calls.length === 0) await Bun.sleep(1);
+    await waitUntil(() => anilist.calls.length > 0, { label: "first anilist call" });
 
     seedOperation(repo, {
       version: 1,
@@ -218,9 +216,7 @@ describe("SyncService drain", () => {
     service.deliverSoon();
     release();
 
-    for (let attempt = 0; attempt < 100 && repo.counts().pending > 0; attempt += 1) {
-      await Bun.sleep(10);
-    }
+    await waitUntil(() => repo.counts().pending === 0, { label: "outbox drained" });
     expect(anilist.calls).toHaveLength(2);
     expect(repo.counts().pending).toBe(0);
   });
@@ -436,9 +432,7 @@ describe("SyncService drain", () => {
     expect(scheduled[0]?.delayMs).toBeGreaterThan(0);
     now = new Date(now.getTime() + 60_000);
     scheduled[0]?.task();
-    for (let attempt = 0; attempt < 20 && repo.counts().pending > 0; attempt += 1) {
-      await Bun.sleep(1);
-    }
+    await waitUntil(() => repo.counts().pending === 0, { label: "outbox drained" });
     expect(anilist.calls).toHaveLength(2);
     expect(repo.counts().pending).toBe(0);
 

--- a/apps/cli/test/unit/support/remove-temp-dir.test.ts
+++ b/apps/cli/test/unit/support/remove-temp-dir.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { removeTempDir } from "../../support/remove-temp-dir";
+
+function busy(): NodeJS.ErrnoException {
+  const error = new Error("EBUSY: resource busy or locked") as NodeJS.ErrnoException;
+  error.code = "EBUSY";
+  return error;
+}
+
+test("removes a real directory", () => {
+  const dir = mkdtempSync(join(tmpdir(), "kunai-rmtest-"));
+  writeFileSync(join(dir, "file.txt"), "x");
+  removeTempDir(dir);
+  expect(existsSync(dir)).toBe(false);
+});
+
+test("an undefined or already-gone path is a no-op", () => {
+  expect(() => removeTempDir(undefined)).not.toThrow();
+  expect(() => removeTempDir(join(tmpdir(), "kunai-rmtest-does-not-exist"))).not.toThrow();
+});
+
+/**
+ * The Windows behaviour this exists for, exercised on any platform.
+ *
+ * POSIX unlinks a file with an open handle happily, so `EBUSY` cannot be
+ * produced here for real — the removal is injected instead. Without this the
+ * retry path would ship untested and only ever run on the one OS where it
+ * matters.
+ */
+test("retries while the OS is still holding the directory, then succeeds", () => {
+  let calls = 0;
+  removeTempDir("/tmp/locked", {
+    rm: () => {
+      calls += 1;
+      if (calls < 3) throw busy();
+    },
+  });
+  expect(calls).toBe(3);
+});
+
+test("gives up with a warning rather than failing the suite", () => {
+  const warnings: string[] = [];
+  let calls = 0;
+
+  expect(() =>
+    removeTempDir("/tmp/permanently-locked", {
+      attempts: 3,
+      rm: () => {
+        calls += 1;
+        throw busy();
+      },
+      onGiveUp: (message) => warnings.push(message),
+    }),
+  ).not.toThrow();
+
+  // A leftover temp directory is not a test failure — the OS reclaims it.
+  expect(calls).toBe(3);
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]).toContain("still locked after 3 attempts");
+});
+
+test("a non-lock error is not retried", () => {
+  let calls = 0;
+  const fatal = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+  fatal.code = "EACCES";
+
+  removeTempDir("/tmp/not-ours", {
+    rm: () => {
+      calls += 1;
+      throw fatal;
+    },
+  });
+
+  // Spinning 20 times on a genuine permission problem would hide it.
+  expect(calls).toBe(1);
+});

--- a/apps/cli/test/unit/support/rendered-width.test.ts
+++ b/apps/cli/test/unit/support/rendered-width.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+
+import { frameWidth, renderedWidth, stripAnsi } from "../../support/rendered-width";
+
+const ESC = String.fromCharCode(27);
+const coloured = `${ESC}[38;2;255;143;176mGeneral${ESC}[39m ${ESC}[2m›${ESC}[22m`;
+
+/**
+ * The defect this exists for: width assertions used `line.length`, which counts
+ * Ink's inline SGR bytes as glyphs. With `FORCE_COLOR=3` a 40-column tab strip
+ * measured 149; at `FORCE_COLOR=0` the same assertion passed. The tests
+ * inverted on an environment variable rather than on the layout.
+ */
+test("colour codes are not glyphs", () => {
+  expect(coloured.length).toBe(42);
+  expect(stripAnsi(coloured)).toBe("General ›");
+  expect(renderedWidth(coloured)).toBe(9);
+});
+
+test("the same content measures the same with and without colour", () => {
+  expect(renderedWidth(coloured)).toBe(renderedWidth("General ›"));
+});
+
+test("cursor and erase sequences are stripped too, not just colour", () => {
+  expect(renderedWidth(`${ESC}[2K${ESC}[1;5Habc`)).toBe(3);
+});
+
+test("trailing padding does not count", () => {
+  expect(renderedWidth("abc     ")).toBe(3);
+});
+
+/** A terminal lays out in columns, which is not character count either. */
+test("wide glyphs occupy two columns", () => {
+  expect(renderedWidth("日本語")).toBe(6);
+  expect(renderedWidth("ab")).toBe(2);
+});
+
+test("combining marks and variation selectors occupy none", () => {
+  expect(renderedWidth("é")).toBe(1);
+  expect(renderedWidth(`x${String.fromCodePoint(0xfe0f)}`)).toBe(1);
+});
+
+test("frameWidth takes the widest line and ignores empty ones", () => {
+  expect(frameWidth(`ab\n${coloured}\nc`)).toBe(9);
+  expect(frameWidth("")).toBe(0);
+});

--- a/apps/cli/test/unit/support/wait-until.test.ts
+++ b/apps/cli/test/unit/support/wait-until.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+
+import { waitUntil } from "../../support/wait-until";
+
+test("returns as soon as the predicate holds, without burning the budget", async () => {
+  let calls = 0;
+  const started = Date.now();
+  await waitUntil(() => {
+    calls += 1;
+    return calls >= 2;
+  });
+  // A generous ceiling must cost nothing when the condition arrives early.
+  expect(Date.now() - started).toBeLessThan(1_000);
+});
+
+test("returns immediately when the predicate already holds", async () => {
+  const started = Date.now();
+  await waitUntil(() => true);
+  expect(Date.now() - started).toBeLessThan(100);
+});
+
+/**
+ * The property the unbounded `while (!cond) await Bun.sleep(1)` loops lacked:
+ * they could not fail, only hang until the runner's global timeout, which
+ * reports as a timeout rather than as the condition that never held.
+ */
+test("a condition that never holds fails, and names what was waited for", async () => {
+  await expect(waitUntil(() => false, { timeoutMs: 50, label: "outbox drained" })).rejects.toThrow(
+    /waitUntil\(outbox drained\) timed out after 50ms/,
+  );
+});
+
+test("without a label it still reports a timeout rather than hanging", async () => {
+  await expect(waitUntil(() => false, { timeoutMs: 50 })).rejects.toThrow(
+    /waitUntil timed out after 50ms/,
+  );
+});
+
+test("a condition that becomes true on the deadline tick is not a failure", async () => {
+  // The loop can exit on the deadline in the same tick the condition flips;
+  // failing then would be its own flake.
+  let ready = false;
+  setTimeout(() => {
+    ready = true;
+  }, 40);
+  await waitUntil(() => ready, { timeoutMs: 200, label: "late flip" });
+  expect(ready).toBe(true);
+});


### PR DESCRIPTION
Closes #122. Closes #143. Closes #148.

Three flakes, one theme: **a red Windows job stopped being evidence about the PR.** All three were observed on changes that could not have caused them — most recently two *different* failures on two runs of #147, a documentation-only PR.

## The headline

The full suite now passes under **both** `FORCE_COLOR=0` and `FORCE_COLOR=3` — 14/14 tasks each. It did not before.

---

## 1. Width assertions counted colour codes (#143)

`lines[0].length` counts Ink's inline SGR bytes as if they were glyphs:

```
FORCE_COLOR=3  →  Expected: <= 40   Received: 149   (2 fail)
FORCE_COLOR=0  →  0 fail
```

`FORCE_COLOR` is set in plenty of developer shells and CI images — and is exactly what you would set to exercise the colour paths — so these tests inverted on an environment variable rather than on the layout they exist to check.

`test/support/rendered-width.ts` measures **display columns**: strips ANSI, treats CJK and emoji as two columns, combining marks and variation selectors as none, and ignores trailing padding.

Two deliberate choices:

- **A local ANSI regex, not `ansi-regex`.** That package is a transitive dependency of Ink, not one this workspace declares — importing it would work today and break whenever Ink's tree moves. Same reasoning ruled out `string-width`.
- **Columns, not characters.** `.length` was wrong twice over: colour bytes are not glyphs, *and* a wide glyph is not one column. The tests are about whether a line fits a terminal.

Applied to the settings tab strip and to `ErrorShell` — including a **third assertion in that file with the same defect** that the issue had not spotted (`renders at every canonical width without exceeding the terminal`, which used `[...line.trimEnd()].length`).

## 2. Teardown raced a Windows file handle (#148)

POSIX unlinks a file with an open handle happily — the entry goes, the inode survives until the last descriptor closes. Windows refuses, and `force: true` does not help.

Tests observe *process exit*, which is not the same event as the OS reclaiming that child's handles and can lag it. So `rmSync` threw `EBUSY` from an `afterAll`, reported as `(fail) (unnamed)` — which reads like an unrelated suite failure and tells the reader nothing.

`test/support/remove-temp-dir.ts` retries **only while the OS is actually refusing** (`EBUSY`/`EPERM`/`ENOTEMPTY`) and returns the instant it succeeds. A genuine `EACCES` is not retried — spinning twenty times on a real permission problem would hide it. A final refusal warns rather than throws: a leftover temp directory is not a test failure.

Deliberately **not** a sleep before the delete — that is a bet on host speed, which is the shape #122 is about.

Applied to **all six** suites that delete a directory a spawned process wrote to, not only the one that failed.

## 3. Poll budgets asserted host speed (#122)

Three shapes across the sync, adapter, and mpv suites:

| Shape | Problem |
| --- | --- |
| `for (let i = 0; i < 100; i++) await Bun.sleep(10)` | 1s ceiling, then it *silently gives up* and the assertion below fails with a misleading message |
| `while (anilist.calls.length === 0) await Bun.sleep(1)` | **Unbounded — cannot fail, only hang** until the runner's global timeout, reporting as a timeout rather than as the condition that never held |
| 200ms on real filesystem teardown | A bet on disk speed |

That second one is worth calling out: it is the same class as the fake gates in #118 — a check that cannot fail is not a check.

`test/support/wait-until.ts` is now the single implementation, with a 5s default and a **label in the failure message** so a timeout says what was being waited for. `download-service.test.ts` had already fixed its own copy in #93; it now routes through the shared one so there is one behaviour rather than two drifting ones.

---

## Verification

The helpers are gated rather than assumed correct — **17 tests** in `test/unit/support/`:

- colour-invariance (`renderedWidth(coloured) === renderedWidth(plain)`), wide glyphs, combining marks, cursor/erase sequences, trailing padding
- retry-then-succeed and give-up-with-a-warning, plus "a non-lock error is not retried". `removeTempDir` takes an injectable `rm` **specifically so this path is testable off Windows** — `EBUSY` cannot be produced on Linux, and the retry logic would otherwise ship untested and only ever run on the one OS where it matters
- that a condition which never holds **fails with a name** instead of hanging

Full `bun run test` under both `FORCE_COLOR` settings: 14/14. `typecheck` 14/14, `lint` and `fmt:check` clean (`fmt:check` caught my wrapping again).

## Scope note

This fixes the flakes and the shapes that caused them. It does not sweep every remaining `Bun.sleep` in the test tree — 81 call sites, most of which are legitimately advancing a timer rather than standing in for synchronisation. The shared helpers now exist, so the next one is a one-line change rather than another hand-rolled loop.

https://claude.ai/code/session_01QN5u9VYwYaU56kfr5KQYoD
