### PR TITLE
feat(share): add web fallback, short codes, and terminal QR

### DIFF
--- a/.archive/plans/share-links-web-fallback-and-qr.md
+++ b/.archive/plans/share-links-web-fallback-and-qr.md
@@ -1,6 +1,6 @@
 # Share: web fallback, short codes, and QR
 
-**Status:** not started · **Owner:** unassigned · **Prereq:** none
+**Status:** implemented 2026-08-24 · **Owner:** release train · **Prereq:** none
 
 A handoff for one agent. The `kunai://` link format is **already built and
 good** — do not redesign it. This plan adds the three things missing for

--- a/.changeset/calm-foxes-share.md
+++ b/.changeset/calm-foxes-share.md
@@ -1,0 +1,11 @@
+---
+"@kitsunekode/kunai": minor
+---
+
+Make shared playback targets easy to open outside an existing Kunai install.
+
+### Features
+
+- Copy browser-safe, catalog-anchored HTTPS links from `/share` and mpv.
+- Add a stateless web handoff with native install guidance and no share-page analytics.
+- Accept compact checksummed share codes and render scannable HTTPS QR codes with `/share --qr`.

--- a/.docs/share-links.md
+++ b/.docs/share-links.md
@@ -1,13 +1,15 @@
 ---
 status: current
-lastReviewed: "2026-07-29"
+lastReviewed: "2026-08-24"
 ---
 
 # Share Links & PlaybackTargetRef
 
 > Agent-facing (L3). Never linked from published docs. Users: see `docs/users/`.
 
-Kunai uses one portable `kunai://` link format for sharing what to play across machines, providers, and surfaces.
+Kunai copies browser-safe `https://kunai.kitsunekode.in/w/<code>` links while preserving the portable `kunai://` application handoff. Both decode to the same catalog-anchored playback target.
+
+The web code is a checksummed, base64url-encoded ref. The landing page is a pure decoder: it uses no share database and drops `/w/` page views before analytics sends. Compact `k1…` catalog codes are accepted directly and inside `/w/<code>`; search anchors deliberately have no compact form.
 
 ## URL grammar
 
@@ -42,21 +44,26 @@ Parser returns `null` when neither `cat` nor `q` is present, or when the catalog
 
 | Path                                                        | Role                                                      |
 | ----------------------------------------------------------- | --------------------------------------------------------- |
-| `apps/cli/src/domain/share/playback-target-ref.ts`          | Model, timestamp helpers, encode/parse codec              |
+| `packages/types/src/share.ts`                               | Shared CLI/docs codec, HTTPS envelope, and compact codes  |
+| `apps/cli/src/domain/share/playback-target-ref.ts`          | CLI-local re-export seam                                  |
 | `apps/cli/src/app/bootstrap/share-ref-from-context.ts`      | Build refs from title/session context                     |
 | `apps/cli/src/app/bootstrap/resolve-share-target.ts`        | Container-aware resolver (catalog, search, anime mapping) |
 | `apps/cli/src/app/bootstrap/apply-resolved-share-target.ts` | Apply resolved targets to bootstrap launch                |
 | `apps/cli/src/app/bootstrap/share-bootstrap-start.ts`       | One-shot shared timestamp mailbox for first play          |
 | `apps/cli/src/app/bootstrap/copy-share-link.ts`             | Clipboard helper                                          |
+| `apps/cli/src/domain/share/qr-code.ts`                      | Dependency-free QR Model 2 encoder                        |
+| `apps/cli/src/app-shell/share-qr-shell.tsx`                 | Half-block terminal QR surface                            |
+| `apps/docs/app/w/[code]/page.tsx`                           | Stateless browser fallback and app handoff                |
 
 ## Surfaces
 
-- `/share` — copy a catalog-anchored link (optional timestamp picker when resume position exists)
-- `/watch` — parse clipboard URL, resolve, launch with `startSeconds`
+- `/share` — copy the browser-safe HTTPS form (optional timestamp picker when resume position exists)
+- `/share --qr` — show a compact HTTPS QR and copy the full HTTPS form
+- `/watch` — parse HTTPS, `kunai://`, or compact clipboard input, resolve, launch with `startSeconds`
 - `kunai --open <url>` — trusted launch (no protocol confirmation)
 - `kunai --handoff-url <url>` — OS protocol handler path (confirmation required)
 - Post-play **Share link** action and history **Copy share link**
-- mpv `Ctrl+Shift+S` — copy link at live `time-pos`
+- mpv `Ctrl+Shift+S` — copy the HTTPS link at live `time-pos`
 - Discord Rich Presence — https catalog button; playable `kunai://` ref in presence text (not a button; Discord only allows http(s) buttons)
 
 ## Timestamp resume
@@ -69,5 +76,7 @@ Shared `t=` is applied once on the first mpv launch via `resolveBootstrapStartSe
 kunai://play?cat=tmdb%3A1396&kind=series&s=1&e=3
 kunai://play?cat=anilist%3A21&kind=anime&s=1&e=1&t=120
 kunai://play?q=One%20Piece&kind=anime
+https://kunai.kitsunekode.in/w/v1.<encoded-ref>
+k1pts.1396.1.3.<checksum>
 kunai --open "kunai://play?cat=tmdb%3A438631&kind=movie"
 ```

--- a/.plans/roadmap.md
+++ b/.plans/roadmap.md
@@ -40,7 +40,6 @@ archive and put only the residue here.
 | Persistent shell            | Full back-stack, root-owned footer                    | [persistent-shell-implementation.md](./persistent-shell-implementation.md)             |
 | Fullscreen root shell       | Flatten remaining nested chrome                       | [fullscreen-root-shell-redesign.md](./fullscreen-root-shell-redesign.md)               |
 | Sakura theme rollout        | Remaining surfaces after the token foundation         | [sakura-rollout.md](./sakura-rollout.md)                                               |
-| Share web fallback + QR     | `https` landing page, short codes, terminal QR        | [share-links-web-fallback-and-qr.md](./share-links-web-fallback-and-qr.md)             |
 | Terminal image protocol     | Flicker hardening and `ink-shell` split               | [ui-polish-and-image-protocol.md](./ui-polish-and-image-protocol.md)                   |
 
 ### Playback and providers

--- a/apps/cli/src/app-shell/commands.ts
+++ b/apps/cli/src/app-shell/commands.ts
@@ -33,6 +33,8 @@ const POST_PLAYBACK_SURFACE_COMMANDS: readonly AppCommandId[] = [
   "source",
   "quality",
   "provider",
+  "share",
+  "share-qr",
   "bookmark",
   "follow",
   "unfollow",

--- a/apps/cli/src/app-shell/share-qr-shell.tsx
+++ b/apps/cli/src/app-shell/share-qr-shell.tsx
@@ -1,0 +1,103 @@
+import { mountRootContent } from "@/app-shell/root-content-state";
+import { ResizeBlocker, ShellFooter } from "@/app-shell/shell-primitives";
+import { truncateLine } from "@/app-shell/shell-text";
+import { palette } from "@/app-shell/shell-theme";
+import { useShellDimensions } from "@/app-shell/use-viewport-policy";
+import { encodeQrMatrix, renderQrHalfBlocks } from "@/domain/share/qr-code";
+import { Box, Text, useInput } from "ink";
+import React, { useMemo } from "react";
+
+export function buildTerminalShareQr(url: string): string | null {
+  try {
+    return renderQrHalfBlocks(encodeQrMatrix(url));
+  } catch {
+    return null;
+  }
+}
+
+function ShareQrShell({
+  title,
+  url,
+  shortCode,
+  onBack,
+}: {
+  readonly title: string;
+  readonly url: string;
+  readonly shortCode: string | null;
+  readonly onBack: () => void;
+}) {
+  const { cols, rows } = useShellDimensions();
+  const qr = useMemo(() => buildTerminalShareQr(url), [url]);
+  const qrLines = qr?.split("\n") ?? [];
+  const minimumColumns = Math.max(40, qrLines[0]?.length ?? 0);
+  const minimumRows = qrLines.length + 4;
+
+  useInput((input, key) => {
+    if (key.escape || key.return || input.toLowerCase() === "q") onBack();
+  });
+
+  if (!qr) {
+    return (
+      <Box flexDirection="column" flexGrow={1} alignItems="center" justifyContent="center">
+        <Text bold color={palette.text}>
+          This share reference is too large for the terminal QR.
+        </Text>
+        <Text color={palette.muted}>The full HTTPS link is still on your clipboard.</Text>
+        <ShellFooter
+          taskLabel="Paste the copied link to share it"
+          actions={[
+            { key: "enter", label: "back", primary: true },
+            { key: "esc", label: "close" },
+          ]}
+          mode="minimal"
+          terminalWidth={cols}
+        />
+      </Box>
+    );
+  }
+
+  if (cols < minimumColumns || rows < minimumRows) {
+    return (
+      <ResizeBlocker
+        columns={cols}
+        rows={rows}
+        minColumns={minimumColumns}
+        minRows={minimumRows}
+        message="Terminal too small for this QR"
+      />
+    );
+  }
+
+  return (
+    <Box flexDirection="column" flexGrow={1} alignItems="center">
+      <Text bold color={palette.text}>
+        {truncateLine(`Scan to share · ${title}`, Math.max(24, cols - 4))}
+      </Text>
+      <Text color={palette.text}>{qr}</Text>
+      <Text color={palette.muted}>{shortCode ? `Code ${shortCode}` : "HTTPS handoff"}</Text>
+      <ShellFooter
+        taskLabel="The full HTTPS link is also on your clipboard"
+        actions={[
+          { key: "enter", label: "back", primary: true },
+          { key: "esc", label: "close" },
+        ]}
+        mode="minimal"
+        terminalWidth={cols}
+      />
+    </Box>
+  );
+}
+
+export function openShareQrShell(input: {
+  readonly title: string;
+  readonly url: string;
+  readonly shortCode: string | null;
+}): Promise<void> {
+  const session = mountRootContent<undefined>({
+    kind: "picker",
+    headerLabel: "Share QR",
+    renderContent: (finish) => <ShareQrShell {...input} onBack={() => finish(undefined)} />,
+    fallbackValue: undefined,
+  });
+  return session.result;
+}

--- a/apps/cli/src/app-shell/types.ts
+++ b/apps/cli/src/app-shell/types.ts
@@ -59,6 +59,7 @@ export type ShellAction =
   | "mark-anime"
   | "mark-series"
   | "share"
+  | "share-qr"
   | "bookmark"
   | "follow"
   | "unfollow"
@@ -498,6 +499,7 @@ export function toShellAction(commandId: AppCommandId): ShellAction {
     case "mark-anime":
     case "mark-series":
     case "share":
+    case "share-qr":
     case "bookmark":
     case "follow":
     case "unfollow":

--- a/apps/cli/src/app-shell/workflows/shell-workflows.ts
+++ b/apps/cli/src/app-shell/workflows/shell-workflows.ts
@@ -24,7 +24,6 @@ import {
 } from "@/app-shell/root-library-playback-bridge";
 import { openDiagnosticsOverlay, openRootOwnedOverlay } from "@/app-shell/root-overlay-bridge";
 import { resolveShareTarget } from "@/app/bootstrap/resolve-share-target";
-import { buildShareRefFromTitleContext } from "@/app/bootstrap/share-ref-from-context";
 import { titleInfoFromSearchResult } from "@/app/bootstrap/title-info";
 import { mapAnimeDiscoveryResultToProviderNative } from "@/app/discover/anime-provider-mapping";
 import { requestUnifiedOfflinePlayback } from "@/app/offline/offline-playback-launch";
@@ -38,13 +37,11 @@ import { createOfflineLibraryEngine } from "@/domain/offline/OfflineLibraryEngin
 import { planEpisodeQueue } from "@/domain/queue/QueuePlanner";
 import type { SessionState } from "@/domain/session/SessionState";
 import { isPlaybackSessionActive } from "@/domain/session/SessionState";
-import {
-  encodePlaybackTargetRef,
-  parsePlaybackTargetRef,
-} from "@/domain/share/playback-target-ref";
+import { parsePlaybackTargetRef } from "@/domain/share/playback-target-ref";
 import type { EpisodeInfo as PlaybackEpisodeInfo, StreamInfo, TitleInfo } from "@/domain/types";
 import { copyToClipboard, readClipboard } from "@/infra/clipboard";
 import { revealPathInOsFileManager } from "@/infra/os/reveal-in-file-manager";
+import { copyShareLinkForContext } from "@/infra/share/copy-share-link";
 import { openExternalUrlAndWait, defaultKunaiDocsUrl } from "@/infra/shell/open-external-url";
 import {
   readLatestHistoryByTitle,
@@ -870,6 +867,7 @@ const actionHandlers: Record<string, ActionHandler | undefined> = {
   "mark-anime": (c) => handleMarkKind(c, "anime"),
   "mark-series": (c) => handleMarkKind(c, "series"),
   share: (c) => handleShare(c),
+  "share-qr": (c) => handleShare(c, { qr: true }),
   bookmark: (c) => handleBookmark(c),
   follow: (c) => handleAttentionPreference(c, "following"),
   unfollow: (c) => handleAttentionPreference(c, "implicit"),
@@ -1826,8 +1824,11 @@ async function handleMarkKind(container: Container, kind: "anime" | "series"): P
   return "handled";
 }
 
-/** Copy a shareable kunai:// link for the current title (+episode) to the clipboard. */
-async function handleShare(container: Container): Promise<"handled"> {
+/** Copy a browser-safe share link for the current title (+episode) to the clipboard. */
+async function handleShare(
+  container: Container,
+  options: { readonly qr?: boolean } = {},
+): Promise<"handled"> {
   const state = container.stateManager.getState();
   const title = state.currentTitle;
   if (!title) {
@@ -1871,27 +1872,36 @@ async function handleShare(container: Container): Promise<"handled"> {
     startSeconds = choice === "resume" ? resumeSeconds : undefined;
   }
 
-  const ref = buildShareRefFromTitleContext({
-    title,
-    mode,
-    episode: episode ? { season: episode.season, episode: episode.episode } : undefined,
-    startSeconds,
-    providerId: state.provider,
-  });
-  if (!ref) {
+  const shared = await copyShareLinkForContext(
+    {
+      title,
+      mode,
+      episode: episode ? { season: episode.season, episode: episode.episode } : undefined,
+      startSeconds,
+      providerId: state.provider,
+    },
+    copyToClipboard,
+  );
+  if (!shared) {
     container.stateManager.dispatch({
       type: "SET_PLAYBACK_FEEDBACK",
       note: "Could not build a share link for this title.",
     });
     return "handled";
   }
-  const url = encodePlaybackTargetRef(ref);
-  const copied = await copyToClipboard(url);
+  if (options.qr) {
+    const { openShareQrShell } = await import("@/app-shell/share-qr-shell");
+    await openShareQrShell({
+      title: title.name,
+      url: shared.qrUrl,
+      shortCode: shared.shortCode,
+    });
+  }
   container.stateManager.dispatch({
     type: "SET_PLAYBACK_FEEDBACK",
-    note: copied
-      ? `Share link for "${title.name}" copied — open with kunai open or /watch.`
-      : `Share link (copy manually): ${url}`,
+    note: shared.copied
+      ? `Web share link for "${title.name}" copied${shared.shortCode ? ` · code ${shared.shortCode}` : ""}.`
+      : `Share link (copy manually): ${shared.webUrl}`,
   });
   return "handled";
 }
@@ -2157,14 +2167,14 @@ function resolveCurrentMediaKind(state: SessionState): MediaKind {
   return title?.type === "movie" ? "movie" : "series";
 }
 
-/** Open a kunai:// share link from the clipboard. */
+/** Open a Kunai app link, HTTPS share link, or compact code from the clipboard. */
 async function handleWatch(container: Container): Promise<ShellWorkflowResult> {
   const clip = await readClipboard();
   const ref = clip ? parsePlaybackTargetRef(clip) : null;
   if (!ref) {
     container.stateManager.dispatch({
       type: "SET_PLAYBACK_FEEDBACK",
-      note: "No Kunai share link on the clipboard. Copy a kunai:// link, then run /watch.",
+      note: "No Kunai share link on the clipboard. Copy an https://, kunai://, or k1 code, then run /watch.",
     });
     return "handled";
   }

--- a/apps/cli/src/app/bootstrap/copy-share-link.ts
+++ b/apps/cli/src/app/bootstrap/copy-share-link.ts
@@ -1,1 +1,4 @@
-export { copyShareLinkForContext } from "@/infra/share/copy-share-link";
+export {
+  buildShareLinkArtifactsForContext,
+  copyShareLinkForContext,
+} from "@/infra/share/copy-share-link";

--- a/apps/cli/src/domain/session/command-registry.ts
+++ b/apps/cli/src/domain/session/command-registry.ts
@@ -50,6 +50,7 @@ export type AppCommandId =
   | "mark-anime"
   | "mark-series"
   | "share"
+  | "share-qr"
   | "watch"
   | "bookmark"
   | "follow"
@@ -139,6 +140,7 @@ export const COMMAND_CONTEXTS = {
     "mark-anime",
     "mark-series",
     "share",
+    "share-qr",
     "bookmark",
     "follow",
     "unfollow",
@@ -187,6 +189,7 @@ export const COMMAND_CONTEXTS = {
     "mark-anime",
     "mark-series",
     "share",
+    "share-qr",
     "bookmark",
     "follow",
     "unfollow",
@@ -607,7 +610,13 @@ export const COMMANDS: readonly AppCommand[] = [
     id: "share",
     label: "Share This",
     aliases: ["share", "share-link", "share-code"],
-    description: "Copy a catalog-anchored kunai:// share link for the current title",
+    description: "Copy a browser-safe HTTPS share link for the current title",
+  },
+  {
+    id: "share-qr",
+    label: "Share This as QR",
+    aliases: ["share --qr", "share-qr", "qr"],
+    description: "Show a scannable HTTPS share QR and copy the full link",
   },
   {
     id: "bookmark",
@@ -832,6 +841,7 @@ export function commandGroupFor(id: AppCommandId): AppCommandGroup {
     case "downloads":
     case "library":
     case "share":
+    case "share-qr":
     case "settings":
     case "providers":
     case "help":
@@ -1302,6 +1312,7 @@ function resolveCommandState(
     case "mark-anime":
     case "mark-series":
     case "share":
+    case "share-qr":
     case "bookmark":
     case "follow":
     case "unfollow":
@@ -1321,7 +1332,7 @@ function resolveCommandState(
         : {
             enabled: false,
             reason:
-              id === "share"
+              id === "share" || id === "share-qr"
                 ? "Play or select a title before sharing it."
                 : id === "bookmark"
                   ? "Play or select a title before bookmarking it."

--- a/apps/cli/src/domain/share/playback-target-ref.ts
+++ b/apps/cli/src/domain/share/playback-target-ref.ts
@@ -1,181 +1,22 @@
-// =============================================================================
-// playback-target-ref.ts — portable catalog-anchored "what to play" model + codec.
-// =============================================================================
-
-export type CatalogNs = "tmdb" | "anilist" | "mal" | "imdb" | "youtube";
-
-export type ShareAnchor =
-  | { readonly by: "catalog"; readonly ns: CatalogNs; readonly id: string }
-  | { readonly by: "search"; readonly query: string };
-
-export type PlaybackTargetRef = {
-  readonly anchor: ShareAnchor;
-  readonly kind: "movie" | "series" | "anime" | "video";
-  readonly season?: number;
-  readonly episode?: number;
-  readonly absoluteEpisode?: number;
-  readonly startSeconds?: number;
-  readonly title?: string;
-  readonly hint?: { readonly providerId: string; readonly quality?: string };
-};
-
-export type KunaiShareAction = "play" | "download";
-
-const CATALOG_NS: ReadonlySet<string> = new Set(["tmdb", "anilist", "mal", "imdb", "youtube"]);
-const PARAM_ORDER = ["cat", "q", "kind", "s", "e", "abs", "t", "src", "sq", "n"] as const;
-
-export function parseTimestampToSeconds(raw: string | null | undefined): number | null {
-  const value = raw?.trim();
-  if (!value) return null;
-  if (/^\d+$/.test(value)) {
-    const seconds = Number.parseInt(value, 10);
-    return seconds >= 0 ? seconds : null;
-  }
-  const clock = /^(?:(\d+):)?(\d{1,2}):(\d{1,2})$/.exec(value);
-  if (clock) {
-    const h = clock[1] ? Number.parseInt(clock[1], 10) : 0;
-    const m = Number.parseInt(clock[2] ?? "", 10);
-    const s = Number.parseInt(clock[3] ?? "", 10);
-    if (m > 59 || s > 59) return null;
-    const total = h * 3600 + m * 60 + s;
-    return total >= 0 ? total : null;
-  }
-  const human = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(value);
-  if (human && (human[1] || human[2] || human[3])) {
-    const h = human[1] ? Number.parseInt(human[1], 10) : 0;
-    const m = human[2] ? Number.parseInt(human[2], 10) : 0;
-    const s = human[3] ? Number.parseInt(human[3], 10) : 0;
-    const total = h * 3600 + m * 60 + s;
-    return total >= 0 ? total : null;
-  }
-  return null;
-}
-
-export function formatSecondsForUrl(seconds: number): string {
-  return String(Math.max(0, Math.round(seconds)));
-}
-
-export function encodePlaybackTargetRef(
-  ref: PlaybackTargetRef,
-  action: KunaiShareAction = "play",
-): string {
-  const params = new URLSearchParams();
-  if (ref.anchor.by === "catalog") {
-    params.set("cat", `${ref.anchor.ns}:${ref.anchor.id}`);
-  } else {
-    params.set("q", ref.anchor.query);
-  }
-  params.set("kind", ref.kind);
-  if (typeof ref.season === "number") params.set("s", String(ref.season));
-  if (typeof ref.episode === "number") params.set("e", String(ref.episode));
-  if (typeof ref.absoluteEpisode === "number") params.set("abs", String(ref.absoluteEpisode));
-  if (typeof ref.startSeconds === "number") {
-    params.set("t", formatSecondsForUrl(ref.startSeconds));
-  }
-  if (ref.hint?.providerId) params.set("src", ref.hint.providerId);
-  if (ref.hint?.quality) params.set("sq", ref.hint.quality);
-  if (ref.title) params.set("n", ref.title);
-  const ordered = PARAM_ORDER.filter((key) => params.has(key))
-    .map((key) => `${key}=${encodeURIComponent(params.get(key) as string)}`)
-    .join("&");
-  return `kunai://${action}?${ordered}`;
-}
-
-export function parsePlaybackTargetRef(raw: string): PlaybackTargetRef | null {
-  const value = raw.trim();
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    return null;
-  }
-  if (url.protocol !== "kunai:") return null;
-
-  const anchor = readAnchor(url.searchParams);
-  if (!anchor) return null;
-
-  const kind = readKind(url.searchParams);
-  const season = readInt(url.searchParams.get("s"));
-  const episode = readInt(url.searchParams.get("e"));
-  const absoluteEpisode = readInt(url.searchParams.get("abs"));
-  const startSeconds = parseTimestampToSeconds(url.searchParams.get("t"));
-  const src = url.searchParams.get("src")?.trim();
-  const quality = url.searchParams.get("sq")?.trim();
-  const title = url.searchParams.get("n")?.trim();
-
-  return {
-    anchor,
-    kind,
-    ...(season !== null ? { season } : {}),
-    ...(episode !== null ? { episode } : {}),
-    ...(absoluteEpisode !== null ? { absoluteEpisode } : {}),
-    ...(startSeconds !== null ? { startSeconds } : {}),
-    ...(src ? { hint: { providerId: src, ...(quality ? { quality } : {}) } } : {}),
-    ...(title ? { title } : {}),
-  };
-}
-
-export function parseKunaiShareUrl(
-  raw: string,
-): { readonly action: KunaiShareAction; readonly ref: PlaybackTargetRef } | null {
-  const value = raw.trim();
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    return null;
-  }
-  if (url.protocol !== "kunai:") return null;
-  const action = resolveShareAction(url);
-  if (!action) return null;
-  const ref = parsePlaybackTargetRef(value);
-  if (!ref) return null;
-  return { action, ref };
-}
-
-export function resolveShareAction(url: URL): KunaiShareAction | null {
-  const hostAction = normalizeToken(url.hostname);
-  if (hostAction === "play" || hostAction === "download") return hostAction;
-  const pathAction = normalizeToken(url.pathname.split("/").find(Boolean) ?? null);
-  if (pathAction === "play" || pathAction === "download") return pathAction;
-  return null;
-}
-
-function readAnchor(params: URLSearchParams): ShareAnchor | null {
-  const cat = params.get("cat")?.trim();
-  if (cat) {
-    const colon = cat.indexOf(":");
-    if (colon <= 0) return null;
-    const ns = cat.slice(0, colon).trim();
-    const id = cat.slice(colon + 1).trim();
-    if (!CATALOG_NS.has(ns) || !id) return null;
-    return { by: "catalog", ns: ns as CatalogNs, id };
-  }
-  const query = params.get("q")?.trim();
-  if (query) return { by: "search", query: query.slice(0, 200) };
-  return null;
-}
-
-function readKind(params: URLSearchParams): PlaybackTargetRef["kind"] {
-  const explicit = params.get("kind")?.trim();
-  if (
-    explicit === "movie" ||
-    explicit === "series" ||
-    explicit === "anime" ||
-    explicit === "video"
-  ) {
-    return explicit;
-  }
-  return "series";
-}
-
-function readInt(value: string | null): number | null {
-  if (!value) return null;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
-}
-
-function normalizeToken(value: string | null): string | null {
-  const trimmed = value?.trim().toLowerCase();
-  return trimmed || null;
-}
+// Kept as the CLI-local import seam. The implementation lives in @kunai/types
+// so the CLI and the public docs route cannot drift into incompatible codecs.
+export {
+  decodePlaybackTargetWebCode,
+  encodePlaybackTargetRef,
+  encodePlaybackTargetShortCode,
+  encodePlaybackTargetWebUrl,
+  formatSecondsForUrl,
+  KUNAI_WEB_SHARE_ORIGIN,
+  parseKunaiShareUrl,
+  parsePlaybackTargetRef,
+  parseTimestampToSeconds,
+  resolveShareAction,
+} from "@kunai/types";
+export type {
+  CatalogNs,
+  KunaiShareAction,
+  ParsedKunaiShare,
+  PlaybackTargetRef,
+  ShareAnchor,
+  WebSharePresentation,
+} from "@kunai/types";

--- a/apps/cli/src/domain/share/qr-code.ts
+++ b/apps/cli/src/domain/share/qr-code.ts
@@ -1,0 +1,459 @@
+// Dependency-free QR Code Model 2 encoder. Share links use byte mode, error
+// correction level L, and versions 1–10 to keep terminal output bounded.
+
+type RsBlock = {
+  readonly count: number;
+  readonly totalCodewords: number;
+  readonly dataCodewords: number;
+};
+
+type QrVersion = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+const QR_VERSIONS: readonly QrVersion[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+type QrFunctionMatrix = {
+  readonly modules: boolean[][];
+  readonly functions: boolean[][];
+};
+
+const RS_BLOCKS_L = {
+  1: [{ count: 1, totalCodewords: 26, dataCodewords: 19 }],
+  2: [{ count: 1, totalCodewords: 44, dataCodewords: 34 }],
+  3: [{ count: 1, totalCodewords: 70, dataCodewords: 55 }],
+  4: [{ count: 1, totalCodewords: 100, dataCodewords: 80 }],
+  5: [{ count: 1, totalCodewords: 134, dataCodewords: 108 }],
+  6: [{ count: 2, totalCodewords: 86, dataCodewords: 68 }],
+  7: [{ count: 2, totalCodewords: 98, dataCodewords: 78 }],
+  8: [{ count: 2, totalCodewords: 121, dataCodewords: 97 }],
+  9: [{ count: 2, totalCodewords: 146, dataCodewords: 116 }],
+  10: [
+    { count: 2, totalCodewords: 86, dataCodewords: 68 },
+    { count: 2, totalCodewords: 87, dataCodewords: 69 },
+  ],
+} as const satisfies Readonly<Record<number, readonly RsBlock[]>>;
+
+const ALIGNMENT_POSITIONS = {
+  1: [],
+  2: [6, 18],
+  3: [6, 22],
+  4: [6, 26],
+  5: [6, 30],
+  6: [6, 34],
+  7: [6, 22, 38],
+  8: [6, 24, 42],
+  9: [6, 26, 46],
+  10: [6, 28, 50],
+} as const satisfies Readonly<Record<number, readonly number[]>>;
+
+const GF_EXP = new Uint8Array(512);
+const GF_LOG = new Uint8Array(256);
+initializeGaloisTables();
+
+export type QrMatrix = readonly (readonly boolean[])[];
+
+export function encodeQrMatrix(payload: string): QrMatrix {
+  const bytes = new TextEncoder().encode(payload);
+  const version = chooseVersion(bytes.length);
+  const codewords = buildCodewords(bytes, version);
+  const base = createFunctionMatrix(version);
+  placeDataBits(base.modules, base.functions, codewords);
+
+  let best: boolean[][] | null = null;
+  let bestPenalty = Number.POSITIVE_INFINITY;
+  for (let mask = 0; mask < 8; mask++) {
+    const candidate = base.modules.map((row) => [...row]);
+    applyMask(candidate, base.functions, mask);
+    drawFormatBits(candidate, mask);
+    const penalty = calculatePenalty(candidate);
+    if (penalty < bestPenalty) {
+      best = candidate;
+      bestPenalty = penalty;
+    }
+  }
+  if (!best) throw new Error("QR mask selection failed");
+  return best;
+}
+
+export function renderQrHalfBlocks(matrix: QrMatrix, quietZone = 4): string {
+  if (matrix.length === 0 || matrix.some((row) => row.length !== matrix.length)) {
+    throw new Error("QR matrix must be non-empty and square");
+  }
+  const width = matrix.length + quietZone * 2;
+  const paddedHeight = matrix.length + quietZone * 2;
+  const lines: string[] = [];
+  for (let y = 0; y < paddedHeight; y += 2) {
+    let line = "";
+    for (let x = 0; x < width; x++) {
+      const top = qrCell(matrix, x - quietZone, y - quietZone);
+      const bottom = qrCell(matrix, x - quietZone, y + 1 - quietZone);
+      line += top ? (bottom ? "█" : "▀") : bottom ? "▄" : " ";
+    }
+    lines.push(line);
+  }
+  return lines.join("\n");
+}
+
+function chooseVersion(byteLength: number): QrVersion {
+  for (const version of QR_VERSIONS) {
+    const blocks = RS_BLOCKS_L[version];
+    const dataCodewords = blocks.reduce((sum, block) => sum + block.count * block.dataCodewords, 0);
+    const lengthBits = version <= 9 ? 8 : 16;
+    if (4 + lengthBits + byteLength * 8 <= dataCodewords * 8) return version;
+  }
+  throw new Error("QR payload is too long for the bounded terminal encoder");
+}
+
+function buildCodewords(bytes: Uint8Array, version: QrVersion): Uint8Array {
+  const blockSpecs = expandBlocks(RS_BLOCKS_L[version]);
+  const dataCapacity = blockSpecs.reduce((sum, block) => sum + block.dataCodewords, 0);
+  const bits: number[] = [0, 1, 0, 0];
+  appendBits(bits, bytes.length, version <= 9 ? 8 : 16);
+  for (const byte of bytes) appendBits(bits, byte, 8);
+  const terminator = Math.min(4, dataCapacity * 8 - bits.length);
+  for (let i = 0; i < terminator; i++) bits.push(0);
+  while (bits.length % 8 !== 0) bits.push(0);
+
+  const data = new Uint8Array(dataCapacity);
+  for (let i = 0; i < bits.length; i++) {
+    if (bits[i]) {
+      const byteIndex = i >>> 3;
+      data[byteIndex] = (data[byteIndex] ?? 0) | (1 << (7 - (i & 7)));
+    }
+  }
+  for (let i = bits.length >>> 3, toggle = 0; i < data.length; i++, toggle ^= 1) {
+    data[i] = toggle === 0 ? 0xec : 0x11;
+  }
+
+  const dataBlocks: Uint8Array[] = [];
+  const errorBlocks: Uint8Array[] = [];
+  let offset = 0;
+  for (const spec of blockSpecs) {
+    const block = data.slice(offset, offset + spec.dataCodewords);
+    offset += spec.dataCodewords;
+    dataBlocks.push(block);
+    errorBlocks.push(reedSolomonRemainder(block, spec.totalCodewords - spec.dataCodewords));
+  }
+
+  const output: number[] = [];
+  const maxDataLength = Math.max(...dataBlocks.map((block) => block.length));
+  for (let i = 0; i < maxDataLength; i++) {
+    for (const block of dataBlocks) if (i < block.length) output.push(block[i] ?? 0);
+  }
+  const maxErrorLength = Math.max(...errorBlocks.map((block) => block.length));
+  for (let i = 0; i < maxErrorLength; i++) {
+    for (const block of errorBlocks) if (i < block.length) output.push(block[i] ?? 0);
+  }
+  return Uint8Array.from(output);
+}
+
+function expandBlocks(groups: readonly RsBlock[]): RsBlock[] {
+  return groups.flatMap((group) => Array.from({ length: group.count }, () => group));
+}
+
+function appendBits(output: number[], value: number, count: number): void {
+  for (let bit = count - 1; bit >= 0; bit--) output.push((value >>> bit) & 1);
+}
+
+function reedSolomonRemainder(data: Uint8Array, degree: number): Uint8Array {
+  let generator = Uint8Array.of(1);
+  for (let i = 0; i < degree; i++) {
+    const next = new Uint8Array(generator.length + 1);
+    for (let j = 0; j < generator.length; j++) {
+      const coefficient = generator[j] ?? 0;
+      next[j] = (next[j] ?? 0) ^ coefficient;
+      next[j + 1] = (next[j + 1] ?? 0) ^ gfMultiply(coefficient, GF_EXP[i] ?? 0);
+    }
+    generator = next;
+  }
+
+  const result = new Uint8Array(data.length + degree);
+  result.set(data);
+  for (let i = 0; i < data.length; i++) {
+    const factor = result[i] ?? 0;
+    if (factor === 0) continue;
+    for (let j = 0; j < generator.length; j++) {
+      result[i + j] = (result[i + j] ?? 0) ^ gfMultiply(generator[j] ?? 0, factor);
+    }
+  }
+  return result.slice(data.length);
+}
+
+function initializeGaloisTables(): void {
+  let value = 1;
+  for (let i = 0; i < 255; i++) {
+    GF_EXP[i] = value;
+    GF_LOG[value] = i;
+    value <<= 1;
+    if (value & 0x100) value ^= 0x11d;
+  }
+  for (let i = 255; i < GF_EXP.length; i++) GF_EXP[i] = GF_EXP[i - 255] ?? 0;
+}
+
+function gfMultiply(left: number, right: number): number {
+  if (left === 0 || right === 0) return 0;
+  return GF_EXP[(GF_LOG[left] ?? 0) + (GF_LOG[right] ?? 0)] ?? 0;
+}
+
+function setMatrixCell(matrix: boolean[][], x: number, y: number, value: boolean): void {
+  const row = matrix[y];
+  if (!row || x < 0 || x >= row.length) throw new Error("QR matrix coordinate is out of bounds");
+  row[x] = value;
+}
+
+function matrixCell(matrix: boolean[][], x: number, y: number): boolean {
+  const row = matrix[y];
+  if (!row || x < 0 || x >= row.length) throw new Error("QR matrix coordinate is out of bounds");
+  return row[x] ?? false;
+}
+
+function createFunctionMatrix(version: QrVersion): QrFunctionMatrix {
+  const size = version * 4 + 17;
+  const modules = Array.from({ length: size }, () => Array<boolean>(size).fill(false));
+  const functions = Array.from({ length: size }, () => Array<boolean>(size).fill(false));
+  const setFunction = (x: number, y: number, dark: boolean) => {
+    if (x < 0 || y < 0 || x >= size || y >= size) return;
+    setMatrixCell(modules, x, y, dark);
+    setMatrixCell(functions, x, y, true);
+  };
+
+  drawFinderPattern(setFunction, 3, 3);
+  drawFinderPattern(setFunction, size - 4, 3);
+  drawFinderPattern(setFunction, 3, size - 4);
+  for (let i = 8; i < size - 8; i++) {
+    setFunction(6, i, i % 2 === 0);
+    setFunction(i, 6, i % 2 === 0);
+  }
+  for (const y of ALIGNMENT_POSITIONS[version] ?? []) {
+    for (const x of ALIGNMENT_POSITIONS[version] ?? []) {
+      if (functions[y]?.[x]) continue;
+      drawAlignmentPattern(setFunction, x, y);
+    }
+  }
+  reserveFormatAreas(setFunction, size);
+  setFunction(8, size - 8, true);
+  if (version >= 7) drawVersionBits(setFunction, version, size);
+  return { modules, functions };
+}
+
+function drawFinderPattern(
+  setFunction: (x: number, y: number, dark: boolean) => void,
+  centerX: number,
+  centerY: number,
+): void {
+  for (let dy = -4; dy <= 4; dy++) {
+    for (let dx = -4; dx <= 4; dx++) {
+      const distance = Math.max(Math.abs(dx), Math.abs(dy));
+      setFunction(centerX + dx, centerY + dy, distance !== 2 && distance !== 4);
+    }
+  }
+}
+
+function drawAlignmentPattern(
+  setFunction: (x: number, y: number, dark: boolean) => void,
+  centerX: number,
+  centerY: number,
+): void {
+  for (let dy = -2; dy <= 2; dy++) {
+    for (let dx = -2; dx <= 2; dx++) {
+      setFunction(centerX + dx, centerY + dy, Math.max(Math.abs(dx), Math.abs(dy)) !== 1);
+    }
+  }
+}
+
+function reserveFormatAreas(
+  setFunction: (x: number, y: number, dark: boolean) => void,
+  size: number,
+): void {
+  for (let i = 0; i <= 5; i++) setFunction(8, i, false);
+  setFunction(8, 7, false);
+  setFunction(8, 8, false);
+  setFunction(7, 8, false);
+  for (let i = 9; i < 15; i++) setFunction(14 - i, 8, false);
+  for (let i = 0; i < 8; i++) setFunction(size - 1 - i, 8, false);
+  for (let i = 8; i < 15; i++) setFunction(8, size - 15 + i, false);
+}
+
+function drawVersionBits(
+  setFunction: (x: number, y: number, dark: boolean) => void,
+  version: number,
+  size: number,
+): void {
+  let remainder = version;
+  for (let i = 0; i < 12; i++) {
+    remainder = (remainder << 1) ^ ((remainder >>> 11) * 0x1f25);
+  }
+  const bits = (version << 12) | remainder;
+  for (let i = 0; i < 18; i++) {
+    const dark = ((bits >>> i) & 1) !== 0;
+    const a = size - 11 + (i % 3);
+    const b = Math.floor(i / 3);
+    setFunction(a, b, dark);
+    setFunction(b, a, dark);
+  }
+}
+
+function placeDataBits(modules: boolean[][], functions: boolean[][], codewords: Uint8Array): void {
+  const size = modules.length;
+  let bitIndex = 0;
+  let upward = true;
+  for (let right = size - 1; right >= 1; right -= 2) {
+    if (right === 6) right--;
+    for (let step = 0; step < size; step++) {
+      const y = upward ? size - 1 - step : step;
+      for (let offset = 0; offset < 2; offset++) {
+        const x = right - offset;
+        if (functions[y]?.[x]) continue;
+        const byte = codewords[bitIndex >>> 3];
+        setMatrixCell(
+          modules,
+          x,
+          y,
+          byte === undefined ? false : ((byte >>> (7 - (bitIndex & 7))) & 1) !== 0,
+        );
+        bitIndex++;
+      }
+    }
+    upward = !upward;
+  }
+}
+
+function applyMask(modules: boolean[][], functions: boolean[][], mask: number): void {
+  for (let y = 0; y < modules.length; y++) {
+    for (let x = 0; x < modules.length; x++) {
+      if (!functions[y]?.[x] && maskBit(mask, x, y)) {
+        setMatrixCell(modules, x, y, !matrixCell(modules, x, y));
+      }
+    }
+  }
+}
+
+function maskBit(mask: number, x: number, y: number): boolean {
+  switch (mask) {
+    case 0:
+      return (x + y) % 2 === 0;
+    case 1:
+      return y % 2 === 0;
+    case 2:
+      return x % 3 === 0;
+    case 3:
+      return (x + y) % 3 === 0;
+    case 4:
+      return (Math.floor(y / 2) + Math.floor(x / 3)) % 2 === 0;
+    case 5:
+      return ((x * y) % 2) + ((x * y) % 3) === 0;
+    case 6:
+      return (((x * y) % 2) + ((x * y) % 3)) % 2 === 0;
+    case 7:
+      return (((x + y) % 2) + ((x * y) % 3)) % 2 === 0;
+    default:
+      throw new Error(`Unsupported QR mask ${mask}`);
+  }
+}
+
+function drawFormatBits(modules: boolean[][], mask: number): void {
+  const size = modules.length;
+  const data = (1 << 3) | mask; // Error correction level L is format value 01.
+  let remainder = data;
+  for (let i = 0; i < 10; i++) remainder = (remainder << 1) ^ ((remainder >>> 9) * 0x537);
+  const bits = ((data << 10) | remainder) ^ 0x5412;
+  const readBit = (index: number) => ((bits >>> index) & 1) !== 0;
+
+  for (let i = 0; i <= 5; i++) setMatrixCell(modules, 8, i, readBit(i));
+  setMatrixCell(modules, 8, 7, readBit(6));
+  setMatrixCell(modules, 8, 8, readBit(7));
+  setMatrixCell(modules, 7, 8, readBit(8));
+  for (let i = 9; i < 15; i++) setMatrixCell(modules, 14 - i, 8, readBit(i));
+  for (let i = 0; i < 8; i++) setMatrixCell(modules, size - 1 - i, 8, readBit(i));
+  for (let i = 8; i < 15; i++) setMatrixCell(modules, 8, size - 15 + i, readBit(i));
+  setMatrixCell(modules, 8, size - 8, true);
+}
+
+function calculatePenalty(modules: boolean[][]): number {
+  const size = modules.length;
+  let penalty = 0;
+  for (let y = 0; y < size; y++) penalty += linePenalty(modules[y] ?? []);
+  for (let x = 0; x < size; x++) {
+    penalty += linePenalty(Array.from({ length: size }, (_, y) => modules[y]?.[x] ?? false));
+  }
+  for (let y = 0; y < size - 1; y++) {
+    for (let x = 0; x < size - 1; x++) {
+      const value = modules[y]?.[x];
+      if (
+        value === modules[y]?.[x + 1] &&
+        value === modules[y + 1]?.[x] &&
+        value === modules[y + 1]?.[x + 1]
+      ) {
+        penalty += 3;
+      }
+    }
+  }
+  let dark = 0;
+  for (const row of modules) for (const cell of row) if (cell) dark++;
+  penalty += Math.floor(Math.abs(dark * 20 - size * size * 10) / (size * size)) * 10;
+  return penalty;
+}
+
+function linePenalty(line: readonly boolean[]): number {
+  let penalty = 0;
+  let runLength = 1;
+  for (let i = 1; i < line.length; i++) {
+    if (line[i] === line[i - 1]) {
+      runLength++;
+      if (runLength === 5) penalty += 3;
+      else if (runLength > 5) penalty++;
+    } else {
+      runLength = 1;
+    }
+  }
+
+  // Finder-like 1:1:3:1:1 runs are penalized at every scale, with four light
+  // modules on either side. Exact 11-cell substring matching misses scaled
+  // patterns and can choose a materially worse mask.
+  const history = Array<number>(7).fill(0);
+  let runColor = false;
+  let finderRunLength = 0;
+  for (const cell of line) {
+    if (cell === runColor) {
+      finderRunLength++;
+    } else {
+      addFinderRun(finderRunLength, history, line.length);
+      if (!runColor) penalty += countFinderPatterns(history) * 40;
+      runColor = cell;
+      finderRunLength = 1;
+    }
+  }
+  if (runColor) {
+    addFinderRun(finderRunLength, history, line.length);
+    finderRunLength = 0;
+  }
+  finderRunLength += line.length;
+  addFinderRun(finderRunLength, history, line.length);
+  penalty += countFinderPatterns(history) * 40;
+  return penalty;
+}
+
+function addFinderRun(runLength: number, history: number[], lineLength: number): void {
+  const adjusted = history[0] === 0 ? runLength + lineLength : runLength;
+  history.pop();
+  history.unshift(adjusted);
+}
+
+function countFinderPatterns(history: readonly number[]): number {
+  const scale = history[1] ?? 0;
+  const core =
+    scale > 0 &&
+    history[2] === scale &&
+    history[3] === scale * 3 &&
+    history[4] === scale &&
+    history[5] === scale;
+  if (!core) return 0;
+  return (
+    Number((history[0] ?? 0) >= scale * 4 && (history[6] ?? 0) >= scale) +
+    Number((history[6] ?? 0) >= scale * 4 && (history[0] ?? 0) >= scale)
+  );
+}
+
+function qrCell(matrix: QrMatrix, x: number, y: number): boolean {
+  return y >= 0 && x >= 0 && y < matrix.length && x < matrix.length
+    ? (matrix[y]?.[x] ?? false)
+    : false;
+}

--- a/apps/cli/src/infra/share/copy-share-link.ts
+++ b/apps/cli/src/infra/share/copy-share-link.ts
@@ -1,23 +1,86 @@
-import { encodePlaybackTargetRef } from "@/domain/share/playback-target-ref";
+import {
+  encodePlaybackTargetRef,
+  encodePlaybackTargetShortCode,
+  encodePlaybackTargetWebUrl,
+  KUNAI_WEB_SHARE_ORIGIN,
+  type PlaybackTargetRef,
+} from "@/domain/share/playback-target-ref";
 import { buildShareRefFromTitleContext } from "@/domain/share/share-ref-from-title-context";
 import type { ShellMode, TitleInfo } from "@/domain/types";
 import { copyToClipboard } from "@/infra/clipboard";
 
+export type ShareLinkContext = {
+  readonly title: Pick<TitleInfo, "id" | "type" | "name" | "externalIds" | "isAnime" | "posterUrl">;
+  readonly mode: ShellMode;
+  readonly episode?: { readonly season: number; readonly episode: number };
+  readonly startSeconds?: number;
+  readonly providerId?: string;
+};
+
+export type ShareLinkArtifacts = {
+  readonly url: string;
+  readonly webUrl: string;
+  readonly appUrl: string;
+  readonly shortCode: string | null;
+  readonly qrUrl: string;
+};
+
+export function buildShareLinkArtifactsForContext(
+  input: ShareLinkContext,
+): ShareLinkArtifacts | null {
+  const ref = buildShareRefFromTitleContext(input);
+  if (!ref) return null;
+  const appUrl = encodePlaybackTargetRef(ref);
+  const webUrl = encodePlaybackTargetWebUrl(ref, "play", { posterUrl: input.title.posterUrl });
+  const qrRef = stripOptionalQrMetadata(ref);
+  const shortCode = tryEncodePlaybackTargetShortCode(qrRef);
+  const qrUrl = shortCode
+    ? `${KUNAI_WEB_SHARE_ORIGIN}/w/${shortCode}`
+    : encodePlaybackTargetWebUrl(qrRef);
+  return { url: webUrl, webUrl, appUrl, shortCode, qrUrl };
+}
+
+function tryEncodePlaybackTargetShortCode(ref: PlaybackTargetRef): string | null {
+  try {
+    return encodePlaybackTargetShortCode(ref);
+  } catch {
+    // A provider-specific catalog identity can be longer than the deliberately
+    // bounded compact codec. The canonical HTTPS form remains shareable.
+    return null;
+  }
+}
+
 export async function copyShareLinkForContext(
-  input: {
-    readonly title: Pick<TitleInfo, "id" | "type" | "name" | "externalIds" | "isAnime">;
-    readonly mode: ShellMode;
-    readonly episode?: { readonly season: number; readonly episode: number };
-    readonly startSeconds?: number;
-    readonly providerId?: string;
-  },
+  input: ShareLinkContext,
   // Injected rather than mock.module'd: Bun's mock.module is process-global and
   // poisons later clipboard unit contracts when this file loads first.
   copy: (text: string) => Promise<boolean> = copyToClipboard,
-): Promise<{ readonly url: string; readonly copied: boolean } | null> {
-  const ref = buildShareRefFromTitleContext(input);
-  if (!ref) return null;
-  const url = encodePlaybackTargetRef(ref);
-  const copied = await copy(url);
-  return { url, copied };
+): Promise<{
+  readonly url: string;
+  readonly webUrl: string;
+  readonly appUrl: string;
+  readonly shortCode: string | null;
+  readonly qrUrl: string;
+  readonly copied: boolean;
+} | null> {
+  const artifacts = buildShareLinkArtifactsForContext(input);
+  if (!artifacts) return null;
+  const copied = await copy(artifacts.webUrl);
+  return { ...artifacts, copied };
 }
+
+function stripOptionalQrMetadata(ref: PlaybackTargetRef): PlaybackTargetRef {
+  const compactRef: MutablePlaybackTargetRef = {
+    anchor: ref.anchor,
+    kind: ref.kind,
+  };
+  if (ref.season !== undefined) compactRef.season = ref.season;
+  if (ref.episode !== undefined) compactRef.episode = ref.episode;
+  if (ref.absoluteEpisode !== undefined) compactRef.absoluteEpisode = ref.absoluteEpisode;
+  if (ref.startSeconds !== undefined) compactRef.startSeconds = ref.startSeconds;
+  return compactRef;
+}
+
+type MutablePlaybackTargetRef = {
+  -readonly [Key in keyof PlaybackTargetRef]: PlaybackTargetRef[Key];
+};

--- a/apps/cli/test/unit/app-shell/command-router.test.ts
+++ b/apps/cli/test/unit/app-shell/command-router.test.ts
@@ -133,6 +133,8 @@ describe("resolveCommandContext scoped surfaces", () => {
       "source",
       "quality",
       "provider",
+      "share",
+      "share-qr",
       "bookmark",
       "follow",
       "unfollow",

--- a/apps/cli/test/unit/app/copy-share-link.test.ts
+++ b/apps/cli/test/unit/app/copy-share-link.test.ts
@@ -1,6 +1,10 @@
 import { expect, mock, test } from "bun:test";
 
-import { copyShareLinkForContext } from "@/app/bootstrap/copy-share-link";
+import {
+  buildShareLinkArtifactsForContext,
+  copyShareLinkForContext,
+} from "@/app/bootstrap/copy-share-link";
+import { parsePlaybackTargetRef } from "@/domain/share/playback-target-ref";
 
 test("copyShareLinkForContext encodes and copies a catalog-anchored URL", async () => {
   const copyToClipboard = mock(async (_text: string) => true);
@@ -12,6 +16,7 @@ test("copyShareLinkForContext encodes and copies a catalog-anchored URL", async 
         id: "tmdb:1396",
         type: "series",
         name: "Breaking Bad",
+        posterUrl: "https://image.tmdb.org/t/p/w500/breaking-bad.jpg",
         externalIds: { tmdbId: "1396" },
       },
       episode: { season: 4, episode: 9 },
@@ -22,10 +27,77 @@ test("copyShareLinkForContext encodes and copies a catalog-anchored URL", async 
   );
 
   expect(out?.copied).toBe(true);
-  expect(out?.url).toBe(
+  expect(out?.appUrl).toBe(
     "kunai://play?cat=tmdb%3A1396&kind=series&s=4&e=9&t=120&src=videasy&n=Breaking%20Bad",
   );
+  expect(out?.url).toStartWith("https://kunai.kitsunekode.in/w/v1.");
+  expect(out?.webUrl).toBe(out?.url);
+  expect(out?.qrUrl).toStartWith("https://kunai.kitsunekode.in/w/k1");
+  expect(parsePlaybackTargetRef(out?.webUrl ?? "")).toEqual(
+    parsePlaybackTargetRef(out?.appUrl ?? ""),
+  );
+  expect(parsePlaybackTargetRef(out?.shortCode ?? "")).toEqual({
+    anchor: { by: "catalog", ns: "tmdb", id: "1396" },
+    kind: "series",
+    season: 4,
+    episode: 9,
+    startSeconds: 120,
+  });
+  expect(out?.shortCode?.length).toBeLessThan(40);
   expect(copyToClipboard).toHaveBeenCalledWith(out?.url);
+});
+
+test("QR handoff strips optional metadata while preserving the catalog target", () => {
+  const out = buildShareLinkArtifactsForContext({
+    mode: "anime",
+    title: {
+      id: "anilist:21",
+      type: "series",
+      name: "A deliberately long presentation title that does not belong in a terminal QR",
+      externalIds: { anilistId: "21" },
+      posterUrl: "https://example.com/poster.jpg",
+      isAnime: true,
+    },
+    episode: { season: 1, episode: 3 },
+    startSeconds: 120,
+    providerId: "allanime",
+  });
+
+  expect(out).not.toBeNull();
+  expect(out?.qrUrl.length).toBeLessThan(100);
+  expect(parsePlaybackTargetRef(out?.qrUrl ?? "")).toEqual({
+    anchor: { by: "catalog", ns: "anilist", id: "21" },
+    kind: "anime",
+    season: 1,
+    episode: 3,
+    startSeconds: 120,
+  });
+  expect(parsePlaybackTargetRef(out?.webUrl ?? "")?.title).toContain("deliberately long");
+});
+
+test("a provider-specific identity that exceeds the compact codec still produces an HTTPS link", () => {
+  const providerIdentity = "episode/".repeat(40);
+  const out = buildShareLinkArtifactsForContext({
+    mode: "youtube",
+    title: {
+      id: "youtube:oversized",
+      type: "movie",
+      name: "Provider-specific video",
+      externalIds: { youtubeId: providerIdentity },
+    },
+  });
+
+  expect(out?.shortCode).toBeNull();
+  expect(out?.qrUrl).toStartWith("https://kunai.kitsunekode.in/w/v1.");
+  expect(parsePlaybackTargetRef(out?.qrUrl ?? "")?.title).toBeUndefined();
+  expect(parsePlaybackTargetRef(out?.webUrl ?? "")?.anchor).toEqual({
+    by: "catalog",
+    ns: "youtube",
+    id: providerIdentity,
+  });
+  expect(parsePlaybackTargetRef(out?.qrUrl ?? "")?.anchor).toEqual(
+    parsePlaybackTargetRef(out?.webUrl ?? "")?.anchor,
+  );
 });
 
 test("copyShareLinkForContext returns null when no portable ref can be built", async () => {

--- a/apps/cli/test/unit/app/resolve-share-target.test.ts
+++ b/apps/cli/test/unit/app/resolve-share-target.test.ts
@@ -5,6 +5,10 @@ import {
   shareTitleCatalogIdForAnimeMapping,
 } from "@/app/bootstrap/resolve-share-target";
 import type { Container } from "@/container";
+import {
+  encodePlaybackTargetWebUrl,
+  parsePlaybackTargetRef,
+} from "@/domain/share/playback-target-ref";
 import type { TitleInfo } from "@/domain/types";
 
 import { createContainerFixture } from "../../support/container-fixture";
@@ -111,6 +115,26 @@ describe("resolveShareTarget", () => {
     expect(out.episode).toEqual({ season: 2, episode: 5 });
     expect(out.startSeconds).toBe(90);
     expect(out.mode).toBe("series");
+  });
+
+  it("keeps an HTTPS series handoff on the direct catalog path", async () => {
+    const container = createResolverContainer();
+    const parsed = parsePlaybackTargetRef(
+      encodePlaybackTargetWebUrl({
+        anchor: { by: "catalog", ns: "tmdb", id: "1396" },
+        kind: "series",
+        season: 1,
+        episode: 3,
+      }),
+    );
+
+    expect(parsed?.anchor).toEqual({ by: "catalog", ns: "tmdb", id: "1396" });
+    if (!parsed) throw new Error("expected the generated HTTPS share link to parse");
+    const out = await resolveShareTarget(parsed, container);
+    expect(out.title.id).toBe("tmdb:1396");
+    expect(out.episode).toEqual({ season: 1, episode: 3 });
+    expect(out.searchQuery).toBeUndefined();
+    expect(out.autoPickIndex).toBeUndefined();
   });
 
   it("maps movie and imdb catalog anchors", async () => {

--- a/apps/cli/test/unit/domain/session/command-registry-contexts.test.ts
+++ b/apps/cli/test/unit/domain/session/command-registry-contexts.test.ts
@@ -26,6 +26,7 @@ describe("command registry contexts", () => {
       "mark-anime",
       "mark-series",
       "share",
+      "share-qr",
       "bookmark",
       "follow",
       "unfollow",
@@ -104,6 +105,7 @@ describe("command registry contexts", () => {
       "mark-anime",
       "mark-series",
       "share",
+      "share-qr",
       "bookmark",
       "follow",
       "unfollow",
@@ -194,6 +196,11 @@ describe("command registry contexts", () => {
     expect(parseCommand("/mute")?.id).toBe("mute");
     expect(parseCommand("/mark-watched")?.id).toBe("mark-watched");
     expect(parseCommand("/watched")?.id).toBe("mark-watched");
+  });
+
+  test("resolves the QR flag form to the QR share action", () => {
+    expect(parseCommand("/share --qr")?.id).toBe("share-qr");
+    expect(parseCommand("/share-qr")?.id).toBe("share-qr");
   });
 
   test("keeps root overlay command order focused on first-run actions", () => {

--- a/apps/cli/test/unit/domain/share/qr-code.test.ts
+++ b/apps/cli/test/unit/domain/share/qr-code.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+
+import { encodeQrMatrix, renderQrHalfBlocks } from "@/domain/share/qr-code";
+
+describe("dependency-free terminal QR", () => {
+  test("matches the qrencode reference fixture for a known byte payload", () => {
+    const matrix = encodeQrMatrix("https://kunai.kitsunekode.in/w/test");
+    const fixtureBytes = `${matrix.map((row) => row.map((cell) => (cell ? "1" : "0")).join("")).join("\n")}\n`;
+
+    expect(matrix).toHaveLength(29);
+    expect(matrix.every((row) => row.length === 29)).toBe(true);
+    expect(createHash("sha256").update(fixtureBytes).digest("hex")).toBe(
+      // Cross-checked against qrencode 4.1.1: all 567 non-function data
+      // modules are identical after removing each encoder's chosen mask.
+      "66476b753ad5fe5967417b57d7fa1773531ad6e94e550abbc2a190bee4f95914",
+    );
+  });
+
+  test("renders two QR rows per terminal cell with a quiet zone", () => {
+    const output = renderQrHalfBlocks(encodeQrMatrix("https://kunai.kitsunekode.in/w/test"));
+    const lines = output.split("\n");
+
+    expect(output).toContain("▀");
+    expect(output).toContain("▄");
+    expect(lines[0]?.trim()).toBe("");
+    expect(lines.at(-1)?.trim()).toBe("");
+    expect(lines.every((line) => line.length === lines[0]?.length)).toBe(true);
+  });
+
+  test("rejects payloads that exceed the bounded terminal QR versions", () => {
+    expect(() => encodeQrMatrix("x".repeat(272))).toThrow("too long");
+  });
+});

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable import/no-unassigned-import */
 import "./global.css";
+import { PrivacyAnalytics } from "@/components/analytics/privacy-analytics";
 import { KunaiSearchDialog } from "@/components/search/kunai-search-dialog";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { fontClassNames } from "@/lib/fonts";
 /* eslint-enable import/no-unassigned-import */
 import { docsSiteUrl } from "@/lib/site";
-import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import type { Metadata, Viewport } from "next";
@@ -52,7 +52,7 @@ export default function RootLayout({ children }: { readonly children: ReactNode 
         >
           <TooltipProvider>{children}</TooltipProvider>
         </RootProvider>
-        <Analytics />
+        <PrivacyAnalytics />
         <SpeedInsights />
       </body>
     </html>

--- a/apps/docs/app/w/[code]/page.tsx
+++ b/apps/docs/app/w/[code]/page.tsx
@@ -1,0 +1,201 @@
+import { CopyButton } from "@/components/ui/copy-button";
+import { NATIVE_INSTALL_PS1, NATIVE_INSTALL_SH } from "@/lib/install-commands";
+import { buildPageMetadata } from "@/lib/page-metadata";
+import {
+  decodePlaybackTargetWebCode,
+  encodePlaybackTargetRef,
+  type ParsedKunaiShare,
+  type PlaybackTargetRef,
+} from "@kunai/types";
+import { IconArrowRight, IconPlayerPlayFilled, IconTerminal2 } from "@tabler/icons-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+type SharePageProps = {
+  readonly params: Promise<{ readonly code: string }>;
+};
+
+export async function generateMetadata({ params }: SharePageProps): Promise<Metadata> {
+  const { code } = await params;
+  const shared = decodePlaybackTargetWebCode(code);
+  if (!shared) return { title: "Invalid share link", robots: { index: false, follow: false } };
+  const title = titleFor(shared.ref);
+  return {
+    ...buildPageMetadata({
+      title: `${title} — shared with Kunai`,
+      description: `${positionFor(shared.ref)}. Open this catalog-anchored link in Kunai or install the terminal client.`,
+      path: `/w/${code}`,
+    }),
+    robots: { index: false, follow: false },
+  };
+}
+
+export default async function SharePage({ params }: SharePageProps) {
+  const { code } = await params;
+  const shared = decodePlaybackTargetWebCode(code);
+  return shared ? <ValidShareLanding shared={shared} /> : <InvalidShareLanding />;
+}
+
+function ValidShareLanding({ shared }: { readonly shared: ParsedKunaiShare }) {
+  const { ref, action } = shared;
+  const title = titleFor(ref);
+  const position = positionFor(ref);
+  const appUrl = encodePlaybackTargetRef(ref, action);
+  const catalog = catalogFor(ref);
+
+  return (
+    <main className="relative isolate flex min-h-[100dvh] items-center overflow-hidden px-5 py-10 sm:px-8">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_18%_20%,color-mix(in_oklab,var(--kunai-accent)_10%,transparent),transparent_34%),radial-gradient(circle_at_82%_82%,color-mix(in_oklab,var(--kunai-ok)_7%,transparent),transparent_32%)]"
+      />
+      <article className="kunai-surface-shell mx-auto w-full max-w-5xl p-2 shadow-2xl">
+        <div className="kunai-surface-shell__inner grid min-h-[34rem] overflow-hidden lg:grid-cols-[0.78fr_1.22fr]">
+          <div className="relative flex min-h-72 flex-col justify-between overflow-hidden border-b border-[var(--kunai-line)] bg-[var(--kunai-surface-elevated)] p-7 sm:p-10 lg:min-h-full lg:border-r lg:border-b-0">
+            {shared.presentation?.posterUrl ? (
+              <div
+                aria-label={`Cover artwork for ${title}`}
+                className="absolute inset-0 bg-cover bg-center opacity-30 grayscale-[0.18]"
+                style={{ backgroundImage: `url(${JSON.stringify(shared.presentation.posterUrl)})` }}
+              />
+            ) : (
+              <div
+                aria-label={`Cover placeholder for ${title}`}
+                className="absolute inset-0 grid place-items-center opacity-[0.07]"
+              >
+                <span className="font-serif text-[clamp(13rem,34vw,24rem)] leading-none font-semibold">
+                  {initialFor(title)}
+                </span>
+              </div>
+            )}
+            <div
+              aria-hidden="true"
+              className="absolute inset-0 bg-linear-to-t from-[var(--kunai-surface-elevated)] via-transparent to-[color-mix(in_oklab,var(--kunai-surface-elevated)_42%,transparent)]"
+            />
+            <div className="relative flex items-center justify-between gap-4">
+              <span className="kunai-step-label">Shared through Kunai</span>
+              <span className="rounded-full border border-[var(--kunai-line)] px-3 py-1 font-mono text-[0.65rem] tracking-[0.14em] text-[var(--color-fd-muted-foreground)] uppercase">
+                {ref.kind}
+              </span>
+            </div>
+            <div className="relative mt-24">
+              <p className="mb-3 font-mono text-xs tracking-[0.12em] text-[var(--kunai-accent)] uppercase">
+                {catalog}
+              </p>
+              <h1 className="max-w-md font-serif text-4xl leading-[1.04] font-semibold text-balance sm:text-5xl">
+                {title}
+              </h1>
+              <p className="mt-5 text-sm font-medium text-[var(--kunai-ok)]">{position}</p>
+            </div>
+          </div>
+
+          <div className="flex flex-col justify-between gap-10 p-7 sm:p-10 lg:p-12">
+            <div>
+              <p className="kunai-step-label">A direct handoff, not a search</p>
+              <h2 className="mt-4 max-w-xl font-serif text-3xl leading-tight sm:text-4xl">
+                Continue this exact title in your own player.
+              </h2>
+              <p className="mt-5 max-w-xl text-sm leading-7 text-[var(--color-fd-muted-foreground)]">
+                The catalog and episode are carried in this link. Kunai resolves providers locally,
+                then hands playback to mpv on your machine.
+              </p>
+              <a className="kunai-button kunai-button-primary mt-8 w-full sm:w-auto" href={appUrl}>
+                <IconPlayerPlayFilled className="mr-2 size-4" aria-hidden="true" />
+                {action === "download" ? "Open download in Kunai" : "Open in Kunai"}
+              </a>
+            </div>
+
+            <section
+              aria-labelledby="install-kunai"
+              className="border-t border-[var(--kunai-line)] pt-8"
+            >
+              <div className="flex items-start gap-3">
+                <IconTerminal2
+                  className="mt-0.5 size-5 shrink-0 text-[var(--kunai-accent)]"
+                  aria-hidden="true"
+                />
+                <div>
+                  <h2 id="install-kunai" className="font-serif text-xl">
+                    New to Kunai?
+                  </h2>
+                  <p className="mt-1 text-xs leading-6 text-[var(--color-fd-muted-foreground)]">
+                    Install the native client, then return to this page and open the link again.
+                  </p>
+                </div>
+              </div>
+              <div className="mt-5 grid gap-3">
+                <InstallCommand label="Linux / macOS" command={NATIVE_INSTALL_SH} />
+                <InstallCommand label="Windows PowerShell" command={NATIVE_INSTALL_PS1} />
+              </div>
+              <p className="mt-5 text-xs leading-6 text-[var(--color-fd-muted-foreground)]">
+                This page stores nothing and sends no share-page analytics. Anyone holding the URL
+                can read the title it contains.{" "}
+                <Link href="/docs/users/share-links">How sharing works</Link>
+              </p>
+            </section>
+          </div>
+        </div>
+      </article>
+    </main>
+  );
+}
+
+function InstallCommand({ label, command }: { readonly label: string; readonly command: string }) {
+  return (
+    <div className="rounded-xl border border-[var(--kunai-line)] bg-[var(--kunai-bg)] p-3.5">
+      <div className="mb-2 flex items-center justify-between gap-4">
+        <span className="font-mono text-[0.65rem] tracking-[0.12em] text-[var(--color-fd-muted-foreground)] uppercase">
+          {label}
+        </span>
+        <CopyButton text={command} label={`share-install-${label}`} />
+      </div>
+      <code className="block overflow-x-auto text-xs leading-6 whitespace-nowrap text-[var(--color-fd-foreground)]">
+        {command}
+      </code>
+    </div>
+  );
+}
+
+function InvalidShareLanding() {
+  return (
+    <main className="grid min-h-[100dvh] place-items-center px-5 py-10">
+      <section className="kunai-surface-shell w-full max-w-xl p-2">
+        <div className="kunai-surface-shell__inner p-8 sm:p-12">
+          <p className="kunai-step-label text-[var(--kunai-danger)]">Link unavailable</p>
+          <h1 className="mt-4 font-serif text-4xl leading-tight">This share link is incomplete.</h1>
+          <p className="mt-5 text-sm leading-7 text-[var(--color-fd-muted-foreground)]">
+            It may have been truncated while copying. Ask the sender for the complete HTTPS link;
+            Kunai will never guess a title from a damaged code.
+          </p>
+          <Link className="kunai-button mt-8" href="/">
+            Kunai home <IconArrowRight className="ml-2 size-4" aria-hidden="true" />
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function titleFor(ref: PlaybackTargetRef): string {
+  if (ref.title) return ref.title;
+  if (ref.anchor.by === "catalog") return `${ref.anchor.ns.toUpperCase()} ${ref.anchor.id}`;
+  return ref.anchor.query;
+}
+
+function catalogFor(ref: PlaybackTargetRef): string {
+  return ref.anchor.by === "catalog"
+    ? `${ref.anchor.ns.toUpperCase()} · ${ref.anchor.id}`
+    : "Search fallback";
+}
+
+function positionFor(ref: PlaybackTargetRef): string {
+  if (ref.season !== undefined && ref.episode !== undefined) {
+    return `Season ${ref.season} · Episode ${ref.episode}`;
+  }
+  if (ref.absoluteEpisode !== undefined) return `Episode ${ref.absoluteEpisode}`;
+  return ref.kind === "movie" ? "Movie" : ref.kind === "video" ? "Video" : "Series";
+}
+
+function initialFor(title: string): string {
+  return Array.from(title.trim())[0]?.toUpperCase() ?? "K";
+}

--- a/apps/docs/components/analytics/privacy-analytics.tsx
+++ b/apps/docs/components/analytics/privacy-analytics.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { filterPrivateShareAnalytics } from "@/lib/analytics-privacy";
+import { Analytics } from "@vercel/analytics/next";
+
+export function PrivacyAnalytics() {
+  return <Analytics beforeSend={filterPrivateShareAnalytics} />;
+}

--- a/apps/docs/lib/analytics-privacy.ts
+++ b/apps/docs/lib/analytics-privacy.ts
@@ -1,0 +1,12 @@
+import type { BeforeSendEvent } from "@vercel/analytics/next";
+
+/** Share paths contain the title/ref itself, so they never enter web analytics. */
+export function filterPrivateShareAnalytics(event: BeforeSendEvent): BeforeSendEvent | null {
+  try {
+    if (new URL(event.url).pathname.startsWith("/w/")) return null;
+  } catch {
+    // An unexpected analytics URL shape is not a share path; preserve the
+    // existing site behavior instead of silently dropping unrelated metrics.
+  }
+  return event;
+}

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,10 +1,10 @@
 {
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceFingerprint": "7eecb6ece14ab8a587bc8254fb10a9de38b892c37d251aaf31e9b88009e039ed",
-  "docsContentFingerprint": "ea0948f8b9fc1f498bcebec01a48978aa48752098014156bbbc680bad2000e69",
+  "cliSourceFingerprint": "f79e2dda398a63e861fe7e83a3d79c8afbc4b5fddfb889e2d668a6cf3d9d5f81",
+  "docsContentFingerprint": "c5442c7f9a98211a85bcdd4780026c21daa57f6704956a93272b675f73e7a18d",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
-  "commandCount": 81,
+  "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],
   "providers": [
     {
@@ -452,7 +452,13 @@
       "id": "share",
       "label": "Share This",
       "aliases": ["share", "share-link", "share-code"],
-      "description": "Copy a catalog-anchored kunai:// share link for the current title"
+      "description": "Copy a browser-safe HTTPS share link for the current title"
+    },
+    {
+      "id": "share-qr",
+      "label": "Share This as QR",
+      "aliases": ["share --qr", "share-qr", "qr"],
+      "description": "Show a scannable HTTPS share QR and copy the full link"
     },
     {
       "id": "bookmark",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@base-ui/react": "catalog:web",
     "@kunai/design": "workspace:*",
+    "@kunai/types": "workspace:*",
     "@tabler/icons-react": "catalog:web",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",

--- a/apps/docs/test/share-landing.test.tsx
+++ b/apps/docs/test/share-landing.test.tsx
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+
+import { encodePlaybackTargetWebUrl } from "@kunai/types";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import SharePage, { generateMetadata } from "../app/w/[code]/page";
+import { filterPrivateShareAnalytics } from "../lib/analytics-privacy";
+
+function webCode(url: string): string {
+  return new URL(url).pathname.split("/").at(-1) ?? "";
+}
+
+test("share landing renders a catalog episode with install and app handoff actions", async () => {
+  const url = encodePlaybackTargetWebUrl(
+    {
+      anchor: { by: "catalog", ns: "tmdb", id: "1396" },
+      kind: "series",
+      season: 1,
+      episode: 3,
+      startSeconds: 83,
+      title: "Breaking Bad",
+    },
+    "play",
+    { posterUrl: "https://image.tmdb.org/t/p/w500/breaking-bad.jpg" },
+  );
+  const code = webCode(url);
+  const html = renderToStaticMarkup(await SharePage({ params: Promise.resolve({ code }) }));
+
+  expect(html).toContain("Breaking Bad");
+  expect(html).toContain("Season 1 · Episode 3");
+  expect(html).toContain("Open in Kunai");
+  expect(html).toContain("breaking-bad.jpg");
+  expect(html).toContain("kunai://play?");
+  expect(html).toContain("curl -fsSL");
+  expect(html).toContain("install.ps1");
+  expect(html).not.toContain("q=");
+});
+
+test("malformed or truncated share codes render recovery guidance instead of throwing", async () => {
+  const html = renderToStaticMarkup(
+    await SharePage({ params: Promise.resolve({ code: "v1.truncated" }) }),
+  );
+  const metadata = await generateMetadata({ params: Promise.resolve({ code: "v1.truncated" }) });
+
+  expect(html).toContain("This share link is incomplete");
+  expect(html).toContain("Kunai home");
+  expect(html).not.toContain("kunai://");
+  expect(metadata.title).toBe("Invalid share link");
+});
+
+test("share codes never enter site analytics", () => {
+  const shareEvent = {
+    type: "pageview" as const,
+    url: "https://kunai.kitsunekode.in/w/v1.private-title-code",
+  };
+  const docsEvent = {
+    type: "pageview" as const,
+    url: "https://kunai.kitsunekode.in/docs/users/getting-started",
+  };
+
+  expect(filterPrivateShareAnalytics(shareEvent)).toBeNull();
+  expect(filterPrivateShareAnalytics(docsEvent)).toBe(docsEvent);
+});

--- a/bun.lock
+++ b/bun.lock
@@ -70,6 +70,7 @@
       "dependencies": {
         "@base-ui/react": "catalog:web",
         "@kunai/design": "workspace:*",
+        "@kunai/types": "workspace:*",
         "@tabler/icons-react": "catalog:web",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",

--- a/docs/users/cli-reference.mdx
+++ b/docs/users/cli-reference.mdx
@@ -77,8 +77,9 @@ For a quick trial without installing, evaluate it in the current session —
 | ---------------------------------- | ------------------------------------------------ |
 | `kunai --open "kunai://play?..."`  | Resolve and play a shared catalog link           |
 | `kunai --install-protocol-handler` | Register `kunai://` with the OS (**Linux-only**) |
-| `/share`                           | Copy link for current playback context           |
-| `/watch`                           | Open link from clipboard                         |
+| `/share`                           | Copy an HTTPS link for current playback context  |
+| `/share --qr`                      | Show an HTTPS QR and copy the full link           |
+| `/watch`                           | Open HTTPS, compact, or `kunai://` clipboard data |
 | `/up-next`                         | Current playback order                           |
 | `/downloads`                       | Download queue overlay                           |
 | `/library`                         | Offline library                                  |

--- a/docs/users/commands-and-shortcuts.mdx
+++ b/docs/users/commands-and-shortcuts.mdx
@@ -38,8 +38,9 @@ deliberately reduced public reference generated from the keybinding registry.
 - `/calendar` opens release calendar results.
 - `/discover` and `/recommendation` open recommendation surfaces without autoplay.
 - `/filters` opens guided search facets (type, year, library, and more).
-- `/share` copies a catalog-anchored `kunai://` play link to the clipboard.
-- `/watch` parses a `kunai://` URL from the clipboard and launches playback.
+- `/share` copies a catalog-anchored HTTPS play link to the clipboard.
+- `/share --qr` shows a compact HTTPS QR and also copies the full link.
+- `/watch` accepts HTTPS, compact `k1…`, or `kunai://` clipboard input and launches playback.
 
 `/stats` is on the default browse palette. Tracker sync is experimental and lives under
 `/settings` → Sync. `/random` and `/surprise` are on the default browse palette

--- a/docs/users/share-links.mdx
+++ b/docs/users/share-links.mdx
@@ -1,10 +1,12 @@
 ---
 title: Share Links
-description: "Copy and open catalog-anchored kunai:// links across machines and providers, and understand the confirmation Kunai requires before a shared link plays."
+description: "Copy browser-safe Kunai links, show a terminal QR, and open HTTPS, compact, or kunai:// handoffs across machines and providers."
 status: shipped
 ---
 
-Kunai uses one portable `kunai://` link format for sharing what to play. Links anchor to catalog metadata (TMDB, AniList, MAL, IMDb) so the receiver can resolve through their own providers.
+Kunai shares browser-safe `https://kunai.kitsunekode.in/w/<code>` links. The web page shows what was shared, offers an **Open in Kunai** handoff, and gives native install commands to someone who does not have Kunai yet. Links remain anchored to catalog metadata (TMDB, AniList, MAL, IMDb), so the receiver resolves through their own providers instead of repeating a title search.
+
+The URL contains the playback ref itself. There is no shortener database, and share-page visits are excluded from site analytics. Anyone holding the URL can read the title and episode it contains.
 
 <ScopeCallout variant="beta" title="Protocol handler is Linux-only">
   `kunai --open` works on every platform without OS registration. `kunai --install-protocol-handler` registers the `kunai://` OS handler on **Linux only** in 0.3.0.
@@ -18,7 +20,15 @@ During or after playback:
 /share
 ```
 
-Copies a catalog-anchored `kunai://play?...` URL to your clipboard. When resume position exists, Kunai can include a timestamp (`t=`) so the receiver starts near where you left off.
+Copies a catalog-anchored HTTPS URL to your clipboard. When resume position exists, Kunai can include a timestamp (`t=`) so the receiver starts near where you left off.
+
+To show a scannable HTTPS QR inside the terminal while copying the full link:
+
+```text
+/share --qr
+```
+
+The QR uses a compact, checksummed catalog code. It intentionally omits display-only title and provider hints to stay readable in ordinary terminal sizes; the catalog, episode, and timestamp remain exact.
 
 From mpv while playing:
 
@@ -32,7 +42,7 @@ Post-playback and History rows also expose **Share link** / **Copy share link** 
 /watch
 ```
 
-Reads a `kunai://` URL from your clipboard, resolves it against your local catalog and providers, and launches mpv with any shared timestamp applied once on the first play.
+Reads an HTTPS URL, a `kunai://` URL, or a compact `k1…` code from your clipboard, resolves it against your local catalog and providers, and launches mpv with any shared timestamp applied once on the first play.
 
 ## Launch from the terminal
 
@@ -51,6 +61,14 @@ kunai --install-protocol-handler
 After registration on Linux (including WSL), `kunai://` links from browsers or chat apps route through `--handoff-url`, which may ask for confirmation. On macOS and Windows-native, keep using `kunai --open`. A WSL registration does not cover Windows-native browsers outside WSL.
 
 ## URL shape
+
+The copied form is HTTPS:
+
+```text
+https://kunai.kitsunekode.in/w/v1.<encoded-ref>
+```
+
+The application handoff inside that page keeps the existing grammar:
 
 ```text
 kunai://play?cat=<namespace>:<id>&kind=<movie|series|anime>&s=<season>&e=<episode>&t=<seconds>
@@ -75,6 +93,8 @@ kunai://play?cat=tmdb%3A1396&kind=series&s=1&e=3
 kunai://play?cat=anilist%3A21&kind=anime&s=1&e=1&t=120
 kunai://play?q=One%20Piece&kind=anime
 ```
+
+Catalog targets also have a checksummed compact form such as `k1pts.1396.1.3.…`. Search fallback links do not: Kunai never turns a direct catalog target into the slower `q=` path merely to shorten it.
 
 ## Timestamp resume
 

--- a/docs/users/what-you-can-do.mdx
+++ b/docs/users/what-you-can-do.mdx
@@ -106,7 +106,7 @@ More: [Continue watching and new episodes](/docs/users/continue-watching-and-new
 
 ## Share links across machines
 
-Copy catalog-anchored `kunai://` URLs with `/share` or mpv **Ctrl+Shift+S**. Open them with `/watch`, `kunai --open`, or the optional OS protocol handler.
+Copy catalog-anchored HTTPS URLs with `/share` or mpv **Ctrl+Shift+S**, or show a terminal QR with `/share --qr`. Open HTTPS, compact, or `kunai://` handoffs with `/watch`; `kunai --open` and the optional OS protocol handler remain available for application links.
 
 More: [Share links](/docs/users/share-links).
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -7,6 +7,7 @@ export type YouTubeLiveStatus = "none" | "live" | "upcoming" | "post_live";
 export type YouTubeContentShape = "video" | "playlist" | "channel";
 
 export type * from "./provider-cycle";
+export * from "./share";
 
 export type ProviderId = string & { readonly __brand?: "ProviderId" };
 

--- a/packages/types/src/share.ts
+++ b/packages/types/src/share.ts
@@ -1,0 +1,489 @@
+// Portable, dependency-free share-link codec used by both the CLI and docs app.
+
+export type CatalogNs = "tmdb" | "anilist" | "mal" | "imdb" | "youtube";
+
+export type ShareAnchor =
+  | { readonly by: "catalog"; readonly ns: CatalogNs; readonly id: string }
+  | { readonly by: "search"; readonly query: string };
+
+export type PlaybackTargetRef = {
+  readonly anchor: ShareAnchor;
+  readonly kind: "movie" | "series" | "anime" | "video";
+  readonly season?: number;
+  readonly episode?: number;
+  readonly absoluteEpisode?: number;
+  readonly startSeconds?: number;
+  readonly title?: string;
+  readonly hint?: { readonly providerId: string; readonly quality?: string };
+};
+
+export type KunaiShareAction = "play" | "download";
+
+export type ParsedKunaiShare = {
+  readonly action: KunaiShareAction;
+  readonly ref: PlaybackTargetRef;
+  readonly presentation?: WebSharePresentation;
+};
+
+export type WebSharePresentation = {
+  readonly posterUrl?: string;
+};
+
+export const KUNAI_WEB_SHARE_ORIGIN = "https://kunai.kitsunekode.in";
+
+const WEB_CODE_PREFIX = "v1.";
+const SHORT_CODE_PREFIX = "k1";
+const MAX_WEB_CODE_LENGTH = 4_096;
+const MAX_SHORT_CODE_LENGTH = 2_048;
+const MAX_DECODED_PAYLOAD_BYTES = 3_072;
+const MAX_COMPACT_TEXT_BYTES = 256;
+const MAX_POSTER_URL_LENGTH = 2_048;
+const BASE64URL_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+const CATALOG_NS: ReadonlySet<string> = new Set(["tmdb", "anilist", "mal", "imdb", "youtube"]);
+const PARAM_ORDER = ["cat", "q", "kind", "s", "e", "abs", "t", "src", "sq", "n"] as const;
+const ACTION_TO_CODE: Readonly<Record<KunaiShareAction, string>> = {
+  play: "p",
+  download: "d",
+};
+const CODE_TO_ACTION = { p: "play", d: "download" } as const;
+const NS_TO_CODE: Readonly<Record<CatalogNs, string>> = {
+  tmdb: "t",
+  anilist: "a",
+  mal: "m",
+  imdb: "i",
+  youtube: "y",
+};
+const CODE_TO_NS = { t: "tmdb", a: "anilist", m: "mal", i: "imdb", y: "youtube" } as const;
+const KIND_TO_CODE: Readonly<Record<PlaybackTargetRef["kind"], string>> = {
+  movie: "m",
+  series: "s",
+  anime: "a",
+  video: "v",
+};
+const CODE_TO_KIND = { m: "movie", s: "series", a: "anime", v: "video" } as const;
+
+export function parseTimestampToSeconds(raw: string | null | undefined): number | null {
+  const value = raw?.trim();
+  if (!value) return null;
+  if (/^\d+$/.test(value)) {
+    const seconds = Number.parseInt(value, 10);
+    return Number.isSafeInteger(seconds) ? seconds : null;
+  }
+  const clock = /^(?:(\d+):)?(\d{1,2}):(\d{1,2})$/.exec(value);
+  if (clock) {
+    const h = clock[1] ? Number.parseInt(clock[1], 10) : 0;
+    const m = Number.parseInt(clock[2] ?? "", 10);
+    const s = Number.parseInt(clock[3] ?? "", 10);
+    if (m > 59 || s > 59) return null;
+    const total = h * 3600 + m * 60 + s;
+    return Number.isSafeInteger(total) ? total : null;
+  }
+  const human = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(value);
+  if (human && (human[1] || human[2] || human[3])) {
+    const h = human[1] ? Number.parseInt(human[1], 10) : 0;
+    const m = human[2] ? Number.parseInt(human[2], 10) : 0;
+    const s = human[3] ? Number.parseInt(human[3], 10) : 0;
+    const total = h * 3600 + m * 60 + s;
+    return Number.isSafeInteger(total) ? total : null;
+  }
+  return null;
+}
+
+export function formatSecondsForUrl(seconds: number): string {
+  return String(Math.max(0, Math.round(seconds)));
+}
+
+export function encodePlaybackTargetRef(
+  ref: PlaybackTargetRef,
+  action: KunaiShareAction = "play",
+): string {
+  return `kunai://${action}?${encodePlaybackTargetQuery(ref)}`;
+}
+
+export function encodePlaybackTargetWebUrl(
+  ref: PlaybackTargetRef,
+  action: KunaiShareAction = "play",
+  presentation?: WebSharePresentation,
+): string {
+  const protocolPayload = `${action}?${encodePlaybackTargetQuery(ref)}`;
+  const posterUrl = normalizePosterUrl(presentation?.posterUrl);
+  const enrichedPayload = posterUrl
+    ? `${protocolPayload}\nposter=${encodeURIComponent(posterUrl)}`
+    : protocolPayload;
+  const payload = webPayloadFits(enrichedPayload) ? enrichedPayload : protocolPayload;
+  const payloadBytes = new TextEncoder().encode(payload);
+  const bytes = new Uint8Array(payloadBytes.length + 4);
+  bytes.set(payloadBytes);
+  new DataView(bytes.buffer).setUint32(payloadBytes.length, crc32(payloadBytes));
+  const code = `${WEB_CODE_PREFIX}${encodeBase64Url(bytes)}`;
+  if (payloadBytes.length > MAX_DECODED_PAYLOAD_BYTES || code.length > MAX_WEB_CODE_LENGTH) {
+    throw new Error("Playback target is too large for a bounded web share link");
+  }
+  return `${KUNAI_WEB_SHARE_ORIGIN}/w/${code}`;
+}
+
+export function decodePlaybackTargetWebCode(code: string): ParsedKunaiShare | null {
+  if (code.startsWith(SHORT_CODE_PREFIX)) return parseCompactShareCode(code);
+  if (
+    !code.startsWith(WEB_CODE_PREFIX) ||
+    code.length > MAX_WEB_CODE_LENGTH ||
+    code.length === WEB_CODE_PREFIX.length
+  ) {
+    return null;
+  }
+  const bytes = decodeBase64Url(code.slice(WEB_CODE_PREFIX.length));
+  if (!bytes || bytes.length < 5 || bytes.length > MAX_DECODED_PAYLOAD_BYTES + 4) return null;
+  const payloadBytes = bytes.subarray(0, -4);
+  const expectedChecksum = new DataView(
+    bytes.buffer,
+    bytes.byteOffset + bytes.length - 4,
+    4,
+  ).getUint32(0);
+  if (crc32(payloadBytes) !== expectedChecksum) return null;
+  const payload = decodeUtf8(payloadBytes);
+  if (!payload) return null;
+  const [protocolPayload, presentationLine, ...unexpectedLines] = payload.split("\n");
+  if (!protocolPayload || unexpectedLines.length > 0) return null;
+  const parsed = parseKunaiProtocolUrl(`kunai://${protocolPayload}`);
+  if (!parsed) return null;
+  if (!presentationLine) return parsed;
+  if (!presentationLine.startsWith("poster=")) return null;
+  let decodedPosterUrl: string;
+  try {
+    decodedPosterUrl = decodeURIComponent(presentationLine.slice("poster=".length));
+  } catch {
+    return null;
+  }
+  const posterUrl = normalizePosterUrl(decodedPosterUrl);
+  return posterUrl ? { ...parsed, presentation: { posterUrl } } : null;
+}
+
+export function encodePlaybackTargetShortCode(
+  ref: PlaybackTargetRef,
+  action: KunaiShareAction = "play",
+): string | null {
+  if (ref.anchor.by !== "catalog") return null;
+  const token = `${SHORT_CODE_PREFIX}${ACTION_TO_CODE[action]}${NS_TO_CODE[ref.anchor.ns]}${KIND_TO_CODE[ref.kind]}`;
+  const fields = [
+    encodeCompactCatalogId(ref.anchor.id),
+    encodeCompactInt(ref.season),
+    encodeCompactInt(ref.episode),
+    encodeCompactInt(ref.absoluteEpisode),
+    encodeCompactInt(ref.startSeconds),
+    encodeOptionalCompactText(ref.hint?.providerId),
+    encodeOptionalCompactText(ref.hint?.quality),
+    encodeOptionalCompactText(ref.title),
+  ];
+  while (fields.at(-1) === "_") fields.pop();
+  const body = `${token}.${fields.join(".")}`;
+  return `${body}.${compactChecksum(body)}`;
+}
+
+export function parsePlaybackTargetRef(raw: string): PlaybackTargetRef | null {
+  return parseKunaiShareUrl(raw)?.ref ?? null;
+}
+
+export function parseKunaiShareUrl(raw: string): ParsedKunaiShare | null {
+  const value = raw.trim();
+  if (!value) return null;
+  if (value.startsWith(SHORT_CODE_PREFIX)) return parseCompactShareCode(value);
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (url.protocol === "kunai:") return parseKunaiProtocolUrl(value);
+  if (url.origin !== KUNAI_WEB_SHARE_ORIGIN || url.search || url.hash) return null;
+  const match = /^\/w\/([^/]+)$/.exec(url.pathname);
+  return match?.[1] ? decodePlaybackTargetWebCode(match[1]) : null;
+}
+
+export function resolveShareAction(url: URL): KunaiShareAction | null {
+  const hostAction = normalizeToken(url.hostname);
+  if (hostAction === "play" || hostAction === "download") return hostAction;
+  const pathAction = normalizeToken(url.pathname.split("/").find(Boolean) ?? null);
+  if (pathAction === "play" || pathAction === "download") return pathAction;
+  return null;
+}
+
+function normalizePosterUrl(raw: string | null | undefined): string | null {
+  const value = raw?.trim();
+  if (!value || value.length > MAX_POSTER_URL_LENGTH) return null;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" || url.username || url.password) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function webPayloadFits(payload: string): boolean {
+  const payloadBytes = new TextEncoder().encode(payload);
+  if (payloadBytes.length > MAX_DECODED_PAYLOAD_BYTES) return false;
+  const encodedLength = WEB_CODE_PREFIX.length + Math.ceil((payloadBytes.length + 4) / 3) * 4;
+  return encodedLength <= MAX_WEB_CODE_LENGTH;
+}
+
+function encodePlaybackTargetQuery(ref: PlaybackTargetRef): string {
+  const params = new URLSearchParams();
+  if (ref.anchor.by === "catalog") {
+    params.set("cat", `${ref.anchor.ns}:${ref.anchor.id}`);
+  } else {
+    params.set("q", ref.anchor.query);
+  }
+  params.set("kind", ref.kind);
+  if (typeof ref.season === "number") params.set("s", String(ref.season));
+  if (typeof ref.episode === "number") params.set("e", String(ref.episode));
+  if (typeof ref.absoluteEpisode === "number") params.set("abs", String(ref.absoluteEpisode));
+  if (typeof ref.startSeconds === "number") {
+    params.set("t", formatSecondsForUrl(ref.startSeconds));
+  }
+  if (ref.hint?.providerId) params.set("src", ref.hint.providerId);
+  if (ref.hint?.quality) params.set("sq", ref.hint.quality);
+  if (ref.title) params.set("n", ref.title);
+  return PARAM_ORDER.filter((key) => params.has(key))
+    .map((key) => `${key}=${encodeURIComponent(params.get(key) as string)}`)
+    .join("&");
+}
+
+function parseKunaiProtocolUrl(value: string): ParsedKunaiShare | null {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "kunai:") return null;
+  const action = resolveShareAction(url);
+  const anchor = readAnchor(url.searchParams);
+  if (!action || !anchor) return null;
+
+  const kind = readKind(url.searchParams);
+  const season = readInt(url.searchParams.get("s"));
+  const episode = readInt(url.searchParams.get("e"));
+  const absoluteEpisode = readInt(url.searchParams.get("abs"));
+  const startSeconds = parseTimestampToSeconds(url.searchParams.get("t"));
+  const src = url.searchParams.get("src")?.trim();
+  const quality = url.searchParams.get("sq")?.trim();
+  const title = url.searchParams.get("n")?.trim();
+
+  return {
+    action,
+    ref: {
+      anchor,
+      kind,
+      ...(season !== null ? { season } : {}),
+      ...(episode !== null ? { episode } : {}),
+      ...(absoluteEpisode !== null ? { absoluteEpisode } : {}),
+      ...(startSeconds !== null ? { startSeconds } : {}),
+      ...(src ? { hint: { providerId: src, ...(quality ? { quality } : {}) } } : {}),
+      ...(title ? { title } : {}),
+    },
+  };
+}
+
+function parseCompactShareCode(value: string): ParsedKunaiShare | null {
+  if (value.length > MAX_SHORT_CODE_LENGTH) return null;
+  const parts = value.split(".");
+  const checksum = parts.pop();
+  const body = parts.join(".");
+  if (!checksum || checksum !== compactChecksum(body)) return null;
+  const [token, ...rawFields] = parts;
+  const tokenMatch = /^k1([pd])([tamiy])([msav])$/.exec(token ?? "");
+  if (!tokenMatch || rawFields.length < 1 || rawFields.length > 8) return null;
+  while (rawFields.length < 8) rawFields.push("_");
+
+  const action = CODE_TO_ACTION[tokenMatch[1] as keyof typeof CODE_TO_ACTION];
+  const ns = CODE_TO_NS[tokenMatch[2] as keyof typeof CODE_TO_NS];
+  const kind = CODE_TO_KIND[tokenMatch[3] as keyof typeof CODE_TO_KIND];
+  const id = decodeCompactCatalogId(rawFields[0] ?? "");
+  const season = decodeCompactInt(rawFields[1] ?? "_");
+  const episode = decodeCompactInt(rawFields[2] ?? "_");
+  const absoluteEpisode = decodeCompactInt(rawFields[3] ?? "_");
+  const startSeconds = decodeCompactInt(rawFields[4] ?? "_");
+  const providerId = decodeOptionalCompactText(rawFields[5] ?? "_");
+  const quality = decodeOptionalCompactText(rawFields[6] ?? "_");
+  const title = decodeOptionalCompactText(rawFields[7] ?? "_");
+
+  if (
+    !action ||
+    !ns ||
+    !kind ||
+    !id ||
+    season === false ||
+    episode === false ||
+    absoluteEpisode === false ||
+    startSeconds === false ||
+    providerId === false ||
+    quality === false ||
+    title === false
+  ) {
+    return null;
+  }
+
+  return {
+    action,
+    ref: {
+      anchor: { by: "catalog", ns, id },
+      kind,
+      ...(season !== null ? { season } : {}),
+      ...(episode !== null ? { episode } : {}),
+      ...(absoluteEpisode !== null ? { absoluteEpisode } : {}),
+      ...(startSeconds !== null ? { startSeconds } : {}),
+      ...(providerId ? { hint: { providerId, ...(quality ? { quality } : {}) } } : {}),
+      ...(title ? { title } : {}),
+    },
+  };
+}
+
+function readAnchor(params: URLSearchParams): ShareAnchor | null {
+  const cat = params.get("cat")?.trim();
+  if (cat) {
+    const colon = cat.indexOf(":");
+    if (colon <= 0) return null;
+    const ns = cat.slice(0, colon).trim();
+    const id = cat.slice(colon + 1).trim();
+    if (!CATALOG_NS.has(ns) || !id) return null;
+    return { by: "catalog", ns: ns as CatalogNs, id };
+  }
+  const query = params.get("q")?.trim();
+  if (query) return { by: "search", query: query.slice(0, 200) };
+  return null;
+}
+
+function readKind(params: URLSearchParams): PlaybackTargetRef["kind"] {
+  const explicit = params.get("kind")?.trim();
+  if (
+    explicit === "movie" ||
+    explicit === "series" ||
+    explicit === "anime" ||
+    explicit === "video"
+  ) {
+    return explicit;
+  }
+  return "series";
+}
+
+function readInt(value: string | null): number | null {
+  if (!value || !/^\d+$/.test(value)) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function normalizeToken(value: string | null): string | null {
+  const trimmed = value?.trim().toLowerCase();
+  return trimmed || null;
+}
+
+function encodeCompactInt(value: number | undefined): string {
+  if (value === undefined) return "_";
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError("Compact share numbers must be non-negative safe integers");
+  }
+  return value.toString(36);
+}
+
+function decodeCompactInt(value: string): number | null | false {
+  if (value === "_") return null;
+  if (!/^[0-9a-z]+$/.test(value)) return false;
+  const parsed = Number.parseInt(value, 36);
+  return Number.isSafeInteger(parsed) ? parsed : false;
+}
+
+function encodeOptionalCompactText(value: string | undefined): string {
+  return value ? encodeCompactText(value) : "_";
+}
+
+function encodeCompactCatalogId(value: string): string {
+  if (/^[A-Za-z0-9_-]{1,64}$/.test(value)) return value;
+  return `~${encodeCompactText(value)}`;
+}
+
+function decodeCompactCatalogId(value: string): string | null {
+  if (/^[A-Za-z0-9_-]{1,64}$/.test(value)) return value;
+  return value.startsWith("~") ? decodeCompactText(value.slice(1)) : null;
+}
+
+function decodeOptionalCompactText(value: string): string | null | false {
+  return value === "_" ? null : decodeCompactText(value) || false;
+}
+
+function encodeCompactText(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  if (bytes.length === 0 || bytes.length > MAX_COMPACT_TEXT_BYTES) {
+    throw new RangeError("Compact share text is empty or too long");
+  }
+  return encodeBase64Url(bytes);
+}
+
+function decodeCompactText(value: string): string | null {
+  const bytes = decodeBase64Url(value);
+  if (!bytes || bytes.length === 0 || bytes.length > MAX_COMPACT_TEXT_BYTES) return null;
+  return decodeUtf8(bytes);
+}
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  let output = "";
+  let buffer = 0;
+  let bitCount = 0;
+  for (const byte of bytes) {
+    buffer = (buffer << 8) | byte;
+    bitCount += 8;
+    while (bitCount >= 6) {
+      bitCount -= 6;
+      output += BASE64URL_ALPHABET[(buffer >>> bitCount) & 0x3f] ?? "";
+    }
+    buffer &= (1 << bitCount) - 1;
+  }
+  if (bitCount > 0) {
+    output += BASE64URL_ALPHABET[(buffer << (6 - bitCount)) & 0x3f] ?? "";
+  }
+  return output;
+}
+
+function decodeBase64Url(value: string): Uint8Array | null {
+  if (!value || value.length % 4 === 1 || !/^[A-Za-z0-9_-]+$/.test(value)) return null;
+  const bytes: number[] = [];
+  let buffer = 0;
+  let bitCount = 0;
+  for (const character of value) {
+    const index = BASE64URL_ALPHABET.indexOf(character);
+    if (index < 0) return null;
+    buffer = (buffer << 6) | index;
+    bitCount += 6;
+    if (bitCount >= 8) {
+      bitCount -= 8;
+      bytes.push((buffer >>> bitCount) & 0xff);
+      buffer &= (1 << bitCount) - 1;
+    }
+  }
+  if (buffer !== 0) return null;
+  const decoded = Uint8Array.from(bytes);
+  return encodeBase64Url(decoded) === value ? decoded : null;
+}
+
+function decodeUtf8(bytes: Uint8Array): string | null {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+function compactChecksum(value: string): string {
+  return crc32(new TextEncoder().encode(value)).toString(36);
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}

--- a/packages/types/test/share-codec.test.ts
+++ b/packages/types/test/share-codec.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  decodePlaybackTargetWebCode,
+  encodePlaybackTargetRef,
+  encodePlaybackTargetShortCode,
+  encodePlaybackTargetWebUrl,
+  parseKunaiShareUrl,
+  parsePlaybackTargetRef,
+  type PlaybackTargetRef,
+} from "../src";
+
+describe("web share codec", () => {
+  const seriesRef: PlaybackTargetRef = {
+    anchor: { by: "catalog", ns: "tmdb", id: "1396" },
+    kind: "series",
+    season: 1,
+    episode: 3,
+    startSeconds: 83,
+    title: "Breaking Bad",
+    hint: { providerId: "videasy", quality: "1080p" },
+  };
+  const sampleRefs: readonly PlaybackTargetRef[] = [
+    seriesRef,
+    {
+      anchor: { by: "catalog", ns: "anilist", id: "21" },
+      kind: "anime",
+      season: 1,
+      episode: 1,
+      absoluteEpisode: 1075,
+      startSeconds: 120,
+      title: "One Piece",
+    },
+    {
+      anchor: { by: "search", query: "Cowboy Bebop" },
+      kind: "anime",
+      title: "Cowboy Bebop",
+    },
+  ];
+
+  test.each([...sampleRefs])("round-trips every playback ref shape through HTTPS", (ref) => {
+    const webUrl = encodePlaybackTargetWebUrl(ref);
+
+    expect(webUrl).toStartWith("https://kunai.kitsunekode.in/w/v1.");
+    expect(parsePlaybackTargetRef(webUrl)).toEqual(ref);
+    expect(parseKunaiShareUrl(webUrl)).toEqual({ action: "play", ref });
+  });
+
+  test("preserves the download action", () => {
+    const ref = seriesRef;
+    const webUrl = encodePlaybackTargetWebUrl(ref, "download");
+
+    expect(parseKunaiShareUrl(webUrl)).toEqual({ action: "download", ref });
+  });
+
+  test("carries a safe optional poster without changing the playback ref", () => {
+    const ref = seriesRef;
+    const webUrl = encodePlaybackTargetWebUrl(ref, "play", {
+      posterUrl: "https://image.tmdb.org/t/p/w500/example.jpg",
+    });
+
+    expect(parseKunaiShareUrl(webUrl)).toEqual({
+      action: "play",
+      ref,
+      presentation: { posterUrl: "https://image.tmdb.org/t/p/w500/example.jpg" },
+    });
+    expect(parsePlaybackTargetRef(webUrl)).toEqual(ref);
+  });
+
+  test("accepts compact codes inside the HTTPS landing path", () => {
+    const ref: PlaybackTargetRef = {
+      anchor: { by: "catalog", ns: "tmdb", id: "1396" },
+      kind: "series",
+      season: 1,
+      episode: 3,
+    };
+    const code = encodePlaybackTargetShortCode(ref);
+
+    expect(code).not.toBeNull();
+    expect(parseKunaiShareUrl(`https://kunai.kitsunekode.in/w/${code}`)).toEqual({
+      action: "play",
+      ref,
+    });
+  });
+
+  test("drops an oversized optional poster instead of minting a self-invalid link", () => {
+    const ref = seriesRef;
+    const webUrl = encodePlaybackTargetWebUrl(ref, "play", {
+      posterUrl: `https://example.com/${"ü".repeat(1_000)}`,
+    });
+
+    expect(parseKunaiShareUrl(webUrl)).toEqual({ action: "play", ref });
+  });
+
+  test("rejects malformed, truncated, foreign-origin, and oversized web codes", () => {
+    const url = new URL(encodePlaybackTargetWebUrl(seriesRef));
+    const code = url.pathname.split("/").at(-1) ?? "";
+
+    expect(decodePlaybackTargetWebCode(code.slice(0, -2))).toBeNull();
+    expect(parsePlaybackTargetRef(`https://example.com/w/${code}`)).toBeNull();
+    expect(parsePlaybackTargetRef("https://kunai.kitsunekode.in/w/v1.***")).toBeNull();
+    expect(decodePlaybackTargetWebCode(`v1.${"A".repeat(4_097)}`)).toBeNull();
+  });
+});
+
+describe("compact catalog share codes", () => {
+  test("is equivalent to the canonical long series ref and stays speakable", () => {
+    const ref: PlaybackTargetRef = {
+      anchor: { by: "catalog", ns: "tmdb", id: "1396" },
+      kind: "series",
+      season: 1,
+      episode: 3,
+      startSeconds: 83,
+    };
+    const short = encodePlaybackTargetShortCode(ref);
+
+    expect(short).not.toBeNull();
+    expect(short?.length).toBeLessThan(40);
+    expect(parsePlaybackTargetRef(short ?? "")).toEqual(ref);
+    expect(parsePlaybackTargetRef(short ?? "")).toEqual(
+      parsePlaybackTargetRef(encodePlaybackTargetRef(ref)),
+    );
+  });
+
+  test("round-trips anime absolute identity, timestamp, title, and source hints", () => {
+    const ref: PlaybackTargetRef = {
+      anchor: { by: "catalog", ns: "anilist", id: "21" },
+      kind: "anime",
+      season: 1,
+      episode: 1,
+      absoluteEpisode: 1075,
+      startSeconds: 120,
+      title: "One Piece",
+      hint: { providerId: "allanime", quality: "1080p" },
+    };
+    const short = encodePlaybackTargetShortCode(ref, "download");
+
+    expect(short).not.toBeNull();
+    expect(parsePlaybackTargetRef(short ?? "")).toEqual(ref);
+    expect(parseKunaiShareUrl(short ?? "")).toEqual({ action: "download", ref });
+  });
+
+  test("does not pretend a search anchor is a catalog short code", () => {
+    expect(
+      encodePlaybackTargetShortCode({
+        anchor: { by: "search", query: "One Piece" },
+        kind: "anime",
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects damaged compact fields instead of partially parsing them", () => {
+    expect(parsePlaybackTargetRef("k1pts.bad.1.nope")).toBeNull();
+    expect(parsePlaybackTargetRef("k1zzz.MTM5Ng")).toBeNull();
+    expect(parsePlaybackTargetRef(`k1${"a".repeat(2_048)}`)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- copies browser-safe checksummed HTTPS share links while preserving kunai protocol handoff
- adds compact catalog codes and watch parsing for all supported forms
- adds a stateless noindex web landing with title, poster, install guidance, and no share-page analytics
- adds a dependency-free bounded terminal QR renderer and share --qr flow

Closes #89.

## Stack

Depends on the anti-slop PR.

## Verification

- 4,702 CLI unit tests and 147 integrations passed
- docs tests and production build passed
- QR fixture cross-check and malformed-link fail-closed tests
- typecheck, zero-warning lint, format, doc paths, host binary build

No deployment or release is performed by this PR.