### PR TITLE
fix(logging): honor KITSUNE_DEBUG end to end

### DIFF
--- a/.docs/diagnostics-guide.md
+++ b/.docs/diagnostics-guide.md
@@ -15,11 +15,16 @@ redaction rules, and export behavior.
 
 ## Fast Debug Loop
 
-Run with debug logs enabled:
+For redacted developer logs on stderr without creating `logs.txt`, redirect the
+environment-only debug stream:
 
 ```sh
-KITSUNE_DEBUG=1 bun run src/main.ts --debug 2> debug.log
+KITSUNE_DEBUG=1 bun run src/main.ts 2> debug.log
 ```
+
+Use `--debug` instead when you want the same debug events persisted to
+`./logs.txt`. Kunai suppresses debug writes to an interactive terminal while
+Ink owns it, but a redirected stderr stream remains active.
 
 Inspect the relevant stage:
 

--- a/.docs/quickstart.md
+++ b/.docs/quickstart.md
@@ -161,7 +161,7 @@ Filters stack in one structured state. Unsupported filters are reported as local
 
 | Var                           | Effect                                                            |
 | ----------------------------- | ----------------------------------------------------------------- |
-| `KITSUNE_DEBUG=1`             | Enable debug JSON logs to stderr                                  |
+| `KITSUNE_DEBUG=1`             | Enable redacted structured debug logs on stderr, without logs.txt |
 | `KUNAI_DISCORD_CLIENT_ID`     | Discord application id for optional `presenceProvider: "discord"` |
 | `KUNAI_VIDEASY_SESSION_TOKEN` | Optional user-provided Videasy browser session token for VidKing  |
 | `KUNAI_RELAY_BASE_URL`        | Optional user-owned provider RPC relay base URL for metadata APIs |

--- a/apps/cli/src/container/bootstrap-persistence.ts
+++ b/apps/cli/src/container/bootstrap-persistence.ts
@@ -97,6 +97,21 @@ export type CoreInfra = {
   readonly logger: Logger;
   readonly tracer: Tracer;
   readonly sessionId: string;
+  readonly debugCapabilities: DebugCapabilities;
+};
+
+export type DebugCapabilities = {
+  readonly enabled: boolean;
+  readonly file: boolean;
+  readonly tracerOutputs: ("console" | "file")[];
+};
+
+export type CoreInfraRuntime = {
+  readonly environment?: Readonly<Record<string, string | undefined>>;
+  readonly workingDirectory?: string;
+  readonly write?: (line: string) => unknown;
+  readonly isInteractiveShellMounted?: () => boolean;
+  readonly stderrIsTTY?: boolean;
 };
 
 export type PersistenceBootstrap = {
@@ -151,30 +166,54 @@ export type PersistenceBootstrap = {
   readonly debugSessionInstructions?: readonly string[];
 };
 
-export function bootstrapCoreInfra(options?: ContainerOptions): CoreInfra {
-  const debug = options?.debug ?? false;
+export function resolveDebugCapabilities(
+  cliDebug: boolean,
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): DebugCapabilities {
+  const environmentDebug = environment.KITSUNE_DEBUG === "1";
+  const enabled = cliDebug || environmentDebug;
+  return {
+    enabled,
+    file: cliDebug,
+    tracerOutputs: cliDebug ? ["console", "file"] : environmentDebug ? ["console"] : [],
+  };
+}
+
+export function bootstrapCoreInfra(
+  options?: ContainerOptions,
+  runtime: CoreInfraRuntime = {},
+): CoreInfra {
+  const debugCapabilities = resolveDebugCapabilities(
+    options?.debug ?? false,
+    runtime.environment ?? process.env,
+  );
+  const shellMounted = runtime.isInteractiveShellMounted ?? isInteractiveShellMounted;
+  const stderrIsTTY = runtime.stderrIsTTY ?? process.stderr.isTTY === true;
   const logger = new StructuredLogger({
-    debug,
-    console: () => !isInteractiveShellMounted(),
-    file: debug ? join(process.cwd(), "logs.txt") : undefined,
+    debug: debugCapabilities.enabled,
+    console: () => !shellMounted() || !stderrIsTTY,
+    file: debugCapabilities.file
+      ? join(runtime.workingDirectory ?? process.cwd(), "logs.txt")
+      : undefined,
+    write: runtime.write,
     sanitize: (value) => redactDiagnosticValue(value, { homeDir: resolveRedactionHomeDir() }),
   });
-  initLogger(debug || process.env.KITSUNE_DEBUG === "1", logger);
+  initLogger(debugCapabilities.enabled, logger);
   const sessionId = createCorrelationId("session");
   const tracer = new TracerImpl({
     logger,
-    outputs: debug ? ["console", "file"] : [],
+    outputs: debugCapabilities.tracerOutputs,
   });
 
-  return { logger, tracer, sessionId };
+  return { logger, tracer, sessionId, debugCapabilities };
 }
 
 export async function bootstrapPersistence(
   options: ContainerOptions | undefined,
   core: CoreInfra,
 ): Promise<PersistenceBootstrap> {
-  const { logger, sessionId } = core;
-  const debug = options?.debug ?? false;
+  const { logger, sessionId, debugCapabilities } = core;
+  const debug = debugCapabilities.enabled;
 
   const storage = new FileStorage(undefined, (message, context) => logger.warn(message, context));
   const paths = getKunaiPaths();

--- a/apps/cli/test/unit/container/bootstrap-debug-capabilities.test.ts
+++ b/apps/cli/test/unit/container/bootstrap-debug-capabilities.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { bootstrapCoreInfra, resolveDebugCapabilities } from "@/container/bootstrap-persistence";
+import { initLogger, dbg } from "@/logger";
+
+afterEach(() => {
+  initLogger(false);
+});
+
+describe("debug capabilities", () => {
+  test("keeps CLI file logging distinct from environment-only stderr logging", () => {
+    expect(resolveDebugCapabilities(false, {})).toEqual({
+      enabled: false,
+      file: false,
+      tracerOutputs: [],
+    });
+    expect(resolveDebugCapabilities(false, { KITSUNE_DEBUG: "1" })).toEqual({
+      enabled: true,
+      file: false,
+      tracerOutputs: ["console"],
+    });
+    expect(resolveDebugCapabilities(true, {})).toEqual({
+      enabled: true,
+      file: true,
+      tracerOutputs: ["console", "file"],
+    });
+  });
+
+  test("environment-only debug reaches facade, child logger, and tracer without creating logs.txt", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "kunai-env-debug-"));
+    const lines: string[] = [];
+    try {
+      const core = bootstrapCoreInfra(
+        { debug: false },
+        {
+          environment: { KITSUNE_DEBUG: "1" },
+          workingDirectory: directory,
+          write: (line) => lines.push(line),
+          isInteractiveShellMounted: () => true,
+          stderrIsTTY: false,
+        },
+      );
+
+      dbg("provider", "facade reached", { operation: "debug.facade" });
+      core.logger.child({ module: "child" }).debug("child reached");
+      await core.tracer.span("resolve", async (span) => {
+        span.addEvent("tracer reached");
+      });
+
+      expect(core.debugCapabilities.enabled).toBe(true);
+      expect(lines.join("\n")).toContain("facade reached");
+      expect(lines.join("\n")).toContain("child reached");
+      expect(lines.join("\n")).toContain("tracer reached");
+      expect(existsSync(join(directory, "logs.txt"))).toBe(false);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("CLI debug continues writing logs.txt while the shell owns stderr", () => {
+    const directory = mkdtempSync(join(tmpdir(), "kunai-cli-debug-"));
+    const lines: string[] = [];
+    try {
+      const core = bootstrapCoreInfra(
+        { debug: true },
+        {
+          environment: {},
+          workingDirectory: directory,
+          write: (line) => lines.push(line),
+          isInteractiveShellMounted: () => true,
+          stderrIsTTY: true,
+        },
+      );
+
+      core.logger.info("file-only while Ink is mounted");
+
+      expect(lines).toEqual([]);
+      expect(readFileSync(join(directory, "logs.txt"), "utf8")).toContain(
+        "file-only while Ink is mounted",
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("debug-off drops debug and info while preserving warning and error behavior", async () => {
+    const lines: string[] = [];
+    const core = bootstrapCoreInfra(
+      { debug: false },
+      {
+        environment: {},
+        write: (line) => lines.push(line),
+        isInteractiveShellMounted: () => false,
+      },
+    );
+
+    dbg("provider", "hidden facade");
+    core.logger.debug("hidden debug");
+    core.logger.info("hidden info");
+    await core.tracer.span("resolve", async (span) => span.addEvent("hidden tracer"));
+    core.logger.warn("visible warning");
+    core.logger.error("visible error");
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain("visible warning");
+    expect(lines[1]).toContain("visible error");
+    expect(lines.join("\n")).not.toContain("hidden");
+  });
+});


### PR DESCRIPTION
Closes #125.

## Summary

- compute one effective debug capability from --debug and KITSUNE_DEBUG=1
- keep CLI file logging distinct: environment-only debugging writes to redirected stderr and does not create logs.txt
- keep terminal output quiet while Ink owns an interactive stderr, while allowing explicitly redirected stderr to remain useful
- pass the same effective mode through the legacy facade, child loggers, tracer, and diagnostics bootstrap
- document the exact stderr/file behavior

## Verification

- focused debug/logger tests: 9 passed
- full repository tests: 23 tasks passed; integration 147 passed / 24 skipped
- typecheck: 14/14
- lint: 12/12 with zero warnings
- formatting: 26/26
- doc paths: 48 docs and 1,965 source files
- full build and Linux x64 standalone binary: 10/10

## Stack

- base: #165 (anti-slop ratchet and shared CI determinism)
- feature patch is unchanged from the previous stack and no longer depends on superseded #172

## Release control

This PR does not merge, publish, tag, deploy, or release anything.