### PR TITLE
ci(lint): ratchet anti-slop checks on changed code

### DIFF
--- a/.docs/lint-policy.md
+++ b/.docs/lint-policy.md
@@ -1,6 +1,6 @@
 ---
 status: current
-lastReviewed: "2026-05-04"
+lastReviewed: "2026-08-24"
 ---
 
 # Lint policy (beta)
@@ -11,23 +11,34 @@ lastReviewed: "2026-05-04"
 - **Budget:** no per-warning budget file — fix new warnings in the same PR that introduces them; burn down existing warnings in focused batches when touching a file anyway.
 - **Rationale:** keeps signal high for agents and humans without blocking unrelated refactors on legacy debt.
 
-## anti-slop (advisory, not yet a gate)
+## anti-slop (changed-file advisory)
 
 `bun run lint:anti-slop` runs the vendored plugin in
 `tools/oxlint/anti-slop/` via `.oxlintrc.anti-slop.json`. All fifteen generic
 rules are set to **error** in that config — the severity is not weakened.
 
-It is a **separate** command on purpose. The rules report **4,675 findings**
-(≈2.5k in source, ≈2.1k in tests), so wiring them into `.oxlintrc.json` would
-turn `bun run lint`, the lint-staged pre-commit hook, and CI red on the first
-run and block every unrelated commit. Severity is not the thing to compromise
-there; scope is.
+It is a **separate** command on purpose. The rules still report thousands of
+historical findings, so wiring them into `.oxlintrc.json` would turn
+`bun run lint` and the lint-staged pre-commit hook red on the first run and
+block every unrelated commit. Severity is not the thing to compromise there;
+scope is.
+
+On pull requests, CI runs `bun run lint:anti-slop:changed` against only the
+added, copied, modified, or renamed JavaScript and TypeScript files in the PR.
+Findings appear as source annotations but do not fail the job. Tooling failures
+still fail: an advisory that silently stopped running would be worse than no
+advisory. This avoids a large legacy baseline and gives new work useful feedback
+without turning opinionated design prompts into release blockers.
+
+Locally, the command compares against `origin/main` by default. Pass a commit or
+branch as its first argument to inspect a different stack boundary.
 
 The findings are real, not false positives — mostly unjustified type
 assertions, `typeof` narrowing at non-boundaries, and `Record<string, unknown>`
 dictionaries. Burn them down the way warnings are handled above: in focused
 batches, when touching a file anyway. Promote the plugin into `.oxlintrc.json`
-once the count reaches zero, and delete this section when that happens.
+once the count reaches zero, then make the full command blocking and delete this
+section.
 
 The Effect rule group is deliberately **not** installed: nothing here declares
 `effect` as a direct dependency.

--- a/.docs/repo-infrastructure.md
+++ b/.docs/repo-infrastructure.md
@@ -1,6 +1,6 @@
 ---
 status: current
-lastReviewed: "2026-08-14"
+lastReviewed: "2026-08-24"
 ---
 
 # Kunai — Repo Infrastructure
@@ -110,7 +110,7 @@ The invariant is enforced two ways:
 | Job                   | PR                                                                                    | Main         |
 | --------------------- | ------------------------------------------------------------------------------------- | ------------ |
 | `fmt`                 | `turbo run fmt:check --affected`                                                      | full         |
-| `lint`                | `turbo run lint --affected`                                                           | full         |
+| `lint`                | `turbo run lint --affected` + changed-file anti-slop advisory                         | full         |
 | `typecheck`           | `turbo run typecheck --affected`                                                      | full         |
 | `test`                | `turbo run test --affected` (CLI splits into cached `test:unit` + `test:integration`) | full         |
 | `windows-cli`         | root typecheck + CLI tests when CLI paths change                                      | same on main |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,10 @@ jobs:
         if: github.event_name == 'push'
         run: bunx turbo run lint --summarize
 
+      - name: Anti-slop changed-file advisory
+        if: github.event_name == 'pull_request'
+        run: bun run lint:anti-slop:changed
+
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest

--- a/apps/cli/src/services/sync/SyncService.ts
+++ b/apps/cli/src/services/sync/SyncService.ts
@@ -91,6 +91,8 @@ export interface SyncServiceDeps {
   readonly outbox: SyncOutboxRepository;
   readonly config: SyncConfigPort;
   readonly diagnostics?: Pick<DiagnosticsService, "record">;
+  /** Injectable so operation-budget continuations can be advanced without real timers in tests. */
+  readonly scheduleContinuation?: (task: () => void) => void;
   /** Injectable only so due-time and shutdown behavior are deterministic in tests. */
   readonly scheduleWake?: (task: () => void, delayMs: number) => () => void;
   readonly now?: () => Date;
@@ -252,6 +254,7 @@ export class SyncService {
   private readonly outbox: SyncOutboxRepository;
   private readonly config: SyncConfigPort;
   private readonly diagnostics?: Pick<DiagnosticsService, "record">;
+  private readonly scheduleContinuation: (task: () => void) => void;
   private readonly scheduleWake: (task: () => void, delayMs: number) => () => void;
   private readonly now: () => Date;
   private readonly maxOperationsPerPass: number;
@@ -273,6 +276,7 @@ export class SyncService {
     this.now = deps.now ?? (() => new Date());
     this.maxOperationsPerPass = clampDrainLimit(deps.maxOperationsPerPass, DRAIN_MAX_OPERATIONS);
     this.batchSize = clampDrainLimit(deps.batchSize, DRAIN_BATCH_LIMIT);
+    this.scheduleContinuation = deps.scheduleContinuation ?? ((task) => setTimeout(task, 0));
     this.scheduleWake =
       deps.scheduleWake ??
       ((task, delayMs) => {
@@ -527,10 +531,10 @@ export class SyncService {
           !this.shutdownController.signal.aborted
         ) {
           this.continuationScheduled = true;
-          setTimeout(() => {
+          this.scheduleContinuation(() => {
             this.continuationScheduled = false;
             if (!this.shutdownController.signal.aborted) this.deliverSoon();
-          }, 0);
+          });
         }
         return undefined;
       })

--- a/apps/cli/test/unit/scripts/anti-slop-changed.test.ts
+++ b/apps/cli/test/unit/scripts/anti-slop-changed.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  formatGitHubWarning,
+  selectChangedLintPaths,
+} from "../../../../../scripts/anti-slop-changed";
+
+describe("anti-slop changed-file advisory", () => {
+  test("selects existing changed source files once in stable order", () => {
+    const existing = new Set(["z.tsx", "a.mts", "script.cjs"]);
+
+    expect(
+      selectChangedLintPaths(
+        ["z.tsx", "README.md", "deleted.ts", "a.mts", "z.tsx", "script.cjs"],
+        (path) => existing.has(path),
+      ),
+    ).toEqual(["a.mts", "script.cjs", "z.tsx"]);
+  });
+
+  test("renders escaped GitHub warning annotations with source positions", () => {
+    expect(
+      formatGitHubWarning({
+        filename: "apps/cli/src/a,b.ts",
+        code: "anti-slop(rule:name)",
+        message: "parse 100%\nnow",
+        labels: [{ span: { line: 12, column: 7 } }],
+      }),
+    ).toBe(
+      "::warning file=apps/cli/src/a%2Cb.ts,line=12,col=7,title=anti-slop(rule%3Aname)::parse 100%25%0Anow",
+    );
+  });
+});

--- a/apps/cli/test/unit/services/sync/sync-drain.test.ts
+++ b/apps/cli/test/unit/services/sync/sync-drain.test.ts
@@ -147,6 +147,7 @@ describe("SyncService drain", () => {
   test("a direct startup drain schedules continuation beyond its operation budget", async () => {
     const repo = outbox();
     const anilist = adapter("anilist");
+    const scheduled: Array<() => void> = [];
     const service = new SyncService({
       adapters: [anilist.adapter],
       outbox: repo,
@@ -157,6 +158,10 @@ describe("SyncService drain", () => {
       // no extra coverage.
       maxOperationsPerPass: BUDGET,
       batchSize: BATCH_SIZE,
+      scheduleWake: (task) => {
+        scheduled.push(task);
+        return () => {};
+      },
     });
 
     for (let id = 1; id <= OVER_BUDGET; id += 1) {
@@ -170,7 +175,13 @@ describe("SyncService drain", () => {
 
     const first = await service.drain();
     expect(first.claimed).toBe(BUDGET);
-    await waitUntil(() => repo.counts().pending === 0, { label: "outbox drained" });
+    expect(anilist.calls).toHaveLength(BUDGET);
+    expect(scheduled).toHaveLength(1);
+
+    // Driving the wake by hand instead of polling a real clock: the pass is
+    // done, so what remains is whether the continuation drains the rest.
+    scheduled.shift()?.();
+    await service.drain();
 
     expect(anilist.calls).toHaveLength(OVER_BUDGET);
     expect(repo.counts().pending).toBe(0);
@@ -242,6 +253,7 @@ describe("SyncService drain", () => {
   test("deliverSoon continues after its operation budget until every due row is attempted", async () => {
     const repo = outbox();
     const anilist = adapter("anilist");
+    const continuations: Array<() => void> = [];
     const service = new SyncService({
       adapters: [anilist.adapter],
       outbox: repo,
@@ -252,6 +264,9 @@ describe("SyncService drain", () => {
       // no extra coverage.
       maxOperationsPerPass: BUDGET,
       batchSize: BATCH_SIZE,
+      scheduleContinuation: (task) => {
+        continuations.push(task);
+      },
     });
 
     for (let id = 1; id <= OVER_BUDGET; id += 1) {
@@ -264,7 +279,16 @@ describe("SyncService drain", () => {
     }
 
     service.deliverSoon();
-    await waitUntil(() => repo.counts().pending === 0, { label: "outbox drained" });
+    const first = await service.drain();
+    expect(first.claimed).toBe(BUDGET);
+    expect(anilist.calls).toHaveLength(BUDGET);
+    expect(continuations).toHaveLength(1);
+
+    // Run the captured continuation directly: no real timer, so the test
+    // proves the continuation drains the remainder rather than that a
+    // `setTimeout(0)` fired before a polling deadline.
+    continuations.shift()?.();
+    await service.drain();
 
     expect(anilist.calls).toHaveLength(OVER_BUDGET);
     expect(repo.counts().pending).toBe(0);

--- a/apps/cli/test/unit/services/sync/sync-reconciliation.test.ts
+++ b/apps/cli/test/unit/services/sync/sync-reconciliation.test.ts
@@ -955,6 +955,9 @@ test("transient prefix backs off so later eligible rows run and retries resume w
   const scheduled: Array<{ task: () => Promise<void>; delayMs: number }> = [];
   const options = {
     maxRows: 3,
+    // Frozen: retry due-times use wallNow, while the operation budget uses a
+    // monotonic clock. This test exercises retry ordering, not runner speed.
+    now: () => 0,
     wallNow: () => wallNow,
     scheduleContinuation: (task: () => Promise<void>, delayMs = 0) =>
       scheduled.push({ task, delayMs }),

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "typecheck": "turbo run typecheck",
     "lint": "turbo run lint",
     "lint:anti-slop": "oxlint --config .oxlintrc.anti-slop.json .",
+    "lint:anti-slop:changed": "bun run scripts/anti-slop-changed.ts",
     "fmt": "turbo run fmt",
     "fmt:check": "turbo run fmt:check",
     "test": "turbo run test",

--- a/scripts/anti-slop-changed.ts
+++ b/scripts/anti-slop-changed.ts
@@ -1,0 +1,123 @@
+#!/usr/bin/env bun
+
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+export type AntiSlopDiagnostic = {
+  readonly filename: string;
+  readonly code: string;
+  readonly message: string;
+  readonly labels?: readonly {
+    readonly span?: {
+      readonly line?: number;
+      readonly column?: number;
+    };
+  }[];
+};
+
+type OxlintJsonReport = {
+  readonly diagnostics: readonly AntiSlopDiagnostic[];
+};
+
+const REPO_ROOT = resolve(import.meta.dirname, "..");
+const LINTABLE_SOURCE = /\.(?:[cm]?[jt]sx?)$/i;
+const MAX_ANNOTATIONS = 50;
+
+export function selectChangedLintPaths(
+  paths: readonly string[],
+  fileExists: (path: string) => boolean = existsSync,
+): string[] {
+  return [...new Set(paths)]
+    .filter((path) => LINTABLE_SOURCE.test(path) && fileExists(path))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+export function formatGitHubWarning(diagnostic: AntiSlopDiagnostic): string {
+  const span = diagnostic.labels?.[0]?.span;
+  const properties = [
+    `file=${escapeWorkflowProperty(diagnostic.filename)}`,
+    ...(span?.line ? [`line=${span.line}`] : []),
+    ...(span?.column ? [`col=${span.column}`] : []),
+    `title=${escapeWorkflowProperty(diagnostic.code)}`,
+  ].join(",");
+  return `::warning ${properties}::${escapeWorkflowData(diagnostic.message)}`;
+}
+
+async function changedPaths(base: string): Promise<string[]> {
+  const child = Bun.spawn(
+    ["git", "diff", "--name-only", "--diff-filter=ACMR", "-z", `${base}...HEAD`, "--"],
+    { cwd: REPO_ROOT, stdout: "pipe", stderr: "inherit" },
+  );
+  const stdout = await new Response(child.stdout).text();
+  const exitCode = await child.exited;
+  if (exitCode !== 0) throw new Error(`git diff exited ${exitCode}`);
+  return stdout.split("\0").filter(Boolean);
+}
+
+async function collectDiagnostics(
+  paths: readonly string[],
+): Promise<readonly AntiSlopDiagnostic[]> {
+  if (paths.length === 0) return [];
+  const child = Bun.spawn(
+    [
+      process.execPath,
+      "x",
+      "oxlint",
+      "--config",
+      ".oxlintrc.anti-slop.json",
+      "--format",
+      "json",
+      ...paths,
+    ],
+    { cwd: REPO_ROOT, stdout: "pipe", stderr: "inherit" },
+  );
+  const stdout = await new Response(child.stdout).text();
+  const exitCode = await child.exited;
+  if (exitCode !== 0 && exitCode !== 1) {
+    throw new Error(`anti-slop oxlint exited ${exitCode}`);
+  }
+  // SAFETY: oxlint's documented JSON formatter owns this subprocess output.
+  const report = JSON.parse(stdout) as OxlintJsonReport;
+  return report.diagnostics;
+}
+
+async function main(): Promise<void> {
+  const base = process.argv[2] || process.env.TURBO_SCM_BASE || "origin/main";
+
+  const paths = selectChangedLintPaths(await changedPaths(base), (path) =>
+    existsSync(resolve(REPO_ROOT, path)),
+  );
+  const diagnostics = await collectDiagnostics(paths);
+  const inGitHubActions = process.env.GITHUB_ACTIONS === "true";
+
+  for (const diagnostic of diagnostics.slice(0, MAX_ANNOTATIONS)) {
+    if (inGitHubActions) {
+      console.log(formatGitHubWarning(diagnostic));
+      continue;
+    }
+    const span = diagnostic.labels?.[0]?.span;
+    console.log(
+      `${diagnostic.filename}:${span?.line ?? 1}:${span?.column ?? 1}: ${diagnostic.code} ${diagnostic.message}`,
+    );
+  }
+  if (diagnostics.length > MAX_ANNOTATIONS) {
+    console.log(
+      `[anti-slop] ${diagnostics.length - MAX_ANNOTATIONS} additional finding(s) omitted`,
+    );
+  }
+  console.log(
+    `[anti-slop] advisory: ${diagnostics.length} finding(s) across ${paths.length} changed source file(s)`,
+  );
+}
+
+function escapeWorkflowData(value: string): string {
+  return value.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
+}
+
+function escapeWorkflowProperty(value: string): string {
+  return escapeWorkflowData(value).replaceAll(":", "%3A").replaceAll(",", "%2C");
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/tools/oxlint/anti-slop/package.json
+++ b/tools/oxlint/anti-slop/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}


### PR DESCRIPTION
## Summary

- adds the anti-slop advisory checker and changed-file ratchet
- keeps the ordinary zero-warning lint gate authoritative
- limits findings to changed source so legacy debt does not block unrelated work
- stabilizes concurrent docs and Windows sync tests with explicit budgets and injectable clocks

Closes #107.

## Stack

Depends on #164.

## Verification

- anti-slop fixture and changed-file tests
- repeated deterministic sync drain and reconciliation tests
- bun run lint
- bun run typecheck
- bun run test
- bun run build

No release is performed by this PR.