### PR TITLE
feat(release): build deterministic native archives

### DIFF
--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -36,6 +36,8 @@ Expected result:
 - unit and integration tests report 0 failures
 - typecheck exits 0
 - build writes `apps/cli/dist/kunai.js` and the host compiled binary under `apps/cli/dist/bin/`
+- an all-target release build writes exactly eight deterministic archives,
+  eight preserved raw binaries, `SHA256SUMS`, and `SHA256SUMS.archives`
 - package check rejects `dist/bin/**`, source/maps, analyze metafiles, lifecycle scripts, dependency drift, and oversized launcher tarballs
 - release dry-run completes build, checks, and packability without publishing
 
@@ -44,6 +46,19 @@ The release workflow additionally opens the exact preserved
 upload and after protected-job download. It must contain only `package.json`,
 `LICENSE`, `README.md`, and `dist/npm-launcher.mjs` under `package/`; publication
 uses those same verified bytes rather than repacking them.
+
+For native release assets, the legacy `SHA256SUMS` name continues to cover the
+eight raw compatibility binaries because already-published installers and
+updaters request it. `SHA256SUMS.archives` separately covers the eight
+archives. Verification rejects
+missing, duplicate, unexpected, empty, oversized, hash-mismatched, or
+non-canonical assets. A canonical archive has one entry whose name is the raw
+asset name and no directory prefix; tar metadata is normalized with executable
+mode `0755`, while zip records that Unix mode but Windows extraction does not
+promise to restore it. Archive consumers are intentionally outside the first
+creation/verification slice. This builder slice does not close issue #132 and
+does not yet reduce user downloads: 0.3.0 release dispatch remains blocked until
+the installer/updater archive-consumption stack lands and is verified.
 
 ## Changelog Gate
 

--- a/.docs/repo-infrastructure.md
+++ b/.docs/repo-infrastructure.md
@@ -132,10 +132,28 @@ Install cache key: `${{ runner.os }}-bun-store-${{ hashFiles('bun.lock') }}` cov
 
 - `build` — npm bundle (`dist/kunai.js`, `dist/assets/**`)
 - `build:binary:host` — host compiled binary (`dist/bin/kunai-*`)
-- `build:binaries` — release cross-compiles (`dist/bin/**`)
+- `build:binaries` — release cross-compiles plus deterministic archives
+  (`dist/bin/**`): `.tar.gz` for Linux/macOS, `.zip` for Windows
 
 `bun run build` at the repo root runs `build` + `build:binary:host` in parallel.
 Compiled binaries never ship on npm; `pkg:check` enforces an allowlist and size budget.
+
+The 0.3.0 GitHub Release compatibility bridge is an exact 18-file set: eight
+canonical archives, the same eight raw standalone binaries, legacy
+`SHA256SUMS` for raw binaries, and `SHA256SUMS.archives` for archives. Keeping
+raw hashes under the legacy name preserves already-published installer/updater
+compatibility. Each archive contains exactly
+one member named after its raw asset. Tar members have normalized uid/gid/mtime
+and mode `0755`; zip members carry normalized DOS timestamps and Unix mode
+metadata, although Windows zip extraction does not restore POSIX executable
+bits. The build reconstructs and byte-compares each archive after preservation,
+then release confirmation and publication reverify the same bytes without a
+rebuild.
+
+Installer/updater archive consumption is a separate stacked change. Until that
+lands, they still follow the functional legacy raw-asset path. This builder
+slice does not close issue #132 or reduce end-user downloads; do not dispatch
+0.3.0 from the archive-creation slice alone.
 
 ### Windows parity
 

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -10,8 +10,13 @@ on:
     branches: [main]
     paths:
       - "apps/cli/scripts/build-binaries.ts"
+      - "apps/cli/scripts/build-release-archives.ts"
       - "apps/cli/scripts/build-shared.ts"
       - "apps/cli/scripts/verify-release-binaries.sh"
+      - "apps/cli/src/services/update/platform-assets.ts"
+      - "scripts/release-asset-contract.ts"
+      - "scripts/verify-release-artifact-directory.ts"
+      - "turbo.json"
       - ".github/workflows/build-binaries.yml"
 
 concurrency:
@@ -54,11 +59,20 @@ jobs:
           if-no-files-found: error
           path: |
             apps/cli/dist/bin/kunai-linux-x64
+            apps/cli/dist/bin/kunai-linux-x64.tar.gz
             apps/cli/dist/bin/kunai-linux-arm64
+            apps/cli/dist/bin/kunai-linux-arm64.tar.gz
             apps/cli/dist/bin/kunai-linux-x64-musl
+            apps/cli/dist/bin/kunai-linux-x64-musl.tar.gz
             apps/cli/dist/bin/kunai-linux-arm64-musl
+            apps/cli/dist/bin/kunai-linux-arm64-musl.tar.gz
             apps/cli/dist/bin/kunai-darwin-x64
+            apps/cli/dist/bin/kunai-darwin-x64.tar.gz
             apps/cli/dist/bin/kunai-darwin-arm64
+            apps/cli/dist/bin/kunai-darwin-arm64.tar.gz
             apps/cli/dist/bin/kunai-windows-x64.exe
+            apps/cli/dist/bin/kunai-windows-x64.zip
             apps/cli/dist/bin/kunai-windows-arm64.exe
+            apps/cli/dist/bin/kunai-windows-arm64.zip
             apps/cli/dist/bin/SHA256SUMS
+            apps/cli/dist/bin/SHA256SUMS.archives

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,8 +592,11 @@ jobs:
           retention-days: 1
           path: |
             apps/cli/dist/bin/kunai-linux-x64
+            apps/cli/dist/bin/kunai-linux-x64.tar.gz
             apps/cli/dist/bin/kunai-linux-x64-musl
+            apps/cli/dist/bin/kunai-linux-x64-musl.tar.gz
             apps/cli/dist/bin/SHA256SUMS
+            apps/cli/dist/bin/SHA256SUMS.archives
 
   installer-docker:
     name: Native installer ${{ matrix.scenario }} / ${{ matrix.variant }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ on:
       - "scripts/release-changelog.ts"
       - "scripts/generate-release-notes.ts"
       - "scripts/release-binary-checksums.ts"
+      - "scripts/release-asset-contract.ts"
+      - "scripts/verify-release-artifact-directory.ts"
+      - "scripts/verify-github-release-assets.ts"
       - "scripts/release-guard.ts"
       - "scripts/release-confirmation-gate.ts"
       - "scripts/set-release-status.ts"
@@ -214,14 +217,23 @@ jobs:
           cp ".release-candidate/${NPM_TARBALL_NAME}" .candidate-upload/
           cp -R .release-candidate/npm-platform .candidate-upload/npm-platform
           cp apps/cli/dist/bin/kunai-linux-x64 \
+            apps/cli/dist/bin/kunai-linux-x64.tar.gz \
             apps/cli/dist/bin/kunai-linux-arm64 \
+            apps/cli/dist/bin/kunai-linux-arm64.tar.gz \
             apps/cli/dist/bin/kunai-linux-x64-musl \
+            apps/cli/dist/bin/kunai-linux-x64-musl.tar.gz \
             apps/cli/dist/bin/kunai-linux-arm64-musl \
+            apps/cli/dist/bin/kunai-linux-arm64-musl.tar.gz \
             apps/cli/dist/bin/kunai-darwin-x64 \
+            apps/cli/dist/bin/kunai-darwin-x64.tar.gz \
             apps/cli/dist/bin/kunai-darwin-arm64 \
+            apps/cli/dist/bin/kunai-darwin-arm64.tar.gz \
             apps/cli/dist/bin/kunai-windows-x64.exe \
+            apps/cli/dist/bin/kunai-windows-x64.zip \
             apps/cli/dist/bin/kunai-windows-arm64.exe \
+            apps/cli/dist/bin/kunai-windows-arm64.zip \
             apps/cli/dist/bin/SHA256SUMS \
+            apps/cli/dist/bin/SHA256SUMS.archives \
             .candidate-upload/
 
       - name: Emit candidate gate evidence
@@ -726,15 +738,32 @@ jobs:
           set -euo pipefail
           mkdir -p apps/cli/dist/bin
           cp .release-download/kunai-linux-x64 \
+            .release-download/kunai-linux-x64.tar.gz \
             .release-download/kunai-linux-arm64 \
+            .release-download/kunai-linux-arm64.tar.gz \
             .release-download/kunai-linux-x64-musl \
+            .release-download/kunai-linux-x64-musl.tar.gz \
             .release-download/kunai-linux-arm64-musl \
+            .release-download/kunai-linux-arm64-musl.tar.gz \
             .release-download/kunai-darwin-x64 \
+            .release-download/kunai-darwin-x64.tar.gz \
             .release-download/kunai-darwin-arm64 \
+            .release-download/kunai-darwin-arm64.tar.gz \
             .release-download/kunai-windows-x64.exe \
+            .release-download/kunai-windows-x64.zip \
             .release-download/kunai-windows-arm64.exe \
+            .release-download/kunai-windows-arm64.zip \
             .release-download/SHA256SUMS \
+            .release-download/SHA256SUMS.archives \
             apps/cli/dist/bin/
+
+      - name: Reverify preserved release artifacts
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.candidate.outputs.version }}"
+          bun run scripts/verify-release-artifact-directory.ts \
+            apps/cli/dist/bin \
+            --expected-version "${VERSION}"
 
       - name: Download every gate evidence document and hashed artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
@@ -851,14 +880,23 @@ jobs:
           set -euo pipefail
           mkdir -p apps/cli/dist/bin .release-candidate
           cp .release-download/kunai-linux-x64 \
+            .release-download/kunai-linux-x64.tar.gz \
             .release-download/kunai-linux-arm64 \
+            .release-download/kunai-linux-arm64.tar.gz \
             .release-download/kunai-linux-x64-musl \
+            .release-download/kunai-linux-x64-musl.tar.gz \
             .release-download/kunai-linux-arm64-musl \
+            .release-download/kunai-linux-arm64-musl.tar.gz \
             .release-download/kunai-darwin-x64 \
+            .release-download/kunai-darwin-x64.tar.gz \
             .release-download/kunai-darwin-arm64 \
+            .release-download/kunai-darwin-arm64.tar.gz \
             .release-download/kunai-windows-x64.exe \
+            .release-download/kunai-windows-x64.zip \
             .release-download/kunai-windows-arm64.exe \
+            .release-download/kunai-windows-arm64.zip \
             .release-download/SHA256SUMS \
+            .release-download/SHA256SUMS.archives \
             apps/cli/dist/bin/
           cp .release-download/kunai-npm.tgz .release-candidate/kunai-npm.tgz
           cp -R .release-download/npm-platform .release-candidate/npm-platform
@@ -974,14 +1012,23 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             apps/cli/dist/bin/kunai-linux-x64
+            apps/cli/dist/bin/kunai-linux-x64.tar.gz
             apps/cli/dist/bin/kunai-linux-arm64
+            apps/cli/dist/bin/kunai-linux-arm64.tar.gz
             apps/cli/dist/bin/kunai-linux-x64-musl
+            apps/cli/dist/bin/kunai-linux-x64-musl.tar.gz
             apps/cli/dist/bin/kunai-linux-arm64-musl
+            apps/cli/dist/bin/kunai-linux-arm64-musl.tar.gz
             apps/cli/dist/bin/kunai-darwin-x64
+            apps/cli/dist/bin/kunai-darwin-x64.tar.gz
             apps/cli/dist/bin/kunai-darwin-arm64
+            apps/cli/dist/bin/kunai-darwin-arm64.tar.gz
             apps/cli/dist/bin/kunai-windows-x64.exe
+            apps/cli/dist/bin/kunai-windows-x64.zip
             apps/cli/dist/bin/kunai-windows-arm64.exe
+            apps/cli/dist/bin/kunai-windows-arm64.zip
             apps/cli/dist/bin/SHA256SUMS
+            apps/cli/dist/bin/SHA256SUMS.archives
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -150,9 +150,20 @@ Job **`candidate`** (no publish):
 
 1. Asserts `inputs.version` equals `apps/cli/package.json` `version`
 2. `bun run ci` → `build` → `pkg:check` → real npm global install → `guard` → `release:notes:check`
-3. Builds all 8 release binaries, verifies them, runs compiled binary smoke
+3. Builds all 8 release binaries plus their deterministic archives, verifies
+   the exact 18 native assets, and runs compiled binary smoke
 4. `bun run release:pack` → `.release-candidate/kunai-npm.tgz`
-5. Uploads artifact `kunai-release-candidate-<version>` (8 binaries + `SHA256SUMS` + `kunai-npm.tgz`, 14-day retention)
+5. Uploads artifact `kunai-release-candidate-<version>` (8 archives + 8 raw
+   binaries + `SHA256SUMS` + `SHA256SUMS.archives` + preserved npm artifacts,
+   14-day retention)
+
+For the 0.3.0 compatibility bridge, legacy `SHA256SUMS` continues to hash raw
+standalone binaries so already-published installers and updaters remain
+functional. `SHA256SUMS.archives` hashes archives. Archive creation is only the
+first stacked layer: this slice does not close issue #132 or reduce user
+downloads. Installers and the in-app updater still consume raw assets until the
+archive-aware follow-up lands. Do not dispatch a release from the
+archive-creation layer alone.
 
 `release:pack` is:
 
@@ -185,7 +196,7 @@ Job **`publish`** needs `confirmation` and declares `environment: release-produc
 3. `bun publish .release-candidate/kunai-npm.tgz --access public`
 4. Retries `npm view @kitsunekode/kunai@<version>` until visible
 5. Creates annotated tag `v<version>` and pushes it
-6. Creates a **draft** GitHub release (`make_latest: false`) with the nine required assets
+6. Creates a **draft** GitHub release (`make_latest: false`) with the 18 required native assets
 7. `bun run scripts/verify-github-release-assets.ts <tag> --expect-draft …`
 8. Promotes: `gh release edit <tag> --draft=false --latest`
 9. Verifies the public release assets again
@@ -238,11 +249,17 @@ git push
 - **CI** (`.github/workflows/ci.yml`): parallel Turbo jobs; installer Docker smoke when installer paths change.
 - `version:packages` runs `changeset version`, mirrors changelog, and regenerates `.release/kunai-v*.md` / `.json` via `bun run release:notes`.
 
-**npm vs GitHub Release artifacts:** npm publishes the preserved `kunai-npm.tgz` (allowlisted `dist/kunai.js` + `dist/assets/**`). Standalone binaries ship only via the GitHub release — `bun run pkg:check` fails if `dist/bin/` appears in the npm tarball.
+**npm vs GitHub Release artifacts:** npm publishes the preserved
+`kunai-npm.tgz` (allowlisted launcher files only). The eight archives and eight
+raw standalone binaries ship only via the GitHub release — `bun run pkg:check`
+fails if `dist/bin/` appears in the npm tarball.
 
 ## GitHub release tags
 
-Prefer tag `vX.Y.Z` created by the **publish** job with the nine required assets (8 binaries + `SHA256SUMS`). Release notes body comes from `.release/kunai-vX.Y.Z.md`. Avoid duplicate `@kitsunekode/kunai@X.Y.Z` releases with empty bodies.
+Prefer tag `vX.Y.Z` created by the **publish** job with the 18 required native
+assets (8 archives + 8 raw binaries + 2 checksum manifests). Release notes body
+comes from `.release/kunai-vX.Y.Z.md`. Avoid duplicate
+`@kitsunekode/kunai@X.Y.Z` releases with empty bodies.
 
 ## Local release utilities
 

--- a/apps/cli/scripts/build-binaries.ts
+++ b/apps/cli/scripts/build-binaries.ts
@@ -13,17 +13,18 @@
 //   bun run scripts/build-binaries.ts
 //   bun run scripts/build-binaries.ts --only linux-x64 --only linux-x64-musl
 //   bun run scripts/build-binaries.ts --jobs 4 --analyze
+//   bun run scripts/build-binaries.ts --output-directory /tmp/kunai-binaries
 
-import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { chmod, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
 
 import {
   mergeReleaseNotesChecksums,
   shouldWriteReleaseChecksums,
 } from "../../../scripts/release-binary-checksums.ts";
 import { RELEASE_BINARY_TARGETS } from "../src/services/update/platform-assets";
+import { buildReleaseArchives } from "./build-release-archives";
 import {
   assertNoForbiddenReleaseInputs,
   compileBinaryBuildOptions,
@@ -38,12 +39,16 @@ import {
 
 const ROOT = join(import.meta.dirname, "..");
 const REPO_ROOT = join(ROOT, "../..");
-const OUT = join(ROOT, "dist/bin");
+const DEFAULT_OUT = join(ROOT, "dist/bin");
 
-async function sha256(path: string): Promise<string> {
-  return createHash("sha256")
-    .update(await readFile(path))
-    .digest("hex");
+function resolveOutputDirectory(): string {
+  for (let index = 0; index < process.argv.length; index++) {
+    if (process.argv[index] !== "--output-directory") continue;
+    const value = process.argv[index + 1];
+    if (!value) throw new Error("[binaries] --output-directory requires a path");
+    return resolve(value);
+  }
+  return DEFAULT_OUT;
 }
 
 function selectedTargets() {
@@ -68,17 +73,6 @@ function selectedTargets() {
   return match;
 }
 
-async function rewriteChecksums(): Promise<void> {
-  const sums: string[] = [];
-  for (const target of RELEASE_BINARY_TARGETS) {
-    const outfile = join(OUT, target.out);
-    if (existsSync(outfile)) {
-      sums.push(`${await sha256(outfile)}  ${target.out}`);
-    }
-  }
-  await writeFile(join(OUT, "SHA256SUMS"), sums.length ? `${sums.join("\n")}\n` : "");
-}
-
 type CompileResult = {
   readonly target: (typeof RELEASE_BINARY_TARGETS)[number];
   readonly bytes: number;
@@ -88,8 +82,9 @@ type CompileResult = {
 async function compileTarget(
   target: (typeof RELEASE_BINARY_TARGETS)[number],
   analyze: boolean,
+  outputDirectory: string,
 ): Promise<CompileResult> {
-  const outfile = join(OUT, target.out);
+  const outfile = join(outputDirectory, target.out);
   console.log(`[binaries] compiling ${target.out} (${target.triple}) ...`);
 
   const result = await Bun.build(
@@ -105,7 +100,7 @@ async function compileTarget(
   assertNoForbiddenReleaseInputs(metafile);
 
   if (analyze) {
-    const metaPath = join(OUT, `${target.out}.meta.json`);
+    const metaPath = join(outputDirectory, `${target.out}.meta.json`);
     await writeFile(metaPath, `${JSON.stringify(metafile, null, 2)}\n`);
     console.log(`[binaries] wrote ${metaPath}`);
     for (const input of topReleaseInputs(metafile, 8)) {
@@ -130,20 +125,27 @@ async function main(): Promise<void> {
   const incremental = process.argv.includes("--only");
   const analyze = process.argv.includes("--analyze") || process.env.KUNAI_BUILD_ANALYZE === "1";
   const jobs = resolveBuildConcurrency(process.argv);
+  const out = resolveOutputDirectory();
 
   if (!incremental) {
-    await rm(OUT, { recursive: true, force: true });
+    if (out === DEFAULT_OUT) {
+      await rm(out, { recursive: true, force: true });
+    } else if (existsSync(out)) {
+      throw new Error(
+        `[binaries] custom --output-directory must not exist before an all-target build: ${out}`,
+      );
+    }
   }
-  await mkdir(OUT, { recursive: true });
+  await mkdir(out, { recursive: true });
 
   const results = await mapWithConcurrency(targets, jobs, (target) =>
-    compileTarget(target, analyze),
+    compileTarget(target, analyze, out),
   );
 
-  await rewriteChecksums();
+  const retainedTargets = buildReleaseArchives(out, targets);
 
   const builtAllTargets = targets.length === RELEASE_BINARY_TARGETS.length;
-  if (builtAllTargets && existsSync(join(OUT, "SHA256SUMS"))) {
+  if (builtAllTargets && existsSync(join(out, "SHA256SUMS"))) {
     if (!shouldWriteReleaseChecksums()) {
       console.log(
         "[binaries] skipped release-notes checksum merge: local build " +
@@ -158,7 +160,7 @@ async function main(): Promise<void> {
           mergeReleaseNotesChecksums({
             repoRoot: REPO_ROOT,
             version: version.version,
-            checksumsPath: join(OUT, "SHA256SUMS"),
+            checksumsPath: join(out, "SHA256SUMS"),
           });
           console.log(`[binaries] merged SHA256SUMS into .release/kunai-v${version.version}.json`);
         } catch (error) {
@@ -180,11 +182,10 @@ async function main(): Promise<void> {
     `[binaries] bundled app graph ~${graphKiB} KiB total across targets; remainder of each file is the embedded Bun runtime.`,
   );
 
-  const built = (await readdir(OUT).catch(() => [])).filter(
-    (f) => f !== "SHA256SUMS" && !f.endsWith(".meta.json"),
-  ).length;
   const ms = Date.now() - start;
-  console.log(`[binaries] wrote ${built} binaries + SHA256SUMS to ${OUT} (${ms}ms)`);
+  console.log(
+    `[binaries] wrote ${results.length} binaries; reconciled ${retainedTargets.length} archive/raw target pairs + 2 manifests in ${out} (${ms}ms)`,
+  );
 }
 
 await main();

--- a/apps/cli/scripts/build-release-archives.ts
+++ b/apps/cli/scripts/build-release-archives.ts
@@ -1,0 +1,336 @@
+#!/usr/bin/env bun
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { deflateRawSync } from "node:zlib";
+
+import {
+  RELEASE_BINARY_TARGETS,
+  type ReleaseBinaryTarget,
+} from "../src/services/update/platform-assets";
+
+const DEFAULT_DIRECTORY = join(import.meta.dirname, "../dist/bin");
+const encoder = new TextEncoder();
+const CRC32_TABLE = Uint32Array.from({ length: 256 }, (_, value) => {
+  let crc = value;
+  for (let bit = 0; bit < 8; bit++) {
+    crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return crc >>> 0;
+});
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc = (crc >>> 8) ^ (CRC32_TABLE[(crc ^ byte) & 0xff] ?? 0);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function writeAscii(buffer: Uint8Array, offset: number, value: string): void {
+  buffer.set(encoder.encode(value), offset);
+}
+
+function writeTarOctal(buffer: Uint8Array, offset: number, length: number, value: number): void {
+  const octal = value.toString(8);
+  if (octal.length > length - 1) {
+    throw new Error(`[archives] tar value ${value} exceeds ${length}-byte field`);
+  }
+  writeAscii(buffer, offset, `${octal.padStart(length - 1, "0")}\0`);
+}
+
+function deterministicTar(entryName: string, mode: number, body: Uint8Array): Uint8Array {
+  const nameBytes = encoder.encode(entryName);
+  if (nameBytes.length === 0 || nameBytes.length > 100 || /[\\/]/.test(entryName)) {
+    throw new Error(`[archives] unsafe tar entry name: ${entryName}`);
+  }
+
+  const paddedBodyBytes = Math.ceil(body.length / 512) * 512;
+  const tar = new Uint8Array(512 + paddedBodyBytes + 1_024);
+  const header = tar.subarray(0, 512);
+  header.set(nameBytes, 0);
+  writeTarOctal(header, 100, 8, mode);
+  writeTarOctal(header, 108, 8, 0);
+  writeTarOctal(header, 116, 8, 0);
+  writeTarOctal(header, 124, 12, body.length);
+  writeTarOctal(header, 136, 12, 0);
+  header.fill(0x20, 148, 156);
+  header[156] = 0x30;
+  writeAscii(header, 257, "ustar\0");
+  writeAscii(header, 263, "00");
+  const checksum = header.reduce((sum, byte) => sum + byte, 0);
+  writeAscii(header, 148, `${checksum.toString(8).padStart(6, "0")}\0 `);
+  tar.set(body, 512);
+  return tar;
+}
+
+function deterministicGzip(body: Uint8Array): Uint8Array {
+  const compressed = deflateRawSync(body, { level: 9 });
+  const output = new Uint8Array(10 + compressed.length + 8);
+  output.set([0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff], 0);
+  output.set(compressed, 10);
+  const footer = new DataView(output.buffer, output.byteOffset + 10 + compressed.length, 8);
+  footer.setUint32(0, crc32(body), true);
+  footer.setUint32(4, body.length >>> 0, true);
+  return output;
+}
+
+function deterministicZip(entryName: string, mode: number, body: Uint8Array): Uint8Array {
+  const name = encoder.encode(entryName);
+  if (name.length === 0 || name.length > 0xffff || /[\\/]/.test(entryName)) {
+    throw new Error(`[archives] unsafe zip entry name: ${entryName}`);
+  }
+  const compressed = deflateRawSync(body, { level: 9 });
+  const localSize = 30 + name.length + compressed.length;
+  const centralSize = 46 + name.length;
+  const output = new Uint8Array(localSize + centralSize + 22);
+  const view = new DataView(output.buffer, output.byteOffset, output.byteLength);
+  const digest = crc32(body);
+
+  view.setUint32(0, 0x04034b50, true);
+  view.setUint16(4, 20, true);
+  view.setUint16(6, 0x0800, true);
+  view.setUint16(8, 8, true);
+  view.setUint16(10, 0, true);
+  view.setUint16(12, 0x21, true);
+  view.setUint32(14, digest, true);
+  view.setUint32(18, compressed.length, true);
+  view.setUint32(22, body.length, true);
+  view.setUint16(26, name.length, true);
+  view.setUint16(28, 0, true);
+  output.set(name, 30);
+  output.set(compressed, 30 + name.length);
+
+  const central = localSize;
+  view.setUint32(central, 0x02014b50, true);
+  view.setUint16(central + 4, 0x0314, true);
+  view.setUint16(central + 6, 20, true);
+  view.setUint16(central + 8, 0x0800, true);
+  view.setUint16(central + 10, 8, true);
+  view.setUint16(central + 12, 0, true);
+  view.setUint16(central + 14, 0x21, true);
+  view.setUint32(central + 16, digest, true);
+  view.setUint32(central + 20, compressed.length, true);
+  view.setUint32(central + 24, body.length, true);
+  view.setUint16(central + 28, name.length, true);
+  view.setUint16(central + 30, 0, true);
+  view.setUint16(central + 32, 0, true);
+  view.setUint16(central + 34, 0, true);
+  view.setUint16(central + 36, 0, true);
+  view.setUint32(central + 38, ((0o100000 | mode) << 16) >>> 0, true);
+  view.setUint32(central + 42, 0, true);
+  output.set(name, central + 46);
+
+  const end = central + centralSize;
+  view.setUint32(end, 0x06054b50, true);
+  view.setUint16(end + 4, 0, true);
+  view.setUint16(end + 6, 0, true);
+  view.setUint16(end + 8, 1, true);
+  view.setUint16(end + 10, 1, true);
+  view.setUint32(end + 12, centralSize, true);
+  view.setUint32(end + 16, central, true);
+  view.setUint16(end + 20, 0, true);
+  return output;
+}
+
+export function createReleaseArchive(target: ReleaseBinaryTarget, binary: Uint8Array): Uint8Array {
+  if (target.archiveFormat === "zip") {
+    return deterministicZip(target.archiveEntryName, target.archiveMode, binary);
+  }
+  return deterministicGzip(deterministicTar(target.archiveEntryName, target.archiveMode, binary));
+}
+
+function checksumManifest(directory: string, names: readonly string[]): string {
+  return `${[...names]
+    .sort()
+    .map((name) => `${sha256(readFileSync(join(directory, name)))}  ${name}`)
+    .join("\n")}\n`;
+}
+
+function validateRawInputs(directory: string, targets: readonly ReleaseBinaryTarget[]): void {
+  for (const target of targets) {
+    const path = join(directory, target.out);
+    let stat;
+    try {
+      stat = statSync(path);
+    } catch {
+      throw new Error(`[archives] missing raw release binary: ${target.out}`);
+    }
+    if (!stat.isFile()) {
+      throw new Error(`[archives] raw release binary is not a file: ${target.out}`);
+    }
+    if (stat.size <= 0) {
+      throw new Error(`[archives] raw release binary is empty: ${target.out}`);
+    }
+    if (stat.size > target.maxBinaryBytes) {
+      throw new Error(
+        `[archives] size budget exceeded for ${target.out}: ${stat.size} > ${target.maxBinaryBytes}`,
+      );
+    }
+  }
+}
+
+function retainedReleaseTargets(
+  directory: string,
+  requestedTargets: readonly ReleaseBinaryTarget[],
+): readonly ReleaseBinaryTarget[] {
+  validateRawInputs(directory, requestedTargets);
+
+  const retained = RELEASE_BINARY_TARGETS.filter((target) =>
+    existsSync(join(directory, target.out)),
+  );
+  validateRawInputs(directory, retained);
+
+  const knownArchiveNames = new Set(RELEASE_BINARY_TARGETS.map((target) => target.archiveName));
+  for (const name of readdirSync(directory)) {
+    if ((name.endsWith(".tar.gz") || name.endsWith(".zip")) && !knownArchiveNames.has(name)) {
+      throw new Error(`[archives] unexpected stale release archive: ${name}`);
+    }
+  }
+
+  const retainedArchiveNames = new Set(retained.map((target) => target.archiveName));
+  for (const target of RELEASE_BINARY_TARGETS) {
+    if (!retainedArchiveNames.has(target.archiveName)) {
+      rmSync(join(directory, target.archiveName), { force: true });
+    }
+  }
+
+  return retained;
+}
+
+export function verifyBuiltReleaseArchives(
+  directory: string,
+  targets: readonly ReleaseBinaryTarget[] = RELEASE_BINARY_TARGETS,
+): void {
+  validateRawInputs(directory, targets);
+  for (const target of targets) {
+    const binary = readFileSync(join(directory, target.out));
+    const archivePath = join(directory, target.archiveName);
+    let archive: Uint8Array;
+    try {
+      archive = readFileSync(archivePath);
+    } catch {
+      throw new Error(`[archives] missing release archive: ${target.archiveName}`);
+    }
+    if (archive.length <= 0 || archive.length > target.maxArchiveBytes) {
+      throw new Error(
+        `[archives] size budget failed for ${target.archiveName}: ${archive.length} (max ${target.maxArchiveBytes})`,
+      );
+    }
+    const canonical = createReleaseArchive(target, binary);
+    if (!Buffer.from(archive).equals(Buffer.from(canonical))) {
+      throw new Error(
+        `[archives] ${target.archiveName} is not the canonical one-member archive for ${target.out}`,
+      );
+    }
+  }
+
+  const expectedArchives = checksumManifest(
+    directory,
+    targets.map((target) => target.archiveName),
+  );
+  const expectedRaw = checksumManifest(
+    directory,
+    targets.map((target) => target.out),
+  );
+  if (readFileSync(join(directory, "SHA256SUMS.archives"), "utf8") !== expectedArchives) {
+    throw new Error("[archives] SHA256SUMS.archives must contain exact sorted archive hashes");
+  }
+  if (readFileSync(join(directory, "SHA256SUMS"), "utf8") !== expectedRaw) {
+    throw new Error("[archives] SHA256SUMS must contain exact sorted raw binary hashes");
+  }
+}
+
+export function buildReleaseArchives(
+  directory: string,
+  targets: readonly ReleaseBinaryTarget[] = RELEASE_BINARY_TARGETS,
+): readonly ReleaseBinaryTarget[] {
+  mkdirSync(directory, { recursive: true });
+  const retainedTargets = retainedReleaseTargets(directory, targets);
+
+  const tempPaths: string[] = [];
+  try {
+    for (const target of retainedTargets) {
+      const archive = createReleaseArchive(target, readFileSync(join(directory, target.out)));
+      if (archive.length <= 0 || archive.length > target.maxArchiveBytes) {
+        throw new Error(
+          `[archives] size budget failed for ${target.archiveName}: ${archive.length} (max ${target.maxArchiveBytes})`,
+        );
+      }
+      const tempPath = join(directory, `.${target.archiveName}.tmp`);
+      writeFileSync(tempPath, archive);
+      tempPaths.push(tempPath);
+    }
+
+    for (const [index, target] of retainedTargets.entries()) {
+      const tempPath = tempPaths[index];
+      if (!tempPath) throw new Error(`[archives] missing staged archive for ${target.archiveName}`);
+      const destination = join(directory, target.archiveName);
+      rmSync(destination, { force: true });
+      renameSync(tempPath, destination);
+    }
+    tempPaths.length = 0;
+
+    writeFileSync(
+      join(directory, "SHA256SUMS.archives"),
+      checksumManifest(
+        directory,
+        retainedTargets.map((target) => target.archiveName),
+      ),
+    );
+    writeFileSync(
+      join(directory, "SHA256SUMS"),
+      checksumManifest(
+        directory,
+        retainedTargets.map((target) => target.out),
+      ),
+    );
+    verifyBuiltReleaseArchives(directory, retainedTargets);
+  } finally {
+    for (const path of tempPaths) rmSync(path, { force: true });
+  }
+  return retainedTargets;
+}
+
+function parseDirectory(argv: readonly string[]): string {
+  let directory = DEFAULT_DIRECTORY;
+  for (let index = 0; index < argv.length; index++) {
+    const argument = argv[index];
+    if (argument === undefined) break;
+    if (argument === "--directory") {
+      const value = argv[++index];
+      if (!value) throw new Error("[archives] --directory requires a path");
+      directory = resolve(value);
+      continue;
+    }
+    throw new Error(`[archives] unknown option: ${argument}`);
+  }
+  return directory;
+}
+
+if (import.meta.main) {
+  try {
+    const directory = parseDirectory(process.argv.slice(2));
+    const retainedTargets = buildReleaseArchives(directory);
+    console.log(
+      `[archives] wrote and verified ${retainedTargets.length} archives + SHA256SUMS + SHA256SUMS.archives in ${directory}`,
+    );
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/apps/cli/scripts/verify-release-binaries.sh
+++ b/apps/cli/scripts/verify-release-binaries.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Verify all release binary targets exist, checksums match, and linux-x64 boots as Kunai.
+# Verify release archives/raw binaries, both manifests, and linux-x64 boots as Kunai.
 #
 # Usage:
 #   bash apps/cli/scripts/verify-release-binaries.sh
-#   bash apps/cli/scripts/verify-release-binaries.sh --partial   # only entries in SHA256SUMS
+#   bash apps/cli/scripts/verify-release-binaries.sh --partial   # only built target pairs
 #   bash apps/cli/scripts/verify-release-binaries.sh --skip-version-smoke
 set -euo pipefail
 
@@ -38,8 +38,8 @@ ASSETS=(
 )
 
 if [[ "$PARTIAL" -eq 1 ]]; then
-  if [[ ! -f "$BIN_DIR/SHA256SUMS" ]]; then
-    echo "✗ missing $BIN_DIR/SHA256SUMS" >&2
+  if [[ ! -f "$BIN_DIR/SHA256SUMS" || ! -f "$BIN_DIR/SHA256SUMS.archives" ]]; then
+    echo "✗ missing release checksum manifest in $BIN_DIR" >&2
     exit 1
   fi
   ASSETS=()
@@ -61,6 +61,7 @@ if [[ "$PARTIAL" -eq 1 ]]; then
   (
     cd "$BIN_DIR"
     verify_checksums SHA256SUMS
+    verify_checksums SHA256SUMS.archives
   )
 
   if [[ "$SKIP_VERSION" -eq 0 && -f "$BIN_DIR/kunai-linux-x64" ]]; then
@@ -73,7 +74,7 @@ if [[ "$PARTIAL" -eq 1 ]]; then
     "$BIN_DIR/kunai-linux-x64" --help >/dev/null
   fi
 
-  echo "✓ release binaries verified (${#ASSETS[@]} targets + SHA256SUMS, partial)"
+  echo "✓ release assets verified (${#ASSETS[@]} archive/raw target pairs + 2 manifests, partial)"
   exit 0
 fi
 
@@ -87,4 +88,4 @@ if [[ "$SKIP_VERSION" -eq 1 ]]; then
 fi
 
 bun "$REPO_ROOT/scripts/verify-release-artifact-directory.ts" "${VERIFY_ARGS[@]}"
-echo "✓ release binaries verified (8 targets + SHA256SUMS)"
+echo "✓ release assets verified (8 archives + 8 raw binaries + 2 manifests)"

--- a/apps/cli/src/services/update/platform-assets.ts
+++ b/apps/cli/src/services/update/platform-assets.ts
@@ -10,6 +10,10 @@
 export type PlatformOs = "linux" | "darwin" | "windows";
 export type PlatformArch = "x64" | "arm64";
 export type PlatformLibc = "gnu" | "musl";
+export type ReleaseArchiveFormat = "tar.gz" | "zip";
+
+const MAX_RELEASE_BINARY_BYTES = 128 * 1024 * 1024;
+const MAX_RELEASE_ARCHIVE_BYTES = 64 * 1024 * 1024;
 
 export type ReleaseBinaryTarget = {
   readonly id: string;
@@ -18,62 +22,98 @@ export type ReleaseBinaryTarget = {
   readonly os: PlatformOs;
   readonly arch: PlatformArch;
   readonly libc?: PlatformLibc;
+  readonly archiveName: string;
+  readonly archiveFormat: ReleaseArchiveFormat;
+  readonly archiveEntryName: string;
+  readonly archiveMode: number;
+  readonly maxBinaryBytes: number;
+  readonly maxArchiveBytes: number;
 };
+
+type ReleaseBinaryTargetInput = Omit<
+  ReleaseBinaryTarget,
+  | "archiveName"
+  | "archiveFormat"
+  | "archiveEntryName"
+  | "archiveMode"
+  | "maxBinaryBytes"
+  | "maxArchiveBytes"
+>;
+
+function releaseBinaryTarget(input: ReleaseBinaryTargetInput): ReleaseBinaryTarget {
+  const archiveFormat: ReleaseArchiveFormat = input.os === "windows" ? "zip" : "tar.gz";
+  const archiveStem = input.out.endsWith(".exe") ? input.out.slice(0, -4) : input.out;
+  return {
+    ...input,
+    archiveName: `${archiveStem}.${archiveFormat}`,
+    archiveFormat,
+    archiveEntryName: input.out,
+    archiveMode: 0o755,
+    maxBinaryBytes: MAX_RELEASE_BINARY_BYTES,
+    maxArchiveBytes: MAX_RELEASE_ARCHIVE_BYTES,
+  };
+}
 
 /** Cross-compile targets published on every GitHub Release (grouped: Linux → macOS → Windows). */
 export const RELEASE_BINARY_TARGETS: readonly ReleaseBinaryTarget[] = [
-  { id: "linux-x64", triple: "bun-linux-x64", out: "kunai-linux-x64", os: "linux", arch: "x64" },
-  {
+  releaseBinaryTarget({
+    id: "linux-x64",
+    triple: "bun-linux-x64",
+    out: "kunai-linux-x64",
+    os: "linux",
+    arch: "x64",
+  }),
+  releaseBinaryTarget({
     id: "linux-x64-musl",
     triple: "bun-linux-x64-musl",
     out: "kunai-linux-x64-musl",
     os: "linux",
     arch: "x64",
     libc: "musl",
-  },
-  {
+  }),
+  releaseBinaryTarget({
     id: "linux-arm64",
     triple: "bun-linux-arm64",
     out: "kunai-linux-arm64",
     os: "linux",
     arch: "arm64",
-  },
-  {
+  }),
+  releaseBinaryTarget({
     id: "linux-arm64-musl",
     triple: "bun-linux-arm64-musl",
     out: "kunai-linux-arm64-musl",
     os: "linux",
     arch: "arm64",
     libc: "musl",
-  },
-  {
+  }),
+  releaseBinaryTarget({
     id: "darwin-x64",
     triple: "bun-darwin-x64",
     out: "kunai-darwin-x64",
     os: "darwin",
     arch: "x64",
-  },
-  {
+  }),
+  releaseBinaryTarget({
     id: "darwin-arm64",
     triple: "bun-darwin-arm64",
     out: "kunai-darwin-arm64",
     os: "darwin",
     arch: "arm64",
-  },
-  {
+  }),
+  releaseBinaryTarget({
     id: "windows-x64",
     triple: "bun-windows-x64",
     out: "kunai-windows-x64.exe",
     os: "windows",
     arch: "x64",
-  },
-  {
+  }),
+  releaseBinaryTarget({
     id: "windows-arm64",
     triple: "bun-windows-arm64",
     out: "kunai-windows-arm64.exe",
     os: "windows",
     arch: "arm64",
-  },
+  }),
 ];
 
 export type DetectedPlatform = {

--- a/apps/cli/test/integration/build-binaries-incremental.test.ts
+++ b/apps/cli/test/integration/build-binaries-incremental.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { RELEASE_BINARY_TARGETS } from "@/services/update/platform-assets";
+
+const CLI_ROOT = join(import.meta.dirname, "../..");
+const BUILD_SCRIPT = join(CLI_ROOT, "scripts/build-binaries.ts");
+
+function runFakeBuild(
+  preload: string,
+  outputDirectory: string,
+  marker: string,
+  args: readonly string[] = [],
+): ReturnType<typeof Bun.spawnSync> {
+  return Bun.spawnSync({
+    cmd: [
+      process.execPath,
+      "--preload",
+      preload,
+      BUILD_SCRIPT,
+      "--output-directory",
+      outputDirectory,
+      "--jobs",
+      "2",
+      ...args,
+    ],
+    cwd: CLI_ROOT,
+    env: {
+      ...process.env,
+      CI: "",
+      KUNAI_FAKE_BINARY_MARKER: marker,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+function manifestNames(directory: string, manifest: string): readonly string[] {
+  return readFileSync(join(directory, manifest), "utf8")
+    .trim()
+    .split("\n")
+    .map((row) => row.slice(66));
+}
+
+describe("build-binaries incremental subprocess", () => {
+  test("all-target then --only reconciles every retained archive/raw pair", () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "kunai-build-binaries-subprocess-"));
+    const outputDirectory = join(fixtureRoot, "output with spaces");
+    const preload = join(fixtureRoot, "fake-bun-build.mjs");
+    writeFileSync(
+      preload,
+      `Bun.build = async (options) => {
+  const outfile = options?.compile?.outfile;
+  if (typeof outfile !== "string") throw new Error("fake compiler requires compile.outfile");
+  const name = outfile.split(/[\\\\/]/).at(-1);
+  await Bun.write(outfile, \`${"${process.env.KUNAI_FAKE_BINARY_MARKER}"}:\${name}\\n\`);
+  return {
+    success: true,
+    logs: [],
+    outputs: [],
+    metafile: { inputs: { "src/main.ts": { bytes: 32 } }, outputs: {} },
+  };
+};
+`,
+    );
+
+    try {
+      const all = runFakeBuild(preload, outputDirectory, "all");
+      expect(all.exitCode, all.stderr?.toString() ?? "").toBe(0);
+
+      const incremental = runFakeBuild(preload, outputDirectory, "only", ["--only", "linux-x64"]);
+      expect(incremental.exitCode, incremental.stderr?.toString() ?? "").toBe(0);
+      expect(incremental.stdout?.toString() ?? "").toContain(
+        "wrote 1 binaries; reconciled 8 archive/raw target pairs + 2 manifests",
+      );
+
+      expect(readdirSync(outputDirectory).sort()).toEqual(
+        [
+          ...RELEASE_BINARY_TARGETS.flatMap((target) => [target.out, target.archiveName]),
+          "SHA256SUMS",
+          "SHA256SUMS.archives",
+        ].sort(),
+      );
+      expect(manifestNames(outputDirectory, "SHA256SUMS")).toEqual(
+        RELEASE_BINARY_TARGETS.map((target) => target.out).sort(),
+      );
+      expect(manifestNames(outputDirectory, "SHA256SUMS.archives")).toEqual(
+        RELEASE_BINARY_TARGETS.map((target) => target.archiveName).sort(),
+      );
+      expect(readFileSync(join(outputDirectory, "kunai-linux-x64"), "utf8")).toBe(
+        "only:kunai-linux-x64\n",
+      );
+      expect(readFileSync(join(outputDirectory, "kunai-darwin-arm64"), "utf8")).toBe(
+        "all:kunai-darwin-arm64\n",
+      );
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/test/integration/compiled-binary-smoke.test.ts
+++ b/apps/cli/test/integration/compiled-binary-smoke.test.ts
@@ -80,7 +80,7 @@ describeBinary("compiled linux binary smoke", () => {
     expect(result.stdout.toString().trim()).toMatch(/^kunai \d+\.\d+\.\d+/);
   });
 
-  test("dist/bin satisfies the exact nine-file release asset contract", async () => {
+  test("dist/bin satisfies the exact 18-file release asset contract", async () => {
     await verifyReleaseArtifactDirectory({
       directory: BIN_DIR,
       expectedVersion: packageVersion(),

--- a/apps/cli/test/unit/scripts/build-release-archives.test.ts
+++ b/apps/cli/test/unit/scripts/build-release-archives.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  truncateSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gunzipSync, inflateRawSync } from "node:zlib";
+
+import { RELEASE_BINARY_TARGETS } from "@/services/update/platform-assets";
+
+import { buildReleaseArchives } from "../../../scripts/build-release-archives";
+
+const SCRIPT = join(import.meta.dirname, "../../../scripts/build-release-archives.ts");
+
+function sha256(bytes: Uint8Array | string): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function fixtureDirectory(label: string): string {
+  const directory = mkdtempSync(join(tmpdir(), `${label} with spaces-`));
+  for (const target of RELEASE_BINARY_TARGETS) {
+    writeFileSync(join(directory, target.out), `fixture:${target.id}\n`);
+  }
+  return directory;
+}
+
+function runBuilder(directory: string): ReturnType<typeof Bun.spawnSync> {
+  return Bun.spawnSync({
+    cmd: [process.execPath, SCRIPT, "--directory", directory],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+function octalField(block: Uint8Array, offset: number, length: number): number {
+  const decoded = new TextDecoder().decode(block.subarray(offset, offset + length));
+  const value = decoded
+    .slice(0, decoded.indexOf("\0") < 0 ? undefined : decoded.indexOf("\0"))
+    .trim();
+  return Number.parseInt(value || "0", 8);
+}
+
+function readTarGz(path: string) {
+  const tar = gunzipSync(readFileSync(path));
+  const header = tar.subarray(0, 512);
+  const decodedName = new TextDecoder().decode(header.subarray(0, 100));
+  const name = decodedName.slice(
+    0,
+    decodedName.indexOf("\0") < 0 ? undefined : decodedName.indexOf("\0"),
+  );
+  const size = octalField(header, 124, 12);
+  return {
+    name,
+    mode: octalField(header, 100, 8),
+    uid: octalField(header, 108, 8),
+    gid: octalField(header, 116, 8),
+    mtime: octalField(header, 136, 12),
+    type: header[156],
+    body: tar.subarray(512, 512 + size),
+    trailing: tar.subarray(512 + Math.ceil(size / 512) * 512),
+  };
+}
+
+function readZip(path: string) {
+  const zip = readFileSync(path);
+  const view = new DataView(zip.buffer, zip.byteOffset, zip.byteLength);
+  expect(view.getUint32(0, true)).toBe(0x04034b50);
+  const method = view.getUint16(8, true);
+  const dosTime = view.getUint16(10, true);
+  const dosDate = view.getUint16(12, true);
+  const compressedSize = view.getUint32(18, true);
+  const uncompressedSize = view.getUint32(22, true);
+  const nameLength = view.getUint16(26, true);
+  const extraLength = view.getUint16(28, true);
+  const name = new TextDecoder().decode(zip.subarray(30, 30 + nameLength));
+  const bodyStart = 30 + nameLength + extraLength;
+  const compressed = zip.subarray(bodyStart, bodyStart + compressedSize);
+  const body = method === 8 ? inflateRawSync(compressed) : compressed;
+  const centralOffset = bodyStart + compressedSize;
+  expect(view.getUint32(centralOffset, true)).toBe(0x02014b50);
+  const externalAttributes = view.getUint32(centralOffset + 38, true);
+  return { name, dosTime, dosDate, body, uncompressedSize, externalAttributes };
+}
+
+describe("deterministic release archive builder", () => {
+  test("builds the exact archive/raw bridge set with separate sorted manifests", () => {
+    const directory = fixtureDirectory("kunai archives");
+    try {
+      const result = runBuilder(directory);
+      expect(result.exitCode, result.stderr?.toString() ?? "").toBe(0);
+      expect(readdirSync(directory).sort()).toEqual(
+        [
+          ...RELEASE_BINARY_TARGETS.flatMap((target) => [target.out, target.archiveName]),
+          "SHA256SUMS",
+          "SHA256SUMS.archives",
+        ].sort(),
+      );
+
+      const archiveRows = readFileSync(join(directory, "SHA256SUMS.archives"), "utf8")
+        .trim()
+        .split("\n");
+      const rawRows = readFileSync(join(directory, "SHA256SUMS"), "utf8").trim().split("\n");
+      expect(archiveRows.map((row) => row.slice(66))).toEqual(
+        RELEASE_BINARY_TARGETS.map((target) => target.archiveName).sort(),
+      );
+      expect(rawRows.map((row) => row.slice(66))).toEqual(
+        RELEASE_BINARY_TARGETS.map((target) => target.out).sort(),
+      );
+      for (const row of [...archiveRows, ...rawRows]) {
+        const [digest, name] = row.split("  ") as [string, string];
+        expect(digest).toBe(sha256(readFileSync(join(directory, name))));
+      }
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("rebuilds byte-for-byte despite source mode and timestamp differences", () => {
+    const first = fixtureDirectory("kunai reproducible first");
+    const second = fixtureDirectory("kunai reproducible second");
+    try {
+      for (const target of RELEASE_BINARY_TARGETS) {
+        chmodSync(join(first, target.out), 0o700);
+        chmodSync(join(second, target.out), 0o644);
+        utimesSync(join(first, target.out), new Date(1_000), new Date(2_000));
+        utimesSync(join(second, target.out), new Date(3_000_000), new Date(4_000_000));
+      }
+      expect(runBuilder(first).exitCode).toBe(0);
+      expect(runBuilder(second).exitCode).toBe(0);
+      for (const target of RELEASE_BINARY_TARGETS) {
+        expect(readFileSync(join(first, target.archiveName))).toEqual(
+          readFileSync(join(second, target.archiveName)),
+        );
+      }
+      expect(readFileSync(join(first, "SHA256SUMS.archives"))).toEqual(
+        readFileSync(join(second, "SHA256SUMS.archives")),
+      );
+      expect(readFileSync(join(first, "SHA256SUMS"))).toEqual(
+        readFileSync(join(second, "SHA256SUMS")),
+      );
+    } finally {
+      rmSync(first, { recursive: true, force: true });
+      rmSync(second, { recursive: true, force: true });
+    }
+  });
+
+  test("an incremental target rebuild reconciles every retained raw target", () => {
+    const directory = fixtureDirectory("kunai retained targets");
+    try {
+      expect(runBuilder(directory).exitCode).toBe(0);
+      const rebuilt = RELEASE_BINARY_TARGETS[0]!;
+      writeFileSync(join(directory, rebuilt.out), "updated linux x64\n");
+
+      buildReleaseArchives(directory, [rebuilt]);
+
+      const rawRows = readFileSync(join(directory, "SHA256SUMS"), "utf8").trim().split("\n");
+      const archiveRows = readFileSync(join(directory, "SHA256SUMS.archives"), "utf8")
+        .trim()
+        .split("\n");
+      expect(rawRows.map((row) => row.slice(66))).toEqual(
+        RELEASE_BINARY_TARGETS.map((target) => target.out).sort(),
+      );
+      expect(archiveRows.map((row) => row.slice(66))).toEqual(
+        RELEASE_BINARY_TARGETS.map((target) => target.archiveName).sort(),
+      );
+      expect(readTarGz(join(directory, rebuilt.archiveName)).body).toEqual(
+        readFileSync(join(directory, rebuilt.out)),
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("an incremental rebuild removes a stale canonical archive with no retained raw binary", () => {
+    const directory = fixtureDirectory("kunai removed retained target");
+    try {
+      expect(runBuilder(directory).exitCode).toBe(0);
+      const retained = RELEASE_BINARY_TARGETS[0]!;
+      const removed = RELEASE_BINARY_TARGETS.at(-1)!;
+      rmSync(join(directory, removed.out));
+
+      buildReleaseArchives(directory, [retained]);
+
+      expect(existsSync(join(directory, removed.archiveName))).toBe(false);
+      expect(readFileSync(join(directory, "SHA256SUMS"), "utf8")).not.toContain(removed.out);
+      expect(readFileSync(join(directory, "SHA256SUMS.archives"), "utf8")).not.toContain(
+        removed.archiveName,
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects an unknown stale archive before rewriting preserved manifests", () => {
+    const directory = fixtureDirectory("kunai unknown stale archive");
+    try {
+      expect(runBuilder(directory).exitCode).toBe(0);
+      const rawManifestBefore = readFileSync(join(directory, "SHA256SUMS"));
+      const archiveManifestBefore = readFileSync(join(directory, "SHA256SUMS.archives"));
+      writeFileSync(join(directory, "kunai-unknown-target.zip"), "stale archive");
+
+      expect(() => buildReleaseArchives(directory, [RELEASE_BINARY_TARGETS[0]!])).toThrow(
+        /unexpected stale release archive.*kunai-unknown-target\.zip/i,
+      );
+      expect(readFileSync(join(directory, "SHA256SUMS"))).toEqual(rawManifestBefore);
+      expect(readFileSync(join(directory, "SHA256SUMS.archives"))).toEqual(archiveManifestBefore);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("writes canonical tar metadata and exactly one raw-named executable member", () => {
+    const directory = fixtureDirectory("kunai tar metadata");
+    try {
+      expect(runBuilder(directory).exitCode).toBe(0);
+      const target = RELEASE_BINARY_TARGETS.find((entry) => entry.id === "linux-x64")!;
+      const archive = readTarGz(join(directory, target.archiveName));
+      expect(archive.name).toBe(target.out);
+      expect(archive.mode).toBe(0o755);
+      expect(archive.uid).toBe(0);
+      expect(archive.gid).toBe(0);
+      expect(archive.mtime).toBe(0);
+      expect([0, 48]).toContain(archive.type ?? -1);
+      expect(archive.body).toEqual(readFileSync(join(directory, target.out)));
+      expect([...archive.trailing]).toEqual(Array.from({ length: 1_024 }, () => 0));
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("writes canonical zip metadata and one raw-named Windows member", () => {
+    const directory = fixtureDirectory("kunai zip metadata");
+    try {
+      expect(runBuilder(directory).exitCode).toBe(0);
+      const target = RELEASE_BINARY_TARGETS.find((entry) => entry.id === "windows-x64")!;
+      const archive = readZip(join(directory, target.archiveName));
+      expect(archive.name).toBe(target.out);
+      expect(archive.name).not.toContain("\\");
+      expect(archive.dosTime).toBe(0);
+      expect(archive.dosDate).toBe(0x21);
+      expect(archive.uncompressedSize).toBe(readFileSync(join(directory, target.out)).length);
+      expect(archive.body).toEqual(readFileSync(join(directory, target.out)));
+      expect(archive.externalAttributes >>> 16).toBe(0o100755);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("fails before preservation when a raw target is missing", () => {
+    const directory = fixtureDirectory("kunai missing input");
+    try {
+      rmSync(join(directory, RELEASE_BINARY_TARGETS[3]!.out));
+      const result = runBuilder(directory);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr?.toString() ?? "").toMatch(/missing.*kunai-linux-arm64-musl/i);
+      expect(readdirSync(directory)).not.toContain("SHA256SUMS");
+      expect(readdirSync(directory).some((name) => /\.(?:zip|tar\.gz)$/.test(name))).toBe(false);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects an oversized raw target before reading or archiving it", () => {
+    const directory = fixtureDirectory("kunai oversized input");
+    try {
+      const target = RELEASE_BINARY_TARGETS[0]!;
+      truncateSync(join(directory, target.out), target.maxBinaryBytes + 1);
+      const result = runBuilder(directory);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr?.toString() ?? "").toMatch(/size budget.*kunai-linux-x64/i);
+      expect(readdirSync(directory).some((name) => /\.(?:zip|tar\.gz)$/.test(name))).toBe(false);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/test/unit/scripts/distribution-contract.test.ts
+++ b/apps/cli/test/unit/scripts/distribution-contract.test.ts
@@ -14,27 +14,38 @@ import {
 } from "../../../../../scripts/release-asset-contract";
 import { shouldWriteReleaseChecksums } from "../../../../../scripts/release-binary-checksums";
 import { verifyReleaseArtifactDirectory } from "../../../../../scripts/verify-release-artifact-directory";
+import { buildReleaseArchives } from "../../../scripts/build-release-archives";
 import { buildNpmPublishManifest } from "../../../scripts/write-npm-publish-manifest";
 
 const REPO_ROOT = join(import.meta.dirname, "../../../../..");
 const requiredAssetNames = REQUIRED_RELEASE_ASSET_NAMES;
 const requiredBinaryNames = RELEASE_BINARY_TARGETS.map((t) => t.out).sort();
+const requiredArchiveNames = RELEASE_BINARY_TARGETS.map((t) => t.archiveName).sort();
+
+function writeCompleteReleaseFixture(directory: string): void {
+  for (const name of requiredBinaryNames) {
+    writeFileSync(join(directory, name), `payload:${name}\n`);
+  }
+  buildReleaseArchives(directory);
+}
 
 function completeSizedAssets(size = 1) {
   return requiredAssetNames.map((name) => ({ name, size }));
 }
 
 describe("distribution release-asset contract", () => {
-  test("required assets are RELEASE_BINARY_TARGETS outs plus SHA256SUMS", () => {
+  test("requires the exact 0.3.0 bridge set of archives, raw binaries, and manifests", () => {
     expect([...REQUIRED_RELEASE_ASSET_NAMES]).toEqual(
-      [...RELEASE_BINARY_TARGETS.map((t) => t.out), "SHA256SUMS"].sort(),
+      [...requiredBinaryNames, ...requiredArchiveNames, "SHA256SUMS", "SHA256SUMS.archives"].sort(),
     );
-    expect(REQUIRED_RELEASE_ASSET_NAMES).toHaveLength(RELEASE_BINARY_TARGETS.length + 1);
+    expect(REQUIRED_RELEASE_ASSET_NAMES).toHaveLength(18);
   });
 
   test("assertRequiredReleaseAssets accepts a complete set and rejects gaps", () => {
     expect(() => assertRequiredReleaseAssets(REQUIRED_RELEASE_ASSET_NAMES)).not.toThrow();
-    expect(() => assertRequiredReleaseAssets(["SHA256SUMS"])).toThrow(/missing/);
+    expect(() => assertRequiredReleaseAssets(["SHA256SUMS", "SHA256SUMS.archives"])).toThrow(
+      /missing/,
+    );
   });
 
   test("assertCompleteReleaseAssetSet accepts a complete non-empty set", () => {
@@ -47,6 +58,26 @@ describe("distribution release-asset contract", () => {
         requiredAssetNames.map((name) => ({ name, size: name === "kunai-linux-x64" ? 0 : 1 })),
       ),
     ).toThrow("kunai-linux-x64");
+  });
+
+  test("rejects required assets that exceed their target size budgets", () => {
+    const archive = RELEASE_BINARY_TARGETS[0]!;
+    expect(() =>
+      assertCompleteReleaseAssetSet(
+        completeSizedAssets().map((asset) =>
+          asset.name === archive.archiveName
+            ? { ...asset, size: archive.maxArchiveBytes + 1 }
+            : asset,
+        ),
+      ),
+    ).toThrow(/size budget.*kunai-linux-x64\.tar\.gz/i);
+    expect(() =>
+      assertCompleteReleaseAssetSet(
+        completeSizedAssets().map((asset) =>
+          asset.name === archive.out ? { ...asset, size: archive.maxBinaryBytes + 1 } : asset,
+        ),
+      ),
+    ).toThrow(/size budget.*kunai-linux-x64/i);
   });
 
   test("rejects a missing required asset", () => {
@@ -87,6 +118,20 @@ describe("distribution release-asset contract", () => {
     for (const name of REQUIRED_RELEASE_ASSET_NAMES) {
       expect(workflow).toContain(`apps/cli/dist/bin/${name}`);
     }
+  });
+
+  test("host and installer-matrix raw-binary checks preserve SHA256SUMS compatibility", () => {
+    const verifier = readFileSync(
+      join(REPO_ROOT, "apps/cli/scripts/verify-host-binary.sh"),
+      "utf8",
+    );
+    const installerMatrix = readFileSync(
+      join(REPO_ROOT, ".github/workflows/installer-matrix.yml"),
+      "utf8",
+    );
+    expect(verifier).toContain("verify_checksums SHA256SUMS >/dev/null");
+    expect(verifier).not.toContain("verify_checksums SHA256SUMS.archives");
+    expect(installerMatrix).toContain("apps/cli/dist/bin/SHA256SUMS");
   });
 });
 
@@ -224,6 +269,18 @@ describe("release workflow candidate-before-publication contract", () => {
       expect(job).toContain("git rev-parse HEAD");
       expect(job).toContain("git rev-parse origin/main");
     }
+  });
+
+  test("confirmation reconstructs and verifies the preserved native archives", () => {
+    const confirm = confirmation();
+    const stage = confirm.indexOf("Stage binaries for confirmation");
+    const verify = confirm.indexOf("verify-release-artifact-directory.ts");
+    const gate = confirm.indexOf("Run confirmation gate");
+
+    expect(stage).toBeGreaterThanOrEqual(0);
+    expect(verify).toBeGreaterThan(stage);
+    expect(gate).toBeGreaterThan(verify);
+    expect(confirm).toContain('--expected-version "${VERSION}"');
   });
 
   test("candidate install gate consumes preserved local tarballs after they are created", () => {
@@ -364,16 +421,10 @@ describe("release:pack script contract", () => {
 });
 
 describe("verifyReleaseArtifactDirectory", () => {
-  test("accepts a fixture with eight checksum rows and matching hashes", async () => {
+  test("accepts eight canonical archives, eight raw binaries, and two manifests", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kunai-release-assets-"));
     try {
-      const sums: string[] = [];
-      for (const name of requiredBinaryNames) {
-        const body = `payload:${name}\n`;
-        writeFileSync(join(dir, name), body);
-        sums.push(`${createHash("sha256").update(body).digest("hex")}  ${name}`);
-      }
-      writeFileSync(join(dir, "SHA256SUMS"), `${sums.join("\n")}\n`);
+      writeCompleteReleaseFixture(dir);
 
       await expect(
         verifyReleaseArtifactDirectory({
@@ -390,12 +441,9 @@ describe("verifyReleaseArtifactDirectory", () => {
   test("rejects checksum mismatch", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kunai-release-assets-"));
     try {
-      const sums: string[] = [];
-      for (const name of requiredBinaryNames) {
-        writeFileSync(join(dir, name), `payload:${name}\n`);
-        sums.push(`${"a".repeat(64)}  ${name}`);
-      }
-      writeFileSync(join(dir, "SHA256SUMS"), `${sums.join("\n")}\n`);
+      writeCompleteReleaseFixture(dir);
+      const archiveName = requiredArchiveNames[0]!;
+      writeFileSync(join(dir, archiveName), "tampered archive");
 
       await expect(
         verifyReleaseArtifactDirectory({
@@ -412,9 +460,7 @@ describe("verifyReleaseArtifactDirectory", () => {
   test("rejects SHA256SUMS with the wrong row count", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kunai-release-assets-"));
     try {
-      for (const name of requiredBinaryNames) {
-        writeFileSync(join(dir, name), `payload:${name}\n`);
-      }
+      writeCompleteReleaseFixture(dir);
       writeFileSync(join(dir, "SHA256SUMS"), `${"a".repeat(64)}  kunai-linux-x64\n`);
 
       await expect(
@@ -424,6 +470,56 @@ describe("verifyReleaseArtifactDirectory", () => {
           skipVersionSmoke: true,
         }),
       ).rejects.toThrow(/8/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a legacy raw SHA256SUMS checksum mismatch", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kunai-release-assets-"));
+    try {
+      writeCompleteReleaseFixture(dir);
+      const rows = readFileSync(join(dir, "SHA256SUMS"), "utf8").split("\n");
+      rows[0] = `${"a".repeat(64)}  ${requiredBinaryNames[0]}`;
+      writeFileSync(join(dir, "SHA256SUMS"), rows.join("\n"));
+
+      await expect(
+        verifyReleaseArtifactDirectory({
+          directory: dir,
+          expectedVersion: "9.9.9",
+          skipVersionSmoke: true,
+        }),
+      ).rejects.toThrow(/SHA256SUMS|checksum|sha256/i);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a non-canonical archive even when its manifest hash matches", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kunai-release-assets-"));
+    try {
+      writeCompleteReleaseFixture(dir);
+      const archiveName = requiredArchiveNames[0]!;
+      const archivePath = join(dir, archiveName);
+      const tampered = Buffer.concat([readFileSync(archivePath), Buffer.from("extra-entry")]);
+      writeFileSync(archivePath, tampered);
+      const rows = readFileSync(join(dir, "SHA256SUMS.archives"), "utf8")
+        .trim()
+        .split("\n")
+        .map((row) =>
+          row.endsWith(`  ${archiveName}`)
+            ? `${createHash("sha256").update(tampered).digest("hex")}  ${archiveName}`
+            : row,
+        );
+      writeFileSync(join(dir, "SHA256SUMS.archives"), `${rows.join("\n")}\n`);
+
+      await expect(
+        verifyReleaseArtifactDirectory({
+          directory: dir,
+          expectedVersion: "9.9.9",
+          skipVersionSmoke: true,
+        }),
+      ).rejects.toThrow(/canonical|member|archive/i);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/apps/cli/test/unit/services/update/platform-assets.test.ts
+++ b/apps/cli/test/unit/services/update/platform-assets.test.ts
@@ -27,6 +27,90 @@ describe("platform release assets", () => {
     }
   });
 
+  test("freezes one canonical archive contract for every raw release binary", () => {
+    expect(
+      RELEASE_BINARY_TARGETS.map((target) => ({
+        id: target.id,
+        raw: target.out,
+        archive: target.archiveName,
+        format: target.archiveFormat,
+        entry: target.archiveEntryName,
+        mode: target.archiveMode,
+      })),
+    ).toEqual([
+      {
+        id: "linux-x64",
+        raw: "kunai-linux-x64",
+        archive: "kunai-linux-x64.tar.gz",
+        format: "tar.gz",
+        entry: "kunai-linux-x64",
+        mode: 0o755,
+      },
+      {
+        id: "linux-x64-musl",
+        raw: "kunai-linux-x64-musl",
+        archive: "kunai-linux-x64-musl.tar.gz",
+        format: "tar.gz",
+        entry: "kunai-linux-x64-musl",
+        mode: 0o755,
+      },
+      {
+        id: "linux-arm64",
+        raw: "kunai-linux-arm64",
+        archive: "kunai-linux-arm64.tar.gz",
+        format: "tar.gz",
+        entry: "kunai-linux-arm64",
+        mode: 0o755,
+      },
+      {
+        id: "linux-arm64-musl",
+        raw: "kunai-linux-arm64-musl",
+        archive: "kunai-linux-arm64-musl.tar.gz",
+        format: "tar.gz",
+        entry: "kunai-linux-arm64-musl",
+        mode: 0o755,
+      },
+      {
+        id: "darwin-x64",
+        raw: "kunai-darwin-x64",
+        archive: "kunai-darwin-x64.tar.gz",
+        format: "tar.gz",
+        entry: "kunai-darwin-x64",
+        mode: 0o755,
+      },
+      {
+        id: "darwin-arm64",
+        raw: "kunai-darwin-arm64",
+        archive: "kunai-darwin-arm64.tar.gz",
+        format: "tar.gz",
+        entry: "kunai-darwin-arm64",
+        mode: 0o755,
+      },
+      {
+        id: "windows-x64",
+        raw: "kunai-windows-x64.exe",
+        archive: "kunai-windows-x64.zip",
+        format: "zip",
+        entry: "kunai-windows-x64.exe",
+        mode: 0o755,
+      },
+      {
+        id: "windows-arm64",
+        raw: "kunai-windows-arm64.exe",
+        archive: "kunai-windows-arm64.zip",
+        format: "zip",
+        entry: "kunai-windows-arm64.exe",
+        mode: 0o755,
+      },
+    ]);
+
+    for (const target of RELEASE_BINARY_TARGETS) {
+      expect(target.maxBinaryBytes).toBeGreaterThan(0);
+      expect(target.maxArchiveBytes).toBeGreaterThan(0);
+      expect(target.archiveEntryName).not.toMatch(/[\\/]/);
+    }
+  });
+
   test("detects the current runtime platform when supported", () => {
     const detected = detectPlatform();
     if (detected.os && detected.arch) {

--- a/scripts/release-asset-contract.ts
+++ b/scripts/release-asset-contract.ts
@@ -1,9 +1,9 @@
 /**
- * Pure required-release-asset contract derived from RELEASE_BINARY_TARGETS + SHA256SUMS.
+ * Pure required-release-asset contract for the 0.3.0 compatibility bridge.
  *
  * Shared by:
  *   - scripts/verify-github-release-assets.ts (live gh release view / download)
- *   - scripts/verify-release-artifact-directory.ts (local nine-file verification)
+ *   - scripts/verify-release-artifact-directory.ts (local 18-file verification)
  *   - apps/cli/test/unit/scripts/distribution-contract.test.ts (workflow lock)
  */
 
@@ -18,8 +18,17 @@ export const REQUIRED_BINARY_ASSET_NAMES = Object.freeze(
   RELEASE_BINARY_TARGETS.map((target) => target.out).sort(),
 );
 
+export const REQUIRED_ARCHIVE_ASSET_NAMES = Object.freeze(
+  RELEASE_BINARY_TARGETS.map((target) => target.archiveName).sort(),
+);
+
 export const REQUIRED_RELEASE_ASSET_NAMES = Object.freeze(
-  [...REQUIRED_BINARY_ASSET_NAMES, "SHA256SUMS"].sort(),
+  [
+    ...REQUIRED_ARCHIVE_ASSET_NAMES,
+    ...REQUIRED_BINARY_ASSET_NAMES,
+    "SHA256SUMS",
+    "SHA256SUMS.archives",
+  ].sort(),
 );
 
 /** Alias used by contract tests / brief wording. */
@@ -36,7 +45,7 @@ export function assertRequiredReleaseAssets(actualNames: readonly string[]): voi
 }
 
 /**
- * Exact nine-file set: eight binaries + SHA256SUMS.
+ * Exact 18-file bridge set: eight archives + eight raw binaries + two manifests.
  * Rejects missing, duplicate, unexpected, and zero-byte assets.
  */
 export function assertCompleteReleaseAssetSet(assets: readonly ReleaseAssetDescriptor[]): void {
@@ -66,6 +75,20 @@ export function assertCompleteReleaseAssetSet(assets: readonly ReleaseAssetDescr
   for (const asset of assets) {
     if (asset.size <= 0) {
       throw new Error(`[release-assets] zero-byte required asset: ${asset.name}`);
+    }
+    const target = RELEASE_BINARY_TARGETS.find(
+      (entry) => entry.out === asset.name || entry.archiveName === asset.name,
+    );
+    const maxBytes =
+      target?.out === asset.name
+        ? target.maxBinaryBytes
+        : target?.archiveName === asset.name
+          ? target.maxArchiveBytes
+          : 64 * 1024;
+    if (asset.size > maxBytes) {
+      throw new Error(
+        `[release-assets] size budget exceeded for ${asset.name}: ${asset.size} > ${maxBytes}`,
+      );
     }
   }
 }

--- a/scripts/verify-release-artifact-directory.ts
+++ b/scripts/verify-release-artifact-directory.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
- * Verify a local directory holds the exact nine-file release asset set:
- * eight binaries + SHA256SUMS, with matching checksums and optional linux-x64 smoke.
+ * Verify a local directory holds the exact 0.3.0 bridge set:
+ * eight archives, eight raw binaries, and two matching checksum manifests.
  *
  * Usage:
  *   bun run scripts/verify-release-artifact-directory.ts <dir> --expected-version 0.3.0
@@ -13,7 +13,9 @@ import { createHash } from "node:crypto";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
+import { verifyBuiltReleaseArchives } from "../apps/cli/scripts/build-release-archives";
 import {
+  REQUIRED_ARCHIVE_ASSET_NAMES,
   REQUIRED_BINARY_ASSET_NAMES,
   assertCompleteReleaseAssetSet,
 } from "./release-asset-contract";
@@ -99,40 +101,50 @@ export async function verifyReleaseArtifactDirectory(
   const files = listReleaseFiles(input.directory);
   assertCompleteReleaseAssetSet(files);
 
-  const sumsPath = join(input.directory, "SHA256SUMS");
-  const checksums = parseSha256sums(readFileSync(sumsPath, "utf8"));
-  if (checksums.length !== REQUIRED_BINARY_ASSET_NAMES.length) {
+  verifyChecksumManifest(input.directory, "SHA256SUMS", REQUIRED_BINARY_ASSET_NAMES);
+  verifyChecksumManifest(input.directory, "SHA256SUMS.archives", REQUIRED_ARCHIVE_ASSET_NAMES);
+  verifyBuiltReleaseArchives(input.directory);
+
+  if (!input.skipVersionSmoke) {
+    smokeLinuxX64(join(input.directory, "kunai-linux-x64"), input.expectedVersion);
+  }
+}
+
+function verifyChecksumManifest(
+  directory: string,
+  manifestName: string,
+  requiredNames: readonly string[],
+): void {
+  const checksums = parseSha256sums(readFileSync(join(directory, manifestName), "utf8"));
+  if (checksums.length !== requiredNames.length) {
     throw new Error(
-      `[release-assets] SHA256SUMS must have exactly ${REQUIRED_BINARY_ASSET_NAMES.length} rows, got ${checksums.length}`,
+      `[release-assets] ${manifestName} must have exactly ${requiredNames.length} rows, got ${checksums.length}`,
     );
   }
-
   const byName = new Map(checksums.map((row) => [row.name, row.sha256]));
   if (byName.size !== checksums.length) {
-    throw new Error("[release-assets] SHA256SUMS contains duplicate filenames");
+    throw new Error(`[release-assets] ${manifestName} contains duplicate filenames`);
   }
-
-  for (const name of REQUIRED_BINARY_ASSET_NAMES) {
+  const sortedNames = [...requiredNames].sort();
+  if (checksums.some((row, index) => row.name !== sortedNames[index])) {
+    throw new Error(`[release-assets] ${manifestName} rows must use exact sorted filenames`);
+  }
+  for (const name of sortedNames) {
     const expected = byName.get(name);
     if (!expected) {
-      throw new Error(`[release-assets] SHA256SUMS missing entry for ${name}`);
+      throw new Error(`[release-assets] ${manifestName} missing entry for ${name}`);
     }
-    const actual = fileSha256(join(input.directory, name));
+    const actual = fileSha256(join(directory, name));
     if (actual !== expected) {
       throw new Error(
         `[release-assets] sha256 checksum mismatch for ${name}: expected ${expected}, got ${actual}`,
       );
     }
   }
-
   for (const name of byName.keys()) {
-    if (!(REQUIRED_BINARY_ASSET_NAMES as readonly string[]).includes(name)) {
-      throw new Error(`[release-assets] SHA256SUMS has unexpected entry: ${name}`);
+    if (!requiredNames.includes(name)) {
+      throw new Error(`[release-assets] ${manifestName} has unexpected entry: ${name}`);
     }
-  }
-
-  if (!input.skipVersionSmoke) {
-    smokeLinuxX64(join(input.directory, "kunai-linux-x64"), input.expectedVersion);
   }
 }
 
@@ -181,7 +193,7 @@ if (import.meta.main) {
     const args = parseCliArgs(process.argv.slice(2));
     await verifyReleaseArtifactDirectory(args);
     console.log(
-      `[release-assets] OK — verified ${REQUIRED_BINARY_ASSET_NAMES.length} binaries + SHA256SUMS in ${args.directory}`,
+      `[release-assets] OK — verified 8 archives + 8 raw binaries + 2 manifests in ${args.directory}`,
     );
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));

--- a/turbo.json
+++ b/turbo.json
@@ -57,7 +57,7 @@
     },
     "build:binary:host": {
       "dependsOn": ["^typecheck", "typecheck"],
-      "outputs": ["dist/bin/kunai-*", "dist/bin/SHA256SUMS", "dist/bin/*.meta.json"],
+      "outputs": ["dist/bin/kunai-*", "dist/bin/SHA256SUMS", "dist/bin/SHA256SUMS.archives", "dist/bin/*.meta.json"],
       "env": ["KUNAI_BUILD_ANALYZE"]
     },
     "build:binaries": {


### PR DESCRIPTION
## Summary

- builds deterministic tar.gz assets for Linux and macOS and zip assets for Windows
- preserves all eight raw executables for compatibility
- emits separate raw and archive checksum manifests
- verifies an exact 18-file release directory and rejects stale or mutated assets

Part of #132. Archive consumption remains in the following stacked PRs.

## Stack

Depends on the Rosetta routing PR.

## Verification

- real eight-target build
- exact 8 archive + 8 raw + 2 manifest verification
- all-target to single-target reconciliation integration
- full repository and pre-push gates

No release is performed by this PR.