### PR TITLE
perf(startup): defer SQLite maintenance until after first paint

### DIFF
--- a/.docs/architecture.md
+++ b/.docs/architecture.md
@@ -1,6 +1,6 @@
 ---
 status: current
-lastReviewed: "2026-08-18"
+lastReviewed: "2026-08-24"
 ---
 
 # Kunai — Runtime Architecture
@@ -206,7 +206,10 @@ Automatic storage maintenance is conservative:
 - it may prune expired `stream_cache`, `source_inventory`, `recommendation_cache`, and `schedule_cache` rows
 - it may cap `resolve_traces` and age out stale provider-health cache
 - it may run `PRAGMA optimize` and an explicit passive WAL checkpoint
-- it runs as best-effort startup background work and must not block playback or shell startup
+- it is admitted through the owned background-work scheduler only after the
+  persistent shell mounts, then yields an event-loop turn before synchronous
+  SQLite begins; shutdown cancels admission and drains active work before the
+  database handles close
 - it must not run automatic `VACUUM`
 - it must not delete user-owned facts such as `history_progress`, lists, config, sync tokens, or completed download records
 

--- a/apps/cli/src/app/bootstrap/post-paint-startup-work.ts
+++ b/apps/cli/src/app/bootstrap/post-paint-startup-work.ts
@@ -1,0 +1,66 @@
+import {
+  type BackgroundWorkDrainResult,
+  type BackgroundWorkScheduler,
+} from "@/services/background/BackgroundWorkScheduler";
+
+export type PostPaintStartupTask = {
+  readonly id: string;
+  readonly run: () => Promise<void> | void;
+};
+
+export type PostPaintStartupWorkInput = {
+  readonly scheduler: Pick<BackgroundWorkScheduler, "drain" | "enqueue">;
+  readonly tasks: readonly PostPaintStartupTask[];
+  readonly yieldToPaint?: (signal: AbortSignal) => Promise<void>;
+};
+
+export type ShellPostPaintStartupWorkInput = PostPaintStartupWorkInput & {
+  readonly launchShell: () => void;
+  readonly recordShellMounted: () => void;
+};
+
+/** Establish the shell boundary before admitting any startup SQLite work. */
+export function launchShellWithPostPaintStartupWork(
+  input: ShellPostPaintStartupWorkInput,
+): Promise<BackgroundWorkDrainResult> {
+  input.launchShell();
+  input.recordShellMounted();
+  return schedulePostPaintStartupWork(input);
+}
+
+/**
+ * Admit startup database work only after the root shell has mounted. Every
+ * item yields one event-loop turn before touching synchronous SQLite. Each
+ * predecessor admits its successor from `finally`, so failures cannot break
+ * ordering and shutdown can reject later admission before database disposal.
+ */
+export function schedulePostPaintStartupWork(
+  input: PostPaintStartupWorkInput,
+): Promise<BackgroundWorkDrainResult> {
+  const yieldToPaint = input.yieldToPaint ?? yieldOneEventLoopTurn;
+  const enqueueTask = (index: number): void => {
+    const task = input.tasks[index];
+    if (!task) return;
+    input.scheduler.enqueue({
+      id: `startup.${String(index + 1).padStart(2, "0")}.${task.id}`,
+      lane: "maintenance-cleanup",
+      run: async (signal) => {
+        try {
+          await yieldToPaint(signal);
+          signal.throwIfAborted();
+          await task.run();
+        } finally {
+          enqueueTask(index + 1);
+        }
+      },
+    });
+  };
+
+  enqueueTask(0);
+  return input.scheduler.drain();
+}
+
+async function yieldOneEventLoopTurn(signal: AbortSignal): Promise<void> {
+  await Bun.sleep(0);
+  signal.throwIfAborted();
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -40,6 +40,7 @@ import {
   prepareReplayTitleForProvider,
   titleFromHistorySelection,
 } from "@/app/bootstrap/launch-entry";
+import { launchShellWithPostPaintStartupWork } from "@/app/bootstrap/post-paint-startup-work";
 import { maybeRunStartupSetup, shouldRunSetupWizard } from "@/app/bootstrap/startup-setup";
 import { resolveSessionConfigOverrides } from "@/app/session/session-overrides";
 import { SessionController } from "@/app/session/SessionController";
@@ -821,9 +822,8 @@ export async function runCli(argv = process.argv.slice(2)): Promise<void> {
   if (Object.keys(sessionOverrides).length > 0) {
     config.applySessionOverrides(sessionOverrides);
   }
-  await maybeRunAutoCleanupDownloads(container);
-
   if (args.supportBundle) {
+    await maybeRunAutoCleanupDownloads(container);
     const { exportLocalSupportBundle } = await import("./app-shell/export-local-support-bundle");
     const written = await exportLocalSupportBundle(container);
     process.stdout.write(`${written.path}\n`);
@@ -986,14 +986,6 @@ export async function runCli(argv = process.argv.slice(2)): Promise<void> {
     });
   }
 
-  runBackgroundTask({
-    task: "storage.maintenance.startup",
-    category: "cache",
-    diagnostics: container.diagnosticsService,
-    logger,
-    run: () => container.storageMaintenance.runStartupMaintenance(),
-  });
-
   if (args.debug) {
     logger.info("Kunai started", {
       version: KUNAI_VERSION,
@@ -1046,8 +1038,30 @@ export async function runCli(argv = process.argv.slice(2)): Promise<void> {
       lazyImportMs: Math.round(performance.now() - shellLoadStartedAt),
     });
   }
-  launchSessionApp(container);
-  recordCliStartupMilestone(container.diagnosticsService, "shell-mounted");
+  runBackgroundTask({
+    task: "startup.post-paint-maintenance",
+    category: "cache",
+    diagnostics: container.diagnosticsService,
+    logger,
+    run: launchShellWithPostPaintStartupWork({
+      scheduler: container.backgroundWorkScheduler,
+      launchShell: () => {
+        void launchSessionApp(container);
+      },
+      recordShellMounted: () =>
+        recordCliStartupMilestone(container.diagnosticsService, "shell-mounted"),
+      tasks: [
+        {
+          id: "storage-maintenance",
+          run: () => container.storageMaintenance.runStartupMaintenance().then(() => undefined),
+        },
+        {
+          id: "download-cleanup-scan",
+          run: () => maybeRunAutoCleanupDownloads(container),
+        },
+      ],
+    }),
+  });
   // Must stay after first paint: the enrich loop and the consolidator it can
   // trigger run synchronous SQLite work that would starve the awaited shell
   // import and delay the first render.

--- a/apps/cli/test/unit/app/bootstrap/post-paint-startup-work.test.ts
+++ b/apps/cli/test/unit/app/bootstrap/post-paint-startup-work.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  launchShellWithPostPaintStartupWork,
+  schedulePostPaintStartupWork,
+} from "@/app/bootstrap/post-paint-startup-work";
+import { BackgroundWorkScheduler } from "@/services/background/BackgroundWorkScheduler";
+
+describe("post-paint startup work", () => {
+  test("runs storage then cleanup after separate post-shell yields at production concurrency", async () => {
+    const order: string[] = [];
+    const releaseYield: Array<() => void> = [];
+    let markCleanupYieldStarted!: () => void;
+    const cleanupYieldStarted = new Promise<void>((resolve) => {
+      markCleanupYieldStarted = resolve;
+    });
+    const scheduler = new BackgroundWorkScheduler({ maxConcurrent: 2 });
+
+    const drain = launchShellWithPostPaintStartupWork({
+      scheduler,
+      launchShell: () => order.push("shell-launched"),
+      recordShellMounted: () => order.push("shell-mounted"),
+      yieldToPaint: () => {
+        const task = releaseYield.length === 0 ? "storage" : "cleanup";
+        order.push(`yielded-${task}`);
+        if (task === "cleanup") markCleanupYieldStarted();
+        return new Promise<void>((resolve) => {
+          releaseYield.push(resolve);
+        });
+      },
+      tasks: [
+        {
+          id: "storage-maintenance",
+          run: () => {
+            order.push("storage-maintenance");
+          },
+        },
+        {
+          id: "download-cleanup-scan",
+          run: () => {
+            order.push("download-cleanup");
+          },
+        },
+      ],
+    });
+
+    await Promise.resolve();
+    expect(order).toEqual(["shell-launched", "shell-mounted", "yielded-storage"]);
+    releaseYield[0]?.();
+    await cleanupYieldStarted;
+    expect(order).toEqual([
+      "shell-launched",
+      "shell-mounted",
+      "yielded-storage",
+      "storage-maintenance",
+      "yielded-cleanup",
+    ]);
+    releaseYield[1]?.();
+    await drain;
+    expect(order).toEqual([
+      "shell-launched",
+      "shell-mounted",
+      "yielded-storage",
+      "storage-maintenance",
+      "yielded-cleanup",
+      "download-cleanup",
+    ]);
+  });
+
+  test("contains one maintenance failure and continues the other startup task", async () => {
+    const scheduler = new BackgroundWorkScheduler({ maxConcurrent: 2 });
+    const calls: string[] = [];
+
+    const result = await schedulePostPaintStartupWork({
+      scheduler,
+      yieldToPaint: async () => {},
+      tasks: [
+        {
+          id: "storage-maintenance",
+          run: () => {
+            calls.push("storage");
+            throw new Error("database busy");
+          },
+        },
+        {
+          id: "download-cleanup-scan",
+          run: () => {
+            calls.push("cleanup");
+          },
+        },
+      ],
+    });
+
+    expect(calls).toEqual(["storage", "cleanup"]);
+    expect(result.failed).toEqual([
+      { id: "startup.01.storage-maintenance", error: "database busy" },
+    ]);
+    expect(result.completed).toEqual(["startup.02.download-cleanup-scan"]);
+  });
+
+  test("shutdown during the yield prevents SQLite work from starting", async () => {
+    let releaseYield!: () => void;
+    const yielded = new Promise<void>((resolve) => {
+      releaseYield = resolve;
+    });
+    const scheduler = new BackgroundWorkScheduler({ maxConcurrent: 1 });
+    let maintenanceStarted = false;
+    let cleanupStarted = false;
+
+    const drain = schedulePostPaintStartupWork({
+      scheduler,
+      yieldToPaint: () => yielded,
+      tasks: [
+        {
+          id: "storage-maintenance",
+          run: () => {
+            maintenanceStarted = true;
+          },
+        },
+        {
+          id: "download-cleanup-scan",
+          run: () => {
+            cleanupStarted = true;
+          },
+        },
+      ],
+    });
+    await Promise.resolve();
+    scheduler.beginShutdown("app-exit");
+    releaseYield();
+
+    const result = await drain;
+    expect(maintenanceStarted).toBe(false);
+    expect(cleanupStarted).toBe(false);
+    expect(result.skipped).toEqual([{ id: "startup.01.storage-maintenance", reason: "aborted" }]);
+  });
+});


### PR DESCRIPTION
## Summary

- schedules startup maintenance and automatic cleanup after the mounted-shell boundary
- explicitly yields before synchronous SQLite work
- contains failures and prevents shutdown from admitting new maintenance

Closes #129.

## Stack

Depends on #164.

## Verification

- first-paint ordering characterization
- shutdown and failure containment coverage
- full repository gates and host build

No release is performed by this PR.