### PR TITLE
fix(player): scope mpv TLS compatibility exception to verified host

### DIFF
--- a/apps/cli/src/infra/player/mpv-stream-http-headers.ts
+++ b/apps/cli/src/infra/player/mpv-stream-http-headers.ts
@@ -68,11 +68,19 @@ export function shouldDisableMpvTlsVerify(
   url: string,
   _headers: Record<string, string> | undefined,
 ): boolean {
+  // WHATWG parsing strips controls and repairs a missing slash before exposing the hostname.
+  for (const character of url) {
+    const code = character.charCodeAt(0);
+    if (code <= 0x1f || code === 0x7f) return false;
+  }
+  if (!/^https:\/\//i.test(url)) return false;
   try {
     const parsed = new URL(url);
     if (parsed.protocol !== "https:") return false;
     const hostname = parsed.hostname.toLowerCase();
-    return hostname === "mp4upload.com" || hostname.endsWith(".mp4upload.com");
+    if (hostname === "mp4upload.com") return true;
+    if (!hostname.endsWith(".mp4upload.com")) return false;
+    return hostname.split(".").every((label) => label.length > 0);
   } catch {
     return false;
   }

--- a/apps/cli/src/infra/player/mpv-stream-http-headers.ts
+++ b/apps/cli/src/infra/player/mpv-stream-http-headers.ts
@@ -63,16 +63,19 @@ export function normalizeStreamHttpHeaders(
   };
 }
 
-/**
- * ani-cli plays mp4upload with `--tls-verify=no`. Detect by stream URL or Referer.
- */
+/** ani-cli parity exception for the real mp4upload HTTPS stream host only. */
 export function shouldDisableMpvTlsVerify(
   url: string,
-  headers: Record<string, string> | undefined,
+  _headers: Record<string, string> | undefined,
 ): boolean {
-  if (/mp4upload\.com/i.test(url)) return true;
-  const { referer } = normalizeStreamHttpHeaders(headers);
-  return Boolean(referer && /mp4upload\.com/i.test(referer));
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") return false;
+    const hostname = parsed.hostname.toLowerCase();
+    return hostname === "mp4upload.com" || hostname.endsWith(".mp4upload.com");
+  } catch {
+    return false;
+  }
 }
 
 export type PersistentLoadfileOptions = {

--- a/apps/cli/test/unit/infra/player/mpv-args-safety.test.ts
+++ b/apps/cli/test/unit/infra/player/mpv-args-safety.test.ts
@@ -68,7 +68,7 @@ describe("mpv URL safety", () => {
     expect(args.some((arg) => /[\r\n]/.test(arg))).toBe(false);
   });
 
-  test("disables tls-verify for mp4upload referers (ani-cli parity)", () => {
+  test("disables tls-verify only for an mp4upload stream host (ani-cli parity)", () => {
     const args = buildMpvArgs(
       {
         url: "https://www6.mp4upload.com/d/file.mp4",
@@ -79,6 +79,20 @@ describe("mpv URL safety", () => {
       null,
     );
     expect(args).toContain("--tls-verify=no");
+    expect(args).toContain("--referrer=https://www.mp4upload.com");
+  });
+
+  test("does not let an mp4upload Referer disable TLS for another stream host", () => {
+    const args = buildMpvArgs(
+      {
+        url: "https://cdn.example/d/file.mp4",
+        headers: { Referer: "https://www.mp4upload.com", "User-Agent": "kunai" },
+        subtitle: null,
+        displayTitle: "Unrelated CDN",
+      },
+      null,
+    );
+    expect(args).not.toContain("--tls-verify=no");
     expect(args).toContain("--referrer=https://www.mp4upload.com");
   });
 

--- a/apps/cli/test/unit/infra/player/mpv-args-safety.test.ts
+++ b/apps/cli/test/unit/infra/player/mpv-args-safety.test.ts
@@ -96,6 +96,21 @@ describe("mpv URL safety", () => {
     expect(args).toContain("--referrer=https://www.mp4upload.com");
   });
 
+  test("keeps TLS verification and HTTP headers for malformed mp4upload-like hosts", () => {
+    const args = buildMpvArgs(
+      {
+        url: "https://.mp4upload.com/d/file.mp4",
+        headers: { Referer: "https://www.mp4upload.com", "User-Agent": "kunai" },
+        subtitle: null,
+        displayTitle: "Malformed Mp4Upload host",
+      },
+      null,
+    );
+    expect(args).not.toContain("--tls-verify=no");
+    expect(args).toContain("--referrer=https://www.mp4upload.com");
+    expect(args).toContain("--user-agent=kunai");
+  });
+
   test("skips local subtitle targets on remote playback", () => {
     const args = buildMpvArgs(
       {

--- a/apps/cli/test/unit/infra/player/mpv-stream-http-headers.test.ts
+++ b/apps/cli/test/unit/infra/player/mpv-stream-http-headers.test.ts
@@ -62,6 +62,8 @@ describe("shouldDisableMpvTlsVerify", () => {
     expect(shouldDisableMpvTlsVerify("https://mp4upload.com/d/file.mp4", {})).toBe(true);
     expect(shouldDisableMpvTlsVerify("https://www6.mp4upload.com/d/file.mp4", {})).toBe(true);
     expect(shouldDisableMpvTlsVerify("https://WWW6.MP4UPLOAD.COM/d/file.mp4", {})).toBe(true);
+    expect(shouldDisableMpvTlsVerify("https://bücher.mp4upload.com/d/file.mp4", {})).toBe(true);
+    expect(shouldDisableMpvTlsVerify("https://ｍｐ４ｕｐｌｏａｄ.com/d/file.mp4", {})).toBe(true);
   });
 
   test("does not let provider-controlled Referer text disable TLS verification", () => {
@@ -86,6 +88,20 @@ describe("shouldDisableMpvTlsVerify", () => {
 
     for (const url of unsafeLookalikes) {
       expect(shouldDisableMpvTlsVerify(url, { Referer: "https://mp4upload.com" })).toBe(false);
+    }
+  });
+
+  test("rejects malformed mp4upload hostnames and control characters", () => {
+    const malformedUrls = [
+      "https://.mp4upload.com/file.mp4",
+      "https://bad..mp4upload.com/file.mp4",
+      "https://mp4upload.\ncom/file.mp4",
+      "https:/mp4upload.com/file.mp4",
+      "http://mp4upload.com/file.mp4",
+    ];
+
+    for (const url of malformedUrls) {
+      expect(shouldDisableMpvTlsVerify(url, {})).toBe(false);
     }
   });
 
@@ -183,6 +199,21 @@ describe("buildPersistentLoadfileOptions", () => {
       "user-agent": "kunai",
       "http-header-fields-clr": "",
       "tls-verify": "no",
+      "demuxer-lavf-o-clr": "",
+    });
+  });
+
+  test("keeps TLS verification and HTTP headers for malformed mp4upload-like hosts", () => {
+    expect(
+      buildPersistentLoadfileOptions("https://bad..mp4upload.com/d/file.mp4", 12, {
+        Referer: "https://www.mp4upload.com",
+        "User-Agent": "kunai",
+      }),
+    ).toEqual({
+      start: "12",
+      referrer: "https://www.mp4upload.com",
+      "user-agent": "kunai",
+      "http-header-fields-clr": "",
       "demuxer-lavf-o-clr": "",
     });
   });

--- a/apps/cli/test/unit/infra/player/mpv-stream-http-headers.test.ts
+++ b/apps/cli/test/unit/infra/player/mpv-stream-http-headers.test.ts
@@ -58,14 +58,35 @@ describe("normalizeStreamHttpHeaders", () => {
 });
 
 describe("shouldDisableMpvTlsVerify", () => {
-  test("detects mp4upload by URL or Referer", () => {
+  test("matches only the mp4upload stream hostname", () => {
+    expect(shouldDisableMpvTlsVerify("https://mp4upload.com/d/file.mp4", {})).toBe(true);
     expect(shouldDisableMpvTlsVerify("https://www6.mp4upload.com/d/file.mp4", {})).toBe(true);
+    expect(shouldDisableMpvTlsVerify("https://WWW6.MP4UPLOAD.COM/d/file.mp4", {})).toBe(true);
+  });
+
+  test("does not let provider-controlled Referer text disable TLS verification", () => {
     expect(
       shouldDisableMpvTlsVerify("https://cdn.example/file.mp4", {
         Referer: "https://www.mp4upload.com",
       }),
-    ).toBe(true);
-    expect(shouldDisableMpvTlsVerify("https://cdn.example/file.mp4", {})).toBe(false);
+    ).toBe(false);
+  });
+
+  test("rejects textual lookalikes outside the parsed stream hostname", () => {
+    const unsafeLookalikes = [
+      "https://cdn.example/mp4upload.com/file.mp4",
+      "https://cdn.example/file.mp4?origin=mp4upload.com",
+      "https://mp4upload.com@cdn.example/file.mp4",
+      "https://notmp4upload.com/file.mp4",
+      "https://mp4upload.com.evil.example/file.mp4",
+      "https://mp4upload.com.invalid/file.mp4",
+      "not a url containing mp4upload.com",
+      "https://mp4uplоad.com/file.mp4",
+    ];
+
+    for (const url of unsafeLookalikes) {
+      expect(shouldDisableMpvTlsVerify(url, { Referer: "https://mp4upload.com" })).toBe(false);
+    }
   });
 
   test("leaves other provider streams on default TLS verification", () => {


### PR DESCRIPTION
## Summary

- scope the mpv TLS compatibility exception to parsed HTTPS hostnames owned by mp4upload
- keep normal certificate verification enabled for unrelated stream hosts regardless of provider header values
- add hostname-boundary and mpv-argument regression coverage

## Verification

- focused player safety tests: 23 passed
- full repository tests: 23 tasks passed; CLI unit 4,696 passed; integration 147 passed / 24 skipped
- typecheck: 14/14
- lint: 12/12 (pre-existing warnings only)
- formatting: 26/26
- full build and Linux x64 standalone binary: 10/10

## Release control

This PR does not merge, publish, tag, deploy, or release anything.
