### PR TITLE
fix(videasy): stop rejecting season 0 specials before the request is made

### DIFF
--- a/packages/providers/src/videasy/direct.ts
+++ b/packages/providers/src/videasy/direct.ts
@@ -2374,7 +2374,34 @@ async function enrichVideasyResolveInput(
   };
 }
 
-function buildQueryVariants(opts: {
+/**
+ * Does this episode carry coordinates Videasy can be asked about?
+ *
+ * The guard was `!opts.episode?.season || !opts.episode.episode`, which is a
+ * truthiness test on a field where zero is meaningful: **season 0 is the
+ * catalog identity for specials and OVAs**. `!0` is true, so every special
+ * returned an empty variant list and the provider was never called — no
+ * request, no failure, no trace. The lane simply reported nothing to play.
+ *
+ * Season and episode are checked differently on purpose:
+ *
+ * - **Season** may be 0. It must be a non-negative integer, so a missing,
+ *   negative, or fractional season still fails here rather than sending a
+ *   nonsense `seasonId` upstream.
+ * - **Episode** may not be 0. Episode numbers are 1-based across Kunai, so a
+ *   zero episode is a bug in the caller, not a special. It stays rejected
+ *   until something proves otherwise for this provider specifically.
+ */
+export function hasResolvableSeriesCoordinates(
+  episode: EpisodeIdentity | undefined,
+): episode is EpisodeIdentity & { readonly season: number; readonly episode: number } {
+  const { season, episode: number } = episode ?? {};
+  if (typeof season !== "number" || !Number.isInteger(season) || season < 0) return false;
+  if (typeof number !== "number" || !Number.isInteger(number) || number < 1) return false;
+  return true;
+}
+
+export function buildQueryVariants(opts: {
   readonly title: TitleIdentity;
   readonly mediaKind: "movie" | "series";
   readonly tmdbId: number;
@@ -2401,7 +2428,7 @@ function buildQueryVariants(opts: {
   }
 
   if (opts.mediaKind === "series") {
-    if (!opts.episode?.season || !opts.episode.episode) {
+    if (!hasResolvableSeriesCoordinates(opts.episode)) {
       return [];
     }
     base.set("seasonId", String(opts.episode.season));

--- a/packages/providers/test/videasy-route-contracts.test.ts
+++ b/packages/providers/test/videasy-route-contracts.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildQueryVariants,
   classifyVideasyHttpFailure,
+  hasResolvableSeriesCoordinates,
   getPhaseAVidkingFlavorIds,
   isVidkingFlavorDeprecated,
   listDeprecatedVidkingEndpoints,
@@ -54,5 +56,71 @@ describe("deprecated Videasy routes stay inert", () => {
     for (const flavor of listVidkingFlavors()) {
       expect(flavor.deprecated).not.toBe(true);
     }
+  });
+});
+
+/**
+ * Season 0 is the catalog identity for specials and OVAs.
+ *
+ * The series guard was `!episode?.season || !episode.episode` — a truthiness
+ * test on a field where zero is meaningful. `!0` is true, so every special
+ * produced an empty variant list and the provider was never called: no
+ * request, no failure, no trace. The lane simply reported nothing to play,
+ * which is indistinguishable from "this special has no source".
+ *
+ * Season and episode are deliberately asymmetric. Season may be 0; episode may
+ * not, because episode numbers are 1-based across Kunai, so a zero episode is
+ * a caller bug rather than a special.
+ */
+describe("videasy series coordinates", () => {
+  const TITLE = { title: "Example Show", year: 2020, tmdbId: "1399" } as const;
+
+  function variantsFor(episode: { season?: number; episode?: number } | undefined) {
+    return buildQueryVariants({
+      title: TITLE as never,
+      mediaKind: "series",
+      tmdbId: 1399,
+      episode: episode as never,
+      singleVariant: true,
+    });
+  }
+
+  test("season 0 with a positive episode produces the request, with seasonId=0", () => {
+    const variants = variantsFor({ season: 0, episode: 3 });
+    expect(variants).toHaveLength(1);
+    expect(variants[0]?.get("seasonId")).toBe("0");
+    expect(variants[0]?.get("episodeId")).toBe("3");
+    expect(variants[0]?.get("mediaType")).toBe("tv");
+    expect(variants[0]?.get("tmdbId")).toBe("1399");
+  });
+
+  test("ordinary seasons are unchanged", () => {
+    const variants = variantsFor({ season: 2, episode: 7 });
+    expect(variants[0]?.get("seasonId")).toBe("2");
+    expect(variants[0]?.get("episodeId")).toBe("7");
+  });
+
+  test("a missing season still fails before any network call", () => {
+    expect(variantsFor({ episode: 3 })).toEqual([]);
+    expect(variantsFor(undefined)).toEqual([]);
+  });
+
+  test("episode 0 stays rejected — episodes are 1-based here", () => {
+    expect(variantsFor({ season: 1, episode: 0 })).toEqual([]);
+    expect(variantsFor({ season: 0, episode: 0 })).toEqual([]);
+  });
+
+  test("a nonsense season is rejected rather than sent upstream", () => {
+    expect(variantsFor({ season: -1, episode: 3 })).toEqual([]);
+    expect(variantsFor({ season: 1.5, episode: 3 })).toEqual([]);
+    expect(variantsFor({ season: Number.NaN, episode: 3 })).toEqual([]);
+  });
+
+  test("the predicate agrees with what the builder does", () => {
+    expect(hasResolvableSeriesCoordinates({ season: 0, episode: 1 })).toBe(true);
+    expect(hasResolvableSeriesCoordinates({ season: 1, episode: 1 })).toBe(true);
+    expect(hasResolvableSeriesCoordinates({ season: 0, episode: 0 })).toBe(false);
+    expect(hasResolvableSeriesCoordinates({ episode: 1 })).toBe(false);
+    expect(hasResolvableSeriesCoordinates(undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #138.

`buildQueryVariants` guarded series coordinates with:

```ts
if (!opts.episode?.season || !opts.episode.episode) return [];
```

A truthiness test on a field where zero is meaningful. **Season 0 is the catalog identity for specials and OVAs**, and `!0` is `true` — so every special returned an empty variant list and the provider was never called. No request, no failure, no trace. The lane reported nothing to play, which is indistinguishable from "this special has no source".

## The guard was inverted at both edges

Fixing the reported case exposed the other half. The old test **refused the one valid value and accepted two invalid ones**:

| `season` | Old guard rejects? | |
| --- | --- | --- |
| `0` | ✅ yes | ← valid specials identity, wrongly refused |
| `-1` | ❌ no | → sent upstream as `seasonId=-1` |
| `1.5` | ❌ no | → sent upstream as `seasonId=1.5` |

So it discarded real specials while forwarding nonsense. `hasResolvableSeriesCoordinates` now checks the numeric domain rather than truthiness.

Season and episode stay **deliberately asymmetric**: season may be `0`, episode may not. Episode numbers are 1-based across Kunai, so a zero episode is a caller bug, not a special — it stays rejected until something proves otherwise for this provider specifically.

## What this does not claim

The issue asked to confirm the upstream accepts `seasonId=0` before advertising the lane as playable. **No captured fixture carries a `seasonId`**, and the live lane sits behind Turnstile, so that is not provable here — and is not claimed.

What changed is the client-side guard: a valid catalog identity is no longer discarded before the network. If the upstream cannot serve specials, the request now fails through the normal provider-failure path — recorded in health and trace — instead of vanishing silently. A visible failure beats a silent no-op either way.

A typed unsupported-season reason is **deliberately not added**. Inventing a classification for upstream behaviour nobody has observed would be a guess wearing a type. Worth revisiting if someone captures the real response.

## Verified against the unfixed code

Restoring the truthiness guard fails **two** of the new tests — the season-0 case *and* the nonsense-season case — so both halves of the defect are pinned, not just the reported one.

The test asserts the exact generated parameters (`seasonId=0`, `episodeId=3`, `mediaType=tv`, `tmdbId`), per the issue's acceptance criteria, and covers: ordinary seasons unchanged, missing season still fails before network, episode 0 still rejected, and negative/fractional/NaN seasons rejected.

`buildQueryVariants` and the predicate are exported for the contract test, matching how `classifyVideasyHttpFailure` is already exposed in this module.

Providers **400 pass**, full `bun run test` **14/14**, `typecheck` 14/14, lint 0 errors.

https://claude.ai/code/session_01QN5u9VYwYaU56kfr5KQYoD