### PR TITLE
fix(release): verify the exact preserved npm candidate

### DIFF
--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -1,6 +1,6 @@
 ---
 status: current
-lastReviewed: "2026-08-14"
+lastReviewed: "2026-08-24"
 ---
 
 # Kunai Release Reliability Gate
@@ -36,8 +36,14 @@ Expected result:
 - unit and integration tests report 0 failures
 - typecheck exits 0
 - build writes `apps/cli/dist/kunai.js` and the host compiled binary under `apps/cli/dist/bin/`
-- package check rejects `dist/bin/**`, analyze metafiles, and oversized tarballs (npm ships JS + assets only)
+- package check rejects `dist/bin/**`, source/maps, analyze metafiles, lifecycle scripts, dependency drift, and oversized launcher tarballs
 - release dry-run completes build, checks, and packability without publishing
+
+The release workflow additionally opens the exact preserved
+`.release-candidate/kunai-npm.tgz` after `release:pack`, both before candidate
+upload and after protected-job download. It must contain only `package.json`,
+`LICENSE`, `README.md`, and `dist/npm-launcher.mjs` under `package/`; publication
+uses those same verified bytes rather than repacking them.
 
 ## Changelog Gate
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,11 @@ jobs:
       - name: Create preserved npm launcher tarball
         run: bun run release:pack
 
+      - name: Verify exact preserved npm launcher tarball
+        run: |
+          set -euo pipefail
+          bun run apps/cli/scripts/verify-npm-pack.ts --tarball .release-candidate/kunai-npm.tgz --expected-version "${{ steps.ver.outputs.version }}" 2>&1 | tee -a artifacts/gates/package.log
+
       - name: Create preserved npm platform tarballs
         run: bun run release:prepare
 
@@ -860,6 +865,12 @@ jobs:
           test -f .release-candidate/kunai-npm.tgz
           test -f apps/cli/dist/bin/SHA256SUMS
           test -d .release-candidate/npm-platform
+
+      - name: Reverify exact preserved npm launcher tarball
+        run: >-
+          bun run apps/cli/scripts/verify-npm-pack.ts --tarball
+          .release-candidate/kunai-npm.tgz --expected-version
+          "${{ needs.confirmation.outputs.version }}"
 
       - name: Reverify preserved binaries
         run: |

--- a/apps/cli/scripts/verify-npm-pack.ts
+++ b/apps/cli/scripts/verify-npm-pack.ts
@@ -1,10 +1,12 @@
 #!/usr/bin/env bun
 // Verify the published npm tarball stays small and never includes compiled binaries.
 
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { gunzipSync } from "node:zlib";
 
+import { RELEASE_BINARY_TARGETS } from "../src/services/update/platform-assets";
 import {
   assertNpmPackBudgets,
   assertNpmPackContents,
@@ -15,14 +17,29 @@ import {
 
 const ROOT = join(import.meta.dirname, "..");
 const NPM_PUBLISH_ROOT = join(ROOT, "dist/npm");
+const TAR_BLOCK_BYTES = 512;
+const TAR_NAME_OFFSET = 0;
+const TAR_NAME_BYTES = 100;
+const TAR_SIZE_OFFSET = 124;
+const TAR_SIZE_BYTES = 12;
+const TAR_CHECKSUM_OFFSET = 148;
+const TAR_CHECKSUM_BYTES = 8;
+const TAR_TYPE_OFFSET = 156;
+const TAR_PREFIX_OFFSET = 345;
+const TAR_PREFIX_BYTES = 155;
+const TAR_REGULAR_FILE = 0x30;
+const TAR_SPACE = 0x20;
+const TAR_CONTAINER_BUDGET_BYTES = NPM_PACK_UNPACKED_BUDGET_BYTES + TAR_BLOCK_BYTES * 16;
+const textDecoder = new TextDecoder();
 
-type NpmPublishManifest = {
+export type NpmPublishManifest = {
   readonly bin?: Record<string, string>;
   readonly dependencies?: unknown;
   readonly engines?: Record<string, string>;
   readonly files?: string[];
   readonly license?: string;
   readonly module?: unknown;
+  readonly name?: string;
   readonly optionalDependencies?: Record<string, string>;
   readonly peerDependencies?: unknown;
   readonly publishConfig?: {
@@ -30,10 +47,26 @@ type NpmPublishManifest = {
     readonly provenance?: boolean;
   };
   readonly scripts?: unknown;
+  readonly type?: string;
+  readonly version?: string;
 };
 
 /** Reject workspace-only metadata before checking the generated tarball. */
-export function assertNpmPublishManifest(manifest: NpmPublishManifest): void {
+export function assertNpmPublishManifest(
+  manifest: NpmPublishManifest,
+  expectedVersion: string,
+): void {
+  if (manifest.name !== "@kitsunekode/kunai") {
+    throw new Error("[pkg:check] npm publish manifest has the wrong package name.");
+  }
+  if (manifest.version !== expectedVersion) {
+    throw new Error(
+      `[pkg:check] npm publish manifest version must be ${expectedVersion}, received ${manifest.version ?? "missing"}.`,
+    );
+  }
+  if (manifest.type !== "module") {
+    throw new Error("[pkg:check] npm publish manifest type must be module.");
+  }
   if (manifest.dependencies !== undefined || manifest.peerDependencies !== undefined) {
     throw new Error(
       "[pkg:check] npm publish manifest must not contain runtime or peer dependencies.",
@@ -44,6 +77,12 @@ export function assertNpmPublishManifest(manifest: NpmPublishManifest): void {
   }
   if (manifest.engines?.bun !== undefined) {
     throw new Error("[pkg:check] npm publish manifest must not require Bun.");
+  }
+  if (
+    manifest.engines?.node !== ">=18.17" ||
+    Object.keys(manifest.engines ?? {}).some((engine) => engine !== "node")
+  ) {
+    throw new Error("[pkg:check] npm publish manifest must require only Node >=18.17.");
   }
   if (manifest.scripts !== undefined) {
     throw new Error("[pkg:check] npm publish manifest must not contain lifecycle scripts.");
@@ -69,6 +108,21 @@ export function assertNpmPublishManifest(manifest: NpmPublishManifest): void {
   }
   if (manifest.publishConfig.provenance !== true) {
     throw new Error("[pkg:check] npm publish manifest must enable provenance.");
+  }
+
+  const expectedOptionalDependencies = Object.fromEntries(
+    RELEASE_BINARY_TARGETS.map((target) => [`@kitsunekode/kunai-${target.id}`, expectedVersion]),
+  );
+  const actualEntries = Object.entries(manifest.optionalDependencies ?? {}).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  const expectedEntries = Object.entries(expectedOptionalDependencies).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  if (JSON.stringify(actualEntries) !== JSON.stringify(expectedEntries)) {
+    throw new Error(
+      "[pkg:check] npm publish manifest optional dependencies must exactly cover every platform package at the launcher version.",
+    );
   }
 }
 
@@ -122,16 +176,21 @@ function parseNpmSize(raw: string): number {
   const value = Number.parseFloat(match[1]);
   if (!Number.isFinite(value)) return 0;
   const unit = match[2].toLowerCase();
-  const multipliers: Record<string, number> = {
-    b: 1,
-    kb: 1_000,
-    kib: 1024,
-    mb: 1_000_000,
-    mib: 1024 * 1024,
-    gb: 1_000_000_000,
-    gib: 1024 * 1024 * 1024,
-  };
-  return Math.round(value * (multipliers[unit] ?? 1));
+  const multiplier =
+    unit === "kb"
+      ? 1_000
+      : unit === "kib"
+        ? 1024
+        : unit === "mb"
+          ? 1_000_000
+          : unit === "mib"
+            ? 1024 * 1024
+            : unit === "gb"
+              ? 1_000_000_000
+              : unit === "gib"
+                ? 1024 * 1024 * 1024
+                : 1;
+  return Math.round(value * multiplier);
 }
 
 export function verifyNpmPackDryRun(stdout: string): NpmPackDryRun {
@@ -141,7 +200,257 @@ export function verifyNpmPackDryRun(stdout: string): NpmPackDryRun {
   return summary;
 }
 
-function main(): void {
+type RawTarMember = {
+  readonly archivePath: string;
+  readonly size: number;
+};
+
+function readTarString(bytes: Uint8Array, offset: number, length: number): string {
+  const field = bytes.subarray(offset, offset + length);
+  const nullOffset = field.indexOf(0);
+  return textDecoder.decode(field.subarray(0, nullOffset === -1 ? field.length : nullOffset));
+}
+
+function readTarOctal(
+  header: Uint8Array,
+  offset: number,
+  length: number,
+  fieldName: string,
+): number {
+  const raw = readTarString(header, offset, length).trim();
+  if (!/^[0-7]+$/.test(raw)) {
+    throw new Error(`[pkg:check] preserved npm tarball has an invalid ${fieldName} field.`);
+  }
+  const value = Number.parseInt(raw, 8);
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`[pkg:check] preserved npm tarball has an unsafe ${fieldName} field.`);
+  }
+  return value;
+}
+
+function assertTarHeaderChecksum(header: Uint8Array): void {
+  const expected = readTarOctal(header, TAR_CHECKSUM_OFFSET, TAR_CHECKSUM_BYTES, "header checksum");
+  let actual = 0;
+  for (let index = 0; index < header.length; index += 1) {
+    const inChecksumField =
+      index >= TAR_CHECKSUM_OFFSET && index < TAR_CHECKSUM_OFFSET + TAR_CHECKSUM_BYTES;
+    actual += inChecksumField ? TAR_SPACE : (header[index] ?? 0);
+  }
+  if (actual !== expected) {
+    throw new Error("[pkg:check] preserved npm tarball has an invalid header checksum.");
+  }
+}
+
+function isZeroTarBlock(block: Uint8Array): boolean {
+  return block.every((byte) => byte === 0);
+}
+
+function rawTarMembers(compressedBytes: Uint8Array): readonly RawTarMember[] {
+  const bytes = gunzipSync(compressedBytes, { maxOutputLength: TAR_CONTAINER_BUDGET_BYTES });
+  if (bytes.length === 0 || bytes.length % TAR_BLOCK_BYTES !== 0) {
+    throw new Error("[pkg:check] preserved npm tarball has an invalid block-aligned payload.");
+  }
+
+  const members: RawTarMember[] = [];
+  const paths = new Set<string>();
+  for (let offset = 0; offset < bytes.length;) {
+    const header = bytes.subarray(offset, offset + TAR_BLOCK_BYTES);
+    if (isZeroTarBlock(header)) {
+      const secondBlock = bytes.subarray(offset + TAR_BLOCK_BYTES, offset + TAR_BLOCK_BYTES * 2);
+      const trailingBytes = bytes.subarray(offset + TAR_BLOCK_BYTES * 2);
+      if (secondBlock.length !== TAR_BLOCK_BYTES || !isZeroTarBlock(secondBlock)) {
+        throw new Error("[pkg:check] preserved npm tarball has an incomplete end marker.");
+      }
+      if (!trailingBytes.every((byte) => byte === 0)) {
+        throw new Error("[pkg:check] preserved npm tarball has data after its end marker.");
+      }
+      return members;
+    }
+
+    assertTarHeaderChecksum(header);
+    const name = readTarString(header, TAR_NAME_OFFSET, TAR_NAME_BYTES);
+    const prefix = readTarString(header, TAR_PREFIX_OFFSET, TAR_PREFIX_BYTES);
+    const archivePath = prefix.length > 0 ? `${prefix}/${name}` : name;
+    if (archivePath.length === 0) {
+      throw new Error("[pkg:check] preserved npm tarball has an empty member path.");
+    }
+    if (paths.has(archivePath)) {
+      throw new Error(
+        `[pkg:check] preserved npm tarball has a duplicate archive member: ${archivePath}`,
+      );
+    }
+    paths.add(archivePath);
+
+    const type = header[TAR_TYPE_OFFSET] ?? 0;
+    if (type !== 0 && type !== TAR_REGULAR_FILE) {
+      throw new Error(
+        `[pkg:check] preserved npm tarball member must be a regular file: ${archivePath}`,
+      );
+    }
+    const size = readTarOctal(header, TAR_SIZE_OFFSET, TAR_SIZE_BYTES, "member size");
+    const dataBlocks = Math.ceil(size / TAR_BLOCK_BYTES);
+    const nextOffset = offset + TAR_BLOCK_BYTES + dataBlocks * TAR_BLOCK_BYTES;
+    if (nextOffset > bytes.length) {
+      throw new Error(
+        `[pkg:check] preserved npm tarball member exceeds the archive payload: ${archivePath}`,
+      );
+    }
+    members.push({ archivePath, size });
+    offset = nextOffset;
+  }
+
+  throw new Error("[pkg:check] preserved npm tarball has no complete end marker.");
+}
+
+/** Verify file and manifest policy against the exact bytes later uploaded and published. */
+export async function verifyPreservedNpmTarball(
+  tarballPath: string,
+  expectedVersion: string,
+): Promise<NpmPackDryRun> {
+  let packedBytes: number;
+  let compressedBytes: Uint8Array;
+  try {
+    const metadata = statSync(tarballPath);
+    if (!metadata.isFile() || metadata.size === 0) {
+      throw new Error("candidate is not a nonempty file");
+    }
+    compressedBytes = readFileSync(tarballPath);
+    packedBytes = compressedBytes.byteLength;
+    if (packedBytes !== metadata.size) {
+      throw new Error("candidate changed while it was being read");
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `[pkg:check] preserved npm tarball is unavailable: ${tarballPath}: ${message}`,
+      {
+        cause: error,
+      },
+    );
+  }
+
+  if (packedBytes > NPM_PACK_PACKED_BUDGET_BYTES) {
+    assertNpmPackBudgets(packedBytes, 0);
+  }
+
+  let members: readonly RawTarMember[];
+  let archiveFiles: Awaited<ReturnType<Bun.Archive["files"]>>;
+  try {
+    members = rawTarMembers(compressedBytes);
+    archiveFiles = await new Bun.Archive(compressedBytes).files();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`[pkg:check] preserved npm tarball could not be read: ${message}`, {
+      cause: error,
+    });
+  }
+
+  const paths: string[] = [];
+  let unpackedBytes = 0;
+  for (const { archivePath, size } of members) {
+    if (!archivePath.startsWith("package/")) {
+      throw new Error(
+        `[pkg:check] preserved npm tarball path must be rooted under package/: ${archivePath}`,
+      );
+    }
+    const path = archivePath.slice("package/".length);
+    const segments = path.split("/");
+    if (
+      path.length === 0 ||
+      path.includes("\\") ||
+      segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")
+    ) {
+      throw new Error(`[pkg:check] preserved npm tarball has an unsafe path: ${archivePath}`);
+    }
+    paths.push(path);
+    unpackedBytes += size;
+    const extractedFile = archiveFiles.get(archivePath);
+    if (!extractedFile || extractedFile.size !== size) {
+      throw new Error(
+        `[pkg:check] preserved npm tarball member could not be extracted exactly: ${archivePath}`,
+      );
+    }
+  }
+  if (archiveFiles.size !== members.length) {
+    throw new Error("[pkg:check] preserved npm tarball extraction changed its member set.");
+  }
+  paths.sort();
+  assertNpmPackContents(paths);
+  assertNpmPackBudgets(packedBytes, unpackedBytes);
+
+  const manifestFile = archiveFiles.get("package/package.json");
+  if (!manifestFile) {
+    throw new Error("[pkg:check] preserved npm tarball is missing package/package.json.");
+  }
+  let manifest: NpmPublishManifest;
+  try {
+    manifest = parseManifestJson(
+      await manifestFile.text(),
+      "preserved npm tarball package/package.json",
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`[pkg:check] preserved npm tarball has invalid package.json: ${message}`, {
+      cause: error,
+    });
+  }
+  assertNpmPublishManifest(manifest, expectedVersion);
+  return { paths, packedBytes, unpackedBytes };
+}
+
+function parseManifestJson(raw: string, context: string): NpmPublishManifest {
+  const parsed: unknown = JSON.parse(raw);
+  if (parsed === null || Array.isArray(parsed) || Object(parsed) !== parsed) {
+    throw new Error(`[pkg:check] ${context} must be a JSON object.`);
+  }
+  // SAFETY: the object boundary is established above; every optional field
+  // consumed from this shape is validated by assertNpmPublishManifest.
+  return parsed as NpmPublishManifest;
+}
+
+type VerifyNpmPackArgs =
+  | { readonly mode: "dry-run" }
+  | { readonly mode: "tarball"; readonly path: string; readonly expectedVersion: string };
+
+function parseArgs(args: readonly string[], sourceVersion: string): VerifyNpmPackArgs {
+  if (args.length === 0) return { mode: "dry-run" };
+  let path: string | undefined;
+  let expectedVersion = sourceVersion;
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--tarball" && args[index + 1]) {
+      path = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (argument === "--expected-version" && args[index + 1]) {
+      expectedVersion = args[index + 1] ?? sourceVersion;
+      index += 1;
+      continue;
+    }
+    throw new Error(`[pkg:check] unknown or incomplete argument: ${argument}`);
+  }
+  if (!path) throw new Error("[pkg:check] --tarball PATH is required for artifact verification.");
+  return { mode: "tarball", path, expectedVersion };
+}
+
+async function main(): Promise<void> {
+  const sourceManifest = parseManifestJson(
+    readFileSync(join(ROOT, "package.json"), "utf8"),
+    "source package manifest",
+  );
+  if (!sourceManifest.version) {
+    throw new Error("[pkg:check] source package manifest has no version.");
+  }
+  const parsedArgs = parseArgs(process.argv.slice(2), sourceManifest.version);
+  if (parsedArgs.mode === "tarball") {
+    const summary = await verifyPreservedNpmTarball(parsedArgs.path, parsedArgs.expectedVersion);
+    console.log(
+      `[pkg:check] exact tarball ok — ${summary.paths.length} files, packed ${formatBuildSize(summary.packedBytes)} / ${formatBuildSize(NPM_PACK_PACKED_BUDGET_BYTES)}, unpacked ${formatBuildSize(summary.unpackedBytes)} / ${formatBuildSize(NPM_PACK_UNPACKED_BUDGET_BYTES)}`,
+    );
+    return;
+  }
+
   const args = ["pack", "--dry-run", "--ignore-scripts"];
   let command = [Bun.which("npm") ?? "npm", ...args];
   if (process.platform === "win32") {
@@ -178,10 +487,11 @@ function main(): void {
     process.exit(result.exitCode ?? 1);
   }
 
-  const manifest = JSON.parse(
+  const manifest = parseManifestJson(
     readFileSync(join(NPM_PUBLISH_ROOT, "package.json"), "utf8"),
-  ) as NpmPublishManifest;
-  assertNpmPublishManifest(manifest);
+    "generated npm publish manifest",
+  );
+  assertNpmPublishManifest(manifest, sourceManifest.version);
   const summary = verifyNpmPackDryRun(output);
   console.log(
     `[pkg:check] ok — ${summary.paths.length} files, packed ${formatBuildSize(summary.packedBytes)} / ${formatBuildSize(NPM_PACK_PACKED_BUDGET_BYTES)}, unpacked ${formatBuildSize(summary.unpackedBytes)} / ${formatBuildSize(NPM_PACK_UNPACKED_BUDGET_BYTES)}`,
@@ -189,5 +499,5 @@ function main(): void {
 }
 
 if (import.meta.path === Bun.main) {
-  main();
+  await main();
 }

--- a/apps/cli/test/integration/npm-pack-guard.test.ts
+++ b/apps/cli/test/integration/npm-pack-guard.test.ts
@@ -75,6 +75,22 @@ describeWithNode("npm pack guard with binaries on disk", () => {
       expect(pack.status, `${pack.stdout ?? ""}${pack.stderr ?? ""}`).toBe(0);
       expect(existsSync(RELEASE_TARBALL)).toBe(true);
       expect(statSync(RELEASE_TARBALL).size).toBeGreaterThan(0);
+
+      const exact = spawnSync(
+        "bun",
+        [
+          "run",
+          "scripts/verify-npm-pack.ts",
+          "--tarball",
+          RELEASE_TARBALL,
+          "--expected-version",
+          manifest.version,
+        ],
+        { cwd: CLI_ROOT, encoding: "utf8" },
+      );
+      const exactOutput = `${exact.stdout ?? ""}${exact.stderr ?? ""}`;
+      expect(exact.status, exactOutput).toBe(0);
+      expect(exactOutput).toContain("[pkg:check] exact tarball ok");
     } finally {
       await rm(STUB_BIN, { force: true });
       await rm(RELEASE_TARBALL, { force: true });

--- a/apps/cli/test/unit/scripts/distribution-contract.test.ts
+++ b/apps/cli/test/unit/scripts/distribution-contract.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 
 import { RELEASE_BINARY_TARGETS } from "@/services/update/platform-assets";
 
+import rootPackage from "../../../../../package.json";
 import {
   REQUIRED_RELEASE_ASSET_NAMES,
   assertCompleteReleaseAssetSet,
@@ -106,9 +107,6 @@ function extractWorkflowJob(yaml: string, jobId: string): string {
 describe("release workflow candidate-before-publication contract", () => {
   const release = readFileSync(join(REPO_ROOT, ".github/workflows/release.yml"), "utf8");
   const publisher = readFileSync(join(REPO_ROOT, "scripts/publish-npm-release.ts"), "utf8");
-  const rootPackage = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")) as {
-    scripts: Record<string, string>;
-  };
   const versionPr = () => extractWorkflowJob(release, "version-pr");
   const candidate = () => extractWorkflowJob(release, "candidate");
   const confirmation = () => extractWorkflowJob(release, "confirmation");
@@ -246,6 +244,24 @@ describe("release workflow candidate-before-publication contract", () => {
     expect(cand).toContain(".release-candidate/npm-platform");
   });
 
+  test("the exact launcher tarball is checked before upload and again before publication", () => {
+    const cand = candidate();
+    const pub = publish();
+    const candidatePack = cand.indexOf("bun run release:pack");
+    const candidateExactCheck = cand.indexOf("verify-npm-pack.ts --tarball");
+    const candidateUpload = cand.indexOf("Upload candidate artifacts");
+    const publishDownload = pub.indexOf("Download candidate artifacts");
+    const publishExactCheck = pub.indexOf("verify-npm-pack.ts --tarball");
+    const npmPublish = pub.search(PUBLISH_STEP);
+
+    expect(candidatePack).toBeGreaterThanOrEqual(0);
+    expect(candidateExactCheck).toBeGreaterThan(candidatePack);
+    expect(candidateUpload).toBeGreaterThan(candidateExactCheck);
+    expect(publishDownload).toBeGreaterThanOrEqual(0);
+    expect(publishExactCheck).toBeGreaterThan(publishDownload);
+    expect(npmPublish).toBeGreaterThan(publishExactCheck);
+  });
+
   test("trusted publication pins compatible Node and npm and prints both versions", () => {
     expect(release).toContain('RELEASE_NODE_VERSION: "22.14.0"');
     expect(release).toContain('RELEASE_NPM_VERSION: "11.5.1"');
@@ -264,7 +280,7 @@ describe("release workflow candidate-before-publication contract", () => {
     expect(release).not.toContain("NODE_AUTH_TOKEN");
     expect(release).not.toContain("bun publish");
     expect(Object.values(rootPackage.scripts).join("\n")).not.toContain("bun publish");
-    expect(rootPackage.scripts["release:publish-tarball"]).toBeUndefined();
+    expect("release:publish-tarball" in rootPackage.scripts).toBe(false);
   });
 
   test("pins every third-party release action to a full commit with its major comment", () => {
@@ -281,9 +297,6 @@ describe("release workflow candidate-before-publication contract", () => {
 });
 
 describe("release:pack script contract", () => {
-  const rootPackage = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")) as {
-    scripts: Record<string, string>;
-  };
   const releasePack = rootPackage.scripts["release:pack"] ?? "";
   test("buildNpmPublishManifest returns the public launcher manifest without filesystem work", () => {
     const source = {

--- a/apps/cli/test/unit/scripts/verify-npm-pack.test.ts
+++ b/apps/cli/test/unit/scripts/verify-npm-pack.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { Buffer } from "node:buffer";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
 
+import cliPackage from "../../../package.json";
 import {
   assertNpmPackBudgets,
   assertNpmPackContents,
@@ -10,8 +16,106 @@ import {
 import {
   assertNpmPublishManifest,
   parseNpmPackDryRun,
+  type NpmPublishManifest,
+  verifyPreservedNpmTarball,
   verifyNpmPackDryRun,
 } from "../../../scripts/verify-npm-pack";
+import { RELEASE_BINARY_TARGETS } from "../../../src/services/update/platform-assets";
+
+const TEST_VERSION = "9.8.7";
+const TAR_BLOCK_BYTES = 512;
+
+function writeTarOctal(header: Buffer, offset: number, length: number, value: number): void {
+  header.write(`${value.toString(8).padStart(length - 1, "0")}\0`, offset, length, "ascii");
+}
+
+function fixtureTar(entries: readonly (readonly [path: string, contents: string])[]): Buffer {
+  const blocks: Buffer[] = [];
+  for (const [path, contents] of entries) {
+    const data = Buffer.from(contents);
+    const header = Buffer.alloc(TAR_BLOCK_BYTES);
+    header.write(path, 0, 100, "utf8");
+    writeTarOctal(header, 100, 8, 0o644);
+    writeTarOctal(header, 108, 8, 0);
+    writeTarOctal(header, 116, 8, 0);
+    writeTarOctal(header, 124, 12, data.length);
+    writeTarOctal(header, 136, 12, 0);
+    header.fill(0x20, 148, 156);
+    header.write("0", 156, 1, "ascii");
+    header.write("ustar\0", 257, 6, "ascii");
+    header.write("00", 263, 2, "ascii");
+    let checksum = 0;
+    for (const byte of header) checksum += byte;
+    header.write(`${checksum.toString(8).padStart(6, "0")}\0 `, 148, 8, "ascii");
+    blocks.push(header, data);
+    const paddingBytes = (TAR_BLOCK_BYTES - (data.length % TAR_BLOCK_BYTES)) % TAR_BLOCK_BYTES;
+    if (paddingBytes > 0) blocks.push(Buffer.alloc(paddingBytes));
+  }
+  blocks.push(Buffer.alloc(TAR_BLOCK_BYTES * 2));
+  return Buffer.concat(blocks);
+}
+
+function minimalManifest(overrides: Partial<NpmPublishManifest> = {}): NpmPublishManifest {
+  return {
+    name: "@kitsunekode/kunai",
+    version: TEST_VERSION,
+    type: "module",
+    bin: { kunai: "dist/npm-launcher.mjs" },
+    files: ["dist/npm-launcher.mjs", "LICENSE", "README.md"],
+    engines: { node: ">=18.17" },
+    license: "MIT",
+    optionalDependencies: Object.fromEntries(
+      RELEASE_BINARY_TARGETS.map((target) => [`@kitsunekode/kunai-${target.id}`, TEST_VERSION]),
+    ),
+    publishConfig: { access: "public", provenance: true },
+    ...overrides,
+  };
+}
+
+async function withFixtureTarball(
+  files: ReadonlyMap<string, string>,
+  run: (path: string) => Promise<void>,
+): Promise<void> {
+  const directory = mkdtempSync(join(tmpdir(), "kunai-npm-tarball-test-"));
+  const path = join(directory, "candidate.tgz");
+  try {
+    const tarBytes = await new Bun.Archive(Object.fromEntries(files)).bytes();
+    await Bun.write(path, gzipSync(tarBytes));
+    await run(path);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+async function withOrderedFixtureTarball(
+  entries: readonly (readonly [path: string, contents: string])[],
+  run: (path: string) => Promise<void>,
+): Promise<void> {
+  const directory = mkdtempSync(join(tmpdir(), "kunai-npm-ordered-tarball-test-"));
+  const path = join(directory, "candidate.tgz");
+  try {
+    await Bun.write(path, gzipSync(fixtureTar(entries)));
+    await run(path);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function fixtureFiles(
+  overrides: readonly (readonly [path: string, contents: string | null])[] = [],
+): ReadonlyMap<string, string> {
+  const files = new Map<string, string>([
+    ["package/package.json", JSON.stringify(minimalManifest())],
+    ["package/LICENSE", "MIT\n"],
+    ["package/README.md", "# Kunai\n"],
+    ["package/dist/npm-launcher.mjs", "#!/usr/bin/env node\n"],
+  ]);
+  for (const [path, contents] of overrides) {
+    if (contents === null) files.delete(path);
+    else files.set(path, contents);
+  }
+  return files;
+}
 
 describe("forbiddenNpmPackPath", () => {
   test("allows the launcher and package metadata", () => {
@@ -129,55 +233,135 @@ npm notice unpacked size: 19.4 kB
 });
 
 describe("assertNpmPublishManifest", () => {
-  const minimalManifest = {
-    bin: { kunai: "dist/npm-launcher.mjs" },
-    files: ["dist/npm-launcher.mjs", "LICENSE", "README.md"],
-    engines: { node: ">=18.17" },
-    license: "MIT",
-    publishConfig: { access: "public", provenance: true },
-  };
-
   test("accepts the Node-only launcher entrypoints", () => {
-    expect(() => assertNpmPublishManifest(minimalManifest)).not.toThrow();
+    expect(() => assertNpmPublishManifest(minimalManifest(), TEST_VERSION)).not.toThrow();
   });
 
   test("rejects workspace runtime metadata and source entrypoints", () => {
     expect(() =>
-      assertNpmPublishManifest({
-        ...minimalManifest,
-        dependencies: { ink: "workspace:*" },
-        peerDependencies: { typescript: "workspace:*" },
-        module: "dist/kunai.js",
-        engines: { bun: ">=1.3.9" },
-        bin: { kunai: "dist/kunai.mjs" },
-      }),
+      assertNpmPublishManifest(
+        minimalManifest({
+          dependencies: { ink: "workspace:*" },
+          peerDependencies: { typescript: "workspace:*" },
+          module: "dist/kunai.js",
+          engines: { bun: ">=1.3.9" },
+          bin: { kunai: "dist/kunai.mjs" },
+        }),
+        TEST_VERSION,
+      ),
     ).toThrow(/runtime or peer dependencies/);
   });
 
   test("rejects missing release policy and lifecycle scripts", () => {
-    expect(() => assertNpmPublishManifest({ ...minimalManifest, license: undefined })).toThrow(
-      /MIT/,
-    );
     expect(() =>
-      assertNpmPublishManifest({ ...minimalManifest, publishConfig: undefined }),
+      assertNpmPublishManifest(minimalManifest({ license: undefined }), TEST_VERSION),
+    ).toThrow(/MIT/);
+    expect(() =>
+      assertNpmPublishManifest(minimalManifest({ publishConfig: undefined }), TEST_VERSION),
     ).toThrow(/public/);
     expect(() =>
-      assertNpmPublishManifest({
-        ...minimalManifest,
-        scripts: { postinstall: "node dist/postinstall.js" },
-      }),
+      assertNpmPublishManifest(
+        minimalManifest({ scripts: { postinstall: "node dist/postinstall.js" } }),
+        TEST_VERSION,
+      ),
     ).toThrow(/lifecycle/);
+  });
+
+  test("requires the exact package identity and platform dependency set", () => {
+    expect(() =>
+      assertNpmPublishManifest(minimalManifest({ name: "kunai" }), TEST_VERSION),
+    ).toThrow(/name/);
+    expect(() =>
+      assertNpmPublishManifest(minimalManifest({ version: "9.8.6" }), TEST_VERSION),
+    ).toThrow(/version/);
+    expect(() =>
+      assertNpmPublishManifest(minimalManifest({ optionalDependencies: {} }), TEST_VERSION),
+    ).toThrow(/optional dependencies/);
+  });
+});
+
+describe("verifyPreservedNpmTarball", () => {
+  test("accepts the exact four-file Bun-packed launcher tarball", async () => {
+    await withFixtureTarball(fixtureFiles(), async (path) => {
+      const summary = await verifyPreservedNpmTarball(path, TEST_VERSION);
+      expect(summary.paths).toEqual([
+        "LICENSE",
+        "README.md",
+        "dist/npm-launcher.mjs",
+        "package.json",
+      ]);
+      expect(summary.packedBytes).toBeGreaterThan(0);
+      expect(summary.unpackedBytes).toBeGreaterThan(0);
+    });
+  });
+
+  test("rejects the preserved artifact when README is missing", async () => {
+    await withFixtureTarball(fixtureFiles([["package/README.md", null]]), async (path) => {
+      await expect(verifyPreservedNpmTarball(path, TEST_VERSION)).rejects.toThrow("README.md");
+    });
+  });
+
+  test("rejects an extra source file or compiled binary in the exact artifact", async () => {
+    for (const forbiddenPath of ["package/src/main.ts", "package/dist/bin/kunai-linux-x64"]) {
+      await withFixtureTarball(fixtureFiles([[forbiddenPath, "forbidden\n"]]), async (path) => {
+        await expect(verifyPreservedNpmTarball(path, TEST_VERSION)).rejects.toThrow(
+          /forbidden paths/,
+        );
+      });
+    }
+  });
+
+  test("validates the manifest embedded in the preserved bytes", async () => {
+    const embedded = JSON.stringify(
+      minimalManifest({ scripts: { postinstall: "node dist/postinstall.js" } }),
+    );
+    await withFixtureTarball(fixtureFiles([["package/package.json", embedded]]), async (path) => {
+      await expect(verifyPreservedNpmTarball(path, TEST_VERSION)).rejects.toThrow(/lifecycle/);
+    });
+  });
+
+  test("rejects duplicate archive members before path-keyed extraction can collapse them", async () => {
+    const entries = [...fixtureFiles().entries(), ["package/README.md", "replacement\n"]] as const;
+    await withOrderedFixtureTarball(entries, async (path) => {
+      await expect(verifyPreservedNpmTarball(path, TEST_VERSION)).rejects.toThrow(
+        /duplicate.*package\/README\.md/i,
+      );
+    });
+  });
+
+  test("rejects duplicate manifests even when the surviving copy is policy-safe", async () => {
+    const unsafeManifest = JSON.stringify(
+      minimalManifest({ scripts: { postinstall: "node dist/postinstall.js" } }),
+    );
+    const entries = [
+      ["package/package.json", unsafeManifest],
+      ...[...fixtureFiles().entries()].filter(([path]) => path !== "package/package.json"),
+      ["package/package.json", JSON.stringify(minimalManifest())],
+    ] as const;
+    await withOrderedFixtureTarball(entries, async (path) => {
+      await expect(verifyPreservedNpmTarball(path, TEST_VERSION)).rejects.toThrow(
+        /duplicate.*package\/package\.json/i,
+      );
+    });
+  });
+
+  test("bounds decompression before a compressed artifact can exceed the unpacked budget", async () => {
+    const entries = [...fixtureFiles().entries()].map(([path, contents]) =>
+      path === "package/README.md"
+        ? ([path, "x".repeat(NPM_PACK_UNPACKED_BUDGET_BYTES * 2)] as const)
+        : ([path, contents] as const),
+    );
+    await withOrderedFixtureTarball(entries, async (path) => {
+      await expect(verifyPreservedNpmTarball(path, TEST_VERSION)).rejects.toThrow(
+        /could not be read.*larger than/i,
+      );
+    });
   });
 });
 
 describe("platform package contract", () => {
   test("every optionalDependency is a platform package pinned to this exact version", async () => {
-    const cli = (await import("../../../package.json", { with: { type: "json" } })).default as {
-      version: string;
-      optionalDependencies?: Record<string, string>;
-      bin?: Record<string, string>;
-    };
-    const optional = cli.optionalDependencies ?? {};
+    const optional = cliPackage.optionalDependencies ?? {};
 
     // The launcher resolves `@kitsunekode/kunai-<targetId>` at runtime. Version
     // skew between the launcher and its platform packages is the classic failure
@@ -185,20 +369,15 @@ describe("platform package contract", () => {
     expect(Object.keys(optional).length).toBeGreaterThan(0);
     for (const [name, range] of Object.entries(optional)) {
       expect(name.startsWith("@kitsunekode/kunai-"), name).toBe(true);
-      expect(range, name).toBe(cli.version);
+      expect(range, name).toBe(cliPackage.version);
     }
 
     // bin must be the Node launcher, never the Bun bundle.
-    expect(cli.bin?.kunai).toBe("dist/kunai.mjs");
+    expect(cliPackage.bin?.kunai).toBe("dist/kunai.mjs");
   });
 
   test("optionalDependencies cover exactly the published binary targets", async () => {
-    const { RELEASE_BINARY_TARGETS } = await import("../../../src/services/update/platform-assets");
-    const cli = (await import("../../../package.json", { with: { type: "json" } })).default as {
-      optionalDependencies?: Record<string, string>;
-    };
-
-    const declared = Object.keys(cli.optionalDependencies ?? {}).sort();
+    const declared = Object.keys(cliPackage.optionalDependencies ?? {}).sort();
     const expected = RELEASE_BINARY_TARGETS.map((t) => `@kitsunekode/kunai-${t.id}`).sort();
     // A target built but not declared is unreachable from npm; a target declared
     // but not built resolves to a package that will never be published.


### PR DESCRIPTION
## Summary

- verifies the exact preserved npm launcher tarball before upload and after protected download
- enforces the canonical four-file package contract
- rejects missing README, scripts, dependencies, workspace paths, binaries, and extra files

Closes #133.

## Stack

Depends on the anti-slop PR.

## Verification

- preserved tarball contract fixtures
- hermetic npm candidate checks
- full typecheck, lint, format, test, and build gates

No package is published by this PR.