### PR TITLE
fix(relay): enforce authenticated pinned upstream transport

### DIFF
--- a/.docs/quickstart.md
+++ b/.docs/quickstart.md
@@ -1,6 +1,6 @@
 ---
 status: current
-lastReviewed: "2026-08-14"
+lastReviewed: "2026-08-24"
 ---
 
 # Kunai — Quickstart
@@ -165,7 +165,7 @@ Filters stack in one structured state. Unsupported filters are reported as local
 | `KUNAI_DISCORD_CLIENT_ID`     | Discord application id for optional `presenceProvider: "discord"` |
 | `KUNAI_VIDEASY_SESSION_TOKEN` | Optional user-provided Videasy browser session token for VidKing  |
 | `KUNAI_RELAY_BASE_URL`        | Optional user-owned provider RPC relay base URL for metadata APIs |
-| `KUNAI_RELAY_TOKEN`           | Optional bearer token for the user-owned provider relay           |
+| `KUNAI_RELAY_TOKEN`           | Bearer token required for an internet-hosted provider relay       |
 
 VidKing may report `Videasy requires a valid browser session` when Videasy's
 guarded API requires a session created by the website. Kunai can use a token you
@@ -215,8 +215,11 @@ export KUNAI_RELAY_BASE_URL=http://127.0.0.1:8787
 bun run test:live:relay-allanime
 ```
 
-For internet deployments, see `apps/relay-server/README.md`. Leave
-`providerRelay.baseUrl` empty to use direct provider fetches only.
+For internet deployments, configure the same required bearer token on the relay
+server and in `KUNAI_RELAY_TOKEN` (or `providerRelay.token`); see
+`apps/relay-server/README.md`. Only the numeric-loopback development server may
+run tokenless. Leave `providerRelay.baseUrl` empty to use direct provider fetches
+only.
 
 ## Common Issues
 

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "7eecb6ece14ab8a587bc8254fb10a9de38b892c37d251aaf31e9b88009e039ed",
-  "docsContentFingerprint": "947cddb53a084fd455b102aa2a36912f0d4fa7f101378a8026be5c4b4adb8693",
+  "docsContentFingerprint": "ea0948f8b9fc1f498bcebec01a48978aa48752098014156bbbc680bad2000e69",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 81,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/apps/relay-server/README.md
+++ b/apps/relay-server/README.md
@@ -92,13 +92,27 @@ export KUNAI_RELAY_TOKEN=...
 ## Safety Model
 
 - Only `POST /rpc/:providerId` and `GET /health` are implemented in v1.
+- Internet deployments reject missing, duplicate, or incorrect bearer credentials
+  before reading the RPC request body. `OPTIONS` remains a body-free CORS preflight.
 - Upstream URLs must match the selected provider manifest `relayProfile`.
-- Private, loopback, link-local, localhost, and non-HTTP(S) upstreams are rejected before fetch.
-- Unsafe headers such as `Authorization`, `Cookie`, `Host`, and `X-Forwarded-*` are never forwarded upstream.
-- Redirects are followed only after each target is validated against the same provider allowlist.
+- Private, loopback, link-local, localhost, and non-HTTP(S) upstreams are rejected
+  before a socket opens. DNS names are resolved once per hop, the complete answer
+  set is rejected if any address is non-public, and the connection is pinned to a
+  vetted address while retaining the original HTTP `Host` and TLS SNI.
+- Client relay credentials, cookies, `Host`, and `X-Forwarded-*` headers are never
+  forwarded upstream. Provider credentials required by an initial request are
+  stripped if a redirect changes origin.
+- Redirects are followed only after each target is validated against the same
+  provider allowlist and receives a fresh pinned DNS lookup. HTTPS-to-HTTP
+  redirects are rejected.
+- GET and HEAD may try another already-vetted DNS address after a connection-level
+  failure before any response. POST is never replayed after an ambiguous attempt.
 - Metadata request bodies default to 64 KiB max; metadata responses default to 2 MiB max.
+- The upstream deadline covers DNS resolution and socket/response work.
 - Relay-generated errors are structured JSON with stable `error.code` values for CLI diagnostics.
-- Upstream response cookies and bodies are not logged or exposed beyond the filtered RPC response.
+- Server diagnostics contain only stable provider/hostname/phase/family/count/error
+  fields. URL paths, queries, addresses, headers, bodies, tokens, and raw errors are
+  never logged. Upstream response cookies remain filtered from the RPC response.
 - Stream/video relaying is intentionally not active by default. mpv receives the final CDN URL and fetches directly.
 
 This app is fail-closed. If a provider host is missing from `relayProfile`, update

--- a/apps/relay-server/README.md
+++ b/apps/relay-server/README.md
@@ -123,8 +123,9 @@ the provider manifest and tests instead of adding a server-side exception route.
 Relay use is controlled by client config, not a server default:
 
 - Empty `providerRelay.baseUrl` means direct provider fetches only.
-- `fallbackToDirect: true` lets a broken user relay degrade back to direct
-  fetches in non-geo-blocked regions.
+- `fallbackToDirect: true` degrades to direct fetches after relay network or
+  relay authorization-policy failures in non-geo-blocked regions. Arbitrary
+  upstream HTTP failures are returned unchanged rather than replayed directly.
 - Per-provider `providerRelay.providers[providerId].enabled = false` disables
   relay routing for one provider without changing the relay deployment.
 - Clearing `providerRelay.baseUrl` or unsetting `KUNAI_RELAY_BASE_URL` is the
@@ -145,6 +146,8 @@ For a Vercel preview, also verify `/health`, an unauthorized RPC when
 ## Post-Deploy Smoke
 
 1. `GET /health` returns `200`.
-2. Unauthorized RPC returns `401` when `RELAY_TOKEN` is set.
+2. Unauthorized RPC returns `401`; an internet deployment without `RELAY_TOKEN`
+   returns `503 relay-not-configured`.
 3. Disallowed hosts return `403 host-not-allowed`.
-4. `KUNAI_RELAY_BASE_URL=<preview-url> bun run test:live:relay-allanime` resolves a stream.
+4. `KUNAI_RELAY_BASE_URL=<preview-url> KUNAI_RELAY_TOKEN=<same-token> bun run test:live:relay-allanime`
+   resolves a stream.

--- a/apps/relay-server/api/rpc/[providerId].ts
+++ b/apps/relay-server/api/rpc/[providerId].ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   DEFAULT_MAX_REQUEST_BODY_BYTES,
   handleRpcRequest,
+  isRelayBearerAuthorized,
   relayError,
   type ProviderRelayRegistry,
   type RelayHandlerOptions,
@@ -60,6 +61,17 @@ export function createRelayRpcHandler(dependencies: RelayRpcHandlerDependencies)
       return;
     }
 
+    if (
+      req.method !== "OPTIONS" &&
+      !isRelayBearerAuthorized(singleAuthorizationValue(req), token)
+    ) {
+      await writeResponse(
+        res,
+        relayError("unauthorized", undefined, "Relay token is required", 401),
+      );
+      return;
+    }
+
     const providerId = firstQueryValue(req.query?.providerId);
     if (!providerId) {
       await writeResponse(res, Response.json({ error: { code: "bad-request" } }, { status: 400 }));
@@ -100,6 +112,28 @@ export default createRelayRpcHandler({
 
 function firstQueryValue(value: string | readonly string[] | undefined): string | undefined {
   return typeof value === "string" ? value : value?.[0];
+}
+
+function singleAuthorizationValue(req: VercelLikeRequest): string | undefined {
+  const distinctValues = req.headersDistinct?.authorization;
+  if (distinctValues !== undefined) {
+    return distinctValues.length === 1 ? distinctValues[0] : undefined;
+  }
+
+  const rawHeaders = req.rawHeaders;
+  if (Array.isArray(rawHeaders) && rawHeaders.length > 0) {
+    const rawValues: string[] = [];
+    for (let index = 0; index < rawHeaders.length; index += 2) {
+      if (rawHeaders[index]?.toLowerCase() === "authorization") {
+        const value = rawHeaders[index + 1];
+        if (value !== undefined) rawValues.push(value);
+      }
+    }
+    return rawValues.length === 1 ? rawValues[0] : undefined;
+  }
+
+  const value = req.headers.authorization;
+  return typeof value === "string" ? value : undefined;
 }
 
 function nodeRequestToWebRequest(

--- a/apps/relay-server/api/rpc/[providerId].ts
+++ b/apps/relay-server/api/rpc/[providerId].ts
@@ -1,6 +1,13 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 
-import { DEFAULT_MAX_REQUEST_BODY_BYTES, handleRpcRequest } from "@kunai/relay";
+import {
+  DEFAULT_MAX_REQUEST_BODY_BYTES,
+  handleRpcRequest,
+  relayError,
+  type ProviderRelayRegistry,
+  type RelayFetch,
+  type RelayHandlerOptions,
+} from "@kunai/relay";
 
 import { relayRegistry } from "../../src/provider-registry";
 
@@ -17,38 +24,79 @@ interface VercelLikeRequest extends IncomingMessage {
   readonly query?: Readonly<Record<string, string | readonly string[]>>;
 }
 
-export default async function handler(req: VercelLikeRequest, res: ServerResponse): Promise<void> {
-  const providerId = firstQueryValue(req.query?.providerId);
-  if (!providerId) {
-    await writeWebResponse(res, Response.json({ error: { code: "bad-request" } }, { status: 400 }));
-    return;
-  }
+type RelayRpcHandler = (req: VercelLikeRequest, res: ServerResponse) => Promise<void>;
+type RelayBodyReader = (
+  req: IncomingMessage,
+  maxBytes: number,
+) => Promise<Uint8Array | "too-large">;
+type RelayRequestAdapter = (req: IncomingMessage, providerId: string, body: Uint8Array) => Request;
+type RelayResponseAdapter = (res: ServerResponse, response: Response) => Promise<void>;
+type SharedRelayHandler = (request: Request, options: RelayHandlerOptions) => Promise<Response>;
 
-  const body = await readNodeBody(req, MAX_BODY_BYTES);
-  if (body === "too-large") {
-    // Matches the shared handler's own refusal, so both entry points answer a
-    // caller the same way.
-    res.setHeader("Connection", "close");
-    await writeWebResponse(
-      res,
-      Response.json(
-        { error: { code: "body-too-large", message: "Relay envelope is too large" } },
-        { status: 413 },
-      ),
-    );
-    // Only after the reply is written: destroying first strands the response.
-    req.destroy();
-    return;
-  }
-
-  const request = nodeRequestToWebRequest(req, providerId, body);
-  const response = await handleRpcRequest(request, {
-    providerId,
-    registry: relayRegistry,
-    authorization: { mode: "bearer", token: process.env.RELAY_TOKEN ?? "" },
-  });
-  await writeWebResponse(res, response);
+export interface RelayRpcHandlerDependencies {
+  readonly readToken: () => string | undefined;
+  readonly registry?: ProviderRelayRegistry;
+  readonly readBody?: RelayBodyReader;
+  readonly createWebRequest?: RelayRequestAdapter;
+  readonly handleRequest?: SharedRelayHandler;
+  readonly writeResponse?: RelayResponseAdapter;
+  readonly fetch?: RelayFetch;
 }
+
+export function createRelayRpcHandler(dependencies: RelayRpcHandlerDependencies): RelayRpcHandler {
+  const registry = dependencies.registry ?? relayRegistry;
+  const readBody = dependencies.readBody ?? readNodeBody;
+  const createWebRequest = dependencies.createWebRequest ?? nodeRequestToWebRequest;
+  const handleRequest = dependencies.handleRequest ?? handleRpcRequest;
+  const writeResponse = dependencies.writeResponse ?? writeWebResponse;
+
+  return async (req, res) => {
+    const token = dependencies.readToken()?.trim();
+    if (!token) {
+      await writeResponse(
+        res,
+        relayError("relay-not-configured", undefined, "Relay authorization is not configured", 503),
+      );
+      return;
+    }
+
+    const providerId = firstQueryValue(req.query?.providerId);
+    if (!providerId) {
+      await writeResponse(res, Response.json({ error: { code: "bad-request" } }, { status: 400 }));
+      return;
+    }
+
+    const body = req.method === "OPTIONS" ? new Uint8Array() : await readBody(req, MAX_BODY_BYTES);
+    if (body === "too-large") {
+      // Matches the shared handler's own refusal, so both entry points answer a
+      // caller the same way.
+      res.setHeader("Connection", "close");
+      await writeResponse(
+        res,
+        Response.json(
+          { error: { code: "body-too-large", message: "Relay envelope is too large" } },
+          { status: 413 },
+        ),
+      );
+      // Only after the reply is written: destroying first strands the response.
+      req.destroy();
+      return;
+    }
+
+    const request = createWebRequest(req, providerId, body);
+    const response = await handleRequest(request, {
+      providerId,
+      registry,
+      authorization: { mode: "bearer", token },
+      fetch: dependencies.fetch,
+    });
+    await writeResponse(res, response);
+  };
+}
+
+export default createRelayRpcHandler({
+  readToken: () => process.env.RELAY_TOKEN,
+});
 
 function firstQueryValue(value: string | readonly string[] | undefined): string | undefined {
   return typeof value === "string" ? value : value?.[0];

--- a/apps/relay-server/api/rpc/[providerId].ts
+++ b/apps/relay-server/api/rpc/[providerId].ts
@@ -5,8 +5,8 @@ import {
   handleRpcRequest,
   relayError,
   type ProviderRelayRegistry,
-  type RelayFetch,
   type RelayHandlerOptions,
+  type RelayTransport,
 } from "@kunai/relay";
 
 import { relayRegistry } from "../../src/provider-registry";
@@ -40,7 +40,7 @@ export interface RelayRpcHandlerDependencies {
   readonly createWebRequest?: RelayRequestAdapter;
   readonly handleRequest?: SharedRelayHandler;
   readonly writeResponse?: RelayResponseAdapter;
-  readonly fetch?: RelayFetch;
+  readonly transport?: RelayTransport;
 }
 
 export function createRelayRpcHandler(dependencies: RelayRpcHandlerDependencies): RelayRpcHandler {
@@ -88,7 +88,7 @@ export function createRelayRpcHandler(dependencies: RelayRpcHandlerDependencies)
       providerId,
       registry,
       authorization: { mode: "bearer", token },
-      fetch: dependencies.fetch,
+      transport: dependencies.transport,
     });
     await writeResponse(res, response);
   };

--- a/apps/relay-server/api/rpc/[providerId].ts
+++ b/apps/relay-server/api/rpc/[providerId].ts
@@ -45,7 +45,7 @@ export default async function handler(req: VercelLikeRequest, res: ServerRespons
   const response = await handleRpcRequest(request, {
     providerId,
     registry: relayRegistry,
-    token: process.env.RELAY_TOKEN,
+    authorization: { mode: "bearer", token: process.env.RELAY_TOKEN ?? "" },
   });
   await writeWebResponse(res, response);
 }

--- a/apps/relay-server/api/rpc/[providerId].ts
+++ b/apps/relay-server/api/rpc/[providerId].ts
@@ -111,7 +111,7 @@ export default createRelayRpcHandler({
 });
 
 function firstQueryValue(value: string | readonly string[] | undefined): string | undefined {
-  return typeof value === "string" ? value : value?.[0];
+  return Array.isArray(value) ? value[0] : value?.toString();
 }
 
 function singleAuthorizationValue(req: VercelLikeRequest): string | undefined {
@@ -133,7 +133,7 @@ function singleAuthorizationValue(req: VercelLikeRequest): string | undefined {
   }
 
   const value = req.headers.authorization;
-  return typeof value === "string" ? value : undefined;
+  return value;
 }
 
 function nodeRequestToWebRequest(
@@ -178,7 +178,7 @@ function readNodeBody(req: IncomingMessage, maxBytes: number): Promise<Uint8Arra
     };
 
     req.on("data", (chunk: Buffer | string) => {
-      const bytes = typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk;
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
       total += bytes.length;
       if (total > maxBytes) {
         req.pause();

--- a/apps/relay-server/scripts/dev-server.ts
+++ b/apps/relay-server/scripts/dev-server.ts
@@ -1,14 +1,16 @@
-import { handleRelayRequest } from "../src/relay-app";
+import {
+  createRelayDevServerOptions,
+  resolveRelayDevelopmentPolicy,
+} from "../src/relay-runtime-policy";
 
-const port = Number(process.env.PORT ?? 8787);
-
-Bun.serve({
-  port,
-  fetch(request) {
-    return handleRelayRequest(request, {
-      relayToken: process.env.RELAY_TOKEN,
-    });
-  },
+const policy = resolveRelayDevelopmentPolicy({
+  PORT: process.env.PORT,
+  RELAY_HOST: process.env.RELAY_HOST,
+  RELAY_TOKEN: process.env.RELAY_TOKEN,
 });
+const options = createRelayDevServerOptions(policy);
 
-console.log(`kunai relay dev server listening on http://127.0.0.1:${port}`);
+Bun.serve(options);
+
+const displayHostname = policy.hostname.includes(":") ? `[${policy.hostname}]` : policy.hostname;
+console.log(`kunai relay dev server listening on http://${displayHostname}:${policy.port}`);

--- a/apps/relay-server/src/relay-app.ts
+++ b/apps/relay-server/src/relay-app.ts
@@ -2,14 +2,14 @@ import {
   handleRpcRequest,
   relayError,
   type RelayAuthorizationPolicy,
-  type RelayFetch,
+  type RelayTransport,
 } from "@kunai/relay";
 
 import { relayRegistry } from "./provider-registry";
 
 export interface RelayAppEnv {
   readonly authorization: RelayAuthorizationPolicy;
-  readonly fetch?: RelayFetch;
+  readonly transport?: RelayTransport;
 }
 
 export async function handleRelayRequest(request: Request, env: RelayAppEnv): Promise<Response> {
@@ -29,7 +29,7 @@ export async function handleRelayRequest(request: Request, env: RelayAppEnv): Pr
       providerId: decodeURIComponent(rpcMatch[1]),
       registry: relayRegistry,
       authorization: env.authorization,
-      fetch: env.fetch,
+      transport: env.transport,
     });
   }
 

--- a/apps/relay-server/src/relay-app.ts
+++ b/apps/relay-server/src/relay-app.ts
@@ -1,16 +1,18 @@
-import { handleRpcRequest, relayError, type RelayFetch } from "@kunai/relay";
+import {
+  handleRpcRequest,
+  relayError,
+  type RelayAuthorizationPolicy,
+  type RelayFetch,
+} from "@kunai/relay";
 
 import { relayRegistry } from "./provider-registry";
 
 export interface RelayAppEnv {
-  readonly relayToken?: string;
+  readonly authorization: RelayAuthorizationPolicy;
   readonly fetch?: RelayFetch;
 }
 
-export async function handleRelayRequest(
-  request: Request,
-  env: RelayAppEnv = {},
-): Promise<Response> {
+export async function handleRelayRequest(request: Request, env: RelayAppEnv): Promise<Response> {
   const url = new URL(request.url);
 
   if (url.pathname === "/health") {
@@ -26,7 +28,7 @@ export async function handleRelayRequest(
     return handleRpcRequest(request, {
       providerId: decodeURIComponent(rpcMatch[1]),
       registry: relayRegistry,
-      token: env.relayToken,
+      authorization: env.authorization,
       fetch: env.fetch,
     });
   }

--- a/apps/relay-server/src/relay-runtime-policy.ts
+++ b/apps/relay-server/src/relay-runtime-policy.ts
@@ -1,0 +1,58 @@
+import type { RelayAuthorizationPolicy } from "@kunai/relay";
+
+import { handleRelayRequest } from "./relay-app";
+
+const DEFAULT_HOSTNAME = "127.0.0.1";
+const DEFAULT_PORT = 8787;
+
+export interface RelayDevelopmentEnvironment {
+  readonly PORT?: string;
+  readonly RELAY_HOST?: string;
+  readonly RELAY_TOKEN?: string;
+}
+
+export interface RelayDevelopmentPolicy {
+  readonly hostname: string;
+  readonly port: number;
+  readonly authorization: RelayAuthorizationPolicy;
+}
+
+export function resolveRelayDevelopmentPolicy(
+  env: RelayDevelopmentEnvironment,
+): RelayDevelopmentPolicy {
+  const hostname = env.RELAY_HOST?.trim() || DEFAULT_HOSTNAME;
+  const token = env.RELAY_TOKEN?.trim();
+
+  if (!token && hostname !== "127.0.0.1" && hostname !== "::1") {
+    throw new Error(`RELAY_TOKEN is required when RELAY_HOST is ${hostname}`);
+  }
+
+  return {
+    hostname,
+    port: resolvePort(env.PORT),
+    authorization: token ? { mode: "bearer", token } : { mode: "local-loopback" },
+  };
+}
+
+export function createRelayDevServerOptions(policy: RelayDevelopmentPolicy) {
+  return {
+    hostname: policy.hostname,
+    port: policy.port,
+    fetch(request: Request) {
+      return handleRelayRequest(request, { authorization: policy.authorization });
+    },
+  };
+}
+
+function resolvePort(value: string | undefined): number {
+  if (value === undefined) return DEFAULT_PORT;
+  const normalized = value.trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(`PORT must be an integer from 1 through 65535; received ${value}`);
+  }
+  const port = Number(normalized);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`PORT must be an integer from 1 through 65535; received ${value}`);
+  }
+  return port;
+}

--- a/apps/relay-server/test/integration/relay-app.test.ts
+++ b/apps/relay-server/test/integration/relay-app.test.ts
@@ -1,9 +1,17 @@
 import { expect, test } from "bun:test";
 
+import type { RelayAuthorizationPolicy } from "@kunai/relay";
+
 import { handleRelayRequest } from "../../src/relay-app";
 
+const localLoopbackAuthorization = {
+  mode: "local-loopback",
+} satisfies RelayAuthorizationPolicy;
+
 test("relay app health route reports configured providers", async () => {
-  const response = await handleRelayRequest(new Request("https://relay.test/health"));
+  const response = await handleRelayRequest(new Request("https://relay.test/health"), {
+    authorization: localLoopbackAuthorization,
+  });
   const body = await response.json();
 
   expect(response.status).toBe(200);
@@ -27,7 +35,7 @@ test("relay app forwards allowlisted provider RPC requests", async () => {
       }),
     }),
     {
-      relayToken: "secret",
+      authorization: { mode: "bearer", token: "secret" },
       async fetch() {
         return Response.json({ data: { ok: true } });
       },
@@ -47,6 +55,7 @@ test("relay app rejects disallowed provider host", async () => {
         upstreamUrl: "https://miruro.bz/api",
       }),
     }),
+    { authorization: localLoopbackAuthorization },
   );
 
   expect(response.status).toBe(403);
@@ -62,7 +71,7 @@ test("relay app enforces token when configured", async () => {
         upstreamUrl: "https://api.allanime.day/api",
       }),
     }),
-    { relayToken: "secret" },
+    { authorization: { mode: "bearer", token: "secret" } },
   );
 
   expect(response.status).toBe(401);

--- a/apps/relay-server/test/integration/relay-app.test.ts
+++ b/apps/relay-server/test/integration/relay-app.test.ts
@@ -36,7 +36,7 @@ test("relay app forwards allowlisted provider RPC requests", async () => {
     }),
     {
       authorization: { mode: "bearer", token: "secret" },
-      async fetch() {
+      async transport() {
         return Response.json({ data: { ok: true } });
       },
     },

--- a/apps/relay-server/test/integration/rpc-body-limit.test.ts
+++ b/apps/relay-server/test/integration/rpc-body-limit.test.ts
@@ -16,12 +16,22 @@ import { createServer, type Server } from "node:http";
 
 import { DEFAULT_MAX_REQUEST_BODY_BYTES } from "@kunai/relay";
 
-import handler from "../../api/rpc/[providerId]";
+import { createRelayRpcHandler } from "../../api/rpc/[providerId]";
 
 let server: Server;
 let base: string;
+let upstreamCalls = 0;
+
+const RELAY_TOKEN = "integration-secret";
 
 beforeAll(async () => {
+  const handler = createRelayRpcHandler({
+    readToken: () => RELAY_TOKEN,
+    async fetch() {
+      upstreamCalls++;
+      throw new Error("unexpected upstream fetch");
+    },
+  });
   server = createServer((req, res) => {
     // Mirrors the platform's file-based route parameter.
     void handler(Object.assign(req, { query: { providerId: "allanime" } }), res);
@@ -34,10 +44,12 @@ afterAll(() => {
   server.close();
 });
 
-function post(body: string) {
+function post(body: string, authorization: string | null = `Bearer ${RELAY_TOKEN}`) {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (authorization) headers.authorization = authorization;
   return fetch(`${base}/rpc/allanime`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers,
     body,
   });
 }
@@ -78,6 +90,7 @@ describe("relay rpc body limit", () => {
         socket.write(
           "POST /rpc/allanime HTTP/1.1\r\n" +
             "Host: 127.0.0.1\r\n" +
+            `Authorization: Bearer ${RELAY_TOKEN}\r\n` +
             "Content-Type: application/json\r\n" +
             "Content-Length: 10000000\r\n\r\n",
         );
@@ -99,12 +112,27 @@ describe("relay rpc body limit", () => {
     expect(status).toContain("413");
   }, 20000);
 
-  test("a body under the ceiling still reaches the shared handler", async () => {
+  test.each([
+    ["missing", null],
+    ["wrong", "Bearer wrong-token"],
+  ])("%s bearer receives 401 without upstream work", async (_label, authorization) => {
+    upstreamCalls = 0;
+    const response = await post(
+      JSON.stringify({ method: "GET", upstreamUrl: "https://api.allanime.day/api" }),
+      authorization,
+    );
+
+    expect(response.status).toBe(401);
+    expect(upstreamCalls).toBe(0);
+  });
+
+  test("an exact bearer under the ceiling reaches normal envelope validation", async () => {
     // Malformed on purpose: the point is that it is judged on its contents
     // rather than rejected for its size, so the fix did not simply refuse
     // everything.
     const response = await post(JSON.stringify({ not: "a relay envelope" }));
 
-    expect(response.status).not.toBe(413);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "bad-request" } });
   });
 });

--- a/apps/relay-server/test/integration/rpc-body-limit.test.ts
+++ b/apps/relay-server/test/integration/rpc-body-limit.test.ts
@@ -126,6 +126,34 @@ describe("relay rpc body limit", () => {
     expect(upstreamCalls).toBe(0);
   });
 
+  test("missing bearer is rejected from headers without waiting for its body", async () => {
+    const { port } = server.address() as { port: number };
+    const status = await readStatusFromIncompleteRequest(
+      port,
+      "POST /rpc/allanime HTTP/1.1\r\n" +
+        "Host: 127.0.0.1\r\n" +
+        "Content-Type: application/json\r\n" +
+        "Content-Length: 10000000\r\n\r\n",
+    );
+
+    expect(status).toContain("401");
+  }, 20000);
+
+  test("duplicate bearer headers are rejected without waiting for the body", async () => {
+    const { port } = server.address() as { port: number };
+    const status = await readStatusFromIncompleteRequest(
+      port,
+      "POST /rpc/allanime HTTP/1.1\r\n" +
+        "Host: 127.0.0.1\r\n" +
+        `Authorization: Bearer ${RELAY_TOKEN}\r\n` +
+        "Authorization: Bearer attacker\r\n" +
+        "Content-Type: application/json\r\n" +
+        "Content-Length: 10000000\r\n\r\n",
+    );
+
+    expect(status).toContain("401");
+  }, 20000);
+
   test("an exact bearer under the ceiling reaches normal envelope validation", async () => {
     // Malformed on purpose: the point is that it is judged on its contents
     // rather than rejected for its size, so the fix did not simply refuse
@@ -136,3 +164,19 @@ describe("relay rpc body limit", () => {
     await expect(response.json()).resolves.toMatchObject({ error: { code: "bad-request" } });
   });
 });
+
+async function readStatusFromIncompleteRequest(port: number, requestHead: string): Promise<string> {
+  const { connect } = await import("node:net");
+  return new Promise((resolve, reject) => {
+    const socket = connect(port, "127.0.0.1", () => socket.write(requestHead));
+    socket.on("data", (chunk) => {
+      resolve(chunk.toString("utf8").split("\r\n")[0] ?? "");
+      socket.destroy();
+    });
+    socket.on("error", reject);
+    socket.setTimeout(5000, () => {
+      socket.destroy();
+      reject(new Error("no response before the unfinished request body"));
+    });
+  });
+}

--- a/apps/relay-server/test/integration/rpc-body-limit.test.ts
+++ b/apps/relay-server/test/integration/rpc-body-limit.test.ts
@@ -27,7 +27,7 @@ const RELAY_TOKEN = "integration-secret";
 beforeAll(async () => {
   const handler = createRelayRpcHandler({
     readToken: () => RELAY_TOKEN,
-    async fetch() {
+    async transport() {
       upstreamCalls++;
       throw new Error("unexpected upstream fetch");
     },

--- a/apps/relay-server/test/unit/relay-deployment-policy.test.ts
+++ b/apps/relay-server/test/unit/relay-deployment-policy.test.ts
@@ -151,6 +151,87 @@ test.each([
   expect(await result.clone().text()).not.toContain("secret");
 });
 
+test.each([
+  ["missing", undefined],
+  ["wrong", "Bearer secres"],
+])(
+  "deployment rejects a %s request bearer before reading its body",
+  async (_label, authorization) => {
+    let bodyReads = 0;
+    let written: Response | undefined;
+    const rpcHandler = createRelayRpcHandler({
+      readToken: () => "secret",
+      registry,
+      async readBody() {
+        bodyReads++;
+        return new TextEncoder().encode(
+          JSON.stringify({ method: "GET", upstreamUrl: "https://api.allanime.day/api" }),
+        );
+      },
+      async writeResponse(_response, result) {
+        written = result;
+      },
+    });
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (authorization) headers.authorization = authorization;
+
+    await rpcHandler(
+      {
+        method: "POST",
+        headers,
+        query: { providerId: "allanime" },
+      } as unknown as Parameters<typeof rpcHandler>[0],
+      {} as Parameters<typeof rpcHandler>[1],
+    );
+
+    expect(written?.status).toBe(401);
+    expect(bodyReads).toBe(0);
+  },
+);
+
+test.each([
+  [
+    "headersDistinct",
+    {
+      headers: { authorization: "Bearer secret" },
+      headersDistinct: { authorization: ["Bearer secret", "Bearer wrong"] },
+    },
+  ],
+  [
+    "rawHeaders",
+    {
+      headers: { authorization: "Bearer secret" },
+      rawHeaders: ["Authorization", "Bearer secret", "Authorization", "Bearer wrong"],
+    },
+  ],
+])("deployment rejects duplicate Authorization preserved by %s", async (_label, rawRequest) => {
+  let bodyReads = 0;
+  let written: Response | undefined;
+  const rpcHandler = createRelayRpcHandler({
+    readToken: () => "secret",
+    registry,
+    async readBody() {
+      bodyReads++;
+      return new Uint8Array();
+    },
+    async writeResponse(_response, result) {
+      written = result;
+    },
+  });
+
+  await rpcHandler(
+    {
+      method: "POST",
+      ...rawRequest,
+      query: { providerId: "allanime" },
+    } as unknown as Parameters<typeof rpcHandler>[0],
+    {} as Parameters<typeof rpcHandler>[1],
+  );
+
+  expect(written?.status).toBe(401);
+  expect(bodyReads).toBe(0);
+});
+
 test("deployment exact bearer reaches the shared relay handler", async () => {
   let upstreamCalls = 0;
   const result = await invokeFactory({

--- a/apps/relay-server/test/unit/relay-deployment-policy.test.ts
+++ b/apps/relay-server/test/unit/relay-deployment-policy.test.ts
@@ -1,0 +1,226 @@
+import { expect, test } from "bun:test";
+
+import {
+  buildProviderRelayRegistry,
+  type ProviderRelayRegistry,
+  type RelayFetch,
+} from "@kunai/relay";
+
+import handler, { createRelayRpcHandler } from "../../api/rpc/[providerId]";
+
+const registry = buildProviderRelayRegistry([
+  {
+    providerId: "allanime",
+    manifest: {
+      relaySafe: true,
+      relayProfile: { upstreamHosts: ["api.allanime.day"] },
+    },
+  },
+] as never);
+
+test("deployment rejects an unset token before reading the request body", async () => {
+  const previousToken = process.env.RELAY_TOKEN;
+  delete process.env.RELAY_TOKEN;
+
+  const request = {
+    method: "POST",
+    headers: {},
+    query: { providerId: "allanime" },
+    on() {
+      throw new Error("request body was accessed");
+    },
+  } as unknown as Parameters<typeof handler>[0];
+  let responseBody: Uint8Array | undefined;
+  const response = {
+    statusCode: 0,
+    setHeader() {},
+    end(body?: Uint8Array) {
+      responseBody = body;
+    },
+  } as unknown as Parameters<typeof handler>[1];
+
+  try {
+    await handler(request, response);
+  } finally {
+    if (previousToken === undefined) delete process.env.RELAY_TOKEN;
+    else process.env.RELAY_TOKEN = previousToken;
+  }
+
+  expect(response.statusCode).toBe(503);
+  expect(JSON.parse(Buffer.from(responseBody ?? []).toString("utf8"))).toMatchObject({
+    error: { code: "relay-not-configured" },
+  });
+});
+
+test.each([undefined, "", "   "])(
+  "deployment rejects unusable token %s before route or body work",
+  async (token) => {
+    const calls = {
+      body: 0,
+      registry: 0,
+      request: 0,
+      shared: 0,
+      token: 0,
+      upstream: 0,
+    };
+    let written: Response | undefined;
+    const guardedRegistry = {
+      providers: [],
+      get() {
+        calls.registry++;
+        return undefined;
+      },
+      findByUpstreamUrl() {
+        calls.registry++;
+        return undefined;
+      },
+      isHostAllowed() {
+        calls.registry++;
+        return false;
+      },
+    } satisfies ProviderRelayRegistry;
+    const rpcHandler = createRelayRpcHandler({
+      readToken() {
+        calls.token++;
+        return token;
+      },
+      registry: guardedRegistry,
+      async readBody() {
+        calls.body++;
+        throw new Error("body reader was called");
+      },
+      createWebRequest() {
+        calls.request++;
+        throw new Error("request adapter was called");
+      },
+      async handleRequest() {
+        calls.shared++;
+        throw new Error("shared handler was called");
+      },
+      async fetch() {
+        calls.upstream++;
+        throw new Error("upstream fetch was called");
+      },
+      async writeResponse(_response, result) {
+        written = result;
+      },
+    });
+    const request = {
+      method: "POST",
+      headers: {},
+      get query(): never {
+        throw new Error("route was inspected");
+      },
+      on() {
+        throw new Error("request body was accessed");
+      },
+    } as unknown as Parameters<typeof rpcHandler>[0];
+
+    await rpcHandler(request, {} as Parameters<typeof rpcHandler>[1]);
+
+    expect(written?.status).toBe(503);
+    expect(await written?.json()).toMatchObject({ error: { code: "relay-not-configured" } });
+    expect(calls).toEqual({
+      body: 0,
+      registry: 0,
+      request: 0,
+      shared: 0,
+      token: 1,
+      upstream: 0,
+    });
+  },
+);
+
+test.each([
+  ["missing", undefined],
+  ["wrong", "Bearer secres"],
+])("deployment returns 401 for %s request bearer without upstream fetch", async (_label, auth) => {
+  let upstreamCalls = 0;
+  const result = await invokeFactory({
+    configuredToken: "secret",
+    authorization: auth,
+    body: JSON.stringify({ method: "GET", upstreamUrl: "https://api.allanime.day/api" }),
+    async fetch() {
+      upstreamCalls++;
+      return Response.json({ ok: true });
+    },
+  });
+
+  expect(result.status).toBe(401);
+  expect(upstreamCalls).toBe(0);
+  expect(await result.clone().text()).not.toContain("secret");
+});
+
+test("deployment exact bearer reaches the shared relay handler", async () => {
+  let upstreamCalls = 0;
+  const result = await invokeFactory({
+    configuredToken: " secret ",
+    authorization: "Bearer secret",
+    body: JSON.stringify({ method: "GET", upstreamUrl: "https://api.allanime.day/api" }),
+    async fetch() {
+      upstreamCalls++;
+      return Response.json({ ok: true });
+    },
+  });
+
+  expect(result.status).toBe(200);
+  expect(await result.json()).toEqual({ ok: true });
+  expect(upstreamCalls).toBe(1);
+});
+
+test("deployment OPTIONS remains a body-free CORS preflight", async () => {
+  let bodyReads = 0;
+  let written: Response | undefined;
+  const rpcHandler = createRelayRpcHandler({
+    readToken: () => "secret",
+    registry,
+    async readBody() {
+      bodyReads++;
+      throw new Error("OPTIONS body was read");
+    },
+    async writeResponse(_response, result) {
+      written = result;
+    },
+  });
+  const request = {
+    method: "OPTIONS",
+    headers: {},
+    query: { providerId: "allanime" },
+  } as unknown as Parameters<typeof rpcHandler>[0];
+
+  await rpcHandler(request, {} as Parameters<typeof rpcHandler>[1]);
+
+  expect(bodyReads).toBe(0);
+  expect(written?.status).toBe(204);
+  expect(written?.headers.get("access-control-allow-methods")).toContain("POST");
+  expect(await written?.text()).toBe("");
+});
+
+async function invokeFactory(input: {
+  readonly configuredToken: string;
+  readonly authorization?: string;
+  readonly body: string;
+  readonly fetch: RelayFetch;
+}): Promise<Response> {
+  let written: Response | undefined;
+  const rpcHandler = createRelayRpcHandler({
+    readToken: () => input.configuredToken,
+    registry,
+    readBody: async () => new TextEncoder().encode(input.body),
+    fetch: input.fetch,
+    async writeResponse(_response, result) {
+      written = result;
+    },
+  });
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (input.authorization) headers.authorization = input.authorization;
+  const request = {
+    method: "POST",
+    headers,
+    query: { providerId: "allanime" },
+  } as unknown as Parameters<typeof rpcHandler>[0];
+
+  await rpcHandler(request, {} as Parameters<typeof rpcHandler>[1]);
+  if (!written) throw new Error("handler did not write a response");
+  return written;
+}

--- a/apps/relay-server/test/unit/relay-deployment-policy.test.ts
+++ b/apps/relay-server/test/unit/relay-deployment-policy.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "bun:test";
 import {
   buildProviderRelayRegistry,
   type ProviderRelayRegistry,
-  type RelayFetch,
+  type RelayTransport,
 } from "@kunai/relay";
 
 import handler, { createRelayRpcHandler } from "../../api/rpc/[providerId]";
@@ -97,7 +97,7 @@ test.each([undefined, "", "   "])(
         calls.shared++;
         throw new Error("shared handler was called");
       },
-      async fetch() {
+      async transport() {
         calls.upstream++;
         throw new Error("upstream fetch was called");
       },
@@ -140,7 +140,7 @@ test.each([
     configuredToken: "secret",
     authorization: auth,
     body: JSON.stringify({ method: "GET", upstreamUrl: "https://api.allanime.day/api" }),
-    async fetch() {
+    async transport() {
       upstreamCalls++;
       return Response.json({ ok: true });
     },
@@ -157,7 +157,7 @@ test("deployment exact bearer reaches the shared relay handler", async () => {
     configuredToken: " secret ",
     authorization: "Bearer secret",
     body: JSON.stringify({ method: "GET", upstreamUrl: "https://api.allanime.day/api" }),
-    async fetch() {
+    async transport() {
       upstreamCalls++;
       return Response.json({ ok: true });
     },
@@ -200,14 +200,14 @@ async function invokeFactory(input: {
   readonly configuredToken: string;
   readonly authorization?: string;
   readonly body: string;
-  readonly fetch: RelayFetch;
+  readonly transport: RelayTransport;
 }): Promise<Response> {
   let written: Response | undefined;
   const rpcHandler = createRelayRpcHandler({
     readToken: () => input.configuredToken,
     registry,
     readBody: async () => new TextEncoder().encode(input.body),
-    fetch: input.fetch,
+    transport: input.transport,
     async writeResponse(_response, result) {
       written = result;
     },

--- a/apps/relay-server/test/unit/relay-runtime-policy.test.ts
+++ b/apps/relay-server/test/unit/relay-runtime-policy.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "bun:test";
+
+import {
+  createRelayDevServerOptions,
+  resolveRelayDevelopmentPolicy,
+} from "../../src/relay-runtime-policy";
+
+test("relay development defaults to numeric IPv4 loopback on port 8787", () => {
+  expect(resolveRelayDevelopmentPolicy({})).toEqual({
+    hostname: "127.0.0.1",
+    port: 8787,
+    authorization: { mode: "local-loopback" },
+  });
+});
+
+test.each(["127.0.0.1", "::1"])("relay development permits tokenless bind to %s", (hostname) => {
+  expect(resolveRelayDevelopmentPolicy({ RELAY_HOST: hostname })).toEqual({
+    hostname,
+    port: 8787,
+    authorization: { mode: "local-loopback" },
+  });
+});
+
+test.each(["", "   "])("relay development treats a blank host as the safe default", (host) => {
+  expect(resolveRelayDevelopmentPolicy({ RELAY_HOST: host })).toEqual({
+    hostname: "127.0.0.1",
+    port: 8787,
+    authorization: { mode: "local-loopback" },
+  });
+});
+
+test.each(["0.0.0.0", "::", "localhost", "192.168.1.20"])(
+  "relay development rejects tokenless non-loopback bind to %s",
+  (hostname) => {
+    expect(() => resolveRelayDevelopmentPolicy({ RELAY_HOST: hostname })).toThrow("RELAY_TOKEN");
+  },
+);
+
+test.each([undefined, "", "   "])(
+  "relay development rejects a non-loopback bind with unusable token %s",
+  (token) => {
+    expect(() =>
+      resolveRelayDevelopmentPolicy({ RELAY_HOST: "0.0.0.0", RELAY_TOKEN: token }),
+    ).toThrow("RELAY_TOKEN");
+  },
+);
+
+test.each(["0.0.0.0", "::", "localhost", "192.168.1.20"])(
+  "relay development uses bearer authorization for tokened bind to %s",
+  (hostname) => {
+    expect(
+      resolveRelayDevelopmentPolicy({ RELAY_HOST: ` ${hostname} `, RELAY_TOKEN: " secret " }),
+    ).toEqual({
+      hostname,
+      port: 8787,
+      authorization: { mode: "bearer", token: "secret" },
+    });
+  },
+);
+
+test("relay development uses bearer authorization when loopback has a token", () => {
+  expect(resolveRelayDevelopmentPolicy({ RELAY_TOKEN: "secret" })).toEqual({
+    hostname: "127.0.0.1",
+    port: 8787,
+    authorization: { mode: "bearer", token: "secret" },
+  });
+});
+
+test.each(["0", "-1", "65536", "8787.5", "abc"])(
+  "relay development rejects invalid port %s",
+  (port) => {
+    expect(() => resolveRelayDevelopmentPolicy({ PORT: port })).toThrow("PORT");
+  },
+);
+
+test("relay development carries resolved host, port, and auth into server behavior", async () => {
+  const policy = resolveRelayDevelopmentPolicy({
+    RELAY_HOST: "0.0.0.0",
+    RELAY_TOKEN: "secret",
+    PORT: "9000",
+  });
+  const options = createRelayDevServerOptions(policy);
+
+  expect(options.hostname).toBe("0.0.0.0");
+  expect(options.port).toBe(9000);
+
+  const response = await options.fetch(
+    new Request("http://relay.test/rpc/allanime", {
+      method: "POST",
+      body: JSON.stringify({
+        method: "GET",
+        upstreamUrl: "https://api.allanime.day/api",
+      }),
+    }),
+  );
+  expect(response.status).toBe(401);
+});

--- a/docs/users/customization.mdx
+++ b/docs/users/customization.mdx
@@ -61,7 +61,7 @@ geo-blocked from your network.
 {
   "providerRelay": {
     "baseUrl": "https://your-relay.example",
-    "token": "",
+    "token": "same-secret-as-the-relay-server",
     "fallbackToDirect": true,
     "providers": {
       "allanime": { "enabled": true }
@@ -69,6 +69,10 @@ geo-blocked from your network.
   }
 }
 ```
+
+Internet relay deployments require a bearer token configured on both the relay
+server and Kunai. A token is optional only for the local development server when
+it is bound to numeric loopback (`127.0.0.1` or `::1`).
 
 `KUNAI_RELAY_BASE_URL` and `KUNAI_RELAY_TOKEN` override local config for smoke
 tests and temporary sessions. The relay is metadata-only. Stream URLs always

--- a/docs/users/providers.mdx
+++ b/docs/users/providers.mdx
@@ -258,7 +258,7 @@ What it does not do:
 - Kunai does not host or proxy video. There is no video-relay configuration; stream URLs always stay direct.
 - The relay does not bypass provider login or DRM.
 
-Installed binaries: leave `providerRelay.baseUrl` empty (the default) for direct fetches. To use a relay you operate, set `baseUrl` (and optional token) in `/settings` or `config.json` to **your** origin — Kunai never ships a public relay URL. `fallbackToDirect: true` lets a broken relay degrade to direct fetches where the provider is not geo-blocked. Env overrides: `KUNAI_RELAY_BASE_URL`, `KUNAI_RELAY_TOKEN`.
+Installed binaries: leave `providerRelay.baseUrl` empty (the default) for direct fetches. To use a relay you operate, set `baseUrl` in `/settings` or `config.json` to **your** origin — Kunai never ships a public relay URL. An internet relay requires a matching bearer `token`; only a relay bound to numeric loopback may run without one. `fallbackToDirect: true` degrades to direct fetches after relay network or authorization-policy failures where the provider is not geo-blocked. Env overrides: `KUNAI_RELAY_BASE_URL`, `KUNAI_RELAY_TOKEN`.
 
 Source-checkout smoke and Vercel deploy steps: [Debugging workflow](/docs/developer/debugging-workflow) and `apps/relay-server/README.md`.
 

--- a/packages/relay/src/create-relay-fetch-port.ts
+++ b/packages/relay/src/create-relay-fetch-port.ts
@@ -1,5 +1,5 @@
 import { resolveEffectiveProviderRelayConfig } from "./resolve-relay-config";
-import type { RelayRpcRequest } from "./types";
+import { RELAY_ERROR_CODE_HEADER, type RelayRpcRequest } from "./types";
 import type { RelayFetchPort, RelayFetchPortOptions } from "./types";
 
 type RelayHeadersInit = ConstructorParameters<typeof Headers>[0];
@@ -38,12 +38,16 @@ export function createRelayFetchPort(options: RelayFetchPortOptions): RelayFetch
       }
 
       try {
-        return await fetchImpl(relayUrl, {
+        const response = await fetchImpl(relayUrl, {
           method: "POST",
           headers,
           body: JSON.stringify(requestInfo),
           signal: init?.signal,
         });
+        if (fallbackToDirect && isRelayAuthorizationFailure(response)) {
+          return fetchImpl(input, init);
+        }
+        return response;
       } catch (error) {
         if (!fallbackToDirect) throw error;
         return fetchImpl(input, init);
@@ -53,6 +57,14 @@ export function createRelayFetchPort(options: RelayFetchPortOptions): RelayFetch
 }
 
 export { normalizeRelayBaseUrl } from "./normalize-relay-base-url";
+
+function isRelayAuthorizationFailure(response: Response): boolean {
+  const code = response.headers.get(RELAY_ERROR_CODE_HEADER);
+  return (
+    (response.status === 503 && code === "relay-not-configured") ||
+    (response.status === 401 && code === "unauthorized")
+  );
+}
 
 async function toRelayRequest(
   input: string | URL | Request,

--- a/packages/relay/src/handler.ts
+++ b/packages/relay/src/handler.ts
@@ -1,6 +1,7 @@
 import { timingSafeEqual } from "node:crypto";
 
 import { filterForwardHeaders, mergeRelayHeaders, RelayValidationError } from "./forward-headers";
+import { createPinnedRelayTransport, isPublicRelayAddress } from "./pinned-transport";
 import { parseHttpUrl } from "./registry";
 import {
   DEFAULT_MAX_REDIRECTS,
@@ -119,8 +120,15 @@ export async function handleRpcRequest(
   }
 
   try {
+    const maxResponseBodyBytes =
+      provider.profile.maxResponseBodyBytes ?? DEFAULT_MAX_RESPONSE_BODY_BYTES;
     const upstream = await fetchWithValidatedRedirects({
-      fetchImpl: options.fetch ?? fetch,
+      fetchImpl:
+        options.transport ??
+        createPinnedRelayTransport({
+          maxRequestBodyBytes: maxBodyBytes,
+          maxResponseBodyBytes,
+        }),
       providerId: options.providerId,
       registry: options.registry,
       url: upstreamUrl,
@@ -135,7 +143,7 @@ export async function handleRpcRequest(
 
     return await relayUpstreamResponse(
       upstream,
-      provider.profile.maxResponseBodyBytes ?? DEFAULT_MAX_RESPONSE_BODY_BYTES,
+      maxResponseBodyBytes,
       options.providerId,
       rpc.method,
     );
@@ -232,7 +240,10 @@ async function fetchWithValidatedRedirects(input: {
         );
       }
       currentUrl = new URL(location, currentUrl);
-      if (!input.registry.isHostAllowed(input.providerId, currentUrl, "metadata")) {
+      if (
+        isUnsafeHostname(currentUrl.hostname) ||
+        !input.registry.isHostAllowed(input.providerId, currentUrl, "metadata")
+      ) {
         throw new RelayValidationError(
           "redirect-not-allowed",
           "Upstream redirect target is not allowed",
@@ -343,66 +354,17 @@ function isAuthorized(request: Request, token: string): boolean {
   return given.length === wanted.length && timingSafeEqual(given, wanted);
 }
 
-/**
- * The dotted-quad an IPv6 literal embeds, or null when it embeds none.
- *
- * Covers both spellings of the `::ffff:` mapping — the dotted tail the user
- * types and the two hex groups WHATWG normalizes it into — plus the deprecated
- * IPv4-compatible `::a.b.c.d` form, which normalizes the same way.
- */
-function embeddedIpv4(ipv6: string): string | null {
-  const dotted = /^::(?:ffff:)?(\d{1,3}(?:\.\d{1,3}){3})$/.exec(ipv6);
-  if (dotted?.[1]) return dotted[1];
-
-  const hex = /^::(?:ffff:)?([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(ipv6);
-  if (!hex?.[1] || !hex[2]) return null;
-  const high = Number.parseInt(hex[1], 16);
-  const low = Number.parseInt(hex[2], 16);
-  // `::1` and `::` are loopback/unspecified, not IPv4 — leave them to the
-  // literal checks so their meaning is not silently reinterpreted.
-  if (high === 0) return null;
-  return [high >> 8, high & 0xff, low >> 8, low & 0xff].join(".");
-}
-
+/** Reject literal targets before registry or DNS work; names are checked again after resolution. */
 function isUnsafeHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase();
   if (normalized === "localhost" || normalized.endsWith(".localhost")) return true;
-  if (normalized === "0.0.0.0") return true;
-  if (normalized.includes(":")) {
-    // WHATWG URL keeps brackets on IPv6 literals ("[::1]"); strip them so
-    // loopback, unspecified, link-local, and unique-local all match.
-    const ipv6 =
-      normalized.startsWith("[") && normalized.endsWith("]") ? normalized.slice(1, -1) : normalized;
-    // An IPv4-mapped address is an IPv4 address, and the prefix checks below
-    // cannot see it: WHATWG rewrites `::ffff:169.254.169.254` — the cloud
-    // metadata endpoint — to the hex form `::ffff:a9fe:a9fe`, which matches
-    // none of them. Judge the address it embeds.
-    const mapped = embeddedIpv4(ipv6);
-    if (mapped) return isUnsafeHostname(mapped);
-    // Link-local is fe80::/10, not fe80::/16 — `fe90::`, `fea0::` and `feb0::`
-    // are link-local too and a `fe80:` prefix test misses all three.
-    return (
-      ipv6 === "::1" ||
-      ipv6 === "::" ||
-      /^fe[89ab][0-9a-f]?:/.test(ipv6) ||
-      ipv6.startsWith("fc") ||
-      ipv6.startsWith("fd")
-    );
-  }
+  const literal =
+    normalized.startsWith("[") && normalized.endsWith("]") ? normalized.slice(1, -1) : normalized;
+  return isIPLiteral(literal) && !isPublicRelayAddress(literal);
+}
 
-  const octets = normalized.split(".").map((part) => Number(part));
-  if (octets.length !== 4 || octets.some((part) => !Number.isInteger(part))) return false;
-  const [a, b] = octets;
-  if (a === undefined || b === undefined) return false;
-  return (
-    a === 0 || // 0.0.0.0/8 — "this network"; 0.0.0.0 alone is not the whole range.
-    a === 10 ||
-    a === 127 ||
-    (a === 100 && b >= 64 && b <= 127) || // CGNAT, routable inside carrier networks.
-    (a === 169 && b === 254) ||
-    (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && b === 168)
-  );
+function isIPLiteral(hostname: string): boolean {
+  return /^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostname) || hostname.includes(":");
 }
 
 function isAbortLike(error: unknown): boolean {

--- a/packages/relay/src/handler.ts
+++ b/packages/relay/src/handler.ts
@@ -1,22 +1,33 @@
 import { timingSafeEqual } from "node:crypto";
 
 import { filterForwardHeaders, mergeRelayHeaders, RelayValidationError } from "./forward-headers";
-import { createPinnedRelayTransport, isPublicRelayAddress } from "./pinned-transport";
+import {
+  createPinnedRelayTransport,
+  isPublicRelayAddress,
+  writeRelayDiagnostic,
+} from "./pinned-transport";
 import { parseHttpUrl } from "./registry";
 import {
   DEFAULT_MAX_REDIRECTS,
   DEFAULT_MAX_REQUEST_BODY_BYTES,
   DEFAULT_MAX_RESPONSE_BODY_BYTES,
   DEFAULT_RELAY_TIMEOUT_MS,
-  type RelayFetch,
   type RelayErrorCode,
   type RelayHandlerOptions,
   type RelayRpcErrorBody,
   type RelayRpcRequest,
   type RelayMethod,
+  type RelayTransport,
 } from "./types";
 
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const CROSS_ORIGIN_SENSITIVE_HEADERS = [
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+  "x-aa-boot",
+  "x-session-token",
+] as const;
 const RELAY_RESPONSE_HEADERS = [
   "content-type",
   "content-length",
@@ -43,7 +54,7 @@ export async function handleRpcRequest(
         503,
       );
     }
-    if (!isAuthorized(request, token)) {
+    if (!isRelayBearerAuthorized(request.headers.get("authorization"), token)) {
       return relayError("unauthorized", options.providerId, "Relay token is required", 401);
     }
   }
@@ -126,6 +137,8 @@ export async function handleRpcRequest(
       fetchImpl:
         options.transport ??
         createPinnedRelayTransport({
+          providerId: options.providerId,
+          diagnostics: options.diagnostics ?? writeRelayDiagnostic,
           maxRequestBodyBytes: maxBodyBytes,
           maxResponseBodyBytes,
         }),
@@ -206,7 +219,7 @@ function isStringRecord(value: unknown): value is Record<string, string> {
 }
 
 async function fetchWithValidatedRedirects(input: {
-  readonly fetchImpl: RelayFetch;
+  readonly fetchImpl: RelayTransport;
   readonly providerId: string;
   readonly registry: RelayHandlerOptions["registry"];
   readonly url: URL;
@@ -217,6 +230,7 @@ async function fetchWithValidatedRedirects(input: {
   let currentUrl = input.url;
   let method = input.init.method ?? "GET";
   let body = input.init.body;
+  const headers = new Headers(input.init.headers);
 
   for (let redirectCount = 0; redirectCount <= input.maxRedirects; redirectCount++) {
     const controller = new AbortController();
@@ -226,6 +240,7 @@ async function fetchWithValidatedRedirects(input: {
         ...input.init,
         method,
         body,
+        headers,
         redirect: "manual",
         signal: controller.signal,
       });
@@ -239,10 +254,17 @@ async function fetchWithValidatedRedirects(input: {
           502,
         );
       }
-      currentUrl = new URL(location, currentUrl);
+      const redirectUrl = new URL(location, currentUrl);
+      if (currentUrl.protocol === "https:" && redirectUrl.protocol === "http:") {
+        throw new RelayValidationError(
+          "redirect-not-allowed",
+          "HTTPS upstream cannot redirect to HTTP",
+          502,
+        );
+      }
       if (
-        isUnsafeHostname(currentUrl.hostname) ||
-        !input.registry.isHostAllowed(input.providerId, currentUrl, "metadata")
+        isUnsafeHostname(redirectUrl.hostname) ||
+        !input.registry.isHostAllowed(input.providerId, redirectUrl, "metadata")
       ) {
         throw new RelayValidationError(
           "redirect-not-allowed",
@@ -250,6 +272,10 @@ async function fetchWithValidatedRedirects(input: {
           502,
         );
       }
+      if (redirectUrl.origin !== currentUrl.origin) {
+        for (const name of CROSS_ORIGIN_SENSITIVE_HEADERS) headers.delete(name);
+      }
+      currentUrl = redirectUrl;
       if (response.status === 303) {
         method = "GET";
         body = undefined;
@@ -343,8 +369,10 @@ function corsPreflightResponse(): Response {
   });
 }
 
-function isAuthorized(request: Request, token: string): boolean {
-  const authorization = request.headers.get("authorization");
+export function isRelayBearerAuthorized(
+  authorization: string | null | undefined,
+  token: string,
+): boolean {
   if (!authorization) return false;
   const expected = `Bearer ${token}`;
   const given = Buffer.from(authorization, "utf8");
@@ -368,8 +396,11 @@ function isIPLiteral(hostname: string): boolean {
 }
 
 function isAbortLike(error: unknown): boolean {
+  const candidate = error as { readonly code?: unknown; readonly name?: unknown } | null;
   return (
     (error instanceof DOMException && error.name === "AbortError") ||
+    candidate?.name === "AbortError" ||
+    candidate?.code === "ABORT_ERR" ||
     String(error).toLowerCase().includes("timeout")
   );
 }

--- a/packages/relay/src/handler.ts
+++ b/packages/relay/src/handler.ts
@@ -32,8 +32,19 @@ export async function handleRpcRequest(
     return relayError("method-not-allowed", options.providerId, "RPC route requires POST", 405);
   }
 
-  if (options.token && !isAuthorized(request, options.token)) {
-    return relayError("unauthorized", options.providerId, "Relay token is required", 401);
+  if (options.authorization.mode === "bearer") {
+    const token = options.authorization.token.trim();
+    if (!token) {
+      return relayError(
+        "relay-not-configured",
+        options.providerId,
+        "Relay authorization is not configured",
+        503,
+      );
+    }
+    if (!isAuthorized(request, token)) {
+      return relayError("unauthorized", options.providerId, "Relay token is required", 401);
+    }
   }
 
   const provider = options.registry.get(options.providerId);

--- a/packages/relay/src/handler.ts
+++ b/packages/relay/src/handler.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_MAX_REQUEST_BODY_BYTES,
   DEFAULT_MAX_RESPONSE_BODY_BYTES,
   DEFAULT_RELAY_TIMEOUT_MS,
+  RELAY_ERROR_CODE_HEADER,
   type RelayErrorCode,
   type RelayHandlerOptions,
   type RelayRpcErrorBody,
@@ -27,6 +28,13 @@ const CROSS_ORIGIN_SENSITIVE_HEADERS = [
   "proxy-authorization",
   "x-aa-boot",
   "x-session-token",
+] as const;
+const REQUEST_BODY_HEADERS = [
+  "content-encoding",
+  "content-language",
+  "content-length",
+  "content-location",
+  "content-type",
 ] as const;
 const RELAY_RESPONSE_HEADERS = [
   "content-type",
@@ -231,11 +239,11 @@ async function fetchWithValidatedRedirects(input: {
   let method = input.init.method ?? "GET";
   let body = input.init.body;
   const headers = new Headers(input.init.headers);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort("relay upstream timeout"), input.timeoutMs);
 
-  for (let redirectCount = 0; redirectCount <= input.maxRedirects; redirectCount++) {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort("relay upstream timeout"), input.timeoutMs);
-    try {
+  try {
+    for (let redirectCount = 0; redirectCount <= input.maxRedirects; redirectCount++) {
       const response = await input.fetchImpl(currentUrl, {
         ...input.init,
         method,
@@ -276,16 +284,24 @@ async function fetchWithValidatedRedirects(input: {
         for (const name of CROSS_ORIGIN_SENSITIVE_HEADERS) headers.delete(name);
       }
       currentUrl = redirectUrl;
-      if (response.status === 303) {
+      if (redirectRewritesToGet(response.status, method)) {
         method = "GET";
         body = undefined;
+        for (const name of REQUEST_BODY_HEADERS) headers.delete(name);
       }
-    } finally {
-      clearTimeout(timeout);
     }
-  }
 
-  throw new RelayValidationError("redirect-not-allowed", "Too many upstream redirects", 502);
+    throw new RelayValidationError("redirect-not-allowed", "Too many upstream redirects", 502);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function redirectRewritesToGet(status: number, method: string): boolean {
+  return (
+    ((status === 301 || status === 302) && method === "POST") ||
+    (status === 303 && method !== "GET" && method !== "HEAD")
+  );
 }
 
 async function relayUpstreamResponse(
@@ -353,6 +369,7 @@ export function relayError(
     status,
     headers: {
       "Access-Control-Allow-Origin": "*",
+      [RELAY_ERROR_CODE_HEADER]: code,
     },
   });
 }
@@ -395,13 +412,13 @@ function isIPLiteral(hostname: string): boolean {
   return /^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostname) || hostname.includes(":");
 }
 
-function isAbortLike(error: unknown): boolean {
-  const candidate = error as { readonly code?: unknown; readonly name?: unknown } | null;
+function isAbortLike(cause: unknown): boolean {
+  if (!(cause instanceof Error)) return String(cause).toLowerCase().includes("timeout");
+  const code = "code" in cause ? String(cause.code) : "";
   return (
-    (error instanceof DOMException && error.name === "AbortError") ||
-    candidate?.name === "AbortError" ||
-    candidate?.code === "ABORT_ERR" ||
-    String(error).toLowerCase().includes("timeout")
+    cause.name === "AbortError" ||
+    code === "ABORT_ERR" ||
+    cause.message.toLowerCase().includes("timeout")
   );
 }
 

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./normalize-relay-base-url";
+export * from "./pinned-transport";
 export * from "./create-relay-fetch-port";
 export * from "./detect-geo-block";
 export * from "./forward-headers";

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -1,5 +1,4 @@
 export * from "./normalize-relay-base-url";
-export * from "./pinned-transport";
 export * from "./create-relay-fetch-port";
 export * from "./detect-geo-block";
 export * from "./forward-headers";

--- a/packages/relay/src/pinned-transport.ts
+++ b/packages/relay/src/pinned-transport.ts
@@ -9,7 +9,21 @@ import { request as httpsRequest } from "node:https";
 import { isIP } from "node:net";
 
 import { RelayValidationError } from "./forward-headers";
-import type { RelayFetch } from "./types";
+import type {
+  RelayConnectionDiagnosticCode,
+  RelayDiagnosticSink,
+  RelayDnsDiagnosticCode,
+  RelayTransport,
+  RelayTransportDiagnostic,
+} from "./types";
+
+const RETRYABLE_CONNECTION_CODES = new Set<RelayConnectionDiagnosticCode>([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ETIMEDOUT",
+]);
 
 export interface RelayResolvedAddress {
   readonly address: string;
@@ -26,6 +40,8 @@ export type RelayNodeRequest = (
 ) => ClientRequest;
 
 export interface PinnedRelayTransportOptions {
+  readonly providerId?: string;
+  readonly diagnostics?: RelayDiagnosticSink;
   readonly resolveAddresses?: RelayAddressResolver;
   readonly request?: RelayNodeRequest;
   readonly maxRequestBodyBytes: number;
@@ -37,7 +53,7 @@ export interface PinnedRelayTransportOptions {
  * exact DNS answer set that was validated for this request. Redirects call the
  * transport again, so each hop receives a fresh all-address validation.
  */
-export function createPinnedRelayTransport(options: PinnedRelayTransportOptions): RelayFetch {
+export function createPinnedRelayTransport(options: PinnedRelayTransportOptions): RelayTransport {
   const resolveAddresses = options.resolveAddresses ?? resolveAllAddresses;
   const request = options.request ?? dispatchNodeRequest;
 
@@ -58,10 +74,28 @@ export function createPinnedRelayTransport(options: PinnedRelayTransportOptions)
 
     const originalHostname = stripIpv6Brackets(url.hostname);
     const literalFamily = isIP(originalHostname);
-    const answers = literalFamily
-      ? [{ address: originalHostname, family: literalFamily as 4 | 6 }]
-      : await resolveAddresses(originalHostname);
+    const diagnosticHostname = literalFamily === 0 ? originalHostname : "ip-literal";
+    let answers: readonly RelayResolvedAddress[];
+    try {
+      answers = literalFamily
+        ? [{ address: originalHostname, family: literalFamily as 4 | 6 }]
+        : await abortable(resolveAddresses(originalHostname), init.signal);
+    } catch (error) {
+      emitDiagnostic(options.diagnostics, {
+        event: "dns-failed",
+        ...(options.providerId ? { providerId: options.providerId } : {}),
+        hostname: diagnosticHostname,
+        code: dnsDiagnosticCode(error),
+      });
+      throw error;
+    }
     if (answers.length === 0) {
+      emitDiagnostic(options.diagnostics, {
+        event: "dns-failed",
+        ...(options.providerId ? { providerId: options.providerId } : {}),
+        hostname: diagnosticHostname,
+        code: "NO_ADDRESSES",
+      });
       throw new RelayValidationError("upstream-error", "Upstream host did not resolve", 502);
     }
     if (
@@ -69,6 +103,14 @@ export function createPinnedRelayTransport(options: PinnedRelayTransportOptions)
         (answer) => isIP(answer.address) !== answer.family || !isPublicRelayAddress(answer.address),
       )
     ) {
+      emitDiagnostic(options.diagnostics, {
+        event: "dns-rejected",
+        ...(options.providerId ? { providerId: options.providerId } : {}),
+        hostname: diagnosticHostname,
+        answerCount: answers.length,
+        families: [...new Set(answers.map((answer) => answer.family))].sort(),
+        code: "NON_PUBLIC_ADDRESS",
+      });
       throw new RelayValidationError(
         "host-not-allowed",
         "Upstream DNS returned a non-public address",
@@ -76,31 +118,59 @@ export function createPinnedRelayTransport(options: PinnedRelayTransportOptions)
       );
     }
 
-    const selected = answers[0];
-    if (!selected) {
-      throw new RelayValidationError("upstream-error", "Upstream host did not resolve", 502);
-    }
-
     const headers: Record<string, string> = {};
     new Headers(init.headers).forEach((value, name) => {
       headers[name] = value;
     });
     headers.host = url.host;
-    const requestOptions: RelayNodeRequestOptions = {
-      protocol: url.protocol,
-      hostname: selected.address,
-      family: selected.family,
-      port: url.port || undefined,
-      path: `${url.pathname}${url.search}`,
-      method: init.method ?? "GET",
-      headers,
-      agent: false,
-      signal: init.signal ?? undefined,
-      ...(url.protocol === "https:" && literalFamily === 0 ? { servername: originalHostname } : {}),
-    };
+    const method = init.method ?? "GET";
+    for (const [index, selected] of answers.entries()) {
+      const requestOptions: RelayNodeRequestOptions = {
+        protocol: url.protocol,
+        hostname: selected.address,
+        family: selected.family,
+        port: url.port || undefined,
+        path: `${url.pathname}${url.search}`,
+        method,
+        headers,
+        agent: false,
+        signal: init.signal ?? undefined,
+        ...(url.protocol === "https:" && literalFamily === 0
+          ? { servername: originalHostname }
+          : {}),
+      };
 
-    return sendBoundedRequest(request, requestOptions, body, options.maxResponseBodyBytes);
+      try {
+        return await sendBoundedRequest(
+          request,
+          requestOptions,
+          body,
+          options.maxResponseBodyBytes,
+        );
+      } catch (error) {
+        if (error instanceof RelayRequestAttemptError && !error.responseStarted) {
+          emitDiagnostic(options.diagnostics, {
+            event: "connection-failed",
+            ...(options.providerId ? { providerId: options.providerId } : {}),
+            hostname: diagnosticHostname,
+            family: selected.family,
+            attempt: index + 1,
+            answerCount: answers.length,
+            code: connectionDiagnosticCode(error.attemptCause),
+          });
+        }
+        if (!shouldRetryAddress(error, method, index, answers.length, init.signal)) {
+          throw unwrapAttemptError(error);
+        }
+      }
+    }
+
+    throw new RelayValidationError("upstream-error", "Upstream host did not resolve", 502);
   };
+}
+
+export function writeRelayDiagnostic(diagnostic: RelayTransportDiagnostic): void {
+  console.warn(JSON.stringify({ scope: "kunai-relay", ...diagnostic }));
 }
 
 export function isPublicRelayAddress(address: string): boolean {
@@ -153,15 +223,17 @@ function sendBoundedRequest(
 ): Promise<Response> {
   return new Promise((resolve, reject) => {
     let settled = false;
+    let responseStarted = false;
     const settleReject = (error: unknown): void => {
       if (settled) return;
       settled = true;
-      reject(error);
+      reject(new RelayRequestAttemptError(error, responseStarted));
     };
 
     let outbound: ClientRequest;
     try {
       outbound = dispatch(requestOptions, (upstream) => {
+        responseStarted = true;
         const declaredLength = parseContentLength(upstream.headers["content-length"]);
         if (declaredLength !== null && declaredLength > maxResponseBodyBytes) {
           const error = responseTooLargeError();
@@ -212,8 +284,105 @@ function sendBoundedRequest(
   });
 }
 
-function requestUrl(input: string | URL | Request): URL {
-  return input instanceof Request ? new URL(input.url) : new URL(input);
+class RelayRequestAttemptError extends Error {
+  override readonly name = "RelayRequestAttemptError";
+
+  constructor(
+    readonly attemptCause: unknown,
+    readonly responseStarted: boolean,
+  ) {
+    super(
+      attemptCause instanceof Error ? attemptCause.message : "Relay connection attempt failed",
+      {
+        cause: attemptCause,
+      },
+    );
+  }
+}
+
+function shouldRetryAddress(
+  error: unknown,
+  method: string,
+  index: number,
+  answerCount: number,
+  signal: AbortSignal | null | undefined,
+): boolean {
+  if (!(error instanceof RelayRequestAttemptError) || error.responseStarted) return false;
+  if (index + 1 >= answerCount || signal?.aborted) return false;
+  const normalizedMethod = method.toUpperCase();
+  if (normalizedMethod !== "GET" && normalizedMethod !== "HEAD") return false;
+  return isRetryableConnectionError(error.attemptCause);
+}
+
+function isRetryableConnectionError(error: unknown): boolean {
+  return connectionDiagnosticCode(error) !== "CONNECTION_FAILED";
+}
+
+function connectionDiagnosticCode(error: unknown): RelayConnectionDiagnosticCode {
+  const code = (error as { readonly code?: unknown } | null)?.code;
+  return typeof code === "string" &&
+    RETRYABLE_CONNECTION_CODES.has(code as RelayConnectionDiagnosticCode)
+    ? (code as RelayConnectionDiagnosticCode)
+    : "CONNECTION_FAILED";
+}
+
+function dnsDiagnosticCode(error: unknown): RelayDnsDiagnosticCode {
+  const code = (error as { readonly code?: unknown } | null)?.code;
+  if (code === "ABORT_ERR" || code === "EAI_AGAIN" || code === "ENOTFOUND") return code;
+  return "DNS_LOOKUP_FAILED";
+}
+
+function emitDiagnostic(
+  sink: RelayDiagnosticSink | undefined,
+  diagnostic: RelayTransportDiagnostic,
+): void {
+  sink?.(diagnostic);
+}
+
+function unwrapAttemptError(error: unknown): unknown {
+  return error instanceof RelayRequestAttemptError ? error.attemptCause : error;
+}
+
+function requestUrl(input: string | URL): URL {
+  if (input instanceof Request) {
+    throw new RelayValidationError(
+      "bad-request",
+      "Relay transport accepts only an explicit URL and request init",
+      400,
+    );
+  }
+  return new URL(input);
+}
+
+function abortable<T>(promise: Promise<T>, signal: AbortSignal | null | undefined): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(relayAbortError(signal.reason));
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => {
+      cleanup();
+      reject(relayAbortError(signal.reason));
+    };
+    const cleanup = (): void => signal.removeEventListener("abort", onAbort);
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        cleanup();
+        return resolve(value);
+      },
+      (error: unknown) => {
+        cleanup();
+        return reject(error);
+      },
+    );
+  });
+}
+
+function relayAbortError(reason: unknown): Error {
+  return Object.assign(new Error("The operation was aborted", { cause: reason }), {
+    name: "AbortError",
+    code: "ABORT_ERR",
+  });
 }
 
 async function requestBodyBytes(body: RequestInit["body"]): Promise<Uint8Array> {

--- a/packages/relay/src/pinned-transport.ts
+++ b/packages/relay/src/pinned-transport.ts
@@ -17,14 +17,6 @@ import type {
   RelayTransportDiagnostic,
 } from "./types";
 
-const RETRYABLE_CONNECTION_CODES = new Set<RelayConnectionDiagnosticCode>([
-  "ECONNREFUSED",
-  "ECONNRESET",
-  "EHOSTUNREACH",
-  "ENETUNREACH",
-  "ETIMEDOUT",
-]);
-
 export interface RelayResolvedAddress {
   readonly address: string;
   readonly family: 4 | 6;
@@ -32,7 +24,7 @@ export interface RelayResolvedAddress {
 
 export type RelayAddressResolver = (hostname: string) => Promise<readonly RelayResolvedAddress[]>;
 
-export type RelayNodeRequestOptions = RequestOptions & { readonly servername?: string };
+export type RelayNodeRequestOptions = RequestOptions & { servername?: string };
 
 export type RelayNodeRequest = (
   options: RelayNodeRequestOptions,
@@ -46,6 +38,10 @@ export interface PinnedRelayTransportOptions {
   readonly request?: RelayNodeRequest;
   readonly maxRequestBodyBytes: number;
   readonly maxResponseBodyBytes: number;
+}
+
+interface DiagnosticProviderContext {
+  providerId?: string;
 }
 
 /**
@@ -77,13 +73,15 @@ export function createPinnedRelayTransport(options: PinnedRelayTransportOptions)
     const diagnosticHostname = literalFamily === 0 ? originalHostname : "ip-literal";
     let answers: readonly RelayResolvedAddress[];
     try {
-      answers = literalFamily
-        ? [{ address: originalHostname, family: literalFamily as 4 | 6 }]
-        : await abortable(resolveAddresses(originalHostname), init.signal);
+      if (literalFamily === 4 || literalFamily === 6) {
+        answers = [{ address: originalHostname, family: literalFamily }];
+      } else {
+        answers = await abortable(resolveAddresses(originalHostname), init.signal);
+      }
     } catch (error) {
       emitDiagnostic(options.diagnostics, {
         event: "dns-failed",
-        ...(options.providerId ? { providerId: options.providerId } : {}),
+        ...diagnosticProviderContext(options.providerId),
         hostname: diagnosticHostname,
         code: dnsDiagnosticCode(error),
       });
@@ -92,7 +90,7 @@ export function createPinnedRelayTransport(options: PinnedRelayTransportOptions)
     if (answers.length === 0) {
       emitDiagnostic(options.diagnostics, {
         event: "dns-failed",
-        ...(options.providerId ? { providerId: options.providerId } : {}),
+        ...diagnosticProviderContext(options.providerId),
         hostname: diagnosticHostname,
         code: "NO_ADDRESSES",
       });
@@ -105,7 +103,7 @@ export function createPinnedRelayTransport(options: PinnedRelayTransportOptions)
     ) {
       emitDiagnostic(options.diagnostics, {
         event: "dns-rejected",
-        ...(options.providerId ? { providerId: options.providerId } : {}),
+        ...diagnosticProviderContext(options.providerId),
         hostname: diagnosticHostname,
         answerCount: answers.length,
         families: [...new Set(answers.map((answer) => answer.family))].sort(),
@@ -135,10 +133,10 @@ export function createPinnedRelayTransport(options: PinnedRelayTransportOptions)
         headers,
         agent: false,
         signal: init.signal ?? undefined,
-        ...(url.protocol === "https:" && literalFamily === 0
-          ? { servername: originalHostname }
-          : {}),
       };
+      if (url.protocol === "https:" && literalFamily === 0) {
+        requestOptions.servername = originalHostname;
+      }
 
       try {
         return await sendBoundedRequest(
@@ -151,7 +149,7 @@ export function createPinnedRelayTransport(options: PinnedRelayTransportOptions)
         if (error instanceof RelayRequestAttemptError && !error.responseStarted) {
           emitDiagnostic(options.diagnostics, {
             event: "connection-failed",
-            ...(options.providerId ? { providerId: options.providerId } : {}),
+            ...diagnosticProviderContext(options.providerId),
             hostname: diagnosticHostname,
             family: selected.family,
             attempt: index + 1,
@@ -224,10 +222,10 @@ function sendBoundedRequest(
   return new Promise((resolve, reject) => {
     let settled = false;
     let responseStarted = false;
-    const settleReject = (error: unknown): void => {
+    const settleReject = (cause: unknown): void => {
       if (settled) return;
       settled = true;
-      reject(new RelayRequestAttemptError(error, responseStarted));
+      reject(new RelayRequestAttemptError(cause, responseStarted));
     };
 
     let outbound: ClientRequest;
@@ -247,7 +245,7 @@ function sendBoundedRequest(
         let total = 0;
         upstream.on("data", (chunk: Buffer | string) => {
           if (settled) return;
-          const bytes = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+          const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
           total += bytes.byteLength;
           if (total > maxResponseBodyBytes) {
             const error = responseTooLargeError();
@@ -286,50 +284,61 @@ function sendBoundedRequest(
 
 class RelayRequestAttemptError extends Error {
   override readonly name = "RelayRequestAttemptError";
+  readonly attemptCause: Error;
 
   constructor(
-    readonly attemptCause: unknown,
+    cause: unknown,
     readonly responseStarted: boolean,
   ) {
-    super(
-      attemptCause instanceof Error ? attemptCause.message : "Relay connection attempt failed",
-      {
-        cause: attemptCause,
-      },
-    );
+    const attemptCause = normalizeRelayError(cause);
+    super(attemptCause.message, { cause: attemptCause });
+    this.attemptCause = attemptCause;
   }
 }
 
 function shouldRetryAddress(
-  error: unknown,
+  cause: unknown,
   method: string,
   index: number,
   answerCount: number,
   signal: AbortSignal | null | undefined,
 ): boolean {
-  if (!(error instanceof RelayRequestAttemptError) || error.responseStarted) return false;
+  if (!(cause instanceof RelayRequestAttemptError) || cause.responseStarted) return false;
   if (index + 1 >= answerCount || signal?.aborted) return false;
   const normalizedMethod = method.toUpperCase();
   if (normalizedMethod !== "GET" && normalizedMethod !== "HEAD") return false;
-  return isRetryableConnectionError(error.attemptCause);
+  return isRetryableConnectionError(cause.attemptCause);
 }
 
-function isRetryableConnectionError(error: unknown): boolean {
-  return connectionDiagnosticCode(error) !== "CONNECTION_FAILED";
+function isRetryableConnectionError(cause: Error): boolean {
+  return connectionDiagnosticCode(cause) !== "CONNECTION_FAILED";
 }
 
-function connectionDiagnosticCode(error: unknown): RelayConnectionDiagnosticCode {
-  const code = (error as { readonly code?: unknown } | null)?.code;
-  return typeof code === "string" &&
-    RETRYABLE_CONNECTION_CODES.has(code as RelayConnectionDiagnosticCode)
-    ? (code as RelayConnectionDiagnosticCode)
-    : "CONNECTION_FAILED";
+function connectionDiagnosticCode(cause: Error): RelayConnectionDiagnosticCode {
+  const code = "code" in cause ? String(cause.code) : "";
+  switch (code) {
+    case "ECONNREFUSED":
+    case "ECONNRESET":
+    case "EHOSTUNREACH":
+    case "ENETUNREACH":
+    case "ETIMEDOUT":
+      return code;
+    default:
+      return "CONNECTION_FAILED";
+  }
 }
 
-function dnsDiagnosticCode(error: unknown): RelayDnsDiagnosticCode {
-  const code = (error as { readonly code?: unknown } | null)?.code;
-  if (code === "ABORT_ERR" || code === "EAI_AGAIN" || code === "ENOTFOUND") return code;
-  return "DNS_LOOKUP_FAILED";
+function dnsDiagnosticCode(cause: unknown): RelayDnsDiagnosticCode {
+  const error = normalizeRelayError(cause);
+  const code = "code" in error ? String(error.code) : "";
+  switch (code) {
+    case "ABORT_ERR":
+    case "EAI_AGAIN":
+    case "ENOTFOUND":
+      return code;
+    default:
+      return "DNS_LOOKUP_FAILED";
+  }
 }
 
 function emitDiagnostic(
@@ -339,8 +348,20 @@ function emitDiagnostic(
   sink?.(diagnostic);
 }
 
-function unwrapAttemptError(error: unknown): unknown {
-  return error instanceof RelayRequestAttemptError ? error.attemptCause : error;
+function diagnosticProviderContext(providerId: string | undefined): DiagnosticProviderContext {
+  const context: DiagnosticProviderContext = {};
+  if (providerId) context.providerId = providerId;
+  return context;
+}
+
+function unwrapAttemptError(cause: unknown): Error {
+  return cause instanceof RelayRequestAttemptError
+    ? cause.attemptCause
+    : normalizeRelayError(cause);
+}
+
+function normalizeRelayError(cause: unknown): Error {
+  return cause instanceof Error ? cause : new Error(String(cause));
 }
 
 function requestUrl(input: string | URL): URL {
@@ -370,16 +391,16 @@ function abortable<T>(promise: Promise<T>, signal: AbortSignal | null | undefine
         cleanup();
         return resolve(value);
       },
-      (error: unknown) => {
+      (cause: unknown) => {
         cleanup();
-        return reject(error);
+        return reject(cause);
       },
     );
   });
 }
 
-function relayAbortError(reason: unknown): Error {
-  return Object.assign(new Error("The operation was aborted", { cause: reason }), {
+function relayAbortError(cause: unknown): Error {
+  return Object.assign(new Error("The operation was aborted", { cause }), {
     name: "AbortError",
     code: "ABORT_ERR",
   });
@@ -387,7 +408,7 @@ function relayAbortError(reason: unknown): Error {
 
 async function requestBodyBytes(body: RequestInit["body"]): Promise<Uint8Array> {
   if (body === undefined || body === null) return new Uint8Array();
-  if (typeof body === "string") return Buffer.from(body);
+  if (body.constructor === String) return Buffer.from(String(body));
   if (body instanceof URLSearchParams) return Buffer.from(body.toString());
   if (body instanceof ArrayBuffer) return new Uint8Array(body);
   if (ArrayBuffer.isView(body)) {

--- a/packages/relay/src/pinned-transport.ts
+++ b/packages/relay/src/pinned-transport.ts
@@ -1,0 +1,351 @@
+import { lookup } from "node:dns/promises";
+import {
+  request as httpRequest,
+  type ClientRequest,
+  type IncomingMessage,
+  type RequestOptions,
+} from "node:http";
+import { request as httpsRequest } from "node:https";
+import { isIP } from "node:net";
+
+import { RelayValidationError } from "./forward-headers";
+import type { RelayFetch } from "./types";
+
+export interface RelayResolvedAddress {
+  readonly address: string;
+  readonly family: 4 | 6;
+}
+
+export type RelayAddressResolver = (hostname: string) => Promise<readonly RelayResolvedAddress[]>;
+
+export type RelayNodeRequestOptions = RequestOptions & { readonly servername?: string };
+
+export type RelayNodeRequest = (
+  options: RelayNodeRequestOptions,
+  onResponse: (response: IncomingMessage) => void,
+) => ClientRequest;
+
+export interface PinnedRelayTransportOptions {
+  readonly resolveAddresses?: RelayAddressResolver;
+  readonly request?: RelayNodeRequest;
+  readonly maxRequestBodyBytes: number;
+  readonly maxResponseBodyBytes: number;
+}
+
+/**
+ * Build a fetch-shaped transport whose socket always dials an address from the
+ * exact DNS answer set that was validated for this request. Redirects call the
+ * transport again, so each hop receives a fresh all-address validation.
+ */
+export function createPinnedRelayTransport(options: PinnedRelayTransportOptions): RelayFetch {
+  const resolveAddresses = options.resolveAddresses ?? resolveAllAddresses;
+  const request = options.request ?? dispatchNodeRequest;
+
+  return async (input, init = {}) => {
+    const url = requestUrl(input);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new RelayValidationError(
+        "protocol-not-allowed",
+        "Only HTTP(S) upstream URLs are allowed",
+        400,
+      );
+    }
+
+    const body = await requestBodyBytes(init.body);
+    if (body.byteLength > options.maxRequestBodyBytes) {
+      throw new RelayValidationError("body-too-large", "Relay request body is too large", 413);
+    }
+
+    const originalHostname = stripIpv6Brackets(url.hostname);
+    const literalFamily = isIP(originalHostname);
+    const answers = literalFamily
+      ? [{ address: originalHostname, family: literalFamily as 4 | 6 }]
+      : await resolveAddresses(originalHostname);
+    if (answers.length === 0) {
+      throw new RelayValidationError("upstream-error", "Upstream host did not resolve", 502);
+    }
+    if (
+      answers.some(
+        (answer) => isIP(answer.address) !== answer.family || !isPublicRelayAddress(answer.address),
+      )
+    ) {
+      throw new RelayValidationError(
+        "host-not-allowed",
+        "Upstream DNS returned a non-public address",
+        403,
+      );
+    }
+
+    const selected = answers[0];
+    if (!selected) {
+      throw new RelayValidationError("upstream-error", "Upstream host did not resolve", 502);
+    }
+
+    const headers: Record<string, string> = {};
+    new Headers(init.headers).forEach((value, name) => {
+      headers[name] = value;
+    });
+    headers.host = url.host;
+    const requestOptions: RelayNodeRequestOptions = {
+      protocol: url.protocol,
+      hostname: selected.address,
+      family: selected.family,
+      port: url.port || undefined,
+      path: `${url.pathname}${url.search}`,
+      method: init.method ?? "GET",
+      headers,
+      agent: false,
+      signal: init.signal ?? undefined,
+      ...(url.protocol === "https:" && literalFamily === 0 ? { servername: originalHostname } : {}),
+    };
+
+    return sendBoundedRequest(request, requestOptions, body, options.maxResponseBodyBytes);
+  };
+}
+
+export function isPublicRelayAddress(address: string): boolean {
+  const family = isIP(address);
+  if (family === 4) return isPublicIpv4(address);
+  if (family !== 6) return false;
+
+  const bytes = parseIpv6(address);
+  if (!bytes) return false;
+  if (isIpv4Mapped(bytes)) {
+    return isPublicIpv4(`${bytes[12]}.${bytes[13]}.${bytes[14]}.${bytes[15]}`);
+  }
+
+  // Public provider endpoints need globally routable unicast. Starting with
+  // that allow-shape keeps unspecified, loopback, ULA, link/site-local,
+  // multicast, translation, and discard-only blocks out by construction.
+  const firstByte = bytes[0];
+  if (firstByte === undefined || (firstByte & 0xe0) !== 0x20) return false; // 2000::/3
+  return !(
+    (
+      hasPrefix(bytes, [0x20, 0x01, 0x00], 23) || // IETF special-purpose space
+      hasPrefix(bytes, [0x20, 0x01, 0x0d, 0xb8], 32) || // documentation
+      hasPrefix(bytes, [0x20, 0x02], 16) || // 6to4
+      hasPrefix(bytes, [0x3f, 0xff, 0x00], 20)
+    ) // documentation
+  );
+}
+
+async function resolveAllAddresses(hostname: string): Promise<readonly RelayResolvedAddress[]> {
+  const answers = await lookup(hostname, { all: true, verbatim: true });
+  return answers.flatMap(({ address, family }) =>
+    family === 4 || family === 6 ? [{ address, family }] : [],
+  );
+}
+
+function dispatchNodeRequest(
+  options: RelayNodeRequestOptions,
+  onResponse: (response: IncomingMessage) => void,
+): ClientRequest {
+  return options.protocol === "https:"
+    ? httpsRequest(options, onResponse)
+    : httpRequest(options, onResponse);
+}
+
+function sendBoundedRequest(
+  dispatch: RelayNodeRequest,
+  requestOptions: RelayNodeRequestOptions,
+  body: Uint8Array,
+  maxResponseBodyBytes: number,
+): Promise<Response> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const settleReject = (error: unknown): void => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+
+    let outbound: ClientRequest;
+    try {
+      outbound = dispatch(requestOptions, (upstream) => {
+        const declaredLength = parseContentLength(upstream.headers["content-length"]);
+        if (declaredLength !== null && declaredLength > maxResponseBodyBytes) {
+          const error = responseTooLargeError();
+          settleReject(error);
+          upstream.destroy(error);
+          outbound.destroy(error);
+          return;
+        }
+
+        const chunks: Uint8Array[] = [];
+        let total = 0;
+        upstream.on("data", (chunk: Buffer | string) => {
+          if (settled) return;
+          const bytes = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+          total += bytes.byteLength;
+          if (total > maxResponseBodyBytes) {
+            const error = responseTooLargeError();
+            settleReject(error);
+            upstream.destroy(error);
+            outbound.destroy(error);
+            return;
+          }
+          chunks.push(bytes);
+        });
+        upstream.on("aborted", () => settleReject(new Error("Upstream response was aborted")));
+        upstream.on("error", settleReject);
+        upstream.on("end", () => {
+          if (settled) return;
+          settled = true;
+          const status = upstream.statusCode ?? 502;
+          const responseBody = Buffer.concat(chunks);
+          resolve(
+            new Response(statusAllowsBody(status) ? responseBody : null, {
+              status,
+              statusText: upstream.statusMessage,
+              headers: nodeResponseHeaders(upstream),
+            }),
+          );
+        });
+      });
+    } catch (error) {
+      settleReject(error);
+      return;
+    }
+
+    outbound.on("error", settleReject);
+    outbound.end(body.byteLength > 0 ? body : undefined);
+  });
+}
+
+function requestUrl(input: string | URL | Request): URL {
+  return input instanceof Request ? new URL(input.url) : new URL(input);
+}
+
+async function requestBodyBytes(body: RequestInit["body"]): Promise<Uint8Array> {
+  if (body === undefined || body === null) return new Uint8Array();
+  if (typeof body === "string") return Buffer.from(body);
+  if (body instanceof URLSearchParams) return Buffer.from(body.toString());
+  if (body instanceof ArrayBuffer) return new Uint8Array(body);
+  if (ArrayBuffer.isView(body)) {
+    return new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+  }
+  if (body instanceof Blob) return new Uint8Array(await body.arrayBuffer());
+  throw new RelayValidationError("bad-request", "Unsupported relay request body", 400);
+}
+
+function nodeResponseHeaders(response: IncomingMessage): Headers {
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(response.headers)) {
+    if (Array.isArray(value)) {
+      for (const entry of value) headers.append(name, entry);
+    } else if (value !== undefined) {
+      headers.set(name, value);
+    }
+  }
+  return headers;
+}
+
+function parseContentLength(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function responseTooLargeError(): RelayValidationError {
+  return new RelayValidationError(
+    "response-too-large",
+    "Upstream metadata response is too large",
+    502,
+  );
+}
+
+function statusAllowsBody(status: number): boolean {
+  return status !== 204 && status !== 205 && status !== 304;
+}
+
+function isPublicIpv4(address: string): boolean {
+  const octets = address.split(".").map(Number);
+  if (
+    octets.length !== 4 ||
+    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
+  ) {
+    return false;
+  }
+  const value = octets.reduce((result, octet) => ((result << 8) | octet) >>> 0, 0);
+  return !IPV4_NON_PUBLIC_RANGES.some(([base, bits]) => inIpv4Range(value, base, bits));
+}
+
+const IPV4_NON_PUBLIC_RANGES = [
+  [0x00000000, 8],
+  [0x0a000000, 8],
+  [0x64400000, 10],
+  [0x7f000000, 8],
+  [0xa9fe0000, 16],
+  [0xac100000, 12],
+  [0xc0000000, 24],
+  [0xc0000200, 24],
+  [0xc01fc400, 24],
+  [0xc034c100, 24],
+  [0xc0586300, 24],
+  [0xc0a80000, 16],
+  [0xc0af3000, 24],
+  [0xc6120000, 15],
+  [0xc6336400, 24],
+  [0xcb007100, 24],
+  [0xe0000000, 4],
+  [0xf0000000, 4],
+] as const;
+
+function inIpv4Range(value: number, base: number, bits: number): boolean {
+  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+  return (value & mask) >>> 0 === (base & mask) >>> 0;
+}
+
+function parseIpv6(address: string): Uint8Array | null {
+  if (address.includes("%")) return null;
+  let normalized = address.toLowerCase();
+  const dottedTail = /(?:^|:)(\d{1,3}(?:\.\d{1,3}){3})$/.exec(normalized)?.[1];
+  if (dottedTail) {
+    const octets = dottedTail.split(".").map(Number);
+    if (octets.some((octet) => !Number.isInteger(octet) || octet > 255)) return null;
+    const [a, b, c, d] = octets;
+    if (a === undefined || b === undefined || c === undefined || d === undefined) return null;
+    const replacement = `${((a << 8) | b).toString(16)}:${((c << 8) | d).toString(16)}`;
+    normalized = `${normalized.slice(0, -dottedTail.length)}${replacement}`;
+  }
+
+  const halves = normalized.split("::");
+  if (halves.length > 2) return null;
+  const left = halves[0] ? halves[0].split(":") : [];
+  const right = halves[1] ? halves[1].split(":") : [];
+  const missing = 8 - left.length - right.length;
+  if ((halves.length === 1 && missing !== 0) || missing < 0) return null;
+  const groups = [...left, ...Array.from({ length: missing }, () => "0"), ...right];
+  if (groups.length !== 8) return null;
+
+  const bytes = new Uint8Array(16);
+  for (const [index, group] of groups.entries()) {
+    if (!/^[0-9a-f]{1,4}$/.test(group)) return null;
+    const value = Number.parseInt(group, 16);
+    bytes[index * 2] = value >> 8;
+    bytes[index * 2 + 1] = value & 0xff;
+  }
+  return bytes;
+}
+
+function isIpv4Mapped(bytes: Uint8Array): boolean {
+  return bytes.slice(0, 10).every((byte) => byte === 0) && bytes[10] === 0xff && bytes[11] === 0xff;
+}
+
+function hasPrefix(address: Uint8Array, prefix: readonly number[], bits: number): boolean {
+  const fullBytes = Math.floor(bits / 8);
+  for (let index = 0; index < fullBytes; index++) {
+    if (address[index] !== prefix[index]) return false;
+  }
+  const remaining = bits % 8;
+  if (remaining === 0) return true;
+  const addressByte = address[fullBytes];
+  const prefixByte = prefix[fullBytes];
+  if (addressByte === undefined || prefixByte === undefined) return false;
+  const mask = 0xff << (8 - remaining);
+  return (addressByte & mask) === (prefixByte & mask);
+}
+
+function stripIpv6Brackets(hostname: string): string {
+  return hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+}

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -3,27 +3,18 @@ import type {
   ProviderFetchPort,
   ProviderId,
   ProviderRelayConfig,
-  RelayErrorCode as SharedRelayErrorCode,
   RelayProfile,
 } from "@kunai/types";
 
 export type {
   ProviderRelayConfig,
   ProviderRelayProviderConfig,
+  RelayErrorCode,
   RelayMethod,
   RelayProfile,
+  RelayRpcErrorBody,
   RelayRpcRequest,
 } from "@kunai/types";
-
-export type RelayErrorCode = SharedRelayErrorCode | "relay-not-configured";
-
-export interface RelayRpcErrorBody {
-  readonly error: {
-    readonly code: RelayErrorCode;
-    readonly providerId?: string;
-    readonly message: string;
-  };
-}
 
 export type RelayableProviderManifest = CoreProviderManifest & {
   readonly relayProfile?: RelayProfile;

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -34,7 +34,49 @@ export interface ProviderRelayRegistry {
 }
 
 export type RelayFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
-export type RelayTransport = RelayFetch;
+export type RelayTransport = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export type RelayConnectionDiagnosticCode =
+  | "ECONNREFUSED"
+  | "ECONNRESET"
+  | "EHOSTUNREACH"
+  | "ENETUNREACH"
+  | "ETIMEDOUT"
+  | "CONNECTION_FAILED";
+
+export type RelayDnsDiagnosticCode =
+  | "ABORT_ERR"
+  | "EAI_AGAIN"
+  | "ENOTFOUND"
+  | "DNS_LOOKUP_FAILED"
+  | "NO_ADDRESSES";
+
+export type RelayTransportDiagnostic =
+  | {
+      readonly event: "dns-failed";
+      readonly providerId?: string;
+      readonly hostname: string;
+      readonly code: RelayDnsDiagnosticCode;
+    }
+  | {
+      readonly event: "dns-rejected";
+      readonly providerId?: string;
+      readonly hostname: string;
+      readonly answerCount: number;
+      readonly families: readonly (4 | 6)[];
+      readonly code: "NON_PUBLIC_ADDRESS";
+    }
+  | {
+      readonly event: "connection-failed";
+      readonly providerId?: string;
+      readonly hostname: string;
+      readonly family: 4 | 6;
+      readonly attempt: number;
+      readonly answerCount: number;
+      readonly code: RelayConnectionDiagnosticCode;
+    };
+
+export type RelayDiagnosticSink = (diagnostic: RelayTransportDiagnostic) => void;
 
 export type RelayAuthorizationPolicy =
   | { readonly mode: "local-loopback" }
@@ -45,6 +87,7 @@ export interface RelayHandlerOptions {
   readonly registry: ProviderRelayRegistry;
   readonly authorization: RelayAuthorizationPolicy;
   readonly transport?: RelayTransport;
+  readonly diagnostics?: RelayDiagnosticSink;
   readonly timeoutMs?: number;
   readonly maxRedirects?: number;
 }

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -34,6 +34,7 @@ export interface ProviderRelayRegistry {
 }
 
 export type RelayFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+export type RelayTransport = RelayFetch;
 
 export type RelayAuthorizationPolicy =
   | { readonly mode: "local-loopback" }
@@ -43,7 +44,7 @@ export interface RelayHandlerOptions {
   readonly providerId: string;
   readonly registry: ProviderRelayRegistry;
   readonly authorization: RelayAuthorizationPolicy;
-  readonly fetch?: RelayFetch;
+  readonly transport?: RelayTransport;
   readonly timeoutMs?: number;
   readonly maxRedirects?: number;
 }

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -109,3 +109,4 @@ export const DEFAULT_MAX_REQUEST_BODY_BYTES = 64 * 1024;
 export const DEFAULT_MAX_RESPONSE_BODY_BYTES = 2 * 1024 * 1024;
 export const DEFAULT_MAX_REDIRECTS = 5;
 export const DEFAULT_RELAY_TIMEOUT_MS = 20_000;
+export const RELAY_ERROR_CODE_HEADER = "X-Kunai-Relay-Error-Code";

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -3,18 +3,27 @@ import type {
   ProviderFetchPort,
   ProviderId,
   ProviderRelayConfig,
+  RelayErrorCode as SharedRelayErrorCode,
   RelayProfile,
 } from "@kunai/types";
 
 export type {
   ProviderRelayConfig,
   ProviderRelayProviderConfig,
-  RelayErrorCode,
   RelayMethod,
   RelayProfile,
-  RelayRpcErrorBody,
   RelayRpcRequest,
 } from "@kunai/types";
+
+export type RelayErrorCode = SharedRelayErrorCode | "relay-not-configured";
+
+export interface RelayRpcErrorBody {
+  readonly error: {
+    readonly code: RelayErrorCode;
+    readonly providerId?: string;
+    readonly message: string;
+  };
+}
 
 export type RelayableProviderManifest = CoreProviderManifest & {
   readonly relayProfile?: RelayProfile;
@@ -35,11 +44,15 @@ export interface ProviderRelayRegistry {
 
 export type RelayFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
+export type RelayAuthorizationPolicy =
+  | { readonly mode: "local-loopback" }
+  | { readonly mode: "bearer"; readonly token: string };
+
 export interface RelayHandlerOptions {
   readonly providerId: string;
   readonly registry: ProviderRelayRegistry;
+  readonly authorization: RelayAuthorizationPolicy;
   readonly fetch?: RelayFetch;
-  readonly token?: string;
   readonly timeoutMs?: number;
   readonly maxRedirects?: number;
 }

--- a/packages/relay/test/handler.test.ts
+++ b/packages/relay/test/handler.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test";
 import { Readable, Writable } from "node:stream";
 
+import type { CoreProviderManifest } from "@kunai/core";
+
 import { handleRpcRequest } from "../src/handler";
 import { createPinnedRelayTransport, type RelayNodeRequest } from "../src/pinned-transport";
 import { buildProviderRelayRegistry } from "../src/registry";
@@ -41,6 +43,39 @@ const providerRegistry = buildProviderRelayRegistry([
     },
   },
 ] as never);
+
+const redirectProbeManifest = {
+  id: "redirect-probe",
+  displayName: "Redirect probe",
+  description: "Exercises relay redirect semantics",
+  domain: "redirect.example",
+  recommended: false,
+  mediaKinds: ["movie"],
+  capabilities: [],
+  runtimePorts: [],
+  cachePolicy: {
+    ttlClass: "provider-metadata",
+    scope: "memory",
+    keyParts: ["redirect-probe"],
+  },
+  browserSafe: false,
+  relaySafe: true,
+  relayProfile: {
+    upstreamHosts: ["redirect.example"],
+    defaultHeaders: {
+      "Content-Encoding": "identity",
+      "Content-Language": "en",
+      "Content-Length": "11",
+      "Content-Location": "/payload",
+      "Content-Type": "application/json",
+    },
+  },
+  status: "experimental",
+} satisfies CoreProviderManifest;
+
+const redirectRegistry = buildProviderRelayRegistry([
+  { providerId: redirectProbeManifest.id, manifest: redirectProbeManifest },
+]);
 
 test("handleRpcRequest forwards allowed metadata requests", async () => {
   let upstreamAuth: string | null = null;
@@ -641,6 +676,215 @@ test("handleRpcRequest retains provider credentials on a same-origin redirect", 
   expect(seenTokens).toEqual(["session-secret", "session-secret"]);
 });
 
+test.each([301, 302])(
+  "handleRpcRequest rewrites same-origin POST %s redirects to bodyless GET",
+  async (status) => {
+    const seen: Array<{
+      body: BodyInit | null | undefined;
+      contentType: string | null;
+      method: string | undefined;
+    }> = [];
+    let attempt = 0;
+    const response = await handleRpcRequest(
+      rpcRequest({
+        method: "POST",
+        upstreamUrl: "https://api.allanime.day/start",
+        headers: { "Content-Type": "application/json" },
+        body: "secret-body",
+      }),
+      {
+        providerId: "allanime",
+        registry: providerRegistry,
+        authorization: localLoopbackAuthorization,
+        async transport(_url, init) {
+          seen.push({
+            body: init?.body,
+            contentType: new Headers(init?.headers).get("content-type"),
+            method: init?.method,
+          });
+          if (attempt++ === 0) {
+            return new Response(null, {
+              status,
+              headers: { location: "https://api.allanime.day/next" },
+            });
+          }
+          return Response.json({ ok: true });
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(seen).toEqual([
+      { body: "secret-body", contentType: "application/json", method: "POST" },
+      { body: undefined, contentType: null, method: "GET" },
+    ]);
+  },
+);
+
+test("handleRpcRequest does not forward a POST body or credentials across a 302 origin change", async () => {
+  const seen: Array<{
+    body: BodyInit | null | undefined;
+    contentType: string | null;
+    method: string | undefined;
+    sessionToken: string | null;
+  }> = [];
+  let attempt = 0;
+  const response = await handleRpcRequest(
+    rpcRequest({
+      method: "POST",
+      upstreamUrl: "https://api.allanime.day/start",
+      headers: {
+        "Content-Type": "application/json",
+        "x-session-token": "header-secret",
+      },
+      body: "body-secret",
+    }),
+    {
+      providerId: "allanime",
+      registry: providerRegistry,
+      authorization: localLoopbackAuthorization,
+      async transport(_url, init) {
+        const headers = new Headers(init?.headers);
+        seen.push({
+          body: init?.body,
+          contentType: headers.get("content-type"),
+          method: init?.method,
+          sessionToken: headers.get("x-session-token"),
+        });
+        if (attempt++ === 0) {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://cdn.api.allanime.day/next" },
+          });
+        }
+        return Response.json({ ok: true });
+      },
+    },
+  );
+
+  expect(response.status).toBe(200);
+  expect(seen).toEqual([
+    {
+      body: "body-secret",
+      contentType: "application/json",
+      method: "POST",
+      sessionToken: "header-secret",
+    },
+    { body: undefined, contentType: null, method: "GET", sessionToken: null },
+  ]);
+});
+
+test("handleRpcRequest strips every body header when a 303 rewrites POST to GET", async () => {
+  const seen: Array<{ body: BodyInit | null | undefined; headers: Headers; method?: string }> = [];
+  let attempt = 0;
+  const response = await handleRpcRequest(
+    rpcRequest({
+      method: "POST",
+      upstreamUrl: "https://redirect.example/start",
+      body: "secret-body",
+    }),
+    {
+      providerId: "redirect-probe",
+      registry: redirectRegistry,
+      authorization: localLoopbackAuthorization,
+      async transport(_url, init) {
+        seen.push({ body: init?.body, headers: new Headers(init?.headers), method: init?.method });
+        if (attempt++ === 0) {
+          return new Response(null, {
+            status: 303,
+            headers: { location: "https://redirect.example/next" },
+          });
+        }
+        return Response.json({ ok: true });
+      },
+    },
+  );
+
+  expect(response.status).toBe(200);
+  expect(seen[1]?.method).toBe("GET");
+  expect(seen[1]?.body).toBeUndefined();
+  for (const header of [
+    "content-encoding",
+    "content-language",
+    "content-length",
+    "content-location",
+    "content-type",
+  ]) {
+    expect(seen[1]?.headers.get(header)).toBeNull();
+  }
+});
+
+test("handleRpcRequest preserves HEAD across a 303 redirect", async () => {
+  const methods: Array<string | undefined> = [];
+  let attempt = 0;
+  const response = await handleRpcRequest(
+    rpcRequest({ method: "HEAD", upstreamUrl: "https://api.allanime.day/start" }),
+    {
+      providerId: "allanime",
+      registry: providerRegistry,
+      authorization: localLoopbackAuthorization,
+      async transport(_url, init) {
+        methods.push(init?.method);
+        if (attempt++ === 0) {
+          return new Response(null, {
+            status: 303,
+            headers: { location: "https://api.allanime.day/next" },
+          });
+        }
+        return new Response(null, { status: 204 });
+      },
+    },
+  );
+
+  expect(response.status).toBe(204);
+  expect(methods).toEqual(["HEAD", "HEAD"]);
+});
+
+test.each([307, 308])(
+  "handleRpcRequest preserves POST body and headers across a %s redirect",
+  async (status) => {
+    const seen: Array<{
+      body: BodyInit | null | undefined;
+      contentType: string | null;
+      method: string | undefined;
+    }> = [];
+    let attempt = 0;
+    const response = await handleRpcRequest(
+      rpcRequest({
+        method: "POST",
+        upstreamUrl: "https://api.allanime.day/start",
+        headers: { "Content-Type": "application/json" },
+        body: "request-body",
+      }),
+      {
+        providerId: "allanime",
+        registry: providerRegistry,
+        authorization: localLoopbackAuthorization,
+        async transport(_url, init) {
+          seen.push({
+            body: init?.body,
+            contentType: new Headers(init?.headers).get("content-type"),
+            method: init?.method,
+          });
+          if (attempt++ === 0) {
+            return new Response(null, {
+              status,
+              headers: { location: "https://api.allanime.day/next" },
+            });
+          }
+          return Response.json({ ok: true });
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(seen).toEqual([
+      { body: "request-body", contentType: "application/json", method: "POST" },
+      { body: "request-body", contentType: "application/json", method: "POST" },
+    ]);
+  },
+);
+
 test("handleRpcRequest strips standard credentials injected by defaults on origin change", async () => {
   const credentialRegistry = buildProviderRelayRegistry([
     {
@@ -739,6 +983,50 @@ test("handleRpcRequest maps Bun node:http AbortError to an upstream timeout", as
   );
 
   expect(response.status).toBe(504);
+  expect(await response.json()).toMatchObject({ error: { code: "upstream-timeout" } });
+});
+
+test("handleRpcRequest applies one deadline to the complete redirect chain", async () => {
+  let attempts = 0;
+  const response = await handleRpcRequest(
+    rpcRequest({ method: "GET", upstreamUrl: "https://api.allanime.day/start" }),
+    {
+      providerId: "allanime",
+      registry: providerRegistry,
+      authorization: localLoopbackAuthorization,
+      timeoutMs: 60,
+      async transport(_url, init) {
+        attempts++;
+        if (attempts === 1) {
+          await Bun.sleep(40);
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://api.allanime.day/next" },
+          });
+        }
+
+        return new Promise((_resolve, reject) => {
+          const timer = setTimeout(() => _resolve(Response.json({ ok: true })), 40);
+          init?.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                  code: "ABORT_ERR",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    },
+  );
+
+  expect(response.status).toBe(504);
+  expect(attempts).toBe(2);
   expect(await response.json()).toMatchObject({ error: { code: "upstream-timeout" } });
 });
 

--- a/packages/relay/test/handler.test.ts
+++ b/packages/relay/test/handler.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test";
+import { Readable, Writable } from "node:stream";
 
 import { handleRpcRequest } from "../src/handler";
+import { createPinnedRelayTransport, type RelayNodeRequest } from "../src/pinned-transport";
 import { buildProviderRelayRegistry } from "../src/registry";
 import type { RelayAuthorizationPolicy } from "../src/types";
 
@@ -60,7 +62,7 @@ test("handleRpcRequest forwards allowed metadata requests", async () => {
       providerId: "allanime",
       registry,
       authorization: localLoopbackAuthorization,
-      async fetch(_url, init) {
+      async transport(_url, init) {
         upstreamAuth = new Headers(init?.headers).get("authorization");
         return Response.json({ ok: true }, { status: 201 });
       },
@@ -82,7 +84,7 @@ test("handleRpcRequest rejects provider confusion", async () => {
       providerId: "allanime",
       registry,
       authorization: localLoopbackAuthorization,
-      async fetch() {
+      async transport() {
         throw new Error("should not fetch");
       },
     },
@@ -102,7 +104,7 @@ test("handleRpcRequest validates redirects before following them", async () => {
       providerId: "allanime",
       registry,
       authorization: localLoopbackAuthorization,
-      async fetch() {
+      async transport() {
         return new Response(null, {
           status: 302,
           headers: { Location: "https://miruro.bz/api" },
@@ -151,7 +153,7 @@ test("handleRpcRequest rejects unsafe upstream hosts before fetch", async () => 
       providerId: "unsafe",
       registry: unsafeRegistry,
       authorization: localLoopbackAuthorization,
-      async fetch() {
+      async transport() {
         throw new Error("should not fetch");
       },
     },
@@ -191,7 +193,7 @@ test.each([
     providerId: "unsafe",
     registry: unsafeRegistry,
     authorization: localLoopbackAuthorization,
-    async fetch() {
+    async transport() {
       throw new Error("should not fetch");
     },
   });
@@ -207,7 +209,6 @@ test.each([
  * are each one digit away from over-blocking.
  */
 test.each([
-  ["site-local fec0, outside fe80::/10", "[fec0::1]", "http://[fec0::1]/rpc"],
   ["public IPv6", "[2606:4700::1111]", "http://[2606:4700::1111]/rpc"],
   ["just below CGNAT", "100.63.255.255", "http://100.63.255.255/rpc"],
   ["just above CGNAT", "100.128.0.1", "http://100.128.0.1/rpc"],
@@ -226,7 +227,7 @@ test.each([
     providerId: "public",
     registry: publicRegistry,
     authorization: localLoopbackAuthorization,
-    async fetch() {
+    async transport() {
       fetched = true;
       return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
     },
@@ -256,7 +257,7 @@ test("handleRpcRequest rejects IPv6 loopback and unique-local literals even when
       providerId: "unsafe6",
       registry: unsafeRegistry,
       authorization: localLoopbackAuthorization,
-      async fetch() {
+      async transport() {
         throw new Error("should not fetch");
       },
     });
@@ -276,7 +277,7 @@ test("handleRpcRequest rejects oversized upstream metadata responses", async () 
       providerId: "allanime",
       registry,
       authorization: localLoopbackAuthorization,
-      async fetch() {
+      async transport() {
         return new Response("x".repeat(257), {
           status: 200,
           headers: { "Content-Type": "text/plain" },
@@ -299,7 +300,7 @@ test("handleRpcRequest does not read or return a body for HEAD responses", async
       providerId: "allanime",
       registry,
       authorization: localLoopbackAuthorization,
-      async fetch(_url, init) {
+      async transport(_url, init) {
         expect(init?.method).toBe("HEAD");
         return new Response("should not be relayed", {
           status: 204,
@@ -323,7 +324,7 @@ test("handleRpcRequest strips upstream set-cookie from metadata responses", asyn
       providerId: "allanime",
       registry,
       authorization: localLoopbackAuthorization,
-      async fetch() {
+      async transport() {
         return Response.json(
           { ok: true },
           {
@@ -359,7 +360,7 @@ test.each([
       providerId: "allanime",
       registry,
       authorization: { mode: "bearer", token: "secret" },
-      async fetch() {
+      async transport() {
         return Response.json({ ok: true });
       },
     },
@@ -378,7 +379,7 @@ test("handleRpcRequest accepts the exact bearer token", async () => {
       providerId: "allanime",
       registry,
       authorization: { mode: "bearer", token: "secret" },
-      async fetch() {
+      async transport() {
         return Response.json({ ok: true });
       },
     },
@@ -398,7 +399,7 @@ test.each(["", "   "])("handleRpcRequest rejects a blank bearer token", async (t
       providerId: "allanime",
       registry,
       authorization: { mode: "bearer", token },
-      async fetch() {
+      async transport() {
         throw new Error("should not fetch");
       },
     },
@@ -418,7 +419,7 @@ test("handleRpcRequest refuses a provider whose manifest is not relay-safe", asy
       providerId: "videasy",
       registry,
       authorization: localLoopbackAuthorization,
-      async fetch() {
+      async transport() {
         throw new Error("should not fetch");
       },
     },
@@ -444,6 +445,129 @@ test("handleRpcRequest handles CORS preflight without upstream fetch", async () 
   expect(response.headers.get("access-control-allow-methods")).toContain("POST");
 });
 
+test("handleRpcRequest authenticates before pinned transport resolves DNS", async () => {
+  let resolutions = 0;
+  const response = await handleRpcRequest(
+    rpcRequest(
+      {
+        method: "GET",
+        upstreamUrl: "https://api.allanime.day/api",
+      },
+      null,
+    ),
+    {
+      providerId: "allanime",
+      registry,
+      authorization: { mode: "bearer", token: "secret" },
+      transport: createPinnedRelayTransport({
+        resolveAddresses: async () => {
+          resolutions++;
+          return [{ address: "93.184.216.34", family: 4 }];
+        },
+        request() {
+          throw new Error("unauthorized request reached the socket");
+        },
+        maxRequestBodyBytes: 128,
+        maxResponseBodyBytes: 256,
+      }),
+    },
+  );
+
+  expect(response.status).toBe(401);
+  expect(resolutions).toBe(0);
+});
+
+test("handleRpcRequest re-resolves and re-pins every allowed redirect target", async () => {
+  const resolvedHosts: string[] = [];
+  const dialedAddresses: string[] = [];
+  const responses: NodeResponseFixture[] = [
+    {
+      status: 302,
+      headers: { location: "https://cdn.api.allanime.day/next" },
+      body: "",
+    },
+    { status: 200, headers: { "content-type": "application/json" }, body: '{"ok":true}' },
+  ];
+  const request: RelayNodeRequest = (options, onResponse) => {
+    dialedAddresses.push(String(options.hostname));
+    const response = responses.shift();
+    if (!response) throw new Error("unexpected outbound request");
+    return nodeResponse(response, onResponse);
+  };
+  const transport = createPinnedRelayTransport({
+    resolveAddresses: async (hostname) => {
+      resolvedHosts.push(hostname);
+      return [
+        {
+          address: hostname.startsWith("cdn.") ? "93.184.216.35" : "93.184.216.34",
+          family: 4,
+        },
+      ];
+    },
+    request,
+    maxRequestBodyBytes: 128,
+    maxResponseBodyBytes: 256,
+  });
+
+  const response = await handleRpcRequest(
+    rpcRequest({ method: "GET", upstreamUrl: "https://api.allanime.day/start" }),
+    {
+      providerId: "allanime",
+      registry,
+      authorization: localLoopbackAuthorization,
+      transport,
+    },
+  );
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({ ok: true });
+  expect(resolvedHosts).toEqual(["api.allanime.day", "cdn.api.allanime.day"]);
+  expect(dialedAddresses).toEqual(["93.184.216.34", "93.184.216.35"]);
+});
+
+test("handleRpcRequest rejects a redirect whose fresh DNS set contains a private answer", async () => {
+  const resolvedHosts: string[] = [];
+  const responses: NodeResponseFixture[] = [
+    {
+      status: 302,
+      headers: { location: "https://cdn.api.allanime.day/next" },
+      body: "",
+    },
+  ];
+  const transport = createPinnedRelayTransport({
+    resolveAddresses: async (hostname) => {
+      resolvedHosts.push(hostname);
+      return hostname.startsWith("cdn.")
+        ? [
+            { address: "93.184.216.35", family: 4 },
+            { address: "10.0.0.4", family: 4 },
+          ]
+        : [{ address: "93.184.216.34", family: 4 }];
+    },
+    request(_options, onResponse) {
+      const response = responses.shift();
+      if (!response) throw new Error("unsafe redirect reached the socket");
+      return nodeResponse(response, onResponse);
+    },
+    maxRequestBodyBytes: 128,
+    maxResponseBodyBytes: 256,
+  });
+
+  const response = await handleRpcRequest(
+    rpcRequest({ method: "GET", upstreamUrl: "https://api.allanime.day/start" }),
+    {
+      providerId: "allanime",
+      registry,
+      authorization: localLoopbackAuthorization,
+      transport,
+    },
+  );
+
+  expect(response.status).toBe(403);
+  expect(await response.json()).toMatchObject({ error: { code: "host-not-allowed" } });
+  expect(resolvedHosts).toEqual(["api.allanime.day", "cdn.api.allanime.day"]);
+});
+
 function rpcRequest(body: unknown, token: string | null = "secret"): Request {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -454,4 +578,28 @@ function rpcRequest(body: unknown, token: string | null = "secret"): Request {
     headers,
     body: JSON.stringify(body),
   });
+}
+
+interface NodeResponseFixture {
+  readonly status: number;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: string;
+}
+
+function nodeResponse(
+  response: NodeResponseFixture,
+  onResponse: (response: import("node:http").IncomingMessage) => void,
+): import("node:http").ClientRequest {
+  const incoming = Readable.from([
+    Buffer.from(response.body),
+  ]) as unknown as import("node:http").IncomingMessage;
+  incoming.statusCode = response.status;
+  incoming.headers = { ...response.headers };
+  queueMicrotask(() => onResponse(incoming));
+  const outgoing = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  }) as unknown as import("node:http").ClientRequest;
+  return outgoing;
 }

--- a/packages/relay/test/handler.test.ts
+++ b/packages/relay/test/handler.test.ts
@@ -10,7 +10,7 @@ const localLoopbackAuthorization = {
   mode: "local-loopback",
 } satisfies RelayAuthorizationPolicy;
 
-const registry = buildProviderRelayRegistry([
+const providerRegistry = buildProviderRelayRegistry([
   {
     providerId: "allanime",
     manifest: {
@@ -60,7 +60,7 @@ test("handleRpcRequest forwards allowed metadata requests", async () => {
     ),
     {
       providerId: "allanime",
-      registry,
+      registry: providerRegistry,
       authorization: localLoopbackAuthorization,
       async transport(_url, init) {
         upstreamAuth = new Headers(init?.headers).get("authorization");
@@ -82,7 +82,7 @@ test("handleRpcRequest rejects provider confusion", async () => {
     }),
     {
       providerId: "allanime",
-      registry,
+      registry: providerRegistry,
       authorization: localLoopbackAuthorization,
       async transport() {
         throw new Error("should not fetch");
@@ -102,7 +102,7 @@ test("handleRpcRequest validates redirects before following them", async () => {
     }),
     {
       providerId: "allanime",
-      registry,
+      registry: providerRegistry,
       authorization: localLoopbackAuthorization,
       async transport() {
         return new Response(null, {
@@ -124,7 +124,11 @@ test("handleRpcRequest rejects oversized upstream request bodies", async () => {
       upstreamUrl: "https://api.allanime.day/api",
       body: "x".repeat(129),
     }),
-    { providerId: "allanime", registry, authorization: localLoopbackAuthorization },
+    {
+      providerId: "allanime",
+      registry: providerRegistry,
+      authorization: localLoopbackAuthorization,
+    },
   );
 
   expect(response.status).toBe(413);
@@ -275,7 +279,7 @@ test("handleRpcRequest rejects oversized upstream metadata responses", async () 
     }),
     {
       providerId: "allanime",
-      registry,
+      registry: providerRegistry,
       authorization: localLoopbackAuthorization,
       async transport() {
         return new Response("x".repeat(257), {
@@ -298,7 +302,7 @@ test("handleRpcRequest does not read or return a body for HEAD responses", async
     }),
     {
       providerId: "allanime",
-      registry,
+      registry: providerRegistry,
       authorization: localLoopbackAuthorization,
       async transport(_url, init) {
         expect(init?.method).toBe("HEAD");
@@ -322,7 +326,7 @@ test("handleRpcRequest strips upstream set-cookie from metadata responses", asyn
     }),
     {
       providerId: "allanime",
-      registry,
+      registry: providerRegistry,
       authorization: localLoopbackAuthorization,
       async transport() {
         return Response.json(
@@ -358,7 +362,7 @@ test.each([
     ),
     {
       providerId: "allanime",
-      registry,
+      registry: providerRegistry,
       authorization: { mode: "bearer", token: "secret" },
       async transport() {
         return Response.json({ ok: true });
@@ -377,7 +381,7 @@ test("handleRpcRequest accepts the exact bearer token", async () => {
     }),
     {
       providerId: "allanime",
-      registry,
+      registry: providerRegistry,
       authorization: { mode: "bearer", token: "secret" },
       async transport() {
         return Response.json({ ok: true });
@@ -397,7 +401,7 @@ test.each(["", "   "])("handleRpcRequest rejects a blank bearer token", async (t
     }),
     {
       providerId: "allanime",
-      registry,
+      registry: providerRegistry,
       authorization: { mode: "bearer", token },
       async transport() {
         throw new Error("should not fetch");
@@ -417,7 +421,7 @@ test("handleRpcRequest refuses a provider whose manifest is not relay-safe", asy
     }),
     {
       providerId: "videasy",
-      registry,
+      registry: providerRegistry,
       authorization: localLoopbackAuthorization,
       async transport() {
         throw new Error("should not fetch");
@@ -436,7 +440,7 @@ test("handleRpcRequest handles CORS preflight without upstream fetch", async () 
     }),
     {
       providerId: "allanime",
-      registry,
+      registry: providerRegistry,
       authorization: localLoopbackAuthorization,
     },
   );
@@ -457,7 +461,7 @@ test("handleRpcRequest authenticates before pinned transport resolves DNS", asyn
     ),
     {
       providerId: "allanime",
-      registry,
+      registry: providerRegistry,
       authorization: { mode: "bearer", token: "secret" },
       transport: createPinnedRelayTransport({
         resolveAddresses: async () => {
@@ -513,7 +517,7 @@ test("handleRpcRequest re-resolves and re-pins every allowed redirect target", a
     rpcRequest({ method: "GET", upstreamUrl: "https://api.allanime.day/start" }),
     {
       providerId: "allanime",
-      registry,
+      registry: providerRegistry,
       authorization: localLoopbackAuthorization,
       transport,
     },
@@ -557,7 +561,7 @@ test("handleRpcRequest rejects a redirect whose fresh DNS set contains a private
     rpcRequest({ method: "GET", upstreamUrl: "https://api.allanime.day/start" }),
     {
       providerId: "allanime",
-      registry,
+      registry: providerRegistry,
       authorization: localLoopbackAuthorization,
       transport,
     },
@@ -566,6 +570,176 @@ test("handleRpcRequest rejects a redirect whose fresh DNS set contains a private
   expect(response.status).toBe(403);
   expect(await response.json()).toMatchObject({ error: { code: "host-not-allowed" } });
   expect(resolvedHosts).toEqual(["api.allanime.day", "cdn.api.allanime.day"]);
+});
+
+test("handleRpcRequest strips provider credentials from a cross-origin redirect", async () => {
+  const seenHeaders: Headers[] = [];
+  let attempt = 0;
+  const response = await handleRpcRequest(
+    rpcRequest({
+      method: "GET",
+      upstreamUrl: "https://api.allanime.day/start",
+      headers: {
+        "x-aa-boot": "boot-secret",
+        "x-build-id": "119",
+        "x-session-token": "session-secret",
+      },
+    }),
+    {
+      providerId: "allanime",
+      registry: providerRegistry,
+      authorization: localLoopbackAuthorization,
+      async transport(_url, init) {
+        seenHeaders.push(new Headers(init?.headers));
+        if (attempt++ === 0) {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://cdn.api.allanime.day/next" },
+          });
+        }
+        return Response.json({ ok: true });
+      },
+    },
+  );
+
+  expect(response.status).toBe(200);
+  expect(seenHeaders).toHaveLength(2);
+  expect(seenHeaders[0]?.get("x-aa-boot")).toBe("boot-secret");
+  expect(seenHeaders[0]?.get("x-session-token")).toBe("session-secret");
+  expect(seenHeaders[1]?.get("x-aa-boot")).toBeNull();
+  expect(seenHeaders[1]?.get("x-session-token")).toBeNull();
+  expect(seenHeaders[1]?.get("x-build-id")).toBe("119");
+});
+
+test("handleRpcRequest retains provider credentials on a same-origin redirect", async () => {
+  const seenTokens: Array<string | null> = [];
+  let attempt = 0;
+  const response = await handleRpcRequest(
+    rpcRequest({
+      method: "GET",
+      upstreamUrl: "https://api.allanime.day/start",
+      headers: { "x-session-token": "session-secret" },
+    }),
+    {
+      providerId: "allanime",
+      registry: providerRegistry,
+      authorization: localLoopbackAuthorization,
+      async transport(_url, init) {
+        seenTokens.push(new Headers(init?.headers).get("x-session-token"));
+        if (attempt++ === 0) {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://api.allanime.day/next" },
+          });
+        }
+        return Response.json({ ok: true });
+      },
+    },
+  );
+
+  expect(response.status).toBe(200);
+  expect(seenTokens).toEqual(["session-secret", "session-secret"]);
+});
+
+test("handleRpcRequest strips standard credentials injected by defaults on origin change", async () => {
+  const credentialRegistry = buildProviderRelayRegistry([
+    {
+      providerId: "credential-probe",
+      manifest: {
+        relaySafe: true,
+        relayProfile: {
+          upstreamHosts: ["a.example", "b.example"],
+          defaultHeaders: {
+            Authorization: "Bearer provider-secret",
+            Cookie: "session=cookie-secret",
+            "Proxy-Authorization": "Basic proxy-secret",
+          },
+        },
+      },
+    },
+  ] as never);
+  const seenHeaders: Headers[] = [];
+  let attempt = 0;
+  const response = await handleRpcRequest(
+    rpcRequest({ method: "GET", upstreamUrl: "https://a.example/start" }),
+    {
+      providerId: "credential-probe",
+      registry: credentialRegistry,
+      authorization: localLoopbackAuthorization,
+      async transport(_url, init) {
+        seenHeaders.push(new Headers(init?.headers));
+        if (attempt++ === 0) {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://b.example/next" },
+          });
+        }
+        return Response.json({ ok: true });
+      },
+    },
+  );
+
+  expect(response.status).toBe(200);
+  expect(seenHeaders[0]?.get("authorization")).toBe("Bearer provider-secret");
+  expect(seenHeaders[0]?.get("cookie")).toBe("session=cookie-secret");
+  expect(seenHeaders[0]?.get("proxy-authorization")).toBe("Basic proxy-secret");
+  expect(seenHeaders[1]?.get("authorization")).toBeNull();
+  expect(seenHeaders[1]?.get("cookie")).toBeNull();
+  expect(seenHeaders[1]?.get("proxy-authorization")).toBeNull();
+});
+
+test("handleRpcRequest rejects an HTTPS to HTTP redirect before another request", async () => {
+  let attempts = 0;
+  const response = await handleRpcRequest(
+    rpcRequest({ method: "GET", upstreamUrl: "https://api.allanime.day/start" }),
+    {
+      providerId: "allanime",
+      registry: providerRegistry,
+      authorization: localLoopbackAuthorization,
+      async transport() {
+        attempts++;
+        return new Response(null, {
+          status: 302,
+          headers: { location: "http://api.allanime.day/next" },
+        });
+      },
+    },
+  );
+
+  expect(response.status).toBe(502);
+  expect(await response.json()).toMatchObject({ error: { code: "redirect-not-allowed" } });
+  expect(attempts).toBe(1);
+});
+
+test("handleRpcRequest maps Bun node:http AbortError to an upstream timeout", async () => {
+  const response = await handleRpcRequest(
+    rpcRequest({ method: "GET", upstreamUrl: "https://api.allanime.day/start" }),
+    {
+      providerId: "allanime",
+      registry: providerRegistry,
+      authorization: localLoopbackAuthorization,
+      timeoutMs: 1,
+      async transport(_url, init) {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => {
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                  code: "ABORT_ERR",
+                }),
+              );
+            },
+            { once: true },
+          );
+        });
+      },
+    },
+  );
+
+  expect(response.status).toBe(504);
+  expect(await response.json()).toMatchObject({ error: { code: "upstream-timeout" } });
 });
 
 function rpcRequest(body: unknown, token: string | null = "secret"): Request {

--- a/packages/relay/test/handler.test.ts
+++ b/packages/relay/test/handler.test.ts
@@ -2,6 +2,11 @@ import { expect, test } from "bun:test";
 
 import { handleRpcRequest } from "../src/handler";
 import { buildProviderRelayRegistry } from "../src/registry";
+import type { RelayAuthorizationPolicy } from "../src/types";
+
+const localLoopbackAuthorization = {
+  mode: "local-loopback",
+} satisfies RelayAuthorizationPolicy;
 
 const registry = buildProviderRelayRegistry([
   {
@@ -38,20 +43,23 @@ const registry = buildProviderRelayRegistry([
 test("handleRpcRequest forwards allowed metadata requests", async () => {
   let upstreamAuth: string | null = null;
   const response = await handleRpcRequest(
-    rpcRequest({
-      method: "POST",
-      upstreamUrl: "https://api.allanime.day/api?x=1",
-      headers: {
-        Authorization: "Bearer should-not-forward",
-        "Content-Type": "application/json",
-        Referer: "https://youtu-chan.com",
+    rpcRequest(
+      {
+        method: "POST",
+        upstreamUrl: "https://api.allanime.day/api?x=1",
+        headers: {
+          Authorization: "Bearer should-not-forward",
+          "Content-Type": "application/json",
+          Referer: "https://youtu-chan.com",
+        },
+        body: '{"ok":true}',
       },
-      body: '{"ok":true}',
-    }),
+      null,
+    ),
     {
       providerId: "allanime",
       registry,
-      token: "secret",
+      authorization: localLoopbackAuthorization,
       async fetch(_url, init) {
         upstreamAuth = new Headers(init?.headers).get("authorization");
         return Response.json({ ok: true }, { status: 201 });
@@ -73,6 +81,7 @@ test("handleRpcRequest rejects provider confusion", async () => {
     {
       providerId: "allanime",
       registry,
+      authorization: localLoopbackAuthorization,
       async fetch() {
         throw new Error("should not fetch");
       },
@@ -92,6 +101,7 @@ test("handleRpcRequest validates redirects before following them", async () => {
     {
       providerId: "allanime",
       registry,
+      authorization: localLoopbackAuthorization,
       async fetch() {
         return new Response(null, {
           status: 302,
@@ -112,7 +122,7 @@ test("handleRpcRequest rejects oversized upstream request bodies", async () => {
       upstreamUrl: "https://api.allanime.day/api",
       body: "x".repeat(129),
     }),
-    { providerId: "allanime", registry },
+    { providerId: "allanime", registry, authorization: localLoopbackAuthorization },
   );
 
   expect(response.status).toBe(413);
@@ -140,6 +150,7 @@ test("handleRpcRequest rejects unsafe upstream hosts before fetch", async () => 
     {
       providerId: "unsafe",
       registry: unsafeRegistry,
+      authorization: localLoopbackAuthorization,
       async fetch() {
         throw new Error("should not fetch");
       },
@@ -179,6 +190,7 @@ test.each([
   const response = await handleRpcRequest(rpcRequest({ method: "GET", upstreamUrl }), {
     providerId: "unsafe",
     registry: unsafeRegistry,
+    authorization: localLoopbackAuthorization,
     async fetch() {
       throw new Error("should not fetch");
     },
@@ -213,6 +225,7 @@ test.each([
   const response = await handleRpcRequest(rpcRequest({ method: "GET", upstreamUrl }), {
     providerId: "public",
     registry: publicRegistry,
+    authorization: localLoopbackAuthorization,
     async fetch() {
       fetched = true;
       return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
@@ -242,6 +255,7 @@ test("handleRpcRequest rejects IPv6 loopback and unique-local literals even when
     const response = await handleRpcRequest(rpcRequest({ method: "GET", upstreamUrl }), {
       providerId: "unsafe6",
       registry: unsafeRegistry,
+      authorization: localLoopbackAuthorization,
       async fetch() {
         throw new Error("should not fetch");
       },
@@ -261,6 +275,7 @@ test("handleRpcRequest rejects oversized upstream metadata responses", async () 
     {
       providerId: "allanime",
       registry,
+      authorization: localLoopbackAuthorization,
       async fetch() {
         return new Response("x".repeat(257), {
           status: 200,
@@ -283,6 +298,7 @@ test("handleRpcRequest does not read or return a body for HEAD responses", async
     {
       providerId: "allanime",
       registry,
+      authorization: localLoopbackAuthorization,
       async fetch(_url, init) {
         expect(init?.method).toBe("HEAD");
         return new Response("should not be relayed", {
@@ -306,6 +322,7 @@ test("handleRpcRequest strips upstream set-cookie from metadata responses", asyn
     {
       providerId: "allanime",
       registry,
+      authorization: localLoopbackAuthorization,
       async fetch() {
         return Response.json(
           { ok: true },
@@ -326,19 +343,69 @@ test("handleRpcRequest strips upstream set-cookie from metadata responses", asyn
   expect(await response.json()).toEqual({ ok: true });
 });
 
-test("handleRpcRequest enforces bearer token when configured", async () => {
+test.each([
+  ["missing", null],
+  ["wrong equal-length", "secres"],
+])("handleRpcRequest rejects a %s bearer token", async (_label, token) => {
   const response = await handleRpcRequest(
     rpcRequest(
       {
         method: "GET",
         upstreamUrl: "https://api.allanime.day/api",
       },
-      null,
+      token,
     ),
-    { providerId: "allanime", registry, token: "secret" },
+    {
+      providerId: "allanime",
+      registry,
+      authorization: { mode: "bearer", token: "secret" },
+      async fetch() {
+        return Response.json({ ok: true });
+      },
+    },
   );
 
   expect(response.status).toBe(401);
+});
+
+test("handleRpcRequest accepts the exact bearer token", async () => {
+  const response = await handleRpcRequest(
+    rpcRequest({
+      method: "GET",
+      upstreamUrl: "https://api.allanime.day/api",
+    }),
+    {
+      providerId: "allanime",
+      registry,
+      authorization: { mode: "bearer", token: "secret" },
+      async fetch() {
+        return Response.json({ ok: true });
+      },
+    },
+  );
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({ ok: true });
+});
+
+test.each(["", "   "])("handleRpcRequest rejects a blank bearer token", async (token) => {
+  const response = await handleRpcRequest(
+    rpcRequest({
+      method: "GET",
+      upstreamUrl: "https://api.allanime.day/api",
+    }),
+    {
+      providerId: "allanime",
+      registry,
+      authorization: { mode: "bearer", token },
+      async fetch() {
+        throw new Error("should not fetch");
+      },
+    },
+  );
+
+  expect(response.status).toBe(503);
+  expect(await response.json()).toMatchObject({ error: { code: "relay-not-configured" } });
 });
 
 test("handleRpcRequest refuses a provider whose manifest is not relay-safe", async () => {
@@ -350,6 +417,7 @@ test("handleRpcRequest refuses a provider whose manifest is not relay-safe", asy
     {
       providerId: "videasy",
       registry,
+      authorization: localLoopbackAuthorization,
       async fetch() {
         throw new Error("should not fetch");
       },
@@ -368,6 +436,7 @@ test("handleRpcRequest handles CORS preflight without upstream fetch", async () 
     {
       providerId: "allanime",
       registry,
+      authorization: localLoopbackAuthorization,
     },
   );
 

--- a/packages/relay/test/pinned-transport.test.ts
+++ b/packages/relay/test/pinned-transport.test.ts
@@ -10,6 +10,7 @@ import {
   type RelayNodeRequest,
   type RelayNodeRequestOptions,
 } from "../src/pinned-transport";
+import type { RelayTransport } from "../src/types";
 
 const publicAddress = { address: "93.184.216.34", family: 4 as const };
 
@@ -189,6 +190,366 @@ test("pinned transport refuses an unsafe literal without consulting DNS", async 
   expect(resolutions).toBe(0);
 });
 
+test("pinned transport rejects Request input instead of silently dropping its state", async () => {
+  let resolutions = 0;
+  const transport = createPinnedRelayTransport({
+    resolveAddresses: async () => {
+      resolutions++;
+      return [publicAddress];
+    },
+    request() {
+      throw new Error("Request input reached the socket");
+    },
+    maxRequestBodyBytes: 64,
+    maxResponseBodyBytes: 64,
+  });
+
+  await expect(
+    transport(
+      new Request("https://upstream.example.test/data", {
+        method: "POST",
+        headers: { "x-probe": "must-not-be-dropped" },
+        body: "payload",
+      }) as never,
+    ),
+  ).rejects.toMatchObject({ code: "bad-request", status: 400 });
+  expect(resolutions).toBe(0);
+});
+
+test("pinned transport aborts while DNS resolution is still pending", async () => {
+  let resolveDns: ((addresses: readonly [typeof publicAddress]) => void) | undefined;
+  let requests = 0;
+  const transport = createPinnedRelayTransport({
+    resolveAddresses: () =>
+      new Promise((resolve) => {
+        resolveDns = resolve;
+      }),
+    request() {
+      requests++;
+      throw new Error("expired DNS result reached the socket");
+    },
+    maxRequestBodyBytes: 64,
+    maxResponseBodyBytes: 64,
+  });
+  const controller = new AbortController();
+  const pending = transport("https://upstream.example.test/data", { signal: controller.signal });
+  controller.abort("relay upstream timeout");
+
+  const outcome = await Promise.race([
+    pending.then(
+      () => "resolved",
+      (error: unknown) => (error as { name?: string }).name,
+    ),
+    Bun.sleep(50).then(() => "still-pending"),
+  ]);
+
+  expect(outcome).toBe("AbortError");
+  resolveDns?.([publicAddress]);
+  await Bun.sleep(0);
+  expect(requests).toBe(0);
+});
+
+test("pinned transport falls back to the next vetted address for a GET connection failure", async () => {
+  const secondAddress = { address: "93.184.216.35", family: 4 as const };
+  const attempts: Array<{ hostname: string; host: string | null; servername?: string }> = [];
+  const transport = createPinnedRelayTransport({
+    resolveAddresses: async () => [publicAddress, secondAddress],
+    request(options, onResponse) {
+      attempts.push({
+        hostname: String(options.hostname),
+        host: new Headers(options.headers as HeadersInit).get("host"),
+        servername: options.servername,
+      });
+      const outgoing = writableRequest();
+      if (attempts.length === 1) {
+        queueMicrotask(() => {
+          outgoing.emit(
+            "error",
+            Object.assign(new Error("connection refused"), { code: "ECONNREFUSED" }),
+          );
+        });
+      } else {
+        queueMicrotask(() => onResponse(nodeResponse("ok")));
+      }
+      return outgoing;
+    },
+    maxRequestBodyBytes: 64,
+    maxResponseBodyBytes: 64,
+  });
+
+  const response = await transport("https://upstream.example.test/data", { method: "GET" });
+
+  expect(await response.text()).toBe("ok");
+  expect(attempts).toEqual([
+    {
+      hostname: publicAddress.address,
+      host: "upstream.example.test",
+      servername: "upstream.example.test",
+    },
+    {
+      hostname: secondAddress.address,
+      host: "upstream.example.test",
+      servername: "upstream.example.test",
+    },
+  ]);
+});
+
+test("pinned transport does not replay POST after an ambiguous connection failure", async () => {
+  const attempts: string[] = [];
+  const transport = createPinnedRelayTransport({
+    resolveAddresses: async () => [publicAddress, { address: "93.184.216.35", family: 4 }],
+    request(options) {
+      attempts.push(String(options.hostname));
+      const outgoing = writableRequest();
+      queueMicrotask(() => {
+        outgoing.emit(
+          "error",
+          Object.assign(new Error("connection reset"), { code: "ECONNRESET" }),
+        );
+      });
+      return outgoing;
+    },
+    maxRequestBodyBytes: 64,
+    maxResponseBodyBytes: 64,
+  });
+
+  await expect(
+    transport("https://upstream.example.test/data", { method: "POST", body: "query" }),
+  ).rejects.toMatchObject({ code: "ECONNRESET" });
+  expect(attempts).toEqual([publicAddress.address]);
+});
+
+test("pinned transport does not retry GET after an upstream response has started", async () => {
+  const attempts: string[] = [];
+  const transport = createPinnedRelayTransport({
+    resolveAddresses: async () => [publicAddress, { address: "93.184.216.35", family: 4 }],
+    request(options, onResponse) {
+      attempts.push(String(options.hostname));
+      const incoming = new Readable({
+        read() {},
+      }) as unknown as import("node:http").IncomingMessage;
+      incoming.statusCode = 200;
+      incoming.headers = {};
+      queueMicrotask(() => {
+        onResponse(incoming);
+        incoming.emit("error", Object.assign(new Error("response reset"), { code: "ECONNRESET" }));
+      });
+      return writableRequest();
+    },
+    maxRequestBodyBytes: 64,
+    maxResponseBodyBytes: 64,
+  });
+
+  await expect(transport("https://upstream.example.test/data")).rejects.toMatchObject({
+    code: "ECONNRESET",
+  });
+  expect(attempts).toEqual([publicAddress.address]);
+});
+
+test("pinned transport does not try another address after cancellation", async () => {
+  const attempts: string[] = [];
+  const controller = new AbortController();
+  const transport = createPinnedRelayTransport({
+    resolveAddresses: async () => [publicAddress, { address: "93.184.216.35", family: 4 }],
+    request(options) {
+      attempts.push(String(options.hostname));
+      const outgoing = writableRequest();
+      queueMicrotask(() => {
+        controller.abort("relay upstream timeout");
+        outgoing.emit(
+          "error",
+          Object.assign(new Error("The operation was aborted"), {
+            name: "AbortError",
+            code: "ABORT_ERR",
+          }),
+        );
+      });
+      return outgoing;
+    },
+    maxRequestBodyBytes: 64,
+    maxResponseBodyBytes: 64,
+  });
+
+  await expect(
+    transport("https://upstream.example.test/data", { signal: controller.signal }),
+  ).rejects.toMatchObject({ code: "ABORT_ERR" });
+  expect(attempts).toEqual([publicAddress.address]);
+});
+
+test("pinned transport emits only sanitized stable fields for a rejected DNS set", async () => {
+  const diagnostics: unknown[] = [];
+  const transport = createPinnedRelayTransport({
+    providerId: "probe-provider",
+    diagnostics: (event) => diagnostics.push(event),
+    resolveAddresses: async () => [publicAddress, { address: "127.0.0.1", family: 4 }],
+    request() {
+      throw new Error("unsafe DNS set reached the socket");
+    },
+    maxRequestBodyBytes: 128,
+    maxResponseBodyBytes: 64,
+  });
+
+  await expect(
+    transport("https://upstream.example.test/private-path?token=query-secret", {
+      method: "POST",
+      headers: { "x-session-token": "header-secret" },
+      body: "body-secret",
+    }),
+  ).rejects.toMatchObject({ code: "host-not-allowed" });
+
+  expect(diagnostics).toEqual([
+    {
+      event: "dns-rejected",
+      providerId: "probe-provider",
+      hostname: "upstream.example.test",
+      answerCount: 2,
+      families: [4],
+      code: "NON_PUBLIC_ADDRESS",
+    },
+  ]);
+  const serialized = JSON.stringify(diagnostics);
+  expect(serialized).not.toContain("private-path");
+  expect(serialized).not.toContain("query-secret");
+  expect(serialized).not.toContain("header-secret");
+  expect(serialized).not.toContain("body-secret");
+  expect(serialized).not.toContain("127.0.0.1");
+});
+
+test("pinned transport diagnostics omit raw connection errors during safe fallback", async () => {
+  const diagnostics: unknown[] = [];
+  let attempts = 0;
+  const transport = createPinnedRelayTransport({
+    providerId: "probe-provider",
+    diagnostics: (event) => diagnostics.push(event),
+    resolveAddresses: async () => [publicAddress, { address: "93.184.216.35", family: 4 }],
+    request(_options, onResponse) {
+      attempts++;
+      const outgoing = writableRequest();
+      if (attempts === 1) {
+        queueMicrotask(() => {
+          outgoing.emit(
+            "error",
+            Object.assign(new Error("raw-error-secret"), { code: "ECONNREFUSED" }),
+          );
+        });
+      } else {
+        queueMicrotask(() => onResponse(nodeResponse("ok")));
+      }
+      return outgoing;
+    },
+    maxRequestBodyBytes: 64,
+    maxResponseBodyBytes: 64,
+  });
+
+  const response = await transport("https://upstream.example.test/data");
+
+  expect(response.status).toBe(200);
+  expect(diagnostics).toEqual([
+    {
+      event: "connection-failed",
+      providerId: "probe-provider",
+      hostname: "upstream.example.test",
+      family: 4,
+      attempt: 1,
+      answerCount: 2,
+      code: "ECONNREFUSED",
+    },
+  ]);
+  expect(JSON.stringify(diagnostics)).not.toContain("raw-error-secret");
+  expect(JSON.stringify(diagnostics)).not.toContain(publicAddress.address);
+});
+
+test("pinned transport diagnostics do not expose a literal upstream address", async () => {
+  const diagnostics: unknown[] = [];
+  const transport = createPinnedRelayTransport({
+    providerId: "probe-provider",
+    diagnostics: (event) => diagnostics.push(event),
+    request() {
+      const outgoing = writableRequest();
+      queueMicrotask(() => {
+        outgoing.emit(
+          "error",
+          Object.assign(new Error("connection refused"), { code: "ECONNREFUSED" }),
+        );
+      });
+      return outgoing;
+    },
+    maxRequestBodyBytes: 64,
+    maxResponseBodyBytes: 64,
+  });
+
+  await expect(transport(`https://${publicAddress.address}/data`)).rejects.toMatchObject({
+    code: "ECONNREFUSED",
+  });
+  expect(diagnostics).toEqual([
+    {
+      event: "connection-failed",
+      providerId: "probe-provider",
+      hostname: "ip-literal",
+      family: 4,
+      attempt: 1,
+      answerCount: 1,
+      code: "ECONNREFUSED",
+    },
+  ]);
+  expect(JSON.stringify(diagnostics)).not.toContain(publicAddress.address);
+});
+
+test("pinned transport emits a sanitized diagnostic when DNS resolution fails", async () => {
+  const diagnostics: unknown[] = [];
+  const transport = createPinnedRelayTransport({
+    providerId: "probe-provider",
+    diagnostics: (event) => diagnostics.push(event),
+    resolveAddresses: async () => {
+      throw Object.assign(new Error("raw-dns-secret"), { code: "EAI_AGAIN" });
+    },
+    request() {
+      throw new Error("failed DNS reached the socket");
+    },
+    maxRequestBodyBytes: 64,
+    maxResponseBodyBytes: 64,
+  });
+
+  await expect(transport("https://upstream.example.test/data")).rejects.toMatchObject({
+    code: "EAI_AGAIN",
+  });
+  expect(diagnostics).toEqual([
+    {
+      event: "dns-failed",
+      providerId: "probe-provider",
+      hostname: "upstream.example.test",
+      code: "EAI_AGAIN",
+    },
+  ]);
+  expect(JSON.stringify(diagnostics)).not.toContain("raw-dns-secret");
+});
+
+test("pinned transport diagnoses an empty DNS answer without opening a socket", async () => {
+  const diagnostics: unknown[] = [];
+  const transport = createPinnedRelayTransport({
+    providerId: "probe-provider",
+    diagnostics: (event) => diagnostics.push(event),
+    resolveAddresses: async () => [],
+    request() {
+      throw new Error("empty DNS answer reached the socket");
+    },
+    maxRequestBodyBytes: 64,
+    maxResponseBodyBytes: 64,
+  });
+
+  await expect(transport("https://upstream.example.test/data")).rejects.toMatchObject({
+    code: "upstream-error",
+  });
+  expect(diagnostics).toEqual([
+    {
+      event: "dns-failed",
+      providerId: "probe-provider",
+      hostname: "upstream.example.test",
+      code: "NO_ADDRESSES",
+    },
+  ]);
+});
+
 function inspectRequest(
   inspect: (options: RelayNodeRequestOptions) => void,
   body = "ok",
@@ -209,6 +570,31 @@ function inspectRequest(
   };
 }
 
+function writableRequest(): ClientRequest {
+  return new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  }) as unknown as ClientRequest;
+}
+
+function nodeResponse(body: string): import("node:http").IncomingMessage {
+  const incoming = Readable.from([
+    Buffer.from(body),
+  ]) as unknown as import("node:http").IncomingMessage;
+  incoming.statusCode = 200;
+  incoming.headers = {};
+  return incoming;
+}
+
 // Compile-time proof that resolver fixtures return the complete DNS answer set.
 const _resolverContract: RelayAddressResolver = async () => [publicAddress];
 void _resolverContract;
+
+const _relayTransportUrlInput: Parameters<RelayTransport>[0] = new URL("https://example.test");
+// @ts-expect-error Relay transport inputs cannot carry implicit Request state.
+const _relayTransportRequestInput: Parameters<RelayTransport>[0] = new Request(
+  "https://example.test",
+);
+void _relayTransportUrlInput;
+void _relayTransportRequestInput;

--- a/packages/relay/test/pinned-transport.test.ts
+++ b/packages/relay/test/pinned-transport.test.ts
@@ -1,0 +1,214 @@
+import { expect, test } from "bun:test";
+import type { ClientRequest } from "node:http";
+import { Readable, Writable } from "node:stream";
+
+import { RelayValidationError } from "../src/forward-headers";
+import {
+  createPinnedRelayTransport,
+  isPublicRelayAddress,
+  type RelayAddressResolver,
+  type RelayNodeRequest,
+  type RelayNodeRequestOptions,
+} from "../src/pinned-transport";
+
+const publicAddress = { address: "93.184.216.34", family: 4 as const };
+
+test.each([
+  "0.1.2.3",
+  "10.0.0.1",
+  "100.64.0.1",
+  "127.0.0.1",
+  "169.254.169.254",
+  "172.16.0.1",
+  "192.0.0.1",
+  "192.0.2.1",
+  "192.31.196.1",
+  "192.52.193.1",
+  "192.88.99.1",
+  "192.168.0.1",
+  "192.175.48.1",
+  "198.18.0.1",
+  "198.51.100.1",
+  "203.0.113.1",
+  "224.0.0.1",
+  "240.0.0.1",
+  "::",
+  "::1",
+  "fe80::1",
+  "fec0::1",
+  "fc00::1",
+  "2001::1",
+  "2001:db8::1",
+  "2002::1",
+  "3fff::1",
+  "ff02::1",
+])("isPublicRelayAddress rejects non-public address %s", (address) => {
+  expect(isPublicRelayAddress(address)).toBe(false);
+});
+
+test.each([
+  "8.8.8.8",
+  "93.184.216.34",
+  "100.63.255.255",
+  "100.128.0.1",
+  "172.32.0.1",
+  "2606:4700:4700::1111",
+  "::ffff:8.8.8.8",
+])("isPublicRelayAddress accepts public address %s", (address) => {
+  expect(isPublicRelayAddress(address)).toBe(true);
+});
+
+test("pinned transport rejects a mixed public and loopback DNS answer set", async () => {
+  let requests = 0;
+  const transport = createPinnedRelayTransport({
+    resolveAddresses: async () => [publicAddress, { address: "127.0.0.1", family: 4 }],
+    request() {
+      requests++;
+      throw new Error("unsafe answer set reached the socket");
+    },
+    maxRequestBodyBytes: 64,
+    maxResponseBodyBytes: 64,
+  });
+
+  await expect(transport("http://upstream.example.test/data")).rejects.toMatchObject({
+    code: "host-not-allowed",
+    status: 403,
+  });
+  expect(requests).toBe(0);
+});
+
+test("pinned transport rejects a mixed public and link-local A/AAAA answer set", async () => {
+  let requests = 0;
+  const transport = createPinnedRelayTransport({
+    resolveAddresses: async () => [publicAddress, { address: "fe80::1", family: 6 }],
+    request() {
+      requests++;
+      throw new Error("unsafe answer set reached the socket");
+    },
+    maxRequestBodyBytes: 64,
+    maxResponseBodyBytes: 64,
+  });
+
+  await expect(transport("https://upstream.example.test/data")).rejects.toBeInstanceOf(
+    RelayValidationError,
+  );
+  expect(requests).toBe(0);
+});
+
+test("pinned transport prevents DNS rebinding by dialing the vetted address and preserving HTTP Host", async () => {
+  let dialedHostname: string | undefined;
+  let hostHeader = "";
+  const transport = createPinnedRelayTransport({
+    resolveAddresses: async () => [publicAddress],
+    request: inspectRequest((options) => {
+      dialedHostname = String(options.hostname);
+      hostHeader = new Headers(options.headers as HeadersInit).get("host") ?? "";
+    }),
+    maxRequestBodyBytes: 64,
+    maxResponseBodyBytes: 128,
+  });
+
+  const response = await transport("http://upstream.example.test:8080/data");
+
+  expect(response.status).toBe(200);
+  expect(dialedHostname).toBe(publicAddress.address);
+  expect(String(hostHeader)).toBe("upstream.example.test:8080");
+});
+
+test("pinned HTTPS transport preserves the original hostname for TLS SNI", async () => {
+  let servername: string | undefined;
+  let dialedHostname: string | undefined;
+  const transport = createPinnedRelayTransport({
+    resolveAddresses: async () => [publicAddress],
+    request: inspectRequest((options) => {
+      dialedHostname = String(options.hostname);
+      servername = options.servername;
+    }),
+    maxRequestBodyBytes: 64,
+    maxResponseBodyBytes: 64,
+  });
+
+  const response = await transport("https://upstream.example.test/data");
+
+  expect(response.status).toBe(200);
+  expect(dialedHostname).toBe(publicAddress.address);
+  expect(servername).toBe("upstream.example.test");
+});
+
+test("pinned transport rejects an oversized request before DNS resolution", async () => {
+  let resolutions = 0;
+  const transport = createPinnedRelayTransport({
+    resolveAddresses: async () => {
+      resolutions++;
+      return [publicAddress];
+    },
+    request() {
+      throw new Error("oversized request reached the socket");
+    },
+    maxRequestBodyBytes: 8,
+    maxResponseBodyBytes: 64,
+  });
+
+  await expect(
+    transport("http://upstream.example.test/data", { method: "POST", body: "123456789" }),
+  ).rejects.toMatchObject({ code: "body-too-large", status: 413 });
+  expect(resolutions).toBe(0);
+});
+
+test("pinned transport destroys an upstream response as soon as its byte ceiling is crossed", async () => {
+  const transport = createPinnedRelayTransport({
+    resolveAddresses: async () => [publicAddress],
+    request: inspectRequest(() => {}, "1234567890"),
+    maxRequestBodyBytes: 64,
+    maxResponseBodyBytes: 8,
+  });
+
+  await expect(transport("http://upstream.example.test/data")).rejects.toMatchObject({
+    code: "response-too-large",
+    status: 502,
+  });
+});
+
+test("pinned transport refuses an unsafe literal without consulting DNS", async () => {
+  let resolutions = 0;
+  const transport = createPinnedRelayTransport({
+    resolveAddresses: async () => {
+      resolutions++;
+      return [publicAddress];
+    },
+    request() {
+      throw new Error("unsafe literal reached the socket");
+    },
+    maxRequestBodyBytes: 64,
+    maxResponseBodyBytes: 64,
+  });
+
+  await expect(transport("http://169.254.169.254/latest/meta-data")).rejects.toMatchObject({
+    code: "host-not-allowed",
+  });
+  expect(resolutions).toBe(0);
+});
+
+function inspectRequest(
+  inspect: (options: RelayNodeRequestOptions) => void,
+  body = "ok",
+): RelayNodeRequest {
+  return (options, onResponse): ClientRequest => {
+    inspect(options);
+    const incoming = Readable.from([
+      Buffer.from(body),
+    ]) as unknown as import("node:http").IncomingMessage;
+    incoming.statusCode = 200;
+    incoming.headers = {};
+    queueMicrotask(() => onResponse(incoming));
+    return new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    }) as unknown as ClientRequest;
+  };
+}
+
+// Compile-time proof that resolver fixtures return the complete DNS answer set.
+const _resolverContract: RelayAddressResolver = async () => [publicAddress];
+void _resolverContract;

--- a/packages/relay/test/relay-fetch-port.test.ts
+++ b/packages/relay/test/relay-fetch-port.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from "bun:test";
 
 import { createRelayFetchPort } from "../src/create-relay-fetch-port";
+import { handleRpcRequest, relayError } from "../src/handler";
 import { normalizeRelayBaseUrl } from "../src/normalize-relay-base-url";
 import { buildProviderRelayRegistry } from "../src/registry";
+import { RELAY_ERROR_CODE_HEADER, type RelayErrorCode } from "../src/types";
 
 const registry = buildProviderRelayRegistry([
   {
@@ -88,6 +90,96 @@ test("createRelayFetchPort falls back to direct when relay network fails", async
   const response = await port.fetch("https://api.allanime.day/api");
   expect(await response.json()).toEqual({ direct: true });
   expect(calls).toEqual(["https://relay.example/rpc/allanime", "https://api.allanime.day/api"]);
+});
+
+test.each([
+  ["relay-not-configured", 503],
+  ["unauthorized", 401],
+] as const)(
+  "createRelayFetchPort falls back to direct for relay authorization failure %s",
+  async (code, status) => {
+    const calls: string[] = [];
+    const port = createRelayFetchPort({
+      relayConfig: { baseUrl: "https://relay.example", fallbackToDirect: true },
+      registry,
+      async fetch(input) {
+        calls.push(String(input));
+        if (new URL(String(input)).origin === "https://relay.example") {
+          return relayError(
+            code satisfies RelayErrorCode,
+            "allanime",
+            "Relay authorization failed",
+            status,
+          );
+        }
+        return Response.json({ direct: true });
+      },
+    });
+
+    const response = await port.fetch("https://api.allanime.day/api");
+
+    expect(await response.json()).toEqual({ direct: true });
+    expect(calls).toEqual(["https://relay.example/rpc/allanime", "https://api.allanime.day/api"]);
+  },
+);
+
+test("createRelayFetchPort does not fall back for an unmarked upstream HTTP failure", async () => {
+  const calls: string[] = [];
+  const port = createRelayFetchPort({
+    relayConfig: { baseUrl: "https://relay.example", fallbackToDirect: true },
+    registry,
+    async fetch(input) {
+      calls.push(String(input));
+      return Response.json(
+        {
+          error: {
+            code: "relay-not-configured",
+            message: "Untrusted upstream body must not control fallback",
+          },
+        },
+        { status: 503 },
+      );
+    },
+  });
+
+  const response = await port.fetch("https://api.allanime.day/api");
+
+  expect(response.status).toBe(503);
+  expect(calls).toEqual(["https://relay.example/rpc/allanime"]);
+});
+
+test("an upstream relay-error marker is stripped before client fallback policy sees it", async () => {
+  const calls: string[] = [];
+  const port = createRelayFetchPort({
+    relayConfig: { baseUrl: "https://relay.example", fallbackToDirect: true },
+    registry,
+    providerId: "allanime",
+    async fetch(input, init) {
+      calls.push(String(input));
+      if (new URL(String(input)).origin !== "https://relay.example") {
+        return Response.json({ direct: true });
+      }
+
+      return handleRpcRequest(new Request(String(input), init), {
+        providerId: "allanime",
+        registry,
+        authorization: { mode: "local-loopback" },
+        async transport() {
+          return new Response("upstream unavailable", {
+            status: 503,
+            headers: { [RELAY_ERROR_CODE_HEADER]: "relay-not-configured" },
+          });
+        },
+      });
+    },
+  });
+
+  const response = await port.fetch("https://api.allanime.day/api");
+
+  expect(response.status).toBe(503);
+  expect(response.headers.get(RELAY_ERROR_CODE_HEADER)).toBeNull();
+  expect(await response.text()).toBe("upstream unavailable");
+  expect(calls).toEqual(["https://relay.example/rpc/allanime"]);
 });
 
 test("createRelayFetchPort stays on direct fetch when the manifest is not relay-safe", async () => {

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -34,6 +34,7 @@ export const relayErrorCodeSchema = z.enum([
   "body-too-large",
   "response-too-large",
   "redirect-not-allowed",
+  "relay-not-configured",
   "unauthorized",
   "upstream-timeout",
   "upstream-error",

--- a/packages/schemas/test/schemas.test.ts
+++ b/packages/schemas/test/schemas.test.ts
@@ -54,6 +54,18 @@ test("relay schemas validate config rpc requests and structured errors", () => {
   expect(error.error.code).toBe("host-not-allowed");
 });
 
+test("relay error schema accepts an unconfigured relay response", () => {
+  const error = relayRpcErrorSchema.parse({
+    error: {
+      code: "relay-not-configured",
+      providerId: "allanime",
+      message: "Relay authorization is not configured",
+    },
+  });
+
+  expect(error.error.code).toBe("relay-not-configured");
+});
+
 test("stream candidate schema accepts serialized cache-safe shape", () => {
   const parsed = streamCandidateSchema.parse({
     id: "stream-1",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -491,6 +491,7 @@ export type RelayErrorCode =
   | "body-too-large"
   | "response-too-large"
   | "redirect-not-allowed"
+  | "relay-not-configured"
   | "unauthorized"
   | "upstream-timeout"
   | "upstream-error"


### PR DESCRIPTION
## Summary

- binds development relay safely and requires explicit runtime authorization
- uses timing-safe token comparison
- validates and pins resolved upstream addresses against private-network and rebinding attacks
- hardens redirects, response limits, and fallback policy

## Stack

Depends on #164.

## Verification

- relay unit and integration coverage for auth, DNS pinning, redirects, and limits
- full typecheck, zero-warning lint, format, test, and build gates

No relay deployment or release is performed by this PR.