### PR TITLE
fix(catalog): stop anime detail mixing identity and facts from two catalogs

### DIFF
--- a/apps/cli/src/services/catalog/TitleDetailService.ts
+++ b/apps/cli/src/services/catalog/TitleDetailService.ts
@@ -282,7 +282,47 @@ function mergeDetails(
       ? (anilist?.synopsis ?? tmdb?.synopsis)
       : (tmdb?.synopsis ?? anilist?.synopsis);
 
-  const genres = dedupe([...(tmdb?.genres ?? []), ...(anilist?.genres ?? [])]);
+  // Do the two records describe the same work?
+  //
+  // Nothing upstream guarantees it. `tmdbId` can arrive from a caller hint or
+  // the AniList->TMDB crosswalk, and a wrong mapping still fetches a perfectly
+  // valid TMDB record — for a different film. The merge then took identity from
+  // one catalog and facts from the other, which is how a panel showed the right
+  // title and synopsis beside another title's year, runtime and genre, and
+  // disagreed with the player's own progress bar about the runtime.
+  //
+  // A release-year gap is the cheapest reliable signal: the same work does not
+  // move by years between catalogs, while two different works usually do. One
+  // year of slack absorbs the real cause of small differences — festival vs
+  // wide release, and JST/UTC boundaries.
+  const yearsDisagree =
+    tmdb?.year !== undefined &&
+    anilist?.year !== undefined &&
+    Math.abs(Number(tmdb.year) - Number(anilist.year)) > 1;
+  const trustTmdbFacts = !yearsDisagree;
+
+  /**
+   * For anime, facts follow the record that supplied the title.
+   *
+   * Title and synopsis already prefer AniList here. Taking year, runtime and
+   * genre from TMDB instead made the panel a blend of two catalogs, so a bad
+   * crosswalk corrupted the visible facts while leaving the name intact —
+   * which reads as a data bug rather than a lookup bug and is much harder to
+   * notice. TMDB still fills anything AniList does not carry.
+   */
+  const factsPreferAniList = artworkKind === "anime";
+  const preferredYear = factsPreferAniList
+    ? (anilist?.year ?? (trustTmdbFacts ? tmdb?.year : undefined))
+    : (tmdb?.year ?? anilist?.year);
+  const preferredRuntime = factsPreferAniList
+    ? (anilist?.runtimeMinutes ?? (trustTmdbFacts ? tmdb?.runtimeMinutes : undefined))
+    : (tmdb?.runtimeMinutes ?? anilist?.runtimeMinutes);
+
+  // A record we do not trust contributes no genres either — a wrong film's
+  // "Comedy" is what surfaces first in the panel's single-genre slot.
+  const genres = factsPreferAniList
+    ? dedupe([...(anilist?.genres ?? []), ...(trustTmdbFacts ? (tmdb?.genres ?? []) : [])])
+    : dedupe([...(tmdb?.genres ?? []), ...(anilist?.genres ?? [])]);
   const studios = dedupe([...(tmdb?.studios ?? []), ...(anilist?.studios ?? [])]);
 
   // Cast: prefer voice cast from AniList for anime, actor cast from TMDB otherwise
@@ -301,11 +341,11 @@ function mergeDetails(
     id,
     type: resolvedType,
     title,
-    year: tmdb?.year ?? anilist?.year ?? undefined,
+    year: preferredYear ?? undefined,
     synopsis,
     genres: genres.length ? genres : undefined,
     studios: studios.length ? studios : undefined,
-    runtimeMinutes: tmdb?.runtimeMinutes ?? anilist?.runtimeMinutes ?? undefined,
+    runtimeMinutes: preferredRuntime ?? undefined,
     contentRating: tmdb?.contentRating ?? undefined,
     releaseDate: tmdb?.releaseDate ?? anilist?.releaseDate ?? undefined,
     status,

--- a/apps/cli/test/unit/services/catalog/title-detail-service.test.ts
+++ b/apps/cli/test/unit/services/catalog/title-detail-service.test.ts
@@ -674,3 +674,130 @@ describe("TitleDetailService — id format compat", () => {
     clearTitleDetailCache();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Cross-catalog coherence
+// ---------------------------------------------------------------------------
+
+/**
+ * An anime panel must not take its identity from one catalog and its facts from
+ * another.
+ *
+ * Observed on *Road to Ninja: Naruto the Movie*: the panel read
+ * "1985 · 1h 37m · Comedy" beside the correct title and synopsis, and
+ * contradicted the player's own progress bar, which showed 1:49:56.
+ *
+ * Nothing upstream guarantees the two records describe the same work. `tmdbId`
+ * can arrive from a caller hint or the AniList→TMDB crosswalk, and a wrong
+ * mapping still returns a perfectly valid TMDB record — for a different film.
+ * Title and synopsis preferred AniList while year, runtime and genre preferred
+ * TMDB, so a bad crosswalk corrupted exactly the visible facts and left the
+ * name intact, which reads as a data bug rather than a lookup bug.
+ */
+describe("anime detail stays coherent across catalogs", () => {
+  const ANIME_HINTS = { isAnime: true, externalIds: { anilistId: "16870", tmdbId: "99999" } };
+
+  function serveMismatch(): () => void {
+    return mockFetch((url) => {
+      if (url.includes("graphql") || url.includes("anilist")) {
+        return jsonResponse({
+          data: {
+            Media: anilistMediaPayload({
+              id: 16870,
+              title: {
+                romaji: "Road to Ninja: Naruto the Movie",
+                english: "Road to Ninja: Naruto the Movie",
+                native: "",
+              },
+              description: "Naruto and Sakura are sent to an alternate world.",
+              format: "MOVIE",
+              episodes: 1,
+              duration: 109,
+              genres: ["Action", "Adventure"],
+              startDate: { year: 2012, month: 7, day: 28 },
+            }),
+          },
+        });
+      }
+      // A different film entirely, which is what a bad crosswalk returns.
+      return jsonResponse(
+        tmdbMoviePayload({
+          id: 99999,
+          title: "Some Unrelated 1985 Comedy",
+          overview: "Not this film.",
+          release_date: "1985-06-01",
+          runtime: 97,
+          genres: [{ id: 35, name: "Comedy" }],
+        }),
+      );
+    });
+  }
+
+  test("a mismatched TMDB record cannot supply year, runtime or genre", async () => {
+    const restore = serveMismatch();
+    try {
+      const detail = await fetchTitleDetail("anilist:16870", "movie", undefined, ANIME_HINTS);
+
+      // Identity was already correct — that is what made this hard to spot.
+      expect(detail.title).toBe("Road to Ninja: Naruto the Movie");
+
+      // The facts must now come from the same record as the identity.
+      expect(detail.year).toBe("2012");
+      expect(detail.runtimeMinutes).toBe(109);
+      expect(detail.genres?.[0]).not.toBe("Comedy");
+    } finally {
+      restore();
+    }
+  });
+
+  test("the panel no longer contradicts the player's runtime", async () => {
+    const restore = serveMismatch();
+    try {
+      const detail = await fetchTitleDetail("anilist:16870", "movie", undefined, ANIME_HINTS);
+      // 1:49:56 on the progress bar; the panel claimed 1h 37m.
+      expect(detail.runtimeMinutes).toBeGreaterThan(100);
+    } finally {
+      restore();
+    }
+  });
+
+  test("an agreeing TMDB record still contributes — this is not TMDB removal", async () => {
+    const restore = mockFetch((url) => {
+      if (url.includes("graphql") || url.includes("anilist")) {
+        return jsonResponse({
+          data: {
+            Media: anilistMediaPayload({
+              id: 16870,
+              title: { romaji: "Agreeing Film", english: "Agreeing Film", native: "" },
+              format: "MOVIE",
+              episodes: 1,
+              duration: undefined,
+              genres: [],
+              startDate: { year: 2012, month: 7, day: 28 },
+            }),
+          },
+        });
+      }
+      return jsonResponse(
+        tmdbMoviePayload({
+          id: 4242,
+          title: "Agreeing Film",
+          release_date: "2012-08-01",
+          runtime: 109,
+          genres: [{ id: 28, name: "Action" }],
+        }),
+      );
+    });
+    try {
+      const detail = await fetchTitleDetail("anilist:16870", "movie", undefined, {
+        isAnime: true,
+        externalIds: { anilistId: "16870", tmdbId: "4242" },
+      });
+      // Same year, so the record is trusted and fills what AniList lacks.
+      expect(detail.runtimeMinutes).toBe(109);
+      expect(detail.genres).toContain("Action");
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
Closes #115.

Observed on *Road to Ninja: Naruto the Movie*: the panel read **"1985 · 1h 37m · Comedy"** beside the correct title and synopsis, and contradicted the player's own progress bar, which showed **1:49:56**.

## Not a cache collision

The issue suspected one cache key serving two identities. It is not that — `cacheKey` is `${type}:${id}`, properly keyed by identity.

The defect is in the merge, and it is an **asymmetry**:

| Field | For anime, prefers |
| --- | --- |
| `title`, `synopsis` | **AniList** |
| `year`, `runtimeMinutes`, `genres` | **TMDB** |

So an anime title took its *identity* from one catalog and its *facts* from another, with nothing requiring the two records to describe the same work. `tmdbId` can arrive from a caller hint or the AniList→TMDB crosswalk, and a wrong mapping still returns a perfectly valid TMDB record — for a different film.

That corrupted exactly the visible facts while leaving the name intact, which reads as a data bug rather than a lookup bug and is much harder to notice. It is also why the panel could disagree with the player in the same frame.

`resolveTitleDetail` already carries defensive code for a related case (the "My Roommate is a Cat shows a 1994 CCTV documentary" corruption), but that guards which **id** is used. Once an id exists, nothing checked that the record it returned was the same work.

## Two changes

**Facts follow the record that supplied the title.** For anime, `year`, `runtimeMinutes` and `genres` now prefer AniList, matching `title` and `synopsis`. TMDB still fills anything AniList does not carry — this is not TMDB removal.

**A mismatched record contributes nothing.** If both catalogs report a year and they differ by more than one, the TMDB record is distrusted for facts *and* genres. A release-year gap is the cheapest reliable signal: the same work does not move years between catalogs, while two different works usually do. One year of slack absorbs festival-vs-wide release and JST/UTC boundaries.

The genre guard matters on its own — the panel shows a single genre, so a wrong film's "Comedy" is exactly what surfaces.

## Verified by reproducing the report

Reverting the merge makes the new tests fail with the **exact values from the bug report**:

```
Expected: "2012"     Received: "1985"
Expected: > 100      Received: 97       (i.e. 1h 37m)
```

A third test pins what must not change: a TMDB record that **agrees** on year still contributes its runtime and genres.

Full `bun run test` 14/14, typecheck 14/14.

## Note on the pre-push hook

The hook failed three times while landing this, each on a *different* integration test unrelated to the change. Isolated `bun test test/integration` passed 145/0 twice. That turned out to be a separate defect — integration tests racing the Turbo build task over the shared `dist/` — filed as #151 and fixed in #152.

https://claude.ai/code/session_01QN5u9VYwYaU56kfr5KQYoD