### PR TITLE
fix(ci): check codegen freshness before regenerating, not after

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,8 +508,15 @@ jobs:
         run: |
           bun run verify:doc-paths
           bun run verify:doc-frontmatter
-          bun run --cwd apps/docs generate
+          # Freshness is checked BEFORE generate, deliberately. The script reads
+          # the committed generated-metadata.json from disk and compares it to
+          # freshly built metadata, so running generate first made it compare a
+          # file the previous line had just rewritten -- it passed
+          # unconditionally and could never fail. Nothing above needs the
+          # generated output, and buildMetadata() reads source, so checking here
+          # is valid; everything below still needs generate to have run.
           bun run --cwd apps/docs scripts/check-codegen-freshness.ts
+          bun run --cwd apps/docs generate
           bun run --cwd apps/docs typecheck:app
           bun run --cwd apps/docs lint
           bun run --cwd apps/docs test

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,7 +1,7 @@
 {
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceFingerprint": "f5b32cafc80befd7a8960408c4e1dba5b464a627c65c1c26a2613e4875a1fd14",
+  "cliSourceFingerprint": "409a48753e3800b84ce7ea659ecb9b6e6431d3bb64ba69b08098fb5b027264ff",
   "docsContentFingerprint": "83329f5e42767962e2d987fdd1de02b25a13a14fa61e4df87d918367580dda00",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 81,


### PR DESCRIPTION
Closes #157.

The docs gate ran `generate` and **then** asked whether the generated file was fresh:

```yaml
bun run --cwd apps/docs generate                            # writes the file
bun run --cwd apps/docs scripts/check-codegen-freshness.ts  # then asks if it is fresh
```

The script reads the **committed** `generated-metadata.json` from disk and compares it to freshly built metadata. After `generate` has just run, `committed` *is* `fresh` by construction — the comparison is against a file the previous line rewrote. It passed unconditionally and could never fail.

## It was already hiding a real staleness

`main` at `58c0b558` carries a stale bake. Merging #144, #146, #150, #153 and #155 changed CLI source, and nothing regenerated afterwards:

```diff
-  "cliSourceFingerprint": "f5b32caf…"
+  "cliSourceFingerprint": "409a4875…"
```

Run against the committed state, the gate correctly exits 1 and says exactly what to do. **Main's CI is green anyway**, because the pipeline never lets it see that state.

That matters beyond tidiness: `sync-code-metadata.ts` derives the published provider table, command count and shortcut metadata from source. A stale bake ships a docs site that disagrees with the CLI — precisely the drift #105 catalogued by hand, and precisely what this gate exists to stop recurring.

## Two changes

**The check moves above `generate`.** Nothing earlier in the job needs the generated output, and `buildMetadata()` reads source rather than the generated file, so checking there is valid. Everything after it still needs `generate` to have run.

**The stale metadata is regenerated**, because the reordered gate correctly fails until it is. Landing a gate that immediately red-lights without fixing what it catches would just be a broken pipeline.

## Verified by watching it fail

Tampering with one committed field:

```
"commandCount": 81  ->  999

$ bun apps/docs/scripts/check-codegen-freshness.ts; echo $?
generated-metadata.json is stale. Run:
  bun run --cwd apps/docs generate
1
```

Restored: gate reports fresh, docs tests **85 pass**.

## Scope note

Deliberately touches only `ci.yml` and the regenerated metadata, so it does not collide with the docs parity sweep — which also regenerates that file and will need one `generate` at merge time.

## Related

Fourth fake gate this cycle, after #104 (allowlist that asserted `A ⊆ A`), #95 (consent test that never created its condition) and #143 (width assertions that inverted on `FORCE_COLOR`). All four reported success while proving nothing. ADR-C in #117 proposes the rule that catches this shape at authoring time: a policy check ships with evidence of a deliberate red run.

https://claude.ai/code/session_01QN5u9VYwYaU56kfr5KQYoD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved documentation build checks to more reliably detect outdated generated metadata.
  - Updated generated metadata to match the latest CLI source state.

- **Bug Fixes**
  - Prevented code-generation freshness checks from passing incorrectly after generated files are rewritten during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->