### PR TITLE
docs: close the parity gaps, and record the 0.3.0 fixes

### DIFF
--- a/.docs/features/queue.md
+++ b/.docs/features/queue.md
@@ -37,7 +37,11 @@ The current shell exposes:
 - `/notifications`: `Enter` restores recoverable Up Next sessions or queues new episode notices
 - `/history`: `q` adds the selected history item to Up Next without replacing playback
 - search, trending, and recommendation browse rows: `q` adds the highlighted row to Up Next without opening it
-- post-playback recommendation rail: `1`, `2`, or `3` adds the visible pick to Up Next without leaving the post-playback controls
+- post-playback recommendation rail: `1`, `2`, or `3` **plays** that pick immediately
+  (`post-play-view.ts` → `{ type: "recommendation" }`). The shifted variants `!`, `@`, `#`
+  open that pick's action menu, which is where adding to Up Next lives
+  (`{ type: "recommendation-actions" }`). This doc previously described the shifted
+  behaviour against the unshifted keys.
 - post-playback recommendation actions: `i` opens details/download actions; download requires confirmation before provider resolution
 
 ## Restore API

--- a/.docs/keybindings.md
+++ b/.docs/keybindings.md
@@ -173,6 +173,79 @@ automatic segment skipping for the current title/session so you can watch intros
 or outros without changing your permanent preferences. The mpv skip banner and
 manual skip key can still offer finite known segments while autoskip is paused.
 
+## Up Next Queue
+
+| Key       | Action                           |
+| --------- | -------------------------------- |
+| `Enter`   | Play the selected item now       |
+| `J` / `K` | Move item down / up one slot     |
+| `g` / `G` | Move to top (play next) / bottom |
+| `x`       | Remove the selected item         |
+| `c` / `C` | Clear queue / clear played       |
+| `r`       | Restore your last queue          |
+
+## History
+
+| Key            | Action                                     |
+| -------------- | ------------------------------------------ |
+| `Enter`        | Resume the highlighted title               |
+| `q`            | Add the highlighted title to Up Next       |
+| `m`            | Open title actions for the highlighted row |
+| `w`            | Toggle watched for the highlighted row     |
+| `Tab` / `⇧Tab` | Cycle history tabs (Shift reverses)        |
+| `←` / `→`      | Cycle type filter (← reverse, → forward)   |
+| `x`            | Delete episode progress                    |
+| `⇧X`           | Delete whole title from history            |
+
+## Notifications
+
+| Key       | Action                              |
+| --------- | ----------------------------------- |
+| `Enter`   | Run the primary notification action |
+| `a`       | Open all notification actions       |
+| `s`       | Cycle notification sort             |
+| `r`       | Mark selected notification as read  |
+| `d`       | Delete selected notification        |
+| `A`       | Mark all notifications as read      |
+| `x`       | Archive the selected notification   |
+| `C`       | Clear archived notifications        |
+| `[` / `]` | Previous / next page                |
+| `Tab`     | Switch Active / Archive             |
+
+## Stats
+
+| Key            | Action                                                                    |
+| -------------- | ------------------------------------------------------------------------- |
+| `Tab` / `⇧Tab` | Next / previous stats tab (Overview · Titles · Insights)                  |
+| `r` / `⇧R`     | Cycle range forward / back (All time · Last 7d · Last 30d)                |
+| `←` / `→`      | Cycle media type forward / back (All · Anime · Series · Movies · YouTube) |
+| `1`–`3`        | Jump straight to a range                                                  |
+| `s`            | Copy a shareable summary                                                  |
+| `e`            | Export stats to a file                                                    |
+| `q`            | Back                                                                      |
+
+## Library
+
+| Key     | Action                    |
+| ------- | ------------------------- |
+| `Enter` | Open selected title       |
+| `x`     | Delete offline title      |
+| `p`     | Toggle cleanup protection |
+| `Tab`   | Switch Library / Up Next  |
+
+The library has no title-control menu key. `m` was registered for one and shown
+in the footer, but no handler read it — the keystroke fell through to the filter
+input. The binding was removed rather than wired: `openTitleControlMenu` drives
+its own picker from a phase, so reaching it from inside the mounted library
+overlay needs a phase/shell seam and a decision about what the menu offers for an
+offline entry.
+
+## Outside The Ink Shell
+
+`Ctrl+Shift+S` copies the share link during mpv playback. It is bound in the mpv
+Lua bridge (`apps/cli/assets/mpv/kunai-bridge.lua`), not in `keybindings.ts`, so
+it does not appear in the `?` overlay or any footer.
+
 ## Collision Notes
 
 | Key | Collision risk                                          | Decision                                                                             |

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -700,6 +700,7 @@ failure modes.
 | `anidb`      | anime         | direct-http | `packages/providers/src/anidb/direct.ts`      |
 | `allanime`   | anime, series | direct-http | `packages/providers/src/allmanga/direct.ts`   |
 | `miruro`     | anime         | direct-http | `packages/providers/src/miruro/direct.ts`     |
+| `youtube`    | video         | direct-http | `packages/providers/src/youtube/direct.ts`    |
 
 ### Anime catalog identity
 
@@ -808,40 +809,6 @@ The cost model matters as much as the data, because this runs in front of the ep
   with curl fallback. HLS ladder expansion uses the same path so a relay miss does not collapse
   qualities to a silent `auto` row. Video remains direct from `hls.anidb.app`; the relay has no
   media route or video fallback configuration.
-
-### AniDB metadata and language evidence
-
-The active `anidb.app` episode endpoint is a stream catalog, not a rich episode metadata catalog:
-it currently returns episode ids, numbers, and filler flags. `anidb.listEpisodes()` first follows
-the title page's explicit cross-link to the official AniDB AID and enriches from the official XML
-catalog. It then uses the existing shared AniList/Jikan path for still thumbnails and missing fields
-when the title identity carries an AniList or MAL id. This keeps the metadata authority explicit
-instead of pretending those fields came from `anidb.app`.
-
-- `anidb.app` language evidence is per episode: `jpn` is the sub/original embed and `eng` is the
-  dub embed when present. Search does not advertise both modes blindly; availability is confirmed
-  only by the episode languages response.
-- A missing requested language is an exhausted AniDB attempt. It must not fall back to the other
-  language and label the stream incorrectly.
-- The embed probe currently exposes an HLS source but no independently addressable subtitle track.
-  AniDB results keep `subtitles: []` and mark subtitle delivery unknown; `jpn` is not sufficient
-  evidence that captions are hardcoded.
-- Official AniDB XML is a separate catalog namespace. It can provide richer anime and episode
-  metadata, but its AIDs must not be confused with the numeric ids in `anidb.app` URLs. See
-  [the metadata capability dossier](./provider-dossiers/anidb-metadata-capabilities.md).
-
-The cost model matters as much as the data, because this runs in front of the episode picker:
-
-- Official AniDB XML is **one request for the whole series**, cached for a month and seeded into
-  the shared episode-metadata cache, so a second listing of the same show is free.
-- AniList runs even when every title is already known — it is a single request and the only source
-  of episode stills AniDB has.
-- Jikan is the expensive pass (100 episodes per page, strict rate limit) and is **skipped** when
-  official titles already cover the catalog, matching the AllManga path via
-  `shouldSkipExternalEpisodeMetadataEnrichment()`.
-- An official response that carries `<error>` (rate limit, ban, bad client credentials) is never
-  cached. Caching what it parses to would suppress every episode title for that show for a month
-  after the block lifted.
 
 ### AniDB season routing and episode numbering
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 One fullscreen, keyboard-driven terminal session.
 
 [![npm](https://img.shields.io/npm/v/@kitsunekode/kunai?color=ff8fb0&label=kunai&logo=npm)](https://www.npmjs.com/package/@kitsunekode/kunai)
-&nbsp;![runtime](https://img.shields.io/badge/runtime-Bun%20%E2%89%A51.3.14-ff8fb0)
+&nbsp;![runtime](https://img.shields.io/badge/runtime-Bun%20%E2%89%A51.4.0-ff8fb0)
 &nbsp;![player](https://img.shields.io/badge/player-mpv-4fd1c5)
 &nbsp;![kinds](https://img.shields.io/badge/anime%20%C2%B7%20series%20%C2%B7%20movies-c98bff)
 &nbsp;[![license](https://img.shields.io/badge/license-MIT-968a98)](LICENSE)
@@ -257,14 +257,14 @@ Inside the shell, `/` opens the command palette from anywhere.
 
 ### What you need up front
 
-| Tool            | Required?            | Why                                                                                                  |
-| --------------- | -------------------- | ---------------------------------------------------------------------------------------------------- |
-| **Bun** ≥1.3.14 | bun/source           | Runtime for Bun-global and source installs. The default binary embeds it. The npm channel uses Node. |
-| **mpv**         | Required             | Plays everything. `sudo pacman -S mpv` / `brew install mpv`                                          |
-| **yt-dlp**      | Required for YouTube | YouTube playback and offline downloads. `sudo pacman -S yt-dlp` / `brew install yt-dlp`              |
-| **ffprobe**     | Optional             | Post-download integrity checks (ships with FFmpeg)                                                   |
-| **curl**        | Anime mode           | AniDB, the default anime provider, is behind Cloudflare. `sudo pacman -S curl`                       |
-| **Discord**     | Optional             | Rich Presence via local Unix-socket / Windows named-pipe IPC                                         |
+| Tool           | Required?            | Why                                                                                                  |
+| -------------- | -------------------- | ---------------------------------------------------------------------------------------------------- |
+| **Bun** ≥1.4.0 | bun/source           | Runtime for Bun-global and source installs. The default binary embeds it. The npm channel uses Node. |
+| **mpv**        | Required             | Plays everything. `sudo pacman -S mpv` / `brew install mpv`                                          |
+| **yt-dlp**     | Required for YouTube | YouTube playback and offline downloads. `sudo pacman -S yt-dlp` / `brew install yt-dlp`              |
+| **ffprobe**    | Optional             | Post-download integrity checks (ships with FFmpeg)                                                   |
+| **curl**       | Anime mode           | AniDB, the default anime provider, is behind Cloudflare. `sudo pacman -S curl`                       |
+| **Discord**    | Optional             | Rich Presence via local Unix-socket / Windows named-pipe IPC                                         |
 
 ### Poster quality
 
@@ -495,10 +495,10 @@ Kunai ships a default Discord application client id; override it in Settings or
 
 ### Required
 
-| Dependency         | Purpose        | Install                                     |
-| ------------------ | -------------- | ------------------------------------------- |
-| **Bun** `>=1.3.14` | Runtime        | `curl -fsSL https://bun.sh/install \| bash` |
-| **mpv**            | Video playback | `sudo pacman -S mpv` / `brew install mpv`   |
+| Dependency        | Purpose        | Install                                     |
+| ----------------- | -------------- | ------------------------------------------- |
+| **Bun** `>=1.4.0` | Runtime        | `curl -fsSL https://bun.sh/install \| bash` |
+| **mpv**           | Video playback | `sudo pacman -S mpv` / `brew install mpv`   |
 
 ### Optional — what each enables
 

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -45,6 +45,29 @@ Launch flags, discovery, and the queue.
   one source from filling the tray.
 - **`/up-next` opens during playback.** The queue was reachable everywhere
   except the one activity that consumes it.
+- **`--dry-run` prints the plan instead of starting a session.** The flag was
+  documented as a general launch flag and read in exactly two places
+  (`--install-protocol-handler` and `rollback`), so `kunai -S "Dune" --dry-run`
+  parsed it, discarded it, and mounted the full interactive shell — starting the
+  session it had just promised not to. It now prints the resolved mode, surface,
+  query or title, auto-pick, and any flag it will ignore, and exits before
+  anything is created: no version lock, no version pruning, no database, no
+  terminal probe.
+- **`--zen` no longer plays a title you did not pick.** Zen is documented as a
+  bare layout, but it set `--quick`, which is not a layout flag at all — it means
+  "auto-pick result #1". `kunai -S "Dune" --zen` skipped the result list and
+  started playing the top hit. Zen now changes chrome only; use `--zen --quick`
+  for the old behaviour.
+- **Finishing a title no longer triggers a search you did not ask for.**
+  Launching with both a query and a direct target (`-S "Dune" --history`, a
+  share link, `-i` with `-t`) left the query armed after the chosen title
+  played, so the session bounced into a stale search when playback ended — and
+  with the auto-pick index still set, under `--quick` that search immediately
+  played its first hit, writing a history row and a tracker sync for a title
+  nobody selected.
+- **The library footer stops advertising a key that did nothing.** `m` was
+  registered for a title-control menu and shown as available; no handler read
+  it, so the keystroke was typed into the filter box instead.
 
 Privacy hardening, and a consent bug in the installer.
 
@@ -81,6 +104,41 @@ Privacy hardening, and a consent bug in the installer.
 - **AllAnime survives a bad response** instead of failing the provider, and the
   relay's private-host guard covers IPv4-mapped IPv6 such as
   `::ffff:169.254.169.254`.
+- **Discord Rich Presence can no longer end your session.** A malformed frame
+  from Discord reached `JSON.parse` inside the socket callback, and a throw
+  there is an uncaught exception rather than a rejected promise — which Kunai
+  escalates to a fatal shutdown. A cosmetic, optional integration was able to
+  print a stack trace over the UI and stop playback. Unreadable frames are now
+  dropped, and a frame claiming an implausible size drops the connection instead
+  of buffering toward it.
+- **An unplugged drive no longer kills the session or strands the download.**
+  When the download folder became unwritable or disappeared mid-session,
+  preparing the output directory threw past the point where the job was claimed:
+  the job stayed claimed for the rest of the run — displayed as queued, never
+  startable again — and the error surfaced as an unhandled rejection, which is
+  also a fatal shutdown. The job is now paused with a readable reason and picked
+  up on a later attempt.
+- **Reordering Up Next is all-or-nothing.** Positions were written one row at a
+  time outside a transaction, so an interruption part-way left the queue with
+  duplicate positions rather than a stale-but-valid order.
+- **Anime playback stops stalling the interface between segments.** The relay
+  decoded every video segment into a JavaScript string twice — once to find a
+  status trailer, once to check whether the bytes were a playlist — which for a
+  6 MiB segment cost about 50 ms of blocked main thread and 60 MiB of garbage,
+  on the same thread that reads your keystrokes. Both checks now work on bytes.
+- **The relay's CDN allowlist is a domain check again.** The patterns matched
+  any hostname _containing_ the allowed name, so a crafted stream URL could
+  point the local relay at an attacker's host.
+- **The mpv control socket lives in a private directory.** It sat in the shared
+  temp directory; on systems with a group-writable umask that left mpv's
+  command interface reachable by another process running as the same group.
+  It now uses `$XDG_RUNTIME_DIR/kunai`, falling back to an owner-only temp
+  subdirectory (macOS sets no runtime dir). Windows is unaffected — it uses a
+  named pipe.
+- **Links open only if they are links.** External URLs went straight to
+  `xdg-open`/`open`/`explorer.exe` whatever their scheme, and a value beginning
+  with `-` was read by the opener as a flag. Only `http`, `https`, and `kunai`
+  URLs are opened now; anything else is still shown and copyable.
 
 - **Downloads:** provider stream URLs and headers are guarded before reaching
   yt-dlp (scheme check, leading-dash rejection, `--` terminator, CRLF-stripped

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "714d222971b43c2eec825c81d973aa8d0def23f78625e159e5925f4c4daa1b8a",
-  "docsContentFingerprint": "a879a3aa32d0d2539acb45f0d3352071f4444d8acf6b7e2a7d1c5ccfb5a5199c",
+  "docsContentFingerprint": "b507955a74b2c3e670420ec4dcb696390433881dd09102b68030c3a69d5c1e10",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/docs/users/cli-reference.mdx
+++ b/docs/users/cli-reference.mdx
@@ -41,6 +41,22 @@ From a repo clone (contributor-oriented), use `bun run dev -- <flags>` so Bun fo
 | `kunai doctor --json`       | Same report as JSON                              |
 | `kunai uninstall`           | Ownership-aware removal                          |
 | `kunai uninstall --purge`   | Also delete config/history/cache                 |
+| `kunai diagnostics recent`  | Print recent redacted diagnostics from the cache DB |
+
+### `kunai diagnostics recent`
+
+Prints the most recent diagnostic events Kunai recorded locally, already
+redacted, without launching the shell. Useful when attaching evidence to an
+issue.
+
+```bash
+kunai diagnostics recent                        # JSONL, most recent first
+kunai diagnostics recent --format markdown      # human-readable table
+kunai diagnostics recent --limit 50             # cap how many events print
+```
+
+`--format` accepts `jsonl` (default) or `markdown`. Events come from the local
+cache database; nothing is uploaded.
 
 ## Shell completions
 

--- a/docs/users/customization.mdx
+++ b/docs/users/customization.mdx
@@ -28,6 +28,8 @@ The main config file is created on first run or after `kunai --setup`. Kunai mer
 | `providerPriority` | Fallback order for movie/series providers (empty = registry default) |
 | `animeProviderPriority` | Fallback order for anime providers |
 | `titleProviderPreferences` | Per-title provider override chosen explicitly by the user |
+| `youtubeProvider` | Default YouTube-mode provider (default `youtube`) |
+| `youtubeProviderPriority` | Fallback order for YouTube-mode providers (default `["youtube"]`) |
 
 Unknown provider ids in priority arrays are ignored. Providers not listed remain available after configured entries.
 
@@ -107,6 +109,8 @@ See [Media selection](/docs/users/media-selection) for how profiles flow into re
 | `recoveryMode` | `guided`, `fallback-first`, or `manual` |
 | `resumeStartChoicePrompt` | Resume vs start-over overlay when resuming mid-episode |
 | `quitNearEndBehavior` | What happens when you quit mpv near the natural end |
+| `quitNearEndThresholdMode` | When "near the end" starts: `credits-or-90-percent` (default), or a fixed percentage |
+| `continueSourcePreference` | Where Continue Watching resumes from: `auto` (default), `local`, `stream`, or `ask` |
 
 ### Shell density and chrome
 
@@ -116,7 +120,11 @@ See [Media selection](/docs/users/media-selection) for how profiles flow into re
 | `minimalMode` / `--minimal` | Collapse companion pane and dim header status |
 | `footerHints` | `detailed` or `minimal` footer guidance |
 | `discoverShowOnStartup` | Faint discover hint in browse footer when history exists |
+| `discoverMode` | What `/discover` mixes: `auto` (default), `unified`, `anime-only`, or `series-only` |
+| `discoverItemLimit` | Rows the Discover tray shows (default `24`) |
 | `powerSaverMode` | Suppress background network and speculative work |
+| `powerSaverAllowManualArtwork` | Still fetch artwork you ask for by hand while power saver is on (default `true`) |
+| `recommendationRailEnabled` | Show the recommendation rail after playback (default `true`) |
 
 Kunai ships with the Sakura design system baked into the terminal UI. There is no separate theme picker today — density modes (`zen`, `minimal`) are how you reduce visual chrome.
 
@@ -131,6 +139,10 @@ Kunai ships with the Sakura design system baked into the terminal UI. There is n
 | `defaultDownloadQuality` | Shared quality floor for new download jobs |
 | `offlineMode` | Persistent local-only shell posture (separate from `--offline` launch) |
 | `autoCleanupWatched` | Surface watched downloads as cleanup candidates |
+| `autoCleanupGraceDays` | Days a watched download is kept before it becomes a cleanup candidate (default `7`) |
+| `autoDownload` | Download ahead automatically: `off` (default), `next`, or `season` |
+| `autoDownloadNextCount` | How many episodes ahead `autoDownload: "next"` fetches (default `1`) |
+| `offlineArtworkCacheEnabled` | Cache poster artwork alongside downloads for offline browsing (default `true`) |
 
 See [Downloads and offline](/docs/users/downloads-and-offline).
 

--- a/docs/users/install-and-update.mdx
+++ b/docs/users/install-and-update.mdx
@@ -197,6 +197,7 @@ Kunai runs a **cached, non-blocking** background update check at startup.
 
 - **Binary installs:** when `autoApplyBinaryUpdates` is enabled (default), Kunai downloads and stages the new version under `versions/` automatically. Restart Kunai to run the new binary. Toggle this from `/update`.
 - **npm/bun/source:** notify-only — run `kunai upgrade` or your package manager manually.
+- **Turning it off:** set `updateChecksEnabled` to `false` in `config.json` (default `true`) and Kunai stops checking entirely — no background request, and no update notice.
 
 Manual check from the shell:
 


### PR DESCRIPTION
Closes #105. Replaces #147.

> **Why a new PR:** #147 was stacked on #119 to pre-resolve their shared `generated-metadata.json` conflict. When #119 merged with `--delete-branch`, GitHub closed #147 automatically — it closes any PR whose base branch is deleted — and refuses to reopen one whose base no longer exists. The branch and commits were never lost; this is the same work, retargeted to `main`. My mistake: I should have retargeted before merging its base.

Every item was verified against the tree rather than taken from the audit that reported it. Two corrections came out of that:

- Four of the seventeen config keys reported as "missing" were **already documented** (`continueSourcePreference`, `analytics`, `analyticsEndpoint`, `autoApplyBinaryUpdates`). Only 13 were real.
- The `1`/`2`/`3` claim was **backwards** — see below.

## Code was right, docs were wrong

**README Bun requirement** said `1.3.14` in three places — badge, requirements table, install table — while `engines` requires `>=1.4.0`. Anyone following the README hit a failing `bun install` with no explanation.

**`.docs/providers.md`** carried the whole `### AniDB metadata and language evidence` section **twice** (`:616` and `:655`). The first copy is a superset — it has a trailing relay bullet the second lacks — so the second was removed, not the first. Its active-provider table also listed six providers while `loadProductionProviderModules()` registers seven; `youtube` was described in prose but missing from the canonical table.

**`.docs/features/queue.md`** said `1`/`2`/`3` *adds* the visible pick to Up Next. It **plays** it — `post-play-view.ts:855` returns `{ type: "recommendation" }`. The shifted `!`/`@`/`#` open the action menu, which is where adding lives. Following the doc would start playback instead of queueing.

**`.docs/keybindings.md`** documented **two of seven** surfaces. Adds Up Next, History, Notifications, Stats and Library — generated from `KEYBINDINGS` by scope rather than transcribed, so they match the code by construction. Plus an **Outside The Ink Shell** note: `Ctrl+Shift+S` copies the share link during mpv playback, bound in the Lua bridge (`kunai-bridge.lua:1068`), so it appears in no footer and no `?` overlay.

**`docs/users/customization.mdx`** was missing 13 valid keys, with defaults read from `packages/config/src/defaults.ts` rather than guessed: YouTube lane, discover, playback, chrome, and download automation.

**`kunai diagnostics recent`** is implemented and in `--help` but appeared in no published doc. Now documented with its real flags.

## Changelog

Folds the twelve fixes from this review into the unpublished `0.3.0` section, in its existing voice. 0.3.0 is unpublished and the section is hand-accumulated (`329bf94d` set that policy), so no changeset.

**Test-only work is deliberately excluded** — fixing a test that could not fail changes nothing a user sees.

## Rebased onto merged main

Merged `main` cleanly — no conflict, because #119's fix removed the churning fields that used to collide here. The regenerated `cliSourceFingerprint` reflects the merges of #144, #146, #150, #153 and #155.

The Library table omits `m` deliberately: that binding was removed in #144, which is now on main, so this describes the current state with a note explaining why it was removed rather than wired.

## Verified

`check-codegen-freshness` fresh · docs tests 85 pass · full `bun run test` **23/23 tasks** · `fmt:check` 26/26 · `verify:doc-paths` (48 docs, 1948 source files) · `verify:doc-frontmatter` clean.

https://claude.ai/code/session_01QN5u9VYwYaU56kfr5KQYoD