### PR TITLE
chore(lint): clear warning debt before the release train

### DIFF
--- a/apps/cli/src/infra/player/mpv-ipc.ts
+++ b/apps/cli/src/infra/player/mpv-ipc.ts
@@ -294,14 +294,21 @@ export async function openMpvIpcSession(options: MpvIpcSessionOptions): Promise<
           // Uncleared it fires 200ms later against an already-closed socket,
           // and `close()` runs on every session release, not only at exit — so
           // each released mpv session left one behind.
-          const fallback = setTimeout(() => {
-            socket.terminate();
-            resolve();
-          }, 200);
-          socket.data.onClose = () => {
+          let settled = false;
+          const finish = () => {
+            if (settled) return;
+            settled = true;
             clearTimeout(fallback);
+            socket.data.onClose = null;
+            // The guard above makes the clean-close/timeout race single-shot.
+            // eslint-disable-next-line promise/no-multiple-resolved
             resolve();
           };
+          const fallback = setTimeout(() => {
+            socket.terminate();
+            finish();
+          }, 200);
+          socket.data.onClose = finish;
           socket.end();
         });
       })();

--- a/apps/cli/test/integration/completion-scripts.test.ts
+++ b/apps/cli/test/integration/completion-scripts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 

--- a/apps/cli/test/integration/helpers/compiled-binary-harness.ts
+++ b/apps/cli/test/integration/helpers/compiled-binary-harness.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 

--- a/apps/cli/test/integration/helpers/installer-script-harness.ts
+++ b/apps/cli/test/integration/helpers/installer-script-harness.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 

--- a/apps/cli/test/integration/helpers/readme-command-harness.ts
+++ b/apps/cli/test/integration/helpers/readme-command-harness.ts
@@ -18,7 +18,6 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
-  rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";

--- a/apps/cli/test/integration/npm-launcher.test.ts
+++ b/apps/cli/test/integration/npm-launcher.test.ts
@@ -6,7 +6,6 @@ import {
   mkdtempSync,
   readFileSync,
   realpathSync,
-  rmSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";

--- a/apps/cli/test/integration/process-shutdown.test.ts
+++ b/apps/cli/test/integration/process-shutdown.test.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
 import { afterEach, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 

--- a/packages/providers/test/providers.test.ts
+++ b/packages/providers/test/providers.test.ts
@@ -1423,7 +1423,9 @@ test("miruro resolve times the episodes stage even when it fails", async () => {
   // The episodes fetch is where the time was proven to go, and a Cloudflare
   // block throws there — so that failure path must still emit a timed stage.
   const events: { readonly sourceId?: string; readonly durationMs?: number }[] = [];
-  const result = await miruroProviderModule.resolve!(
+  const { resolve: resolveMiruro } = miruroProviderModule;
+  if (!resolveMiruro) throw new Error("miruro module must expose resolve");
+  const result = await resolveMiruro(
     {
       title: { id: "anilist:999", anilistId: "999", kind: "anime", title: "Evidence Fox" },
       episode: { episode: 1 },

--- a/packages/providers/test/rivestream-input-validation.test.ts
+++ b/packages/providers/test/rivestream-input-validation.test.ts
@@ -27,7 +27,9 @@ function buildInput(overrides: Record<string, unknown> = {}): ProviderResolveInp
 }
 
 async function resolve(input: ProviderResolveInput) {
-  return rivestreamProviderModule.resolve!(input, CONTEXT);
+  const { resolve: resolveStream } = rivestreamProviderModule;
+  if (!resolveStream) throw new Error("rivestream module must expose resolve");
+  return resolveStream(input, CONTEXT);
 }
 
 describe("rivestream input validation", () => {

--- a/packages/relay/test/handler.test.ts
+++ b/packages/relay/test/handler.test.ts
@@ -202,7 +202,7 @@ test.each([
   ["just outside 172.16/12", "172.32.0.1", "http://172.32.0.1/rpc"],
   ["ipv4-mapped public", "[::ffff:808:808]", "http://[::ffff:8.8.8.8]/rpc"],
 ])("handleRpcRequest still reaches %s", async (_label, host, upstreamUrl) => {
-  const registry = buildProviderRelayRegistry([
+  const publicRegistry = buildProviderRelayRegistry([
     {
       providerId: "public",
       manifest: { relaySafe: true, relayProfile: { upstreamHosts: [host] } },
@@ -212,7 +212,7 @@ test.each([
   let fetched = false;
   const response = await handleRpcRequest(rpcRequest({ method: "GET", upstreamUrl }), {
     providerId: "public",
-    registry,
+    registry: publicRegistry,
     async fetch() {
       fetched = true;
       return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });


### PR DESCRIPTION
## Summary

- clears the remaining CLI and relay lint warnings
- establishes a zero-warning base for the release train
- keeps behavior unchanged

## Stack

Depends on #158.

## Verification

- bun run lint: zero warnings and zero errors
- bun run typecheck
- bun run test
- bun run fmt

No release is performed by this PR.