### PR TITLE
fix(download): supervise background queue passes

### DIFF
--- a/.changeset/tidy-wolves-download.md
+++ b/.changeset/tidy-wolves-download.md
@@ -1,0 +1,6 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Keep unexpected background download-queue failures inside the download
+subsystem so they cannot terminate playback.

--- a/.docs/download-offline-onboarding.md
+++ b/.docs/download-offline-onboarding.md
@@ -69,6 +69,12 @@ Layering rule: UI asks services for capability/state; services do not render UI.
 - Abort terminates active download processes (`yt-dlp`), deletes temporary files, and persists an aborted job state.
 - App shutdown pauses active downloads, cleans temporary workers, and leaves jobs retryable.
 - Failed jobs retry with bounded backoff and then surface as failed when retry limits are exhausted.
+- Background queue triggers enter through one supervised seam. An unexpected
+  reconciliation, repository, filesystem, or worker failure records a redacted
+  download diagnostic and cannot terminate playback or the CLI.
+- Explicitly awaited queue processing and drain calls still reject on unexpected
+  failures so download-only mode, shutdown, tests, and operators receive honest
+  failure semantics.
 - Quit with active downloads asks whether to keep, wait, or cancel; Ctrl+C and signals use the same cleanup path.
 - Progress is parsed from yt-dlp newline output and persisted for shell diagnostics/UI.
 - Download-only mode resolves a playable stream without launching mpv.

--- a/apps/cli/src/app-shell/download-manager-shell.tsx
+++ b/apps/cli/src/app-shell/download-manager-shell.tsx
@@ -357,7 +357,7 @@ export function DownloadManagerContent({
             .then(() => {
               refresh();
               if (job.status !== "repairable") {
-                void container.downloadService.processQueue();
+                container.downloadService.kickQueue("download-manager");
               }
               return undefined;
             })

--- a/apps/cli/src/app-shell/workflows/shell-workflows.ts
+++ b/apps/cli/src/app-shell/workflows/shell-workflows.ts
@@ -319,7 +319,7 @@ export async function openOfflineLibraryGroupPicker(
           repairEntries.length === 1 ? "item" : "items"
         }`,
       });
-      void container.downloadService.processQueue();
+      container.downloadService.kickQueue("offline-repair");
       continue;
     }
     if (picked.type === "download-more") {
@@ -604,7 +604,7 @@ export async function openOfflineLibraryGroupPicker(
             ? `Sidecar repair checked: ${formatOfflineJobListingTitle(job)}`
             : `Re-download queued: ${formatOfflineJobListingTitle(job)}`,
       });
-      void container.downloadService.processQueue();
+      container.downloadService.kickQueue("download-manager");
       continue;
     }
     await container.downloadService.deleteJob(job.id, {
@@ -1662,7 +1662,7 @@ export async function enqueueCurrentPlaybackDownload({
         });
       }
     }, 3000);
-    void container.downloadService.processQueue();
+    container.downloadService.kickQueue("shell-download");
     return true;
   } catch (error) {
     const message =

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -917,7 +917,7 @@ export async function runCli(argv = process.argv.slice(2)): Promise<void> {
   }
 
   if (!config.offlineMode) {
-    void container.downloadService.processQueue();
+    container.downloadService.kickQueue("startup");
   }
   // Background update: binary channel auto-applies; others notify-only.
   if (!config.offlineMode)

--- a/apps/cli/src/services/diagnostics/operation-taxonomy.ts
+++ b/apps/cli/src/services/diagnostics/operation-taxonomy.ts
@@ -445,6 +445,14 @@ export const DIAGNOSTIC_OPERATION_CATALOG: readonly DiagnosticOperationCatalogEn
     userAction: "Retry the download; if it repeats, export diagnostics.",
   },
   {
+    operation: "download.queue.pass.failed",
+    category: "download",
+    audience: "both",
+    summary:
+      "An unexpected background queue-pass failure was contained inside the download subsystem.",
+    userAction: "Export diagnostics, then retry the affected download from /downloads.",
+  },
+  {
     operation: "download.artifact.integrity.checked",
     category: "download",
     audience: "both",

--- a/apps/cli/src/services/download/DownloadIntentService.ts
+++ b/apps/cli/src/services/download/DownloadIntentService.ts
@@ -211,7 +211,7 @@ export async function commitDownloadIntent(
           : `Download failed: ${message}`,
     });
     if (queuedCount > 0) persistSeriesPolicy();
-    void container.downloadService.processQueue();
+    container.downloadService.kickQueue("download-intent");
     return { status: queuedCount > 0 ? "queued" : "none", queuedCount };
   }
 
@@ -247,6 +247,6 @@ export async function commitDownloadIntent(
             count: queuedCount,
           })} · ${title.name}`,
   });
-  void container.downloadService.processQueue();
+  container.downloadService.kickQueue("download-intent");
   return { status: "queued", queuedCount };
 }

--- a/apps/cli/src/services/download/DownloadService.ts
+++ b/apps/cli/src/services/download/DownloadService.ts
@@ -76,6 +76,9 @@ const FFPROBE_TERMINATION_GRACE_MS = 2_500;
 const FFPROBE_FORCE_WAIT_MS = 2_500;
 const FFPROBE_IO_CLEANUP_MS = 250;
 const YTDLP_HEADER_CRLF_PATTERN = /[\r\n]/g;
+const DOWNLOAD_QUEUE_FAILURE_NAME_MAX_LENGTH = 40;
+const DOWNLOAD_QUEUE_FAILURE_MESSAGE_MAX_LENGTH = 160;
+const DOWNLOAD_QUEUE_AGGREGATE_MESSAGE_MAX_LENGTH = 1_000;
 
 /** Sanitized yt-dlp argv tail: validated stream URL, scrubbed headers, `--` before positional URL. */
 export function buildYtDlpDownloadStreamArgs(
@@ -688,7 +691,7 @@ export class DownloadService {
         this.claimedJobIds.delete(next.id);
         // Another process won the durable claim after our read. Its update makes
         // this row ineligible, so continue with the next queued candidate.
-        return await this.processNextQueued();
+        return await this.processNextQueued(queueContext);
       }
       stopHeartbeat = this.startHeartbeat(next.id);
     } catch (error) {
@@ -2000,12 +2003,28 @@ async function readUtf8Stream(reader: {
 
 function buildDownloadQueueAggregateMessage(failures: readonly unknown[]): string {
   const summaries = failures.map((failure) => {
-    const name = failure instanceof Error ? failure.name : typeof failure;
+    const name = redactDownloadQueueAggregateText(
+      failure instanceof Error ? failure.name : typeof failure,
+      DOWNLOAD_QUEUE_FAILURE_NAME_MAX_LENGTH,
+    );
     const rawMessage = failure instanceof Error ? failure.message : String(failure);
-    const message = redactDiagnosticValue(rawMessage, { maxStringLength: 160 });
-    return `${name.slice(0, 40)}: ${typeof message === "string" ? message : "unknown failure"}`;
+    const message = redactDownloadQueueAggregateText(
+      rawMessage,
+      DOWNLOAD_QUEUE_FAILURE_MESSAGE_MAX_LENGTH,
+    );
+    return `${name}: ${message}`;
   });
-  return `Multiple download queue workers failed (${failures.length}): ${summaries.join("; ")}`;
+  // AggregateError.errors intentionally retains the original reasons for
+  // awaited callers; only its human-readable summary crosses logging/UI seams.
+  return redactDownloadQueueAggregateText(
+    `Multiple download queue workers failed (${failures.length}): ${summaries.join("; ")}`,
+    DOWNLOAD_QUEUE_AGGREGATE_MESSAGE_MAX_LENGTH,
+  );
+}
+
+function redactDownloadQueueAggregateText(value: string, maxStringLength: number): string {
+  const redacted = redactDiagnosticValue(value, { maxStringLength });
+  return typeof redacted === "string" ? redacted : "unknown failure";
 }
 
 export function analyzeDownloadFailure(message: string): DownloadFailureAnalysis {

--- a/apps/cli/src/services/download/DownloadService.ts
+++ b/apps/cli/src/services/download/DownloadService.ts
@@ -15,7 +15,9 @@ import { writeAtomicBytes } from "@/infra/fs/atomic-write";
 import type { Logger } from "@/infra/logger/Logger";
 import { isAllowedMpvUrl } from "@/infra/player/mpv-playback-url";
 import { runBackgroundTask } from "@/services/diagnostics/background-task";
+import { buildDownloadDiagnosticEvent } from "@/services/diagnostics/diagnostic-event-helpers";
 import type { DiagnosticsService } from "@/services/diagnostics/DiagnosticsService";
+import { redactDiagnosticValue } from "@/services/diagnostics/redaction";
 import {
   cacheOfflinePosterArtwork,
   resolveOfflinePosterArtifactPath,
@@ -173,11 +175,33 @@ export type DownloadEvent =
   | { type: "aborted"; jobId: string }
   | { type: "deleted"; jobId: string };
 
+export type DownloadQueueKickSource =
+  | "startup"
+  | "download-intent"
+  | "shell-download"
+  | "download-manager"
+  | "offline-repair"
+  | "offline-runway";
+
 type DownloadEventListener = (event: DownloadEvent) => void;
 
 type ManagedProcess = {
   readonly exited: Promise<number>;
   kill(signal?: NodeJS.Signals | number): void;
+};
+
+type DownloadQueuePassStage = "resume-paused" | "reconcile" | "worker";
+
+type DownloadQueueFailureContext = {
+  readonly stage: DownloadQueuePassStage;
+  readonly workerIndex?: number;
+  readonly workerFailures?: number;
+  readonly jobId?: string;
+};
+
+type DownloadQueueWorkerContext = {
+  readonly workerIndex: number;
+  jobId?: string;
 };
 
 type ActiveDownloadProcess = {
@@ -225,6 +249,7 @@ type DownloadSidecarResult = {
 
 export class DownloadService {
   private queueWorkerRunning = false;
+  private lastQueuePassFailureContext: DownloadQueueFailureContext | undefined;
   private reconciledStartupJobs = false;
   private shutdownRequested = false;
   private readonly cancellationRequests = new Map<
@@ -580,7 +605,10 @@ export class DownloadService {
     return { checked: jobs.length, repaired, stillRepairable, failed };
   }
 
-  async processNextQueued(): Promise<DownloadJobRecord | null> {
+  async processNextQueued(
+    queueContext?: DownloadQueueWorkerContext,
+  ): Promise<DownloadJobRecord | null> {
+    if (queueContext) queueContext.jobId = undefined;
     const eligibility = this.getEnqueueEligibility();
     if (!eligibility.allowed) {
       return null;
@@ -591,6 +619,7 @@ export class DownloadService {
     if (!next) {
       return null;
     }
+    if (queueContext) queueContext.jobId = next.id;
     // Claim synchronously (no await before this) so a concurrent worker's
     // selectEligibleQueuedJob skips this job until it is markRunning or released.
     this.claimedJobIds.add(next.id);
@@ -600,9 +629,9 @@ export class DownloadService {
     // drive or a dropped network share. That throw used to escape past the
     // claim: `claimedJobIds` still held the id, `selectEligibleQueuedJob` skips
     // claimed ids forever, and the job became unstartable for the rest of the
-    // session while still showing as queued. It also reached every
-    // `void processQueue()` call site as an unhandled rejection, which
-    // `main.ts` escalates to a fatal shutdown.
+    // session while still showing as queued. Before queue supervision, it also
+    // reached discarded `processQueue()` promises as an unhandled rejection,
+    // which `main.ts` escalates to a fatal shutdown.
     let storage: Awaited<ReturnType<DownloadService["evaluateStorageForPath"]>>;
     try {
       storage = await this.evaluateStorageForPath(
@@ -746,16 +775,30 @@ export class DownloadService {
     }
   }
 
+  /**
+   * The only non-awaited queue entry point. Production callers that merely
+   * nudge background work use this seam so an unexpected repository or worker
+   * rejection remains diagnosable without reaching the CLI-wide fatal policy.
+   */
+  kickQueue(source: DownloadQueueKickSource): void {
+    void this.processQueue().catch((error: unknown) => {
+      this.reportQueuePassFailure(source, error);
+    });
+  }
+
   async processQueue(): Promise<void> {
     if (this.queueWorkerRunning || this.shutdownRequested) {
       return;
     }
     this.queueWorkerRunning = true;
+    this.lastQueuePassFailureContext = undefined;
+    let stage: DownloadQueuePassStage = "resume-paused";
     try {
       if (!this.reconciledStartupJobs) {
         this.resumeEligiblePausedJobs();
         this.reconciledStartupJobs = true;
       }
+      stage = "reconcile";
       await this.reconcileInterruptedJobs();
       // Run up to `maxConcurrentDownloads` workers in parallel; each drains the
       // queue (claim → download) until no eligible job remains. The atomic claim
@@ -764,14 +807,104 @@ export class DownloadService {
         1,
         Math.min(5, Math.trunc(this.deps.config.maxConcurrentDownloads) || 1),
       );
-      const worker = async (): Promise<void> => {
-        while (!this.shutdownRequested && (await this.processNextQueued())) {
+      stage = "worker";
+      const workerContexts = Array.from(
+        { length: limit },
+        (_, workerIndex): DownloadQueueWorkerContext => ({ workerIndex }),
+      );
+      const worker = async (context: DownloadQueueWorkerContext): Promise<void> => {
+        while (!this.shutdownRequested && (await this.processNextQueued(context))) {
           // keep pulling jobs
         }
       };
-      await Promise.all(Array.from({ length: limit }, () => worker()));
+      const results = await Promise.allSettled(workerContexts.map((context) => worker(context)));
+      const failures: Array<{
+        readonly reason: unknown;
+        readonly context: DownloadQueueWorkerContext;
+      }> = [];
+      for (const [workerIndex, result] of results.entries()) {
+        const context = workerContexts[workerIndex];
+        if (result.status === "rejected" && context) {
+          failures.push({ reason: result.reason as unknown, context });
+        }
+      }
+      if (failures.length === 1) {
+        const [failure] = failures;
+        if (failure) {
+          this.lastQueuePassFailureContext = {
+            stage: "worker",
+            workerIndex: failure.context.workerIndex,
+            jobId: failure.context.jobId,
+          };
+          throw failure.reason;
+        }
+      }
+      if (failures.length > 1) {
+        const aggregate = new AggregateError(
+          failures.map((failure) => failure.reason),
+          buildDownloadQueueAggregateMessage(failures.map((failure) => failure.reason)),
+        );
+        this.lastQueuePassFailureContext = {
+          stage: "worker",
+          workerFailures: failures.length,
+        };
+        throw aggregate;
+      }
+    } catch (error) {
+      this.lastQueuePassFailureContext ??= { stage };
+      throw error;
     } finally {
       this.queueWorkerRunning = false;
+    }
+  }
+
+  private reportQueuePassFailure(source: DownloadQueueKickSource, error: unknown): void {
+    const failureContext = this.lastQueuePassFailureContext ?? { stage: "worker" as const };
+    this.lastQueuePassFailureContext = undefined;
+    let event: ReturnType<typeof buildDownloadDiagnosticEvent>;
+    try {
+      event = buildDownloadDiagnosticEvent({
+        operation: "download.queue.pass.failed",
+        stage: failureContext.stage,
+        status: "failed",
+        severity: "degraded",
+        failureClass: "storage",
+        recommendedAction: "export-diagnostics",
+        message: "Background download queue pass failed",
+        correlation: failureContext.jobId ? { downloadJobId: failureContext.jobId } : undefined,
+        context: {
+          source,
+          workerIndex: failureContext.workerIndex,
+          workerFailures: failureContext.workerFailures,
+          jobId: failureContext.jobId,
+          errorName: error instanceof Error ? error.name : typeof error,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        },
+      });
+    } catch {
+      try {
+        this.deps.logger.warn("Background download queue pass failed", {
+          source,
+          stage: failureContext.stage,
+        });
+      } catch {
+        // The supervisor itself must remain non-throwing.
+      }
+      return;
+    }
+
+    try {
+      if (this.deps.diagnostics) {
+        this.deps.diagnostics.record(event);
+        return;
+      }
+    } catch {
+      // Fall through to the already-redacted logger context.
+    }
+    try {
+      this.deps.logger.warn(event.message, event.context);
+    } catch {
+      // A broken reporting side channel cannot create a second rejection.
     }
   }
 
@@ -1862,6 +1995,17 @@ async function readUtf8Stream(reader: {
   } finally {
     reader.releaseLock();
   }
+}
+
+
+function buildDownloadQueueAggregateMessage(failures: readonly unknown[]): string {
+  const summaries = failures.map((failure) => {
+    const name = failure instanceof Error ? failure.name : typeof failure;
+    const rawMessage = failure instanceof Error ? failure.message : String(failure);
+    const message = redactDiagnosticValue(rawMessage, { maxStringLength: 160 });
+    return `${name.slice(0, 40)}: ${typeof message === "string" ? message : "unknown failure"}`;
+  });
+  return `Multiple download queue workers failed (${failures.length}): ${summaries.join("; ")}`;
 }
 
 export function analyzeDownloadFailure(message: string): DownloadFailureAnalysis {

--- a/apps/cli/src/services/offline/OfflineRunwayService.ts
+++ b/apps/cli/src/services/offline/OfflineRunwayService.ts
@@ -45,7 +45,7 @@ export class OfflineRunwayService {
         | "getJob"
         | "hasJobForEpisode"
         | "enqueue"
-        | "processQueue"
+        | "kickQueue"
         | "listActive"
         | "estimateAvailableEpisodeSlots"
       >;
@@ -174,7 +174,7 @@ export class OfflineRunwayService {
       }
       throw error;
     }
-    if (enqueued > 0) void this.deps.downloadService.processQueue();
+    if (enqueued > 0) this.deps.downloadService.kickQueue("offline-runway");
     this.deps.diagnostics?.record({
       category: "download",
       operation: "offline-runway.evaluate",

--- a/apps/cli/src/services/offline/offline-library-action-router.ts
+++ b/apps/cli/src/services/offline/offline-library-action-router.ts
@@ -146,7 +146,7 @@ export async function routeOfflineLibraryGroupAction(
         inspected: entries.length,
       }),
     });
-    if (repairEntries.length > 0) void container.downloadService.processQueue();
+    if (repairEntries.length > 0) container.downloadService.kickQueue("offline-repair");
     return "refresh";
   }
 

--- a/apps/cli/test/harness/capture-downloads.tsx
+++ b/apps/cli/test/harness/capture-downloads.tsx
@@ -102,7 +102,7 @@ const container = {
     abort: async () => undefined,
     deleteJob: async () => undefined,
     retry: async () => undefined,
-    processQueue: async () => undefined,
+    kickQueue: () => undefined,
   },
 } as unknown as Container;
 

--- a/apps/cli/test/harness/capture-library.tsx
+++ b/apps/cli/test/harness/capture-library.tsx
@@ -96,7 +96,7 @@ function gatedContainer(entries: readonly OfflineLibraryEntry[]) {
       deleteJob: () => undefined,
       abort: async () => undefined,
       retry: async () => undefined,
-      processQueue: async () => undefined,
+      kickQueue: () => undefined,
       repairRepairableSidecars: async () => ({
         checked: 0,
         repaired: 0,

--- a/apps/cli/test/unit/app-shell/download-manager-shell.test.tsx
+++ b/apps/cli/test/unit/app-shell/download-manager-shell.test.tsx
@@ -59,7 +59,7 @@ function createContainerFixture() {
       abort: async () => undefined,
       deleteJob: async () => undefined,
       retry: async () => undefined,
-      processQueue: async () => undefined,
+      kickQueue: () => undefined,
     },
   } as unknown as Container;
 

--- a/apps/cli/test/unit/app-shell/library-input-ownership.useinput.test.tsx
+++ b/apps/cli/test/unit/app-shell/library-input-ownership.useinput.test.tsx
@@ -69,7 +69,7 @@ function fixture(options: FixtureOptions = {}): Container {
       },
       abort: async () => undefined,
       retry: async () => undefined,
-      processQueue: async () => undefined,
+      kickQueue: () => undefined,
       repairRepairableSidecars: async () => ({
         checked: 0,
         repaired: 0,

--- a/apps/cli/test/unit/app-shell/library-playback-handoff.test.tsx
+++ b/apps/cli/test/unit/app-shell/library-playback-handoff.test.tsx
@@ -68,7 +68,7 @@ test("/library returns the selected offline episode to the session workflow", as
       deleteJob: () => undefined,
       abort: async () => undefined,
       retry: async () => undefined,
-      processQueue: async () => undefined,
+      kickQueue: () => undefined,
       repairRepairableSidecars: async () => ({
         checked: 0,
         repaired: 0,

--- a/apps/cli/test/unit/app-shell/offline-library-download-more.test.tsx
+++ b/apps/cli/test/unit/app-shell/offline-library-download-more.test.tsx
@@ -223,7 +223,7 @@ test("anime movie download-more restores its persisted lane before actual enqueu
         return await service.enqueue(input);
       },
       // Persistence is the boundary under test; do not start the worker.
-      processQueue: () => undefined,
+      kickQueue: () => undefined,
     },
     offlineTitlePolicies: { get: () => undefined },
     offlineRunwayService: { enqueueEvaluation: () => undefined },

--- a/apps/cli/test/unit/app-shell/workflows/shell-workflows-overlay.test.ts
+++ b/apps/cli/test/unit/app-shell/workflows/shell-workflows-overlay.test.ts
@@ -87,7 +87,7 @@ describe("enqueueCurrentPlaybackDownload feedback", () => {
             outputPath: "/downloads/out.mp4",
             ...job,
           }) as DownloadJobRecord,
-        processQueue: async () => {},
+        kickQueue: () => {},
       },
     } as unknown as Container;
 

--- a/apps/cli/test/unit/app/download-only-phase.test.ts
+++ b/apps/cli/test/unit/app/download-only-phase.test.ts
@@ -84,7 +84,7 @@ test("DownloadOnlyPhase does not contact anime providers before download profile
           enqueues += 1;
           return { id: "job-1" };
         },
-        processQueue: () => {},
+        kickQueue: () => {},
       },
       offlineTitlePolicies: { upsert: () => {} },
       diagnosticsService: { record: () => {} },
@@ -137,7 +137,7 @@ test("DownloadOnlyPhase schedules a bounded runway evaluation when enrolling kee
       downloadService: {
         getEnqueueEligibility: () => ({ allowed: true }),
         enqueue: async () => ({ id: "job-1" }),
-        processQueue: () => {},
+        kickQueue: () => {},
       },
       offlineTitlePolicies: {
         get: () => undefined,
@@ -216,7 +216,7 @@ test("DownloadOnlyPhase persists the confirmed title cleanup preference with the
       downloadService: {
         getEnqueueEligibility: () => ({ allowed: true }),
         enqueue: async () => ({ id: "job-1" }),
-        processQueue: () => {},
+        kickQueue: () => {},
       },
       offlineTitlePolicies: {
         get: () => undefined,
@@ -274,7 +274,7 @@ test("DownloadOnlyPhase stores a one-off series cleanup choice without enrolling
       downloadService: {
         getEnqueueEligibility: () => ({ allowed: true }),
         enqueue: async () => ({ id: "job-1" }),
-        processQueue: () => {},
+        kickQueue: () => {},
       },
       offlineTitlePolicies: {
         get: () => undefined,
@@ -330,7 +330,7 @@ test("DownloadOnlyPhase keeps an existing offline runway enrollment during a one
       downloadService: {
         getEnqueueEligibility: () => ({ allowed: true }),
         enqueue: async () => ({ id: "job-1" }),
-        processQueue: () => {},
+        kickQueue: () => {},
       },
       offlineTitlePolicies: {
         get: () => ({
@@ -387,7 +387,7 @@ test("DownloadOnlyPhase persists profile intent after a partially queued series 
           if (enqueueCount === 2) throw new Error("second item rejected");
           return { id: "job-1" };
         },
-        processQueue: () => {},
+        kickQueue: () => {},
       },
       offlineTitlePolicies: {
         get: () => undefined,
@@ -443,7 +443,7 @@ function titleLevelContext(mode: string, enqueued: Record<string, unknown>[]) {
           enqueued.push(input);
           return { id: `job-${enqueued.length}` };
         },
-        processQueue: () => {},
+        kickQueue: () => {},
       },
       offlineTitlePolicies: { get: () => undefined, upsert: () => {} },
       offlineRunwayService: { enqueueEvaluation: () => {} },

--- a/apps/cli/test/unit/architecture/contract-conformance.test.ts
+++ b/apps/cli/test/unit/architecture/contract-conformance.test.ts
@@ -56,6 +56,20 @@ function readerFilesFor(symbol: string, definedIn: readonly string[]): string[] 
 }
 
 describe("contract conformance", () => {
+  test("background download queue kicks use the supervised entry point", () => {
+    const discardedQueuePasses = PRODUCTION_SOURCES.flatMap(({ file, text }) =>
+      file === "apps/cli/src/services/download/DownloadService.ts"
+        ? []
+        : text
+            .split("\n")
+            .flatMap((line, index) =>
+              /\bvoid\b.*\.processQueue\(\)/.test(line) ? [`${file}:${index + 1}`] : [],
+            ),
+    );
+
+    expect(discardedQueuePasses).toEqual([]);
+  });
+
   /**
    * A command the palette never offers is unreachable: `resolveCommands` only
    * surfaces ids listed in a `COMMAND_CONTEXTS` entry or the browse command pool

--- a/apps/cli/test/unit/services/diagnostics/operation-taxonomy.test.ts
+++ b/apps/cli/test/unit/services/diagnostics/operation-taxonomy.test.ts
@@ -10,6 +10,7 @@ describe("diagnostic operation taxonomy", () => {
   test("keeps high-value runtime operations named and user-actionable", () => {
     expect(isKnownDiagnosticOperation("download.artifact.validated")).toBe(true);
     expect(isKnownDiagnosticOperation("download.artifact.repairable")).toBe(true);
+    expect(isKnownDiagnosticOperation("download.queue.pass.failed")).toBe(true);
     expect(isKnownDiagnosticOperation("source-inventory.cache.hit")).toBe(true);
     expect(isKnownDiagnosticOperation("post-playback.recommendations.seed")).toBe(true);
     expect(isKnownDiagnosticOperation("post-playback.autonext.prefetch-wait")).toBe(true);
@@ -28,6 +29,11 @@ describe("diagnostic operation taxonomy", () => {
       category: "download",
       audience: "both",
       userAction: "Open /downloads or /library if the artifact later disappears.",
+    });
+    expect(getDiagnosticOperation("download.queue.pass.failed")).toMatchObject({
+      category: "download",
+      audience: "both",
+      userAction: "Export diagnostics, then retry the affected download from /downloads.",
     });
     expect(getDiagnosticOperation("provider.selection.decision")).toMatchObject({
       category: "provider",

--- a/apps/cli/test/unit/services/download/download-intent-service.test.ts
+++ b/apps/cli/test/unit/services/download/download-intent-service.test.ts
@@ -151,7 +151,7 @@ describe("commitDownloadIntent", () => {
           enqueues += 1;
           return { id: "job" };
         },
-        processQueue: () => {},
+        kickQueue: () => {},
       },
       diagnosticsService: { record: () => {} },
       stateManager: {
@@ -186,7 +186,7 @@ describe("commitDownloadIntent", () => {
           enqueues += 1;
           return { id: `job-${enqueues}` };
         },
-        processQueue: () => {
+        kickQueue: () => {
           processed += 1;
         },
       },
@@ -232,7 +232,7 @@ describe("commitDownloadIntent", () => {
           if (enqueues === 2) throw new Error("rejected");
           return { id: "job-1" };
         },
-        processQueue: () => {},
+        kickQueue: () => {},
       },
       offlineTitlePolicies: {
         get: () => undefined,
@@ -279,7 +279,7 @@ describe("commitDownloadIntent authoritative kind", () => {
           enqueued.push(input);
           return { id: `job-${enqueued.length}` };
         },
-        processQueue: () => {},
+        kickQueue: () => {},
       },
       offlineTitlePolicies: { get: () => undefined, upsert: () => {} },
       offlineRunwayService: { enqueueEvaluation: () => {} },

--- a/apps/cli/test/unit/services/download/download-path-unavailable.test.ts
+++ b/apps/cli/test/unit/services/download/download-path-unavailable.test.ts
@@ -17,9 +17,9 @@ import { DownloadJobsRepository, openKunaiDatabase, runMigrations } from "@kunai
  *   - `selectEligibleQueuedJob` skips claimed ids, and `claimedJobIds` is
  *     process-lifetime state, so the job became unstartable until restart while
  *     still displaying as queued.
- *   - every caller is `void downloadService.processQueue()` with no `.catch()`,
- *     so it surfaced as an unhandled rejection, which `main.ts` escalates to a
- *     fatal shutdown.
+ *   - production callers used to discard `downloadService.processQueue()` with
+ *     no catch, so it surfaced as an unhandled rejection, which `main.ts`
+ *     escalates to a fatal shutdown.
  *
  * The unavailable path is simulated with a regular *file* where the download
  * directory should be. `chmod` would be the obvious choice and is the wrong
@@ -90,8 +90,8 @@ test("an unavailable download folder does not strand the job or reject", async (
   rmSync(downloadRoot, { recursive: true, force: true });
   writeFileSync(downloadRoot, "not a directory");
 
-  // Must resolve, not reject: every call site is `void processQueue()`, so a
-  // rejection here reaches the unhandledRejection handler and kills the session.
+  // Must resolve, not reject: this path is a classified per-job condition, not
+  // an unexpected queue-pass failure for the supervisor to contain and report.
   const first = await service.processNextQueued();
   expect(first).toBeNull();
 

--- a/apps/cli/test/unit/services/download/download-service.test.ts
+++ b/apps/cli/test/unit/services/download/download-service.test.ts
@@ -1828,6 +1828,60 @@ describe("DownloadService", () => {
     markRunningSpy.mockRestore();
   });
 
+  test("attributes a failed second claim after another process wins the first job", async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const service = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      downloadPath: tempDir,
+      diagnostics: {
+        record: (event) => events.push(event as unknown as Record<string, unknown>),
+      },
+      configService: {
+        downloadsEnabled: true,
+        downloadPath: tempDir,
+        maxConcurrentDownloads: 1,
+      } as ConfigService,
+    });
+    const firstJob = await service.enqueue({
+      title: { id: "tmdb:claim-a", type: "movie", name: "Claim A" },
+      stream: { url: "https://example.com/a.m3u8", headers: {}, timestamp: 0 },
+      providerId: "vidking",
+      mode: "series",
+    });
+    const secondJob = await service.enqueue({
+      title: { id: "tmdb:claim-b", type: "movie", name: "Claim B" },
+      stream: { url: "https://example.com/b.m3u8", headers: {}, timestamp: 0 },
+      providerId: "vidking",
+      mode: "series",
+    });
+    const originalMarkRunning = repo.markRunning.bind(repo);
+    const claimedJobIds: string[] = [];
+    const markRunningSpy = spyOn(repo, "markRunning").mockImplementation((jobId, updatedAt) => {
+      claimedJobIds.push(jobId);
+      if (claimedJobIds.length === 1) {
+        // Simulate another Kunai process winning this row between selection and
+        // our compare-and-set. The durable update makes the recursive pass pick B.
+        expect(originalMarkRunning(jobId, updatedAt)).toBe(true);
+        return false;
+      }
+      throw new Error("simulated SQLite claim failure for job B");
+    });
+
+    service.kickQueue("download-manager");
+    await waitUntil(() => events.length === 1);
+
+    expect(claimedJobIds).toEqual([firstJob.id, secondJob.id]);
+    expect(events[0]?.context).toMatchObject({
+      source: "download-manager",
+      stage: "worker",
+      workerIndex: 0,
+      jobId: secondJob.id,
+    });
+    markRunningSpy.mockRestore();
+  });
+
   test("keeps processQueue and drainQueue failures explicit for awaited callers", async () => {
     const service = buildService({
       repo,
@@ -1952,6 +2006,42 @@ describe("DownloadService", () => {
     expect(failure).toBeInstanceOf(AggregateError);
     expect((failure as AggregateError).errors).toHaveLength(2);
     expect((failure as Error).message).not.toContain("sentinel-secret-never-log");
+    expect((failure as Error).message.length).toBeLessThan(500);
+    processNextSpy.mockRestore();
+  });
+
+  test("redacts and bounds hostile error names in an aggregate worker summary", async () => {
+    const service = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      downloadPath: tempDir,
+      configService: {
+        downloadsEnabled: true,
+        downloadPath: tempDir,
+        maxConcurrentDownloads: 2,
+      } as ConfigService,
+    });
+    const namedFailure = new Error("worker A failed");
+    namedFailure.name = "https://x.test/?token=hostile-name-secret";
+    const longNamedFailure = new Error("worker B failed");
+    longNamedFailure.name = "E".repeat(200);
+    const processNextSpy = spyOn(service, "processNextQueued")
+      .mockImplementationOnce(() => Promise.reject(namedFailure))
+      .mockImplementationOnce(() => Promise.reject(longNamedFailure));
+
+    let failure: unknown;
+    try {
+      await service.processQueue();
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect((failure as AggregateError).errors).toEqual([namedFailure, longNamedFailure]);
+    expect((failure as Error).message).not.toContain("hostile-name");
+    expect((failure as Error).message).toContain("token=[redacted]");
+    expect((failure as Error).message).not.toContain("E".repeat(41));
     expect((failure as Error).message.length).toBeLessThan(500);
     processNextSpy.mockRestore();
   });

--- a/apps/cli/test/unit/services/download/download-service.test.ts
+++ b/apps/cli/test/unit/services/download/download-service.test.ts
@@ -1655,6 +1655,307 @@ describe("DownloadService", () => {
     expect(recovered?.errorMessage).toBe("download paused by recovery shutdown");
   });
 
+  test("supervises startup reconciliation failures without an unhandled rejection", async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const service = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      downloadPath: tempDir,
+      diagnostics: {
+        record: (event) => events.push(event as unknown as Record<string, unknown>),
+      },
+    });
+    const secretUrl =
+      "https://cdn.example.test/private/manifest.m3u8?token=sentinel-secret-never-log";
+    const listRunningSpy = spyOn(repo, "listRunning").mockImplementation(() => {
+      throw new Error(`simulated SQLite failure while reading ${secretUrl}`);
+    });
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      expect(service.kickQueue("startup")).toBeUndefined();
+      await waitUntil(() => events.length === 1);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(unhandled).toEqual([]);
+      expect(events).toHaveLength(1);
+      expect(events[0]?.category).toBe("download");
+      expect(events[0]?.operation).toBe("download.queue.pass.failed");
+      expect(events[0]?.context).toMatchObject({
+        source: "startup",
+        stage: "reconcile",
+        status: "failed",
+        severity: "degraded",
+      });
+      const serialized = JSON.stringify(events);
+      expect(serialized).not.toContain(secretUrl);
+      expect(serialized).not.toContain("sentinel-secret-never-log");
+      expect(serialized).toContain("[redacted]");
+      expect(serialized.length).toBeLessThan(2_000);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      listRunningSpy.mockRestore();
+    }
+  });
+
+  test("contains diagnostic and logger failures inside the supervised queue boundary", async () => {
+    let reporterCalls = 0;
+    const service = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      downloadPath: tempDir,
+      diagnostics: {
+        record: () => {
+          reporterCalls += 1;
+          throw new Error("diagnostics sink unavailable");
+        },
+      },
+      logger: {
+        debug() {},
+        info() {},
+        warn() {
+          throw new Error("logger unavailable");
+        },
+        error() {},
+        fatal() {},
+        child() {
+          return this;
+        },
+      },
+    });
+    const listRunningSpy = spyOn(repo, "listRunning").mockImplementation(() => {
+      throw new Error("simulated SQLite failure");
+    });
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      service.kickQueue("startup");
+      await waitUntil(() => reporterCalls === 1);
+      await Bun.sleep(0);
+      await Bun.sleep(0);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      listRunningSpy.mockRestore();
+    }
+  });
+
+  test("resets a failed supervised pass so a later kick completes queued work", async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const service = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      downloadPath: tempDir,
+      diagnostics: {
+        record: (event) => events.push(event as unknown as Record<string, unknown>),
+      },
+    });
+    const originalListRunning = repo.listRunning.bind(repo);
+    let failReconciliation = true;
+    const listRunningSpy = spyOn(repo, "listRunning").mockImplementation((limit) => {
+      if (failReconciliation) throw new Error("simulated SQLite failure");
+      return originalListRunning(limit);
+    });
+
+    service.kickQueue("startup");
+    await waitUntil(() => events.length === 1);
+    failReconciliation = false;
+    spawnSpy.mockImplementation((command: string[]) => {
+      const oIndex = command.indexOf("-o");
+      const outputPath = oIndex >= 0 ? command[oIndex + 1] : command[command.length - 1];
+      if (typeof outputPath === "string") writeFileSync(outputPath, "video-bytes");
+      return {
+        stdout: streamOf("[download] 100% of 1.2GiB\n"),
+        stderr: streamOf(""),
+        exited: Promise.resolve(0),
+      } as never;
+    });
+    const job = await service.enqueue({
+      title: { id: "tmdb:queue-retry", type: "movie", name: "Queue Retry" },
+      stream: { url: "https://example.com/master.m3u8", headers: {}, timestamp: 0 },
+      providerId: "vidking",
+      mode: "series",
+    });
+
+    service.kickQueue("download-intent");
+    await waitUntil(() => repo.get(job.id)?.status === "completed");
+
+    expect(repo.get(job.id)?.status).toBe("completed");
+    listRunningSpy.mockRestore();
+  });
+
+  test("records the known worker and job when a queue worker fails unexpectedly", async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const service = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      downloadPath: tempDir,
+      diagnostics: {
+        record: (event) => events.push(event as unknown as Record<string, unknown>),
+      },
+    });
+    const job = await service.enqueue({
+      title: { id: "tmdb:worker-context", type: "movie", name: "Worker Context" },
+      stream: { url: "https://example.com/master.m3u8", headers: {}, timestamp: 0 },
+      providerId: "vidking",
+      mode: "series",
+    });
+    const markRunningSpy = spyOn(repo, "markRunning").mockImplementation(() => {
+      throw new Error(
+        "simulated SQLite claim failure https://cdn.example.test/file?token=worker-secret",
+      );
+    });
+
+    service.kickQueue("download-manager");
+    await waitUntil(() => events.length === 1);
+
+    expect(events[0]?.context).toMatchObject({
+      source: "download-manager",
+      stage: "worker",
+      workerIndex: 0,
+      jobId: job.id,
+    });
+    expect(JSON.stringify(events)).not.toContain("worker-secret");
+    markRunningSpy.mockRestore();
+  });
+
+  test("keeps processQueue and drainQueue failures explicit for awaited callers", async () => {
+    const service = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      downloadPath: tempDir,
+    });
+    await service.enqueue({
+      title: { id: "tmdb:awaited-failure", type: "movie", name: "Awaited Failure" },
+      stream: { url: "https://example.com/master.m3u8", headers: {}, timestamp: 0 },
+      providerId: "vidking",
+      mode: "series",
+    });
+    const listRunningSpy = spyOn(repo, "listRunning").mockImplementation(() => {
+      throw new Error("simulated SQLite failure");
+    });
+
+    await expect(service.processQueue()).rejects.toThrow("simulated SQLite failure");
+    await expect(service.drainQueue()).rejects.toThrow("simulated SQLite failure");
+    listRunningSpy.mockRestore();
+  });
+
+  test("waits for sibling queue workers before rejecting and reopening admission", async () => {
+    const service = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      downloadPath: tempDir,
+      configService: {
+        downloadsEnabled: true,
+        downloadPath: tempDir,
+        maxConcurrentDownloads: 2,
+      } as ConfigService,
+    });
+    const workerFailure = new Error("worker A failed");
+    let calls = 0;
+    let siblingProgress = 0;
+    let releaseSibling!: () => void;
+    let markSiblingStarted!: () => void;
+    const siblingStarted = new Promise<void>((resolve) => {
+      markSiblingStarted = resolve;
+    });
+    const processNextSpy = spyOn(service, "processNextQueued").mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) return Promise.reject(workerFailure);
+      if (calls === 2) {
+        markSiblingStarted();
+        return new Promise((resolve) => {
+          releaseSibling = () => {
+            siblingProgress += 1;
+            resolve(null);
+          };
+        });
+      }
+      return Promise.resolve(null);
+    });
+
+    let settled = false;
+    const running = service.processQueue();
+    void running.then(
+      () => {
+        settled = true;
+        return undefined;
+      },
+      () => {
+        settled = true;
+        return undefined;
+      },
+    );
+    await siblingStarted;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+    await service.processQueue();
+    expect(calls).toBe(2);
+
+    releaseSibling();
+    await expect(running).rejects.toBe(workerFailure);
+    expect(siblingProgress).toBe(1);
+
+    let laterPassCalls = 0;
+    processNextSpy.mockImplementation(() => {
+      laterPassCalls += 1;
+      return Promise.resolve(null);
+    });
+    await service.processQueue();
+    expect(laterPassCalls).toBe(2);
+    processNextSpy.mockRestore();
+  });
+
+  test("aggregates multiple worker failures with a bounded redacted message", async () => {
+    const service = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      downloadPath: tempDir,
+      configService: {
+        downloadsEnabled: true,
+        downloadPath: tempDir,
+        maxConcurrentDownloads: 2,
+      } as ConfigService,
+    });
+    const processNextSpy = spyOn(service, "processNextQueued").mockImplementationOnce(() =>
+      Promise.reject(
+        new Error(
+          "worker A failed https://cdn.example.test/one.m3u8?token=sentinel-secret-never-log",
+        ),
+      ),
+    );
+    processNextSpy.mockImplementationOnce(() =>
+      Promise.reject(new Error("worker B failed ".repeat(100))),
+    );
+
+    let failure: unknown;
+    try {
+      await service.processQueue();
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect((failure as AggregateError).errors).toHaveLength(2);
+    expect((failure as Error).message).not.toContain("sentinel-secret-never-log");
+    expect((failure as Error).message.length).toBeLessThan(500);
+    processNextSpy.mockRestore();
+  });
+
   test("does not recover a freshly heartbeating job owned by another process", async () => {
     const enqueueService = buildService({
       repo,
@@ -1745,6 +2046,8 @@ describe("DownloadService", () => {
 
     service.beginShutdown("download paused by shutdown");
     await service.processQueue();
+    service.kickQueue("startup");
+    await Promise.resolve();
 
     // The queued job must not be claimed after shutdown began.
     expect(spawnSpy).not.toHaveBeenCalled();
@@ -1808,6 +2111,7 @@ function buildService({
   ffprobeAvailable = false,
   ffprobeDeadline,
   diagnostics,
+  logger,
   configService,
   titleAliases = { upsertAliases() {} },
 }: {
@@ -1820,6 +2124,7 @@ function buildService({
   ffprobeAvailable?: boolean;
   ffprobeDeadline?: ConstructorParameters<typeof DownloadService>[0]["ffprobeDeadline"];
   diagnostics?: ConstructorParameters<typeof DownloadService>[0]["diagnostics"];
+  logger?: ConstructorParameters<typeof DownloadService>[0]["logger"];
   configService?: ConfigService;
   titleAliases?: ConstructorParameters<typeof DownloadService>[0]["titleAliases"];
 }): DownloadService {
@@ -1837,7 +2142,7 @@ function buildService({
     ytDlpAvailable,
     ffprobeAvailable,
     diagnostics,
-    logger: {
+    logger: logger ?? {
       debug() {},
       info() {},
       warn() {},

--- a/apps/cli/test/unit/services/media-actions/create-container-media-action-router.test.ts
+++ b/apps/cli/test/unit/services/media-actions/create-container-media-action-router.test.ts
@@ -192,7 +192,7 @@ describe("queueDownloadFromMediaItem authoritative kind", () => {
           enqueued.push(input);
           return { id: `job-${enqueued.length}` };
         },
-        processQueue: () => {},
+        kickQueue: () => {},
       },
       offlineTitlePolicies: { get: () => undefined, upsert: () => {} },
       offlineRunwayService: { enqueueEvaluation: () => {} },

--- a/apps/cli/test/unit/services/offline/offline-runway-service.test.ts
+++ b/apps/cli/test/unit/services/offline/offline-runway-service.test.ts
@@ -64,7 +64,7 @@ function createService(overrides: Record<string, unknown> = {}) {
         enqueued.push(input);
         return {} as never;
       },
-      processQueue: async () => {},
+      kickQueue: () => {},
     },
     scheduler: { enqueue: () => {}, drain: async () => ({}) as never },
     ...overrides,
@@ -114,7 +114,7 @@ describe("OfflineRunwayService", () => {
         enqueue: async () => {
           throw new DownloadEnqueueRejectedError("insufficient-disk", "full");
         },
-        processQueue: async () => {},
+        kickQueue: () => {},
       },
     });
 
@@ -157,7 +157,7 @@ describe("OfflineRunwayService", () => {
           enqueued.push(input);
           return {} as never;
         },
-        processQueue: async () => {},
+        kickQueue: () => {},
       },
     });
 


### PR DESCRIPTION
## Summary

- supervise every fire-and-forget download queue pass so a per-job failure cannot reach the CLI fatal unhandled-rejection policy
- preserve the active worker/job context through contested claims while keeping diagnostics bounded and redacted
- keep explicitly awaited queue operations rejecting for callers and reopen admission after a failed supervised pass

Closes #124

## Stack

This is stacked on #158. Merge #158 first, then retarget this PR to `main`.

## Verification

- `bun run test` (23/23 tasks; CLI unit 4703 pass; integration 147 pass / 24 opt-in skips)
- `bun run typecheck`
- `bun run lint`
- `bun run fmt`
- `bun run verify:doc-paths`
- `bun run build`
- focused download supervision tests: 75 pass
- `git diff --check`