### PR TITLE
fix(sync): make background drain failures deterministic

### DIFF
--- a/apps/cli/src/services/sync/SyncService.ts
+++ b/apps/cli/src/services/sync/SyncService.ts
@@ -91,6 +91,8 @@ export interface SyncServiceDeps {
   readonly outbox: SyncOutboxRepository;
   readonly config: SyncConfigPort;
   readonly diagnostics?: Pick<DiagnosticsService, "record">;
+  /** Injectable so operation-budget continuations can be advanced without real timers in tests. */
+  readonly scheduleContinuation?: (task: () => void) => void;
   /** Injectable only so due-time and shutdown behavior are deterministic in tests. */
   readonly scheduleWake?: (task: () => void, delayMs: number) => () => void;
   readonly now?: () => Date;
@@ -208,6 +210,7 @@ export class SyncService {
   private readonly outbox: SyncOutboxRepository;
   private readonly config: SyncConfigPort;
   private readonly diagnostics?: Pick<DiagnosticsService, "record">;
+  private readonly scheduleContinuation: (task: () => void) => void;
   private readonly scheduleWake: (task: () => void, delayMs: number) => () => void;
   private readonly now: () => Date;
   private readonly shutdownController = new AbortController();
@@ -225,6 +228,7 @@ export class SyncService {
     this.config = deps.config;
     this.diagnostics = deps.diagnostics;
     this.now = deps.now ?? (() => new Date());
+    this.scheduleContinuation = deps.scheduleContinuation ?? ((task) => setTimeout(task, 0));
     this.scheduleWake =
       deps.scheduleWake ??
       ((task, delayMs) => {
@@ -479,10 +483,10 @@ export class SyncService {
           !this.shutdownController.signal.aborted
         ) {
           this.continuationScheduled = true;
-          setTimeout(() => {
+          this.scheduleContinuation(() => {
             this.continuationScheduled = false;
             if (!this.shutdownController.signal.aborted) this.deliverSoon();
-          }, 0);
+          });
         }
         return undefined;
       })

--- a/apps/cli/test/unit/services/sync/sync-drain.test.ts
+++ b/apps/cli/test/unit/services/sync/sync-drain.test.ts
@@ -132,10 +132,15 @@ describe("SyncService drain", () => {
   test("a direct startup drain schedules continuation beyond its operation budget", async () => {
     const repo = outbox();
     const anilist = adapter("anilist");
+    const scheduled: Array<() => void> = [];
     const service = new SyncService({
       adapters: [anilist.adapter],
       outbox: repo,
       config: configPort(),
+      scheduleWake: (task) => {
+        scheduled.push(task);
+        return () => {};
+      },
     });
 
     for (let id = 1; id <= 103; id += 1) {
@@ -149,7 +154,11 @@ describe("SyncService drain", () => {
 
     const first = await service.drain(25);
     expect(first.claimed).toBe(100);
-    await waitUntil(() => repo.counts().pending === 0, { label: "outbox drained" });
+    expect(anilist.calls).toHaveLength(100);
+    expect(scheduled).toHaveLength(1);
+
+    scheduled.shift()!();
+    await service.drain();
 
     expect(anilist.calls).toHaveLength(103);
     expect(repo.counts().pending).toBe(0);
@@ -158,10 +167,14 @@ describe("SyncService drain", () => {
   test("deliverSoon continues after its operation budget until every due row is attempted", async () => {
     const repo = outbox();
     const anilist = adapter("anilist");
+    const continuations: Array<() => void> = [];
     const service = new SyncService({
       adapters: [anilist.adapter],
       outbox: repo,
       config: configPort(),
+      scheduleContinuation: (task) => {
+        continuations.push(task);
+      },
     });
 
     for (let id = 1; id <= 103; id += 1) {
@@ -174,7 +187,13 @@ describe("SyncService drain", () => {
     }
 
     service.deliverSoon();
-    await waitUntil(() => repo.counts().pending === 0, { label: "outbox drained" });
+    const first = await service.drain();
+    expect(first.claimed).toBe(100);
+    expect(anilist.calls).toHaveLength(100);
+    expect(continuations).toHaveLength(1);
+
+    continuations.shift()!();
+    await service.drain();
 
     expect(anilist.calls).toHaveLength(103);
     expect(repo.counts().pending).toBe(0);

--- a/apps/cli/test/unit/services/sync/sync-reconciliation.test.ts
+++ b/apps/cli/test/unit/services/sync/sync-reconciliation.test.ts
@@ -955,6 +955,9 @@ test("transient prefix backs off so later eligible rows run and retries resume w
   const scheduled: Array<{ task: () => Promise<void>; delayMs: number }> = [];
   const options = {
     maxRows: 3,
+    // Frozen: retry due-times use wallNow, while the operation budget uses a
+    // monotonic clock. This test exercises retry ordering, not runner speed.
+    now: () => 0,
     wallNow: () => wallNow,
     scheduleContinuation: (task: () => Promise<void>, delayMs = 0) =>
       scheduled.push({ task, delayMs }),


### PR DESCRIPTION
## Summary

- supervises fire-and-forget sync drain work
- contains per-pass failures under the CLI fatal rejection policy
- preserves retryable queued work instead of ending the session

## Stack

Depends on #158. PR #162 is stacked on this branch.

## Verification

- sync drain failure and retry coverage
- full typecheck, lint, format, test, and build gates

No release is performed by this PR.