### PR TITLE
fix(installer): select native arm64 under Rosetta

### DIFF
--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -44,6 +44,43 @@ async function runInstallShAsync(
   return { status, stdout, stderr };
 }
 
+type DarwinSysctlFixture = "missing" | "failing" | "0" | "1" | "unexpected";
+
+function runInstallShForDarwin(
+  machine: "arm64" | "x86_64",
+  sysctlFixture?: DarwinSysctlFixture,
+): { status: number | null; stdout: string; stderr: string } {
+  const sandbox = createInstallerSandbox(`install-sh-darwin-${machine}`);
+  try {
+    const shimDir = join(sandbox.root, "shims");
+    mkdirSync(shimDir, { recursive: true });
+    installCommandShim(
+      shimDir,
+      "uname",
+      `#!/bin/sh\nif [ "$1" = "-s" ]; then echo Darwin; else echo ${machine}; fi\n`,
+    );
+    if (sysctlFixture === "failing") {
+      installCommandShim(shimDir, "sysctl", "#!/bin/sh\nexit 2\n");
+    } else if (sysctlFixture !== undefined && sysctlFixture !== "missing") {
+      installCommandShim(shimDir, "sysctl", `#!/bin/sh\necho ${sysctlFixture}\n`);
+    }
+
+    let path = `${shimDir}${delimiter}${sandbox.env.PATH ?? ""}`;
+    if (sysctlFixture === "missing") {
+      installCommandShim(shimDir, "bash", '#!/bin/sh\nexec /bin/bash "$@"\n');
+      installCommandShim(shimDir, "cat", '#!/bin/sh\nexec /bin/cat "$@"\n');
+      path = shimDir;
+    }
+
+    return runInstallSh(["--dry-run", "--yes", "--skip-deps", "--version", "9.8.7"], {
+      ...sandbox.env,
+      PATH: path,
+    });
+  } finally {
+    sandbox.cleanup();
+  }
+}
+
 describe("install.sh dry-run", () => {
   test("prints the binary install plan without downloading", () => {
     const result = spawnSync("bash", [INSTALL_SH, "--dry-run", "--yes"], {
@@ -112,6 +149,42 @@ describe("install.sh dry-run", () => {
     } finally {
       sandbox.cleanup();
     }
+  });
+
+  test("macOS arm64 selects and reports the darwin-arm64 target", () => {
+    const result = runInstallShForDarwin("arm64");
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Detected native target: darwin-arm64");
+    expect(result.stdout).toContain("Downloading kunai-darwin-arm64");
+  });
+
+  test("Intel macOS selects and reports the darwin-x64 target", () => {
+    const result = runInstallShForDarwin("x86_64", "0");
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Detected native target: darwin-x64");
+    expect(result.stdout).toContain("Downloading kunai-darwin-x64");
+  });
+
+  test("Rosetta-translated macOS selects the native darwin-arm64 target", () => {
+    const result = runInstallShForDarwin("x86_64", "1");
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Detected native target: darwin-arm64");
+    expect(result.stdout).toContain("Downloading kunai-darwin-arm64");
+  });
+
+  test.each<readonly [string, DarwinSysctlFixture]>([
+    ["missing", "missing"],
+    ["failing", "failing"],
+    ["non-1", "unexpected"],
+  ])("%s Rosetta sysctl output safely retains darwin-x64", (_case, sysctlFixture) => {
+    const result = runInstallShForDarwin("x86_64", sysctlFixture);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Detected native target: darwin-x64");
+    expect(result.stdout).toContain("Downloading kunai-darwin-x64");
   });
 
   test("rejects lifecycle flags — use kunai upgrade / kunai uninstall instead", () => {

--- a/install.sh
+++ b/install.sh
@@ -686,12 +686,18 @@ read_previous_active_version() {
 }
 
 install_binary() {
-	local os arch asset base url sums resolved_version version_path versions_dir
+	local os arch translated asset base url sums resolved_version version_path versions_dir
 	local staging txn_id txn_path lock_path staged_bin staged_sums want got size_bytes
 	local target previous kind metadata_path cleanup_done=0
 
 	os="$(detect_os)"
 	arch="$(detect_arch)"
+	# Rosetta reports its translated process as x86_64; only Apple's exact
+	# translated marker is enough evidence to select the native arm64 build.
+	if [[ "$os" == darwin && "$arch" == x64 ]]; then
+		translated="$(sysctl -n sysctl.proc_translated 2>/dev/null || true)"
+		[[ "$translated" == 1 ]] && arch="arm64"
+	fi
 	if [[ "$os" == unknown || "$arch" == unknown ]]; then
 		err "No prebuilt binary for this OS/arch ($(uname -s)/$(uname -m))."
 		err "Supported: linux|darwin x x64|arm64. Try --method npm or --method source."
@@ -705,6 +711,7 @@ install_binary() {
 		target="${os}-${arch}"
 		[[ "$os" == linux ]] && target="linux-${arch}-gnu"
 	fi
+	[[ "$DRY" == 1 ]] && info "Detected native target: $target"
 
 	# Validate pinned versions before any filesystem mutation or network I/O.
 	if [[ "$VERSION" != latest ]]; then


### PR DESCRIPTION
## Summary

- detects translated macOS x64 shells with sysctl.proc_translated
- routes Apple Silicon users to the native darwin-arm64 binary
- preserves conservative Intel and missing-sysctl fallback behavior

Closes #131.

## Stack

Depends on the exact npm candidate PR.

## Verification

- injected Darwin arm64, Intel x64, and Rosetta cases
- Linux glibc and musl regression coverage
- full repository gates and installer integration tests

No release is performed by this PR.