### PR TITLE
fix(ci): order integration tests after the build they share a directory with

### DIFF
--- a/apps/cli/turbo.json
+++ b/apps/cli/turbo.json
@@ -24,8 +24,14 @@
       ],
       "outputs": []
     },
+    // Depends on `build` because two integration tests spawn a real build into
+    // the shared `dist/`: release-build.test.ts and npm-pack-guard.test.ts.
+    // Without the edge, Turbo may run the build task -- or restore its cached
+    // dist/ outputs -- at the same time, and a test asserting on empty stderr
+    // or a file's contents sees torn state. It then fails naming a test
+    // unrelated to the change under review.
     "test:integration": {
-      "dependsOn": ["transit"],
+      "dependsOn": ["transit", "build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "!docs/**",


### PR DESCRIPTION
Closes #151.

`bun run test` failed **three times in a row** on a branch that touched only `TitleDetailService.ts` — and named a *different* test each time:

```
(fail) Settings enable and an unrelated save preserve one install id on disk
(fail) npm pack guard with binaries on disk > builds and release-packs only the policy-safe launcher files
(fail) CLI distribution build > produces the development app bundle and public launcher package
```

`bun test test/integration` in isolation, same tree: **145 pass, 0 fail**, twice. That gap is the whole diagnosis — the tests are fine, the environment they ran in was not exclusive.

## Cause

`build` declares `dist/` outputs, so Turbo both **writes** them and **restores them from cache**. `test:integration` did not depend on `build`, so Turbo could schedule the two concurrently — and two integration tests spawn a *real* build into that same directory:

| Test | What it does to `dist/` |
| --- | --- |
| `release-build.test.ts:11` | runs `scripts/build.ts`, then asserts `stderr === ""` and reads `dist/kunai.js` |
| `npm-pack-guard.test.ts:36` | runs `bun run build`, and writes `dist/bin/` stubs |

Up to three writers on `apps/cli/dist/` at once. A test asserting on empty stderr, or on a file's contents, then sees torn state — and reports a failure in code the branch never touched.

## The edge has to go in the package config

The root `turbo.json` looks like the right place and **is not**. `apps/cli/turbo.json` redefines `test:integration`, so a root-level `dependsOn` would have been a **silent no-op** for the only package that has integration tests. I put it there first, noticed it would do nothing, and moved it.

Verified in the resolved graph rather than assumed:

```
@kitsunekode/kunai#test:integration
  Dependencies = @kitsunekode/kunai#build, @kitsunekode/kunai#transit
```

The rationale is a **JSONC comment, not a `"//"` key** — Turbo rejects unknown keys outright:

```
x Failed to parse turbo.json.
`->   x Found an unknown key `//`.
```

The dry run caught that before it was committed.

## Cost

**1.5 s on a warm run** — 36.5 s vs 35.0 s, about 4% — because Turbo caches the build. The integration tests were spawning a build anyway; this only orders it.

## Verified

Three consecutive full `bun run test` runs: **23/23 tasks, no failures**. Before the change, three consecutive runs failed on three different tests.

## What I did not do

Not fixed by sleeping or retrying around the assertions. The tests are correct about what they assert; adding tolerance would have hidden the race instead of removing it — and that is the shape #122 is about.

The stronger fix is to give `scripts/build.ts` an output-directory override so build-shaped tests never touch the shared `dist/` at all. That also decouples `release-build.test.ts` from `npm-pack-guard.test.ts`, which currently both write the same tree. It is a production-script change for a test-only problem, so I left it as the documented alternative in #151 rather than doing it here.

## Related

Fourth instance this cycle of a CI failure that says nothing about the change under review — after #122 (wall-clock budgets), #143 (ANSI width), and #148 (Windows handle race). Same cost each time: a red gate stops being evidence.

https://claude.ai/code/session_01QN5u9VYwYaU56kfr5KQYoD
