### PR TITLE
fix(player): finish private IPC directory and timer hardening

### DIFF
--- a/.superpowers/sdd/pr146-hardening-repair/report.md
+++ b/.superpowers/sdd/pr146-hardening-repair/report.md
@@ -1,0 +1,61 @@
+# PR #146 hardening repair report
+
+## Revisions
+
+- Original PR branch and repair base: `0bb210f8e5e48897b0a3da06a7ed28c336f41d3b`
+- Local implementation commit: `77275ece51139de7eee24643c8f35dcfc309c952`
+- Current post-#146 `origin/main`: `58c0b558a61484138800643c387ba17343aa69f8`
+- The implementation patch applies cleanly to current `origin/main`. Verified with a temporary index loaded from `origin/main` and `git apply --cached --check` over the exact `0bb210f8..77275ece` binary diff.
+
+## Changes
+
+- Removed every bare/shared temp-directory candidate and the hard-coded `/tmp` socket fallback.
+- Added an injected Unix-directory operations seam. Production creates candidates with mode `0700`, then checks `lstat` and `stat` facts before selecting one:
+  - final path is a real directory and not a symlink;
+  - `lstat` and `stat` identify the same device/inode;
+  - permission bits are exactly owner `rwx` with no group/other access;
+  - ownership matches the current uid when uid facts are available.
+- Resolution prefers `$XDG_RUNTIME_DIR/kunai`, then `$TMPDIR/kunai-ipc`, and throws a bounded actionable error before spawn if neither is safe and bindable.
+- Windows named-pipe spelling and behavior remain unchanged, and its path bypasses every filesystem operation.
+- Added an opaque injected close-timer seam for mpv IPC. Clean close cancels the 200 ms fallback; the fallback is single-shot if close never arrives.
+- Extracted `createDismissTimerRegistry` from the private Ink root. Fired alert handles remove themselves, and disposal clears every still-active overlapping 6 s/10 s handle.
+- The reviewed external URL scheme/option guard was not changed.
+
+## Strict TDD evidence
+
+RED was observed before each production slice:
+
+1. Unix fail-closed policy: 5 failures showed bare-temp candidates and `/tmp` fallback were still returned.
+2. Directory verification seam: 4 failures showed the injected operations/facts were ignored, including symlink, wrong-owner, and unsafe-mode cases.
+3. Clean mpv close: 1 failure showed the injected fallback timer was not scheduled/cleared.
+4. Missing close event: 1 failure showed the fallback callback could terminate twice.
+5. Streak dismissal registry: the new behavioral test failed because the extracted registry did not yet exist.
+
+GREEN:
+
+- Focused repair suite: 24 passed, 0 failed, 49 assertions.
+- Earlier combined focused run including the existing streak milestone tests: 26 passed, 0 failed.
+
+## Verification gates
+
+- `bun run --cwd apps/cli test:unit`: 4,637 passed, 0 failed across 675 files.
+- `bun run --cwd apps/cli test:integration -- test/integration/mpv-ipc-endpoint-native.test.ts`: the command exercised the complete CLI integration directory; 145 passed, 24 skipped, 0 failed. Both real-mpv endpoint tests passed.
+- `bun run typecheck`: 14/14 tasks succeeded.
+- `bun run lint`: 12/12 tasks succeeded. CLI reported 0 warnings/errors; one pre-existing `packages/relay/test/handler.test.ts` no-shadow warning remains outside this repair.
+- `bun run fmt`: 12/12 tasks succeeded.
+- `bun run build`: 10/10 tasks succeeded, including the development bundle and Linux host binary.
+- `git diff --check`: passed before the implementation commit.
+
+## Self-review
+
+- Security mutations covered: reintroducing bare temp, trusting a symlink, accepting a different uid, permitting group/world bits, skipping creation failure, returning overlong paths, or touching filesystem operations on Windows all fail tests.
+- Lifecycle mutations covered: omitting clean-close cancellation, allowing repeat fallback termination, retaining fired dismissal handles, or clearing only one overlapping dismissal all fail tests.
+- The directory seam is confined to endpoint preparation; no user configuration root is hard-coded and no provider/player layering boundary changed.
+- The timer extraction is non-React and limited to streak dismissals; alert text, durations, refresh cadence, and shell rendering behavior are unchanged.
+
+## Remote state and actions
+
+- Initial pre-edit GitHub verification: branch `fix/local-surface-hardening` existed at the required `0bb210f8e5e48897b0a3da06a7ed28c336f41d3b`.
+- During the repair, PR #146 became `MERGED` with merge commit `b573f7000562d4ac9696d03a80746160dcf89d9d`; its head oid remained `0bb210f8`, and the remote head branch was deleted.
+- No push, PR edit, merge, release, or publish action was performed.
+- The local repair commit is ready to cherry-pick onto a new follow-up branch from current `origin/main`.

--- a/.superpowers/sdd/pr146-hardening-repair/report.md
+++ b/.superpowers/sdd/pr146-hardening-repair/report.md
@@ -30,15 +30,18 @@ RED was observed before each production slice:
 3. Clean mpv close: 1 failure showed the injected fallback timer was not scheduled/cleared.
 4. Missing close event: 1 failure showed the fallback callback could terminate twice.
 5. Streak dismissal registry: the new behavioral test failed because the extracted registry did not yet exist.
+6. Non-directory discrimination: after adding the regular-file regression, temporarily removing only the `lstat` directory guard failed with the unsafe runtime path selected instead of the private temp fallback.
+7. Replacement-race discrimination: after adding the identity regression, removing the device/inode guard failed on the changed-device fixture; retaining the device check but removing the inode check failed on the changed-inode fixture after the device case passed.
 
 GREEN:
 
 - Focused repair suite: 24 passed, 0 failed, 49 assertions.
 - Earlier combined focused run including the existing streak milestone tests: 26 passed, 0 failed.
+- Follow-up review regressions: 2 passed, 0 failed, 3 assertions. The two behavioral tests cover a non-symlink regular file plus independent device and inode replacement identities.
 
 ## Verification gates
 
-- `bun run --cwd apps/cli test:unit`: 4,637 passed, 0 failed across 675 files.
+- `bun run --cwd apps/cli test:unit`: 4,639 passed, 0 failed, 15,445 assertions across 675 files.
 - `bun run --cwd apps/cli test:integration -- test/integration/mpv-ipc-endpoint-native.test.ts`: the command exercised the complete CLI integration directory; 145 passed, 24 skipped, 0 failed. Both real-mpv endpoint tests passed.
 - `bun run typecheck`: 14/14 tasks succeeded.
 - `bun run lint`: 12/12 tasks succeeded. CLI reported 0 warnings/errors; one pre-existing `packages/relay/test/handler.test.ts` no-shadow warning remains outside this repair.
@@ -52,6 +55,7 @@ GREEN:
 - Lifecycle mutations covered: omitting clean-close cancellation, allowing repeat fallback termination, retaining fired dismissal handles, or clearing only one overlapping dismissal all fail tests.
 - The directory seam is confined to endpoint preparation; no user configuration root is hard-coded and no provider/player layering boundary changed.
 - The timer extraction is non-React and limited to streak dismissals; alert text, durations, refresh cadence, and shell rendering behavior are unchanged.
+- Follow-up mutation review now proves that removing the regular-file guard, device identity guard, or inode identity guard makes the socket-directory suite fail.
 
 ## Remote state and actions
 

--- a/apps/cli/src/app-shell/dismiss-timer-registry.ts
+++ b/apps/cli/src/app-shell/dismiss-timer-registry.ts
@@ -1,0 +1,39 @@
+export type DismissTimerOperations = {
+  readonly setTimeout: (callback: () => void, delayMs: number) => unknown;
+  readonly clearTimeout: (handle: unknown) => void;
+};
+
+const defaultTimerOperations: DismissTimerOperations = {
+  setTimeout(callback, delayMs) {
+    return setTimeout(callback, delayMs);
+  },
+  clearTimeout(handle) {
+    clearTimeout(handle as ReturnType<typeof setTimeout>);
+  },
+};
+
+export type DismissTimerRegistry = {
+  readonly schedule: (callback: () => void, delayMs: number) => void;
+  readonly dispose: () => void;
+};
+
+export function createDismissTimerRegistry(
+  timers: DismissTimerOperations = defaultTimerOperations,
+): DismissTimerRegistry {
+  const active = new Set<unknown>();
+
+  return {
+    schedule(callback, delayMs) {
+      let handle: unknown;
+      handle = timers.setTimeout(() => {
+        active.delete(handle);
+        callback();
+      }, delayMs);
+      active.add(handle);
+    },
+    dispose() {
+      for (const handle of active) timers.clearTimeout(handle);
+      active.clear();
+    },
+  };
+}

--- a/apps/cli/src/app-shell/ink-shell.tsx
+++ b/apps/cli/src/app-shell/ink-shell.tsx
@@ -36,6 +36,7 @@ import { useBrowseDestinationLabel } from "./browse-destination";
 import { CapabilityIssueStrip } from "./CapabilityIssueStrip";
 import { dispatchAppCommand } from "./command-router";
 import { recordRender } from "./diagnostics/render-trace";
+import { createDismissTimerRegistry } from "./dismiss-timer-registry";
 import { startDownloadStatusMonitor } from "./download-status-monitor";
 import { ExitShell } from "./exit-shell";
 import { useSettledValue } from "./hooks/use-settled-value";
@@ -438,7 +439,7 @@ function AppRoot({ container }: { container: Container }) {
 
   useEffect(() => {
     /** Auto-dismiss handles for the streak alerts, cleared on unmount. */
-    const dismissTimers = new Set<ReturnType<typeof setTimeout>>();
+    const dismissTimers = createDismissTimerRegistry();
     const refresh = () => {
       let currentStreak: number | undefined;
       try {
@@ -467,7 +468,7 @@ function AppRoot({ container }: { container: Container }) {
             .update({ lastStreakMilestoneDays: nextMilestone })
             .then(() => container.config.save())
             .catch(() => undefined);
-          dismissTimers.add(setTimeout(() => setStreakMilestoneAlert(null), 6_000));
+          dismissTimers.schedule(() => setStreakMilestoneAlert(null), 6_000);
         }
 
         // Streak-at-risk: after 20:00 local time, if user hasn't watched today
@@ -477,7 +478,7 @@ function AppRoot({ container }: { container: Container }) {
             const watchedToday = container.statsService.watchedToday();
             if (!watchedToday) {
               setStreakAtRiskAlert(`🔥 ${days}d streak at risk — watch something tonight`);
-              dismissTimers.add(setTimeout(() => setStreakAtRiskAlert(null), 10_000));
+              dismissTimers.schedule(() => setStreakAtRiskAlert(null), 10_000);
             }
           } catch {
             // best-effort
@@ -494,8 +495,7 @@ function AppRoot({ container }: { container: Container }) {
       // transitions, so each mount could leave timers firing against a stale
       // setter. A set, not a single handle: overlapping refreshes can schedule
       // more than one.
-      for (const dismiss of dismissTimers) clearTimeout(dismiss);
-      dismissTimers.clear();
+      dismissTimers.dispose();
     };
   }, [container.statsService, container.syncService, container.queueService, container.config]);
 

--- a/apps/cli/src/infra/player/mpv-ipc-endpoint.ts
+++ b/apps/cli/src/infra/player/mpv-ipc-endpoint.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from "node:fs";
+import { lstatSync, mkdirSync, statSync } from "node:fs";
 import { posix as posixPath } from "node:path";
 
 /** Where Bun connects for mpv JSON IPC (`--input-ipc-server` value). */
@@ -19,6 +19,76 @@ function ipcPipeSuffix(sessionId: string): string {
  * long `XDG_RUNTIME_DIR` plus a session id can genuinely reach it.
  */
 const MAX_UNIX_SOCKET_PATH_BYTES = 100;
+
+export type MpvIpcDirectoryFacts = {
+  readonly directory: boolean;
+  readonly symbolicLink: boolean;
+  readonly mode: number;
+  readonly uid?: number;
+  readonly device: number;
+  readonly inode: number;
+};
+
+export type MpvIpcDirectoryOperations = {
+  readonly makeDirectory: (path: string, mode: number) => void;
+  readonly lstat: (path: string) => MpvIpcDirectoryFacts;
+  readonly stat: (path: string) => MpvIpcDirectoryFacts;
+  readonly currentUid: () => number | undefined;
+};
+
+function directoryFacts(path: string, followSymbolicLinks: boolean): MpvIpcDirectoryFacts {
+  const facts = followSymbolicLinks ? statSync(path) : lstatSync(path);
+  return {
+    directory: facts.isDirectory(),
+    symbolicLink: facts.isSymbolicLink(),
+    mode: facts.mode,
+    uid: facts.uid,
+    device: facts.dev,
+    inode: facts.ino,
+  };
+}
+
+const nodeDirectoryOperations: MpvIpcDirectoryOperations = {
+  makeDirectory(path, mode) {
+    mkdirSync(path, { recursive: true, mode });
+  },
+  lstat(path) {
+    return directoryFacts(path, false);
+  },
+  stat(path) {
+    return directoryFacts(path, true);
+  },
+  currentUid() {
+    return typeof process.getuid === "function" ? process.getuid() : undefined;
+  },
+};
+
+function isVerifiedPrivateDirectory(
+  linkFacts: MpvIpcDirectoryFacts,
+  targetFacts: MpvIpcDirectoryFacts,
+  currentUid: number | undefined,
+): boolean {
+  if (linkFacts.symbolicLink || !linkFacts.directory || !targetFacts.directory) return false;
+  if (linkFacts.device !== targetFacts.device || linkFacts.inode !== targetFacts.inode)
+    return false;
+  if ((targetFacts.mode & 0o777) !== 0o700) return false;
+  if (currentUid === undefined) return true;
+  if (linkFacts.uid !== undefined && linkFacts.uid !== currentUid) return false;
+  return targetFacts.uid === undefined || targetFacts.uid === currentUid;
+}
+
+function preparePrivateDirectory(path: string, operations: MpvIpcDirectoryOperations): boolean {
+  try {
+    operations.makeDirectory(path, 0o700);
+    return isVerifiedPrivateDirectory(
+      operations.lstat(path),
+      operations.stat(path),
+      operations.currentUid(),
+    );
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Directory for the mpv IPC socket, most private first.
@@ -53,44 +123,36 @@ export function mpvIpcSocketDirCandidates(
   return [
     ...(runtimeDir ? [posixPath.join(runtimeDir, "kunai")] : []),
     posixPath.join(tempDir, "kunai-ipc"),
-    tempDir,
   ];
 }
 
 /**
- * First candidate directory that exists at 0700 and yields a bindable path.
+ * First candidate directory verified as a real, owner-only 0700 directory that
+ * yields a bindable path.
  *
  * Creating the directory is a deliberate side effect of resolving the endpoint:
- * mpv binds the socket itself, so the parent has to be there first. Each step
- * is best-effort — an unwritable `XDG_RUNTIME_DIR` falls through rather than
- * failing the launch, and the last candidate is the bare temp dir, which is
- * where this lived before, so the worst case is the old behaviour.
+ * mpv binds the socket itself, so the parent has to be there first. Each private
+ * candidate is best-effort, but resolution fails closed if none can be created
+ * and verified; a shared bare temp directory is never returned.
  */
 function resolveUnixSocketPath(
   sessionId: string,
   env: Record<string, string | undefined>,
-  makeDir: (path: string) => void,
+  directoryOperations: MpvIpcDirectoryOperations,
 ): string {
   const fileName = `kunai-mpv-${sessionId}.sock`;
   const candidates = mpvIpcSocketDirCandidates(env);
 
-  for (const [index, dir] of candidates.entries()) {
+  for (const dir of candidates) {
     const candidate = posixPath.join(dir, fileName);
     if (Buffer.byteLength(candidate, "utf8") >= MAX_UNIX_SOCKET_PATH_BYTES) continue;
-    // The final candidate is the plain temp dir, which already exists.
-    if (index < candidates.length - 1) {
-      try {
-        makeDir(dir);
-      } catch {
-        continue;
-      }
-    }
+    if (!preparePrivateDirectory(dir, directoryOperations)) continue;
     return candidate;
   }
 
-  // Every candidate was too long or unusable. Fall back to the shortest path
-  // that can still bind rather than returning something that cannot.
-  return posixPath.join("/tmp", fileName);
+  throw new Error(
+    "Unable to prepare a private mpv IPC directory. Check XDG_RUNTIME_DIR/TMPDIR permissions and path lengths.",
+  );
 }
 
 function randomHex(byteCount: number): string {
@@ -122,8 +184,8 @@ export function createMpvIpcEndpoint(
   platform: NodeJS.Platform = process.platform,
   options: {
     readonly env?: Record<string, string | undefined>;
-    /** Injectable for tests; creates the directory owner-only. */
-    readonly makeDir?: (path: string) => void;
+    /** Injectable filesystem boundary for deterministic directory trust checks. */
+    readonly directoryOperations?: MpvIpcDirectoryOperations;
   } = {},
 ): MpvIpcEndpoint {
   if (platform === "win32") {
@@ -134,11 +196,13 @@ export function createMpvIpcEndpoint(
       path: `\\\\.\\pipe\\kunai-mpv-${ipcPipeSuffix(sessionId)}`,
     };
   }
-  const makeDir =
-    options.makeDir ?? ((path: string) => mkdirSync(path, { recursive: true, mode: 0o700 }));
   return {
     kind: "unix_socket",
-    path: resolveUnixSocketPath(sessionId, options.env ?? Bun.env, makeDir),
+    path: resolveUnixSocketPath(
+      sessionId,
+      options.env ?? Bun.env,
+      options.directoryOperations ?? nodeDirectoryOperations,
+    ),
   };
 }
 

--- a/apps/cli/src/infra/player/mpv-ipc.ts
+++ b/apps/cli/src/infra/player/mpv-ipc.ts
@@ -54,6 +54,21 @@ export type MpvIpcSessionOptions = {
   onEndFile: EndFileHandler;
   onFileLoaded?: FileLoadedHandler;
   onCommandResult?: (result: MpvIpcCommandResult) => void;
+  closeTimers?: MpvIpcCloseTimers;
+};
+
+export type MpvIpcCloseTimers = {
+  readonly setTimeout: (callback: () => void, delayMs: number) => unknown;
+  readonly clearTimeout: (handle: unknown) => void;
+};
+
+const defaultCloseTimers: MpvIpcCloseTimers = {
+  setTimeout(callback, delayMs) {
+    return setTimeout(callback, delayMs);
+  },
+  clearTimeout(handle) {
+    clearTimeout(handle as ReturnType<typeof setTimeout>);
+  },
 };
 
 export type MpvIpcSessionState =
@@ -146,6 +161,7 @@ export interface MpvIpcSession {
 }
 
 export async function openMpvIpcSession(options: MpvIpcSessionOptions): Promise<MpvIpcSession> {
+  const closeTimers = options.closeTimers ?? defaultCloseTimers;
   const requestIds = new Map<number, string>();
   const pendingCommands = new Map<number, PendingCommand>();
   let nextRequestId = 1;
@@ -290,25 +306,26 @@ export async function openMpvIpcSession(options: MpvIpcSessionOptions): Promise<
         markClosed("session closed");
         if (socket.readyState !== 1) return;
         await new Promise<void>((resolve) => {
+          let settled = false;
+          const finish = () => {
+            if (settled) return false;
+            settled = true;
+            socket.data.onClose = null;
+            resolve();
+            return true;
+          };
           // The fallback has to be cleared when the socket closes cleanly.
           // Uncleared it fires 200ms later against an already-closed socket,
           // and `close()` runs on every session release, not only at exit — so
           // each released mpv session left one behind.
-          let settled = false;
-          const finish = () => {
-            if (settled) return;
-            settled = true;
-            clearTimeout(fallback);
-            socket.data.onClose = null;
-            // The guard above makes the clean-close/timeout race single-shot.
-            // eslint-disable-next-line promise/no-multiple-resolved
-            resolve();
-          };
-          const fallback = setTimeout(() => {
+          const fallback = closeTimers.setTimeout(() => {
+            if (!finish()) return;
             socket.terminate();
-            finish();
           }, 200);
-          socket.data.onClose = finish;
+          socket.data.onClose = () => {
+            closeTimers.clearTimeout(fallback);
+            finish();
+          };
           socket.end();
         });
       })();

--- a/apps/cli/test/unit/app-shell/dismiss-timer-registry.test.ts
+++ b/apps/cli/test/unit/app-shell/dismiss-timer-registry.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import { createDismissTimerRegistry } from "@/app-shell/dismiss-timer-registry";
+
+function createTimerHarness() {
+  const scheduled: Array<{ id: number; callback: () => void; delayMs: number }> = [];
+  const cleared: number[] = [];
+  return {
+    scheduled,
+    cleared,
+    timers: {
+      setTimeout(callback: () => void, delayMs: number) {
+        const id = scheduled.length + 1;
+        scheduled.push({ id, callback, delayMs });
+        return id;
+      },
+      clearTimeout(handle: unknown) {
+        if (typeof handle !== "number") throw new Error("unexpected timer handle");
+        cleared.push(handle);
+      },
+    },
+  };
+}
+
+describe("dismiss timer registry", () => {
+  test("disposal clears every overlapping 6s and 10s dismissal", () => {
+    const clock = createTimerHarness();
+    const registry = createDismissTimerRegistry(clock.timers);
+
+    registry.schedule(() => {}, 6_000);
+    registry.schedule(() => {}, 10_000);
+    registry.schedule(() => {}, 6_000);
+    registry.dispose();
+
+    expect(clock.scheduled.map(({ id, delayMs }) => ({ id, delayMs }))).toEqual([
+      { id: 1, delayMs: 6_000 },
+      { id: 2, delayMs: 10_000 },
+      { id: 3, delayMs: 6_000 },
+    ]);
+    expect(clock.cleared).toEqual([1, 2, 3]);
+  });
+
+  test("fired dismissals leave no handle for disposal to clear", () => {
+    const clock = createTimerHarness();
+    const registry = createDismissTimerRegistry(clock.timers);
+    let fired = 0;
+
+    registry.schedule(() => {
+      fired++;
+    }, 6_000);
+    registry.schedule(() => {}, 10_000);
+
+    clock.scheduled[0]?.callback();
+    registry.dispose();
+
+    expect(fired).toBe(1);
+    expect(clock.cleared).toEqual([2]);
+  });
+});

--- a/apps/cli/test/unit/infra/player/mpv-ipc-socket-dir.test.ts
+++ b/apps/cli/test/unit/infra/player/mpv-ipc-socket-dir.test.ts
@@ -133,6 +133,38 @@ describe("mpv IPC socket directory", () => {
     expect(endpoint.path).toBe("/tmp/kunai-ipc/kunai-mpv-abc-123.sock");
   });
 
+  test("rejects a regular file where the private directory must be", () => {
+    const fake = directoryOperations((path, kind) =>
+      path.startsWith("/run/user") && kind === "lstat"
+        ? { ...SAFE_DIRECTORY, directory: false, symbolicLink: false }
+        : SAFE_DIRECTORY,
+    );
+
+    const endpoint = createMpvIpcEndpoint("abc-123", "linux", {
+      env: { XDG_RUNTIME_DIR: "/run/user/1000", TMPDIR: "/tmp" },
+      directoryOperations: fake.operations,
+    });
+
+    expect(endpoint.path).toBe("/tmp/kunai-ipc/kunai-mpv-abc-123.sock");
+  });
+
+  test("rejects a directory replaced between lstat and stat", () => {
+    for (const replacement of [{ device: 2 }, { inode: 3 }]) {
+      const fake = directoryOperations((path, kind) =>
+        path.startsWith("/run/user") && kind === "stat"
+          ? { ...SAFE_DIRECTORY, ...replacement }
+          : SAFE_DIRECTORY,
+      );
+
+      const endpoint = createMpvIpcEndpoint("abc-123", "linux", {
+        env: { XDG_RUNTIME_DIR: "/run/user/1000", TMPDIR: "/tmp" },
+        directoryOperations: fake.operations,
+      });
+
+      expect(endpoint.path).toBe("/tmp/kunai-ipc/kunai-mpv-abc-123.sock");
+    }
+  });
+
   test("rejects a directory owned by another user", () => {
     const fake = directoryOperations((path) =>
       path.startsWith("/run/user") ? { ...SAFE_DIRECTORY, uid: 2000 } : SAFE_DIRECTORY,

--- a/apps/cli/test/unit/infra/player/mpv-ipc-socket-dir.test.ts
+++ b/apps/cli/test/unit/infra/player/mpv-ipc-socket-dir.test.ts
@@ -2,6 +2,47 @@ import { describe, expect, test } from "bun:test";
 
 import { createMpvIpcEndpoint, mpvIpcSocketDirCandidates } from "@/infra/player/mpv-ipc-endpoint";
 
+type DirectoryFacts = {
+  readonly directory: boolean;
+  readonly symbolicLink: boolean;
+  readonly mode: number;
+  readonly uid?: number;
+  readonly device: number;
+  readonly inode: number;
+};
+
+const SAFE_DIRECTORY: DirectoryFacts = {
+  directory: true,
+  symbolicLink: false,
+  mode: 0o700,
+  uid: 1000,
+  device: 1,
+  inode: 2,
+};
+
+function directoryOperations(
+  factsFor: (path: string, kind: "lstat" | "stat") => DirectoryFacts = () => SAFE_DIRECTORY,
+) {
+  const made: Array<{ path: string; mode: number }> = [];
+  return {
+    made,
+    operations: {
+      makeDirectory(path: string, mode: number) {
+        made.push({ path, mode });
+      },
+      lstat(path: string) {
+        return factsFor(path, "lstat");
+      },
+      stat(path: string) {
+        return factsFor(path, "stat");
+      },
+      currentUid() {
+        return 1000;
+      },
+    },
+  };
+}
+
 /**
  * The socket used to sit directly in the shared temp dir.
  *
@@ -16,10 +57,10 @@ import { createMpvIpcEndpoint, mpvIpcSocketDirCandidates } from "@/infra/player/
  * directory closes it for free.
  */
 describe("mpv IPC socket directory", () => {
-  test("prefers XDG_RUNTIME_DIR, then a private temp subdir, then bare temp", () => {
+  test("prefers XDG_RUNTIME_DIR, then a private temp subdir, never bare temp", () => {
     expect(
       mpvIpcSocketDirCandidates({ XDG_RUNTIME_DIR: "/run/user/1000", TMPDIR: "/tmp" }),
-    ).toEqual(["/run/user/1000/kunai", "/tmp/kunai-ipc", "/tmp"]);
+    ).toEqual(["/run/user/1000/kunai", "/tmp/kunai-ipc"]);
   });
 
   test("macOS has no XDG_RUNTIME_DIR, so the private temp subdir leads", () => {
@@ -27,25 +68,31 @@ describe("mpv IPC socket directory", () => {
     // exists is how a Linux-shaped fix regresses every Mac.
     expect(mpvIpcSocketDirCandidates({ TMPDIR: "/var/folders/ab/xyz/T/" })).toEqual([
       "/var/folders/ab/xyz/T/kunai-ipc",
-      "/var/folders/ab/xyz/T/",
     ]);
+
+    const fake = directoryOperations();
+    const endpoint = createMpvIpcEndpoint("abc-123", "darwin", {
+      env: { TMPDIR: "/var/folders/ab/xyz/T/" },
+      directoryOperations: fake.operations,
+    });
+    expect(fake.made).toEqual([{ path: "/var/folders/ab/xyz/T/kunai-ipc", mode: 0o700 }]);
+    expect(endpoint.path).toBe("/var/folders/ab/xyz/T/kunai-ipc/kunai-mpv-abc-123.sock");
   });
 
   test("an empty XDG_RUNTIME_DIR is ignored rather than producing a bare path", () => {
     expect(mpvIpcSocketDirCandidates({ XDG_RUNTIME_DIR: "   ", TMPDIR: "/tmp" })).toEqual([
       "/tmp/kunai-ipc",
-      "/tmp",
     ]);
   });
 
   test("creates the chosen directory owner-only and puts the socket in it", () => {
-    const made: Array<string> = [];
+    const fake = directoryOperations();
     const endpoint = createMpvIpcEndpoint("abc-123", "linux", {
       env: { XDG_RUNTIME_DIR: "/run/user/1000", TMPDIR: "/tmp" },
-      makeDir: (path) => made.push(path),
+      directoryOperations: fake.operations,
     });
 
-    expect(made).toEqual(["/run/user/1000/kunai"]);
+    expect(fake.made).toEqual([{ path: "/run/user/1000/kunai", mode: 0o700 }]);
     expect(endpoint).toEqual({
       kind: "unix_socket",
       path: "/run/user/1000/kunai/kunai-mpv-abc-123.sock",
@@ -53,28 +100,78 @@ describe("mpv IPC socket directory", () => {
   });
 
   test("falls through when the runtime dir cannot be created", () => {
-    const made: Array<string> = [];
+    const fake = directoryOperations();
+    const makeDirectory = fake.operations.makeDirectory;
+    fake.operations.makeDirectory = (path, mode) => {
+      makeDirectory(path, mode);
+      if (path.startsWith("/run/user")) throw new Error("EACCES");
+    };
     const endpoint = createMpvIpcEndpoint("abc-123", "linux", {
       env: { XDG_RUNTIME_DIR: "/run/user/1000", TMPDIR: "/tmp" },
-      makeDir: (path) => {
-        made.push(path);
-        if (path.startsWith("/run/user")) throw new Error("EACCES");
-      },
+      directoryOperations: fake.operations,
     });
 
-    expect(made).toEqual(["/run/user/1000/kunai", "/tmp/kunai-ipc"]);
+    expect(fake.made).toEqual([
+      { path: "/run/user/1000/kunai", mode: 0o700 },
+      { path: "/tmp/kunai-ipc", mode: 0o700 },
+    ]);
     expect(endpoint.path).toBe("/tmp/kunai-ipc/kunai-mpv-abc-123.sock");
   });
 
-  test("falls back to bare temp when every private directory fails", () => {
+  test("rejects an existing symlink and falls through to a verified private directory", () => {
+    const fake = directoryOperations((path, kind) =>
+      path.startsWith("/run/user") && kind === "lstat"
+        ? { ...SAFE_DIRECTORY, directory: false, symbolicLink: true }
+        : SAFE_DIRECTORY,
+    );
+
     const endpoint = createMpvIpcEndpoint("abc-123", "linux", {
       env: { XDG_RUNTIME_DIR: "/run/user/1000", TMPDIR: "/tmp" },
-      makeDir: () => {
-        throw new Error("EROFS");
-      },
+      directoryOperations: fake.operations,
     });
-    // The previous behaviour, so a locked-down box still plays.
-    expect(endpoint.path).toBe("/tmp/kunai-mpv-abc-123.sock");
+
+    expect(endpoint.path).toBe("/tmp/kunai-ipc/kunai-mpv-abc-123.sock");
+  });
+
+  test("rejects a directory owned by another user", () => {
+    const fake = directoryOperations((path) =>
+      path.startsWith("/run/user") ? { ...SAFE_DIRECTORY, uid: 2000 } : SAFE_DIRECTORY,
+    );
+
+    const endpoint = createMpvIpcEndpoint("abc-123", "linux", {
+      env: { XDG_RUNTIME_DIR: "/run/user/1000", TMPDIR: "/tmp" },
+      directoryOperations: fake.operations,
+    });
+
+    expect(endpoint.path).toBe("/tmp/kunai-ipc/kunai-mpv-abc-123.sock");
+  });
+
+  test("rejects a group- or world-accessible directory", () => {
+    for (const mode of [0o710, 0o701]) {
+      const fake = directoryOperations((path) =>
+        path.startsWith("/run/user") ? { ...SAFE_DIRECTORY, mode } : SAFE_DIRECTORY,
+      );
+
+      const endpoint = createMpvIpcEndpoint("abc-123", "linux", {
+        env: { XDG_RUNTIME_DIR: "/run/user/1000", TMPDIR: "/tmp" },
+        directoryOperations: fake.operations,
+      });
+
+      expect(endpoint.path).toBe("/tmp/kunai-ipc/kunai-mpv-abc-123.sock");
+    }
+  });
+
+  test("fails closed when every private directory cannot be created", () => {
+    const fake = directoryOperations();
+    fake.operations.makeDirectory = () => {
+      throw new Error("EROFS");
+    };
+    expect(() =>
+      createMpvIpcEndpoint("abc-123", "linux", {
+        env: { XDG_RUNTIME_DIR: "/run/user/1000", TMPDIR: "/tmp" },
+        directoryOperations: fake.operations,
+      }),
+    ).toThrow("Unable to prepare a private mpv IPC directory");
   });
 
   /**
@@ -84,13 +181,32 @@ describe("mpv IPC socket directory", () => {
    */
   test("skips candidates that would exceed the sun_path limit", () => {
     const long = `/run/user/1000/${"d".repeat(90)}`;
+    const fake = directoryOperations();
     const endpoint = createMpvIpcEndpoint("abc-123", "linux", {
       env: { XDG_RUNTIME_DIR: long, TMPDIR: "/tmp" },
-      makeDir: () => {},
+      directoryOperations: fake.operations,
     });
 
     expect(endpoint.path.startsWith(long)).toBe(false);
     expect(Buffer.byteLength(endpoint.path, "utf8")).toBeLessThan(100);
+  });
+
+  test("fails closed when every private candidate exceeds the sun_path limit", () => {
+    const tooLong = `/private/${"d".repeat(110)}`;
+    const fake = directoryOperations();
+    let filesystemCalls = 0;
+    fake.operations.makeDirectory = () => {
+      filesystemCalls++;
+      throw new Error("overlong candidates must not touch the filesystem");
+    };
+
+    expect(() =>
+      createMpvIpcEndpoint("abc-123", "darwin", {
+        env: { TMPDIR: tooLong },
+        directoryOperations: fake.operations,
+      }),
+    ).toThrow("Unable to prepare a private mpv IPC directory");
+    expect(filesystemCalls).toBe(0);
   });
 
   /**
@@ -114,7 +230,7 @@ describe("mpv IPC socket directory", () => {
 
     const endpoint = createMpvIpcEndpoint("abc-123", "linux", {
       env: { XDG_RUNTIME_DIR: "/run/user/1000", TMPDIR: "/tmp" },
-      makeDir: () => {},
+      directoryOperations: directoryOperations().operations,
     });
     expect(endpoint.path).not.toContain("\\");
     expect(endpoint.path.startsWith("/")).toBe(true);
@@ -123,8 +239,19 @@ describe("mpv IPC socket directory", () => {
   test("Windows is untouched — named pipes, and the backslash spelling mpv needs", () => {
     const endpoint = createMpvIpcEndpoint("abc-123", "win32", {
       env: { TMPDIR: "C:\\Temp" },
-      makeDir: () => {
-        throw new Error("must not be called on win32");
+      directoryOperations: {
+        makeDirectory() {
+          throw new Error("must not make directories on win32");
+        },
+        lstat() {
+          throw new Error("must not lstat on win32");
+        },
+        stat() {
+          throw new Error("must not stat on win32");
+        },
+        currentUid() {
+          throw new Error("must not read uid on win32");
+        },
       },
     });
 

--- a/apps/cli/test/unit/infra/player/mpv-ipc.test.ts
+++ b/apps/cli/test/unit/infra/player/mpv-ipc.test.ts
@@ -4,8 +4,85 @@ import {
   buildMpvIpcCommand,
   MPV_INITIAL_PROPERTIES,
   MPV_OBSERVED_PROPERTIES,
+  openMpvIpcSession,
   parseMpvIpcLine,
 } from "@/infra/player/mpv-ipc";
+
+type FakeSocketState = { onClose: (() => void) | null };
+
+type CloseTimerHarness = {
+  readonly scheduled: Array<{ id: number; callback: () => void; delayMs: number }>;
+  readonly cleared: number[];
+  readonly timers: {
+    setTimeout(callback: () => void, delayMs: number): number;
+    clearTimeout(handle: unknown): void;
+  };
+};
+
+function createCloseTimerHarness(): CloseTimerHarness {
+  const scheduled: CloseTimerHarness["scheduled"] = [];
+  const cleared: number[] = [];
+  return {
+    scheduled,
+    cleared,
+    timers: {
+      setTimeout(callback, delayMs) {
+        const id = scheduled.length + 1;
+        scheduled.push({ id, callback, delayMs });
+        return id;
+      },
+      clearTimeout(handle) {
+        if (typeof handle !== "number") throw new Error("unexpected timer handle");
+        cleared.push(handle);
+      },
+    },
+  };
+}
+
+async function withFakeMpvSocket(
+  closeOnEnd: boolean,
+  run: (counts: { readonly end: () => number; readonly terminate: () => number }) => Promise<void>,
+): Promise<void> {
+  const bun = Bun as unknown as { connect: typeof Bun.connect };
+  const originalConnect = bun.connect;
+  let endCount = 0;
+  let terminateCount = 0;
+  bun.connect = (async (rawOptions: unknown) => {
+    const options = rawOptions as {
+      data: FakeSocketState;
+      socket: {
+        close(socket: FakeSocket): void;
+      };
+    };
+    const socket: FakeSocket = {
+      data: options.data,
+      readyState: 1,
+      write() {},
+      end() {
+        endCount++;
+        if (closeOnEnd) options.socket.close(socket);
+      },
+      terminate() {
+        terminateCount++;
+      },
+    };
+    return socket;
+  }) as typeof Bun.connect;
+
+  try {
+    await run({ end: () => endCount, terminate: () => terminateCount });
+  } finally {
+    bun.connect = originalConnect;
+  }
+}
+
+type FakeSocket = {
+  data: FakeSocketState;
+  readyState: number;
+  write(data: string): void;
+  end(): void;
+  terminate(): void;
+};
 
 describe("mpv-ipc", () => {
   test("builds newline-delimited ipc commands without a request id", () => {
@@ -71,6 +148,61 @@ describe("mpv-ipc", () => {
       request_id: 12,
       error: "success",
       data: true,
+    });
+  });
+
+  test("clean socket close clears the 200ms terminate fallback", async () => {
+    const clock = createCloseTimerHarness();
+
+    await withFakeMpvSocket(true, async (counts) => {
+      const session = await openMpvIpcSession({
+        endpoint: { kind: "unix_socket", path: "/private/kunai.sock" },
+        onPropertyUpdate() {},
+        onEndFile() {},
+        closeTimers: clock.timers,
+      });
+
+      await session.close();
+
+      expect(clock.scheduled.map(({ id, delayMs }) => ({ id, delayMs }))).toEqual([
+        { id: 1, delayMs: 200 },
+      ]);
+      expect(clock.cleared).toEqual([1]);
+      expect(counts.end()).toBe(1);
+      expect(counts.terminate()).toBe(0);
+    });
+  });
+
+  test("terminate fallback resolves close exactly once when close never arrives", async () => {
+    const clock = createCloseTimerHarness();
+
+    await withFakeMpvSocket(false, async (counts) => {
+      const session = await openMpvIpcSession({
+        endpoint: { kind: "unix_socket", path: "/private/kunai.sock" },
+        onPropertyUpdate() {},
+        onEndFile() {},
+        closeTimers: clock.timers,
+      });
+
+      let resolutionCount = 0;
+      const closePromise = session.close().then(() => {
+        resolutionCount++;
+        return undefined;
+      });
+      expect(clock.scheduled.map(({ id, delayMs }) => ({ id, delayMs }))).toEqual([
+        { id: 1, delayMs: 200 },
+      ]);
+
+      clock.scheduled[0]?.callback();
+      await closePromise;
+      expect(counts.end()).toBe(1);
+      expect(counts.terminate()).toBe(1);
+      expect(resolutionCount).toBe(1);
+
+      clock.scheduled[0]?.callback();
+      await Promise.resolve();
+      expect(counts.terminate()).toBe(1);
+      expect(resolutionCount).toBe(1);
     });
   });
 });

--- a/apps/cli/test/unit/mpv-ipc-endpoint.test.ts
+++ b/apps/cli/test/unit/mpv-ipc-endpoint.test.ts
@@ -36,11 +36,39 @@ test("Windows pipe path uses backslashes, never the forward-slash spelling", () 
   expect(path).not.toContain("/");
 });
 
-test("builds a unix socket endpoint off Windows", () => {
-  const endpoint = createMpvIpcEndpoint("abc123", "linux");
+test("builds a unix socket endpoint with simulated POSIX filesystem facts off Windows", () => {
+  const endpoint = createMpvIpcEndpoint("abc123", "linux", {
+    env: { TMPDIR: "/tmp" },
+    directoryOperations: {
+      makeDirectory() {},
+      lstat() {
+        return {
+          directory: true,
+          symbolicLink: false,
+          mode: 0o700,
+          uid: 1000,
+          device: 1,
+          inode: 2,
+        };
+      },
+      stat() {
+        return {
+          directory: true,
+          symbolicLink: false,
+          mode: 0o700,
+          uid: 1000,
+          device: 1,
+          inode: 2,
+        };
+      },
+      currentUid() {
+        return 1000;
+      },
+    },
+  });
 
   expect(endpoint.kind).toBe("unix_socket");
-  expect(endpoint.path).toContain("kunai-mpv-abc123.sock");
+  expect(endpoint.path).toBe("/tmp/kunai-ipc/kunai-mpv-abc123.sock");
   expect(mpvIpcTransportTag(endpoint)).toBe("unix");
   expect(shouldUnlinkUnixSocket(endpoint)).toBe(true);
 });


### PR DESCRIPTION
## Summary

Follow-up to merged PR #146 after independent post-merge review:

- verify an existing Unix IPC directory is a real directory owned by the current user with owner-only permissions
- detect path replacement between `lstat` and `stat`, and never fall back to the shared bare temp directory
- make mpv-close and overlapping shell-dismiss timers explicitly disposable
- add deterministic tests for regular-file, symlink, ownership, mode, device/inode replacement, timeout, and Windows named-pipe behavior

## Verification

- focused IPC/timer tests: 26 passed
- full repository tests: 23 tasks passed; CLI unit 4,639 passed; integration 147 passed / 24 skipped
- typecheck: 14/14
- lint: 12/12 (pre-existing warnings only)
- formatting: 26/26
- full build and Linux x64 standalone binary: 10/10
- independent review: production behavior clean; both initially missing mutation cases added and proven RED/GREEN

## Stack

- base: #158 (codegen freshness ordering)
- this PR contains only the PR #146 hardening residue above that base

## Release control

This PR does not merge, publish, tag, deploy, or release anything.
