### PR TITLE
fix(providers): stop caching failures as healthy empty results

### DIFF
--- a/apps/cli/src/app/discover/anime-provider-mapping.ts
+++ b/apps/cli/src/app/discover/anime-provider-mapping.ts
@@ -66,7 +66,12 @@ export async function mapAnimeDiscoveryResultToProviderNative(
         query,
         animeLang,
         context.signal,
-      ).catch(() => []);
+      ).catch(() => null);
+      // null is an unreachable catalog, not a confirmed miss. Skipping keeps a
+      // transient AllAnime failure from silently downgrading this title to a
+      // title-based match, or to no provider mapping at all.
+      if (matches === null) continue;
+
       const match =
         matches.find((candidate) => candidate.aniListId === discoveryAniListId) ??
         chooseProviderSearchMatch(result, matches);

--- a/packages/providers/src/allmanga/api-client.ts
+++ b/packages/providers/src/allmanga/api-client.ts
@@ -594,6 +594,15 @@ export async function loadShowCatalogInfo(
     thumbnail: normalizeShowThumbnail(show?.thumbnail),
   };
 
+  // Both attempts came back without a show: a timeout, 429, 5xx, or an upstream
+  // rotation, not a catalog that is genuinely empty. Caching the synthesised
+  // `{}` pinned an empty episode list for the full TTL, so a transient failure
+  // kept showing "no episodes" long after AllAnime recovered.
+  //
+  // The empty info is still returned for *this* call — the callers already
+  // handle an empty detail — it simply is not remembered as fact.
+  if (!show?.availableEpisodesDetail) return info;
+
   showCatalogCache.set(cacheKey, info);
   return info;
 }
@@ -921,7 +930,7 @@ export async function searchAllManga(
   query: string,
   animeLang: "sub" | "dub",
   signal?: AbortSignal,
-): Promise<AllMangaSearchResult[]> {
+): Promise<AllMangaSearchResult[] | null> {
   const gqlQuery = `query($search:SearchInput $limit:Int $page:Int $translationType:VaildTranslationTypeEnumType $countryOrigin:VaildCountryOriginEnumType){
     shows(search:$search limit:$limit page:$page translationType:$translationType countryOrigin:$countryOrigin){
       edges{
@@ -988,7 +997,19 @@ export async function searchAllManga(
     };
   } | null;
 
-  const edges = data?.data?.shows?.edges ?? [];
+  // `gqlPost` returns null for a timeout, 429, 5xx, DNS failure, or an upstream
+  // rotation. This used to coalesce to `[]`, which is the same value a healthy
+  // search with no matches produces — so transport failure rendered as
+  // "No results", invisible to provider health and diagnostics. Empty stays
+  // empty; unreachable becomes null.
+  // `gqlPost` returns null for a timeout, 429, 5xx, DNS failure, or an upstream
+  // rotation. This used to coalesce to `[]`, which is the same value a healthy
+  // search with no matches produces — so transport failure rendered as
+  // "No results", invisible to provider health and diagnostics. Empty stays
+  // empty; unreachable becomes null.
+  if (data === null) return null;
+
+  const edges = data.data?.shows?.edges ?? [];
   return edges.map((edge): AllMangaSearchResult => {
     const epRaw = edge.availableEpisodes[animeLang];
     const epCount =

--- a/packages/providers/src/allmanga/direct.ts
+++ b/packages/providers/src/allmanga/direct.ts
@@ -150,6 +150,12 @@ export const allmangaProviderModule: CoreProviderModule = {
       animeLang,
       context.signal,
     );
+    // The provider contract already has a null channel for failure — this
+    // method's own return type is `| null`. Passing transport failure straight
+    // through means ProviderRegistry sees it, provider health records it, and
+    // the shell can say the provider is unreachable instead of "No results".
+    if (results === null) return null;
+
     return results.map((result) => ({
       id: result.id,
       type: result.type,

--- a/packages/providers/src/allmanga/resolve-show-id.ts
+++ b/packages/providers/src/allmanga/resolve-show-id.ts
@@ -101,7 +101,13 @@ async function bridgeAllMangaShowIdFromAnilist(
       query,
       animeLang,
       context.signal,
-    ).catch(() => []);
+    ).catch(() => null);
+
+    // null is "this query could not be checked", not "this query has no match".
+    // Treating the two the same made a timeout look like a confirmed miss and
+    // sent the caller on to the next query -- or out of the loop -- as though
+    // the catalog had answered.
+    if (matches === null) continue;
 
     const idMatch = matches.find((result) => String(result.aniListId) === anilistId);
     if (idMatch?.id) return idMatch.id;

--- a/packages/providers/src/shared/anime-metadata.ts
+++ b/packages/providers/src/shared/anime-metadata.ts
@@ -176,20 +176,41 @@ async function fetchJson<T>(url: string, signal?: AbortSignal): Promise<T | null
   }
 }
 
+/**
+ * Episode metadata plus whether the network pass that produced it finished.
+ *
+ * Without the flag there is no way to tell "this anime has 12 episodes" from
+ * "page 2 of 6 failed", because both arrive as a Map. The caller caches under a
+ * 30-day TTL, so conflating them freezes an incomplete catalog for a month.
+ */
+type EpisodeMetadataFetch = {
+  readonly episodes: Map<number, AnimeEpisodeMetadata>;
+  readonly complete: boolean;
+};
+
+/** Guard against an unbounded catalog; also a reason a pass is incomplete. */
+const JIKAN_MAX_PAGES = 50;
+
 async function fetchJikanEpisodes(
   malId: number,
   signal?: AbortSignal,
-): Promise<Map<number, AnimeEpisodeMetadata>> {
+): Promise<EpisodeMetadataFetch> {
   const episodes = new Map<number, AnimeEpisodeMetadata>();
   let page = 1;
-  let hasNext = true;
 
-  while (hasNext) {
+  for (;;) {
     const payload = await fetchJson<{
       readonly data?: readonly JikanEpisode[];
       readonly pagination?: { readonly has_next_page?: boolean };
     }>(`${JIKAN_BASE}/anime/${malId}/episodes?page=${page}`, signal);
-    const rows = payload?.data ?? [];
+
+    // `fetchJson` returns null for a non-OK response *or* a thrown request, so
+    // null here is a transport failure — not an empty page. It used to fall
+    // through to `rows = []`, which set `hasNext` false and returned the pages
+    // gathered so far as though pagination had completed.
+    if (payload === null) return { episodes, complete: false };
+
+    const rows = payload.data ?? [];
     for (const row of rows) {
       const number = row.mal_id;
       if (!number || number < 1) continue;
@@ -201,18 +222,21 @@ async function fetchJikanEpisodes(
         source: "jikan",
       });
     }
-    hasNext = payload?.pagination?.has_next_page === true && rows.length > 0;
-    page += 1;
-    if (page > 50) break;
-  }
 
-  return episodes;
+    if (payload.pagination?.has_next_page !== true || rows.length === 0) {
+      return { episodes, complete: true };
+    }
+
+    page += 1;
+    // Stopping at the ceiling is a truncated catalog, not a finished one.
+    if (page > JIKAN_MAX_PAGES) return { episodes, complete: false };
+  }
 }
 
 async function fetchAniListStreamingEpisodes(
   anilistId: string,
   signal?: AbortSignal,
-): Promise<Map<number, AnimeEpisodeMetadata>> {
+): Promise<EpisodeMetadataFetch> {
   const episodes = new Map<number, AnimeEpisodeMetadata>();
   try {
     const response = await fetch(ANILIST_GRAPHQL, {
@@ -229,7 +253,7 @@ async function fetchAniListStreamingEpisodes(
         variables: { id: Number(anilistId) },
       }),
     });
-    if (!response.ok) return episodes;
+    if (!response.ok) return { episodes, complete: false };
     const payload = (await response.json()) as {
       readonly data?: {
         readonly Media?: {
@@ -248,9 +272,10 @@ async function fetchAniListStreamingEpisodes(
       });
     });
   } catch {
-    return episodes;
+    // Timeout, DNS, abort — none of which mean the anime has no episodes.
+    return { episodes, complete: false };
   }
-  return episodes;
+  return { episodes, complete: true };
 }
 
 export function mergeMiruroPipeEpisodeMetadata(
@@ -308,22 +333,34 @@ export async function fetchAnimeEpisodeMetadataByNumber(
 
   const merged = new Map<number, AnimeEpisodeMetadata>();
   const malId = ids.malId ? Number.parseInt(ids.malId, 10) : Number.NaN;
+  let complete = true;
 
   if (ids.anilistId) {
-    const anilistEpisodes = await fetchAniListStreamingEpisodes(ids.anilistId, signal);
-    for (const [number, meta] of anilistEpisodes) {
+    const anilist = await fetchAniListStreamingEpisodes(ids.anilistId, signal);
+    for (const [number, meta] of anilist.episodes) {
       mergeEpisodeMetadata(merged, number, meta);
     }
+    complete &&= anilist.complete;
   }
 
   if (pass === "full" && Number.isFinite(malId) && malId > 0) {
-    const jikanEpisodes = await fetchJikanEpisodes(malId, signal);
-    for (const [number, meta] of jikanEpisodes) {
+    const jikan = await fetchJikanEpisodes(malId, signal);
+    for (const [number, meta] of jikan.episodes) {
       mergeEpisodeMetadata(merged, number, meta);
     }
+    complete &&= jikan.complete;
   }
 
-  metadataCache.set(metadataCacheKey(ids, pass), merged);
+  // Return what was gathered — partial metadata is still better than none for
+  // *this* call — but only freeze it for 30 days when every source that ran
+  // finished. A single transient 429 used to pin an incomplete episode list,
+  // with missing titles, air dates and filler flags, for a month.
+  //
+  // An aborted request is incomplete by the same rule: the caller cancelled, so
+  // what arrived is not evidence about the catalog.
+  if (complete && !signal?.aborted) {
+    metadataCache.set(metadataCacheKey(ids, pass), merged);
+  }
   return merged;
 }
 

--- a/packages/providers/src/youtube/invidious-instance-pool.ts
+++ b/packages/providers/src/youtube/invidious-instance-pool.ts
@@ -11,7 +11,15 @@ type CachedInstances = {
   readonly instances: readonly string[];
 };
 
-let cachedInstances: CachedInstances | null = null;
+/**
+ * Keyed by registry URL, not a single slot.
+ *
+ * Production uses one URL, so a bare variable worked — but it meant any change
+ * of `instancesUrl` silently answered from the previous registry's pool, and it
+ * made every test in a file share one cache entry regardless of the URL each
+ * one served.
+ */
+const cachedInstancesByUrl = new Map<string, CachedInstances>();
 const cooldownUntil = new Map<string, number>();
 
 export type InvidiousInstancePoolOptions = {
@@ -33,11 +41,13 @@ export async function fetchHealthyInvidiousInstances(
     }
   }
 
+  const instancesUrl = options.instancesUrl ?? DEFAULT_INSTANCES_URL;
+  const cachedInstances = cachedInstancesByUrl.get(instancesUrl);
   if (cachedInstances && now - cachedInstances.fetchedAt < 15 * 60 * 1000) {
     return filterAvailableInstances(cachedInstances.instances, now);
   }
 
-  const response = await fetch(options.instancesUrl ?? DEFAULT_INSTANCES_URL, {
+  const response = await fetch(instancesUrl, {
     headers: { Accept: "application/json" },
     signal: options.signal,
   });
@@ -51,7 +61,24 @@ export async function fetchHealthyInvidiousInstances(
   ])[];
   const instances = selectReachableInstances(payload);
 
-  cachedInstances = { fetchedAt: now, instances };
+  // An empty selection is not a healthy pool.
+  //
+  // A 200 that yields zero reachable API instances means the registry is
+  // degraded, or its shape changed, or everything it listed is unusable — none
+  // of which is knowledge worth holding for the full TTL. Caching it made
+  // `pickInvidiousInstance` throw "No healthy Invidious instances available"
+  // from a *cached* empty pool for 15 minutes, so YouTube stayed broken long
+  // after the registry recovered.
+  //
+  // Thrown requests and non-OK responses were already left uncached; this
+  // closes the third path to the same state.
+  if (instances.length === 0) {
+    // A previous non-empty pool is better evidence than an empty one. Keep it
+    // and let its own TTL expire rather than replacing it with nothing.
+    return cachedInstances ? filterAvailableInstances(cachedInstances.instances, now) : [];
+  }
+
+  cachedInstancesByUrl.set(instancesUrl, { fetchedAt: now, instances });
   return filterAvailableInstances(instances, now);
 }
 

--- a/packages/providers/test/allmanga.test.ts
+++ b/packages/providers/test/allmanga.test.ts
@@ -1352,3 +1352,81 @@ function jsonResponse(value: unknown): Response {
 function nowFixture(): string {
   return "2026-05-19T00:00:00.000Z";
 }
+
+/**
+ * Transport failure must not render as a healthy empty catalog.
+ *
+ * `gqlPost` returns null for a timeout, 429, 5xx, DNS failure, or an upstream
+ * rotation. The search path used to coalesce that to `[]` — the same value a
+ * healthy search with no matches produces — so an unreachable AllAnime showed
+ * "No results" and was invisible to provider health and diagnostics.
+ */
+describe("AllManga transport failure is preserved, not flattened", () => {
+  const API = "https://api.example/graphql";
+
+  function serve(handler: () => Response) {
+    globalThis.fetch = (async () => handler()) as unknown as typeof fetch;
+  }
+
+  test("a 5xx is null, while a genuinely empty result stays an empty array", async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      serve(() => new Response("upstream exploded", { status: 503 }));
+      const failed = await searchAllManga(
+        TEST_CONTEXT,
+        API,
+        "https://referer.example",
+        "ua",
+        "Example",
+        "sub",
+      );
+      expect(failed).toBeNull();
+
+      serve(
+        () =>
+          new Response(JSON.stringify({ data: { shows: { edges: [] } } }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      );
+      const empty = await searchAllManga(
+        TEST_CONTEXT,
+        API,
+        "https://referer.example",
+        "ua",
+        "Nothing Matches This",
+        "sub",
+      );
+      // A catalog that answered and had nothing is not a failure.
+      expect(empty).toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("a rate limit is null, not an empty catalog", async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      serve(() => new Response("slow down", { status: 429 }));
+      expect(
+        await searchAllManga(TEST_CONTEXT, API, "https://referer.example", "ua", "Example", "sub"),
+      ).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("a thrown request is null, not an empty catalog", async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = (async () => {
+        throw new Error("ENOTFOUND api.example");
+      }) as unknown as typeof fetch;
+      expect(
+        await searchAllManga(TEST_CONTEXT, API, "https://referer.example", "ua", "Example", "sub"),
+      ).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/packages/providers/test/anime-metadata.test.ts
+++ b/packages/providers/test/anime-metadata.test.ts
@@ -5,6 +5,7 @@ import {
   clearAnimeMetadataCacheForTest,
   enrichEpisodeOptionsWithAnimeMetadata,
   episodeMetadataTitleCoverage,
+  fetchAnimeEpisodeMetadataByNumber,
   formatAnimeEpisodeLabel,
   getSeededEpisodeMetadata,
   mergeMiruroPipeEpisodeMetadata,
@@ -102,5 +103,106 @@ describe("anime metadata helpers", () => {
         { number: 3 },
       ]),
     ).toBeCloseTo(2 / 3);
+  });
+});
+
+/**
+ * A failed page must not be cached as a complete catalog.
+ *
+ * `fetchJson` returns null for a non-OK response *or* a thrown request, so a
+ * transient 429 mid-pagination used to fall through to `rows = []`, set
+ * `hasNext` false, and return the pages gathered so far as though pagination
+ * had finished. The caller then wrote that under the full-pass key with a
+ * **30-day** TTL, freezing incomplete titles, air dates and filler flags for a
+ * month.
+ */
+describe("episode metadata pagination completeness", () => {
+  const MAL_ID = "5678";
+
+  function jikanPage(episodes: readonly number[], hasNext: boolean): Response {
+    return new Response(
+      JSON.stringify({
+        data: episodes.map((n) => ({ mal_id: n, title: `Episode ${n}`, filler: false })),
+        pagination: { has_next_page: hasNext },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  test("a page failure is not remembered as a finished catalog", async () => {
+    const originalFetch = globalThis.fetch;
+    let jikanCalls = 0;
+    try {
+      globalThis.fetch = (async (input: string | URL | Request) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (!url.includes("jikan")) {
+          return new Response(JSON.stringify({ data: { Media: { streamingEpisodes: [] } } }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        jikanCalls += 1;
+        // Page 1 succeeds and promises more; page 2 is rate limited.
+        if (url.includes("page=1")) return jikanPage([1, 2], true);
+        return new Response("rate limited", { status: 429 });
+      }) as unknown as typeof fetch;
+
+      const first = await fetchAnimeEpisodeMetadataByNumber({ malId: MAL_ID });
+      // The partial data is still useful for this call.
+      expect(first.get(1)?.title).toBe("Episode 1");
+      expect(first.get(3)).toBeUndefined();
+      const callsAfterFirst = jikanCalls;
+
+      // The registry recovers. A second call must go back to the network
+      // rather than serving the truncated catalog from a 30-day cache.
+      globalThis.fetch = (async (input: string | URL | Request) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (!url.includes("jikan")) {
+          return new Response(JSON.stringify({ data: { Media: { streamingEpisodes: [] } } }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        jikanCalls += 1;
+        if (url.includes("page=1")) return jikanPage([1, 2], true);
+        return jikanPage([3, 4], false);
+      }) as unknown as typeof fetch;
+
+      const second = await fetchAnimeEpisodeMetadataByNumber({ malId: MAL_ID });
+      expect(jikanCalls).toBeGreaterThan(callsAfterFirst);
+      expect(second.get(3)?.title).toBe("Episode 3");
+      expect(second.get(4)?.title).toBe("Episode 4");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("a catalog that really did finish is cached and not refetched", async () => {
+    const originalFetch = globalThis.fetch;
+    let jikanCalls = 0;
+    try {
+      globalThis.fetch = (async (input: string | URL | Request) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (!url.includes("jikan")) {
+          return new Response(JSON.stringify({ data: { Media: { streamingEpisodes: [] } } }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        jikanCalls += 1;
+        return jikanPage([1, 2], false);
+      }) as unknown as typeof fetch;
+
+      const first = await fetchAnimeEpisodeMetadataByNumber({ malId: "9999" });
+      expect(first.get(2)?.title).toBe("Episode 2");
+      const callsAfterFirst = jikanCalls;
+
+      // Completeness still earns the cache — this fix must not disable it.
+      const second = await fetchAnimeEpisodeMetadataByNumber({ malId: "9999" });
+      expect(jikanCalls).toBe(callsAfterFirst);
+      expect(second.get(2)?.title).toBe("Episode 2");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/packages/providers/test/youtube/invidious-instance-pool.test.ts
+++ b/packages/providers/test/youtube/invidious-instance-pool.test.ts
@@ -104,3 +104,74 @@ describe("invidious instance pool", () => {
     }
   });
 });
+
+/**
+ * A 200 that selects zero reachable instances is a degraded registry, a changed
+ * response shape, or a list where nothing is usable — not a healthy pool.
+ *
+ * It was cached for the full 15-minute TTL, so `pickInvidiousInstance` threw
+ * "No healthy Invidious instances available" from a *cached* empty pool on
+ * every attempt until expiry, keeping YouTube broken long after the registry
+ * recovered. Thrown requests and non-OK responses were already left uncached;
+ * this was the third path to the same state.
+ */
+describe("an empty selection is not a healthy pool", () => {
+  function serve(body: string, status = 200) {
+    globalThis.fetch = (async () =>
+      new Response(body, {
+        status,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof fetch;
+  }
+
+  test("an empty selection does not replace a pool that already worked", async () => {
+    const originalFetch = globalThis.fetch;
+    const url = "https://fixtures.test/instances-empty-selection.json";
+    try {
+      // A healthy pass populates the cache.
+      serve(JSON.stringify([["good.example", { api: false, uri: "https://good.example" }]]));
+      const healthy = await fetchHealthyInvidiousInstances({
+        instancesUrl: url,
+        now: () => 1_900_000_000_000,
+      });
+      expect(healthy).toEqual(["https://good.example"]);
+
+      // Past the TTL, the registry answers 200 with nothing selectable.
+      serve(JSON.stringify([["only.onion", { api: null, uri: "http://only.onion" }]]));
+      const afterDegraded = await fetchHealthyInvidiousInstances({
+        instancesUrl: url,
+        now: () => 1_900_000_000_000 + 16 * 60 * 1000,
+      });
+
+      // The previous non-empty pool is better evidence than an empty one.
+      expect(afterDegraded).toEqual(["https://good.example"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("a recovered registry is picked up immediately, not after a stale TTL", async () => {
+    const originalFetch = globalThis.fetch;
+    const url = "https://fixtures.test/instances-recovery.json";
+    try {
+      // First contact is degraded, so there is no previous pool to fall back to.
+      serve(JSON.stringify([["only.i2p", { api: null, uri: "http://only.i2p" }]]));
+      const degraded = await fetchHealthyInvidiousInstances({
+        instancesUrl: url,
+        now: () => 2_000_000_000_000,
+      });
+      expect(degraded).toEqual([]);
+
+      // One second later the registry is healthy again. Before the fix the
+      // empty pool was cached, so this still returned nothing for 15 minutes.
+      serve(JSON.stringify([["back.example", { api: false, uri: "https://back.example" }]]));
+      const recovered = await fetchHealthyInvidiousInstances({
+        instancesUrl: url,
+        now: () => 2_000_000_000_000 + 1_000,
+      });
+      expect(recovered).toEqual(["https://back.example"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
Closes #126. Closes #128. Closes #140.

Three issues, **one defect**: a network failure converted into a successful-looking empty value, then cached. Each renders as *"there is nothing here"* rather than *"this could not be reached"* — indistinguishable to the user, and invisible to provider health and diagnostics.

They are fixed together because they need the same decision: what failure looks like in the provider contract, and what may never be cached.

---

## 1. Jikan pagination cached a truncated catalog for 30 days (#128)

`fetchJson` returns `null` for a non-OK response *or* a thrown request. A failure at page N fell through:

```ts
const rows = payload?.data ?? [];                                    // → []
hasNext = payload?.pagination?.has_next_page === true && rows.length > 0;  // → false
```

…so the pages gathered so far were returned as though pagination had finished. The caller wrote that under the full-pass key with a **30-day** TTL. One transient 429 froze incomplete episode titles, air dates, filler and recap flags for a month.

Both fetchers now report completeness. **`fetchAniListStreamingEpisodes` had the identical defect** at its `!response.ok` and `catch` — the issue described only Jikan, and both feed the same cache.

Partial data is still returned for the current call, because it beats nothing. It is simply not frozen. An **aborted** request counts as incomplete by the same rule: the caller cancelled, so what arrived is not evidence about the catalog.

The `page > 50` ceiling is now also incomplete rather than silently finished — a second trigger for the same freeze that the issue did not mention.

## 2. Invidious cached an empty pool as healthy for 15 minutes (#140)

A 200 that selects zero reachable instances means the registry is degraded, its shape changed, or nothing listed is usable. It was cached for the full TTL, so `pickInvidiousInstance` threw *"No healthy Invidious instances available"* from a **cached** empty pool on every attempt until expiry — YouTube stayed broken long after the registry recovered.

Thrown requests and non-OK responses were already left uncached; this closes the third path to the same state. A previous non-empty pool is kept rather than replaced with nothing.

**Also keyed the pool cache by registry URL.** It was a single module-level slot, so changing `instancesUrl` silently answered from the previous registry's pool — and every test in a file shared one entry regardless of what it served, which is what made the new cases order-dependent. Fixing the design was the right move rather than working around it in the tests.

## 3. AllManga flattened transport failure into "No results" (#126)

`gqlPost` correctly returns `null` for a timeout, 429, 5xx, DNS failure, or an upstream rotation. `searchAllManga` coalesced that to `[]` — **the same value a healthy search with no matches produces**.

Empty stays empty; unreachable is now `null`. Worth noting: the provider's own `search()` **already declared `| null`** for failure, so the contract had the channel all along and this is a pass-through to `ProviderRegistry` and provider health.

The compiler found the three callers. Each got the handling that fits it:

| Caller | Handling |
| --- | --- |
| `direct.ts` provider `search()` | pass `null` through — it is already the failure channel |
| `resolve-show-id.ts` | `continue` — an unchecked query is not a confirmed miss |
| `anime-provider-mapping.ts` | `continue` — otherwise a transient failure silently downgrades the title to a title-based match |

The episode-catalog path no longer caches a synthesised `{}` when both attempts came back without a show, which pinned an empty episode list for the full 45s TTL.

---

## Verification

Each guard was removed and the tests re-run, so none of them passes for the wrong reason:

| Guard removed | Result |
| --- | --- |
| Jikan completeness | page-failure test fails |
| Empty-pool guard | both Invidious tests fail |
| Null preservation | all three AllManga tests fail |

The tests also pin **what must not change** — that was the main risk in a change like this:

- a genuinely empty search still returns `[]`, not `null`
- a catalog that really did finish is still cached and **not** refetched
- a recovered registry is picked up immediately rather than after a stale TTL

Providers **398 pass**, full `bun run test` **14/14 tasks**, `typecheck` 14/14, `lint` and `fmt:check` clean.

## The shape, for the record

This is the same defect the last few PRs have been about, one layer down:

- #118 — a test that passes while proving nothing
- #144 — a flag that parses while doing nothing
- here — a request that fails while reporting nothing wrong

All three report success while doing nothing, and all three are only visible once you ask what the failure path actually produces. Worth keeping in mind for the remaining provider issues (#135, #136, #138, #139), which sit in the same code.

https://claude.ai/code/session_01QN5u9VYwYaU56kfr5KQYoD
