### PR TITLE
fix(download): make active admission unique

### DIFF
--- a/.docs/download-offline-onboarding.md
+++ b/.docs/download-offline-onboarding.md
@@ -60,6 +60,9 @@ Layering rule: UI asks services for capability/state; services do not render UI.
   after that validation. An invalid candidate never replaces an existing playable output.
 - Queue ownership is a SQLite compare-and-set from `queued` to `running`. Heartbeats form a
   bounded lease across Kunai processes; recovery never touches a freshly heartbeating owner.
+- Blocking download intent is unique in SQLite by canonical title and exact nullable
+  season/episode coordinates. Concurrent surfaces or Kunai processes therefore admit one job;
+  the loser receives the ordinary duplicate-intent result instead of sharing an output path.
 - Once an interrupted lease expires, recovery validates any already-published output. A valid
   artifact is adopted without another network request; an invalid regular file is removed before
   bounded retry. This closes the unavoidable filesystem-rename/SQLite-commit crash window.

--- a/apps/cli/src/services/download/DownloadService.ts
+++ b/apps/cli/src/services/download/DownloadService.ts
@@ -29,6 +29,7 @@ import {
   runYtDlpProcess,
 } from "@kunai/providers/youtube";
 import {
+  DownloadJobAdmissionConflictError,
   externalIdsToAliases,
   getKunaiPaths,
   type DownloadArtifactStatus,
@@ -380,31 +381,41 @@ export class DownloadService {
 
     const mediaKind = resolveEnqueueMediaKind(input);
 
-    this.deps.repo.enqueue({
-      id,
-      titleId: canonicalTitleId,
-      externalIds: input.title.externalIds,
-      titleName: input.title.name,
-      mediaKind,
-      contentType: input.title.type,
-      season: input.episode?.season,
-      episode: input.episode?.episode,
-      providerId: input.providerId,
-      mode: input.mode,
-      subLang,
-      animeLang,
-      selectedSourceId: input.selectedSourceId,
-      selectedStreamId: input.selectedStreamId,
-      selectedQualityLabel: input.selectedQualityLabel ?? input.qualityPreference,
-      streamUrl: input.stream?.url ?? "",
-      headers: input.stream?.headers ?? {},
-      outputPath,
-      tempPath,
-      posterUrl: input.posterUrl ?? input.title.posterUrl,
-      createdAt: now,
-      updatedAt: now,
-      completedAt: undefined,
-    });
+    try {
+      this.deps.repo.enqueue({
+        id,
+        titleId: canonicalTitleId,
+        externalIds: input.title.externalIds,
+        titleName: input.title.name,
+        mediaKind,
+        contentType: input.title.type,
+        season: input.episode?.season,
+        episode: input.episode?.episode,
+        providerId: input.providerId,
+        mode: input.mode,
+        subLang,
+        animeLang,
+        selectedSourceId: input.selectedSourceId,
+        selectedStreamId: input.selectedStreamId,
+        selectedQualityLabel: input.selectedQualityLabel ?? input.qualityPreference,
+        streamUrl: input.stream?.url ?? "",
+        headers: input.stream?.headers ?? {},
+        outputPath,
+        tempPath,
+        posterUrl: input.posterUrl ?? input.title.posterUrl,
+        createdAt: now,
+        updatedAt: now,
+        completedAt: undefined,
+      });
+    } catch (error) {
+      if (error instanceof DownloadJobAdmissionConflictError) {
+        throw new DownloadEnqueueRejectedError(
+          "duplicate-intent",
+          "A playable or active offline copy already exists for this episode.",
+        );
+      }
+      throw error;
+    }
 
     // Register the download's identity so a later playback read can find its
     // assets under any id form. Without this a title that was only ever
@@ -503,7 +514,17 @@ export class DownloadService {
       await this.repairSidecars(job);
       return;
     }
-    this.deps.repo.requeue(jobId, new Date().toISOString());
+    try {
+      this.deps.repo.requeue(jobId, new Date().toISOString());
+    } catch (error) {
+      if (error instanceof DownloadJobAdmissionConflictError) {
+        throw new DownloadEnqueueRejectedError(
+          "duplicate-intent",
+          "A playable or active offline copy already exists for this episode.",
+        );
+      }
+      throw error;
+    }
   }
 
   async repairRepairableSidecars(limit = 100): Promise<DownloadRepairSummary> {

--- a/apps/cli/test/unit/services/download/download-service.test.ts
+++ b/apps/cli/test/unit/services/download/download-service.test.ts
@@ -297,6 +297,48 @@ describe("DownloadService", () => {
     expect(repo.listQueued(10)).toHaveLength(1);
   });
 
+  test("maps concurrent durable admission conflicts to one duplicate-intent result", async () => {
+    const service = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      downloadPath: tempDir,
+    });
+    const input = {
+      title: { id: "tmdb:1", type: "series" as const, name: "Example" },
+      episode: { season: 1, episode: 1, name: "Episode 1" },
+      providerId: "vidking",
+    };
+
+    const results = await Promise.allSettled([service.enqueue(input), service.enqueue(input)]);
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
+    expect(results.find((result) => result.status === "rejected")).toMatchObject({
+      reason: { code: "duplicate-intent" },
+    });
+    expect(repo.listQueued(10)).toHaveLength(1);
+  });
+
+  test("maps retry admission conflicts without exposing a SQLite constraint", async () => {
+    const service = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      downloadPath: tempDir,
+    });
+    const input = {
+      title: { id: "tmdb:1", type: "series" as const, name: "Example" },
+      episode: { season: 1, episode: 1, name: "Episode 1" },
+      providerId: "vidking",
+    };
+    const failed = await service.enqueue(input);
+    repo.fail(failed.id, "terminal", false, new Date().toISOString(), "terminal");
+    await service.enqueue(input);
+
+    await expect(service.retry(failed.id)).rejects.toMatchObject({ code: "duplicate-intent" });
+  });
+
   test("processes successful queue entries", async () => {
     const service = buildService({
       repo,

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -62,7 +62,10 @@ export type {
   WatchStatsTotalsRow,
   WatchStatsWeekRow,
 } from "./repositories/watch-stats";
-export { DownloadJobsRepository } from "./repositories/download-jobs";
+export {
+  DownloadJobAdmissionConflictError,
+  DownloadJobsRepository,
+} from "./repositories/download-jobs";
 export type {
   DownloadArtifactStatus,
   DownloadJobRecord,

--- a/packages/storage/src/migrations.ts
+++ b/packages/storage/src/migrations.ts
@@ -681,6 +681,60 @@ export const dataMigrations: readonly Migration[] = [
         ON history_progress(title_id, updated_at DESC);
     `,
   },
+  {
+    id: "036_data_download_job_unique_intent",
+    database: "data",
+    sql: `
+      -- Download admission is a durable invariant, not a read-then-write
+      -- convention. Preserve the strongest existing artifact for each intent
+      -- and quarantine only the duplicate rows before adding the constraint.
+      WITH ranked AS (
+        SELECT rowid,
+               ROW_NUMBER() OVER (
+                 PARTITION BY
+                   title_id,
+                   CASE WHEN season IS NULL THEN 'null' ELSE 'value:' || CAST(season AS TEXT) END,
+                   CASE WHEN episode IS NULL THEN 'null' ELSE 'value:' || CAST(episode AS TEXT) END
+                 ORDER BY
+                   CASE
+                     WHEN status IN ('completed', 'completed-with-notes', 'repairable')
+                       AND artifact_status IN ('missing', 'invalid-file') THEN 1
+                     ELSE 0
+                   END,
+                   CASE status
+                     WHEN 'completed' THEN 0
+                     WHEN 'completed-with-notes' THEN 1
+                     WHEN 'repairable' THEN 2
+                     WHEN 'running' THEN 3
+                     WHEN 'queued' THEN 4
+                     ELSE 5
+                   END,
+                   CASE WHEN completed_at IS NULL THEN 1 ELSE 0 END,
+                   completed_at DESC,
+                   created_at ASC,
+                   rowid ASC
+               ) AS duplicate_rank
+        FROM download_jobs
+        WHERE status IN ('queued', 'running', 'completed', 'completed-with-notes', 'repairable')
+      )
+      UPDATE download_jobs
+      SET status = 'aborted',
+          failure_kind = 'duplicate-intent-migrated',
+          error_message = 'Duplicate download intent quarantined during storage migration',
+          next_retry_at = NULL
+      WHERE rowid IN (
+        SELECT rowid FROM ranked WHERE duplicate_rank > 1
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_download_jobs_blocking_intent
+        ON download_jobs(
+          title_id,
+          CASE WHEN season IS NULL THEN 'null' ELSE 'value:' || CAST(season AS TEXT) END,
+          CASE WHEN episode IS NULL THEN 'null' ELSE 'value:' || CAST(episode AS TEXT) END
+        )
+        WHERE status IN ('queued', 'running', 'completed', 'completed-with-notes', 'repairable');
+    `,
+  },
 ];
 
 export const cacheMigrations: readonly Migration[] = [

--- a/packages/storage/src/repositories/download-jobs.ts
+++ b/packages/storage/src/repositories/download-jobs.ts
@@ -1,3 +1,5 @@
+import { SQLiteError } from "bun:sqlite";
+
 import type { MediaKind, ProviderExternalIds, ProviderId } from "@kunai/types";
 
 import type { KunaiDatabase } from "../sqlite";
@@ -122,6 +124,17 @@ interface DownloadJobRow {
   readonly last_validated_at: string | null;
 }
 
+export class DownloadJobAdmissionConflictError extends Error {
+  readonly code = "duplicate-intent";
+
+  constructor() {
+    super("A blocking download intent already exists");
+    this.name = "DownloadJobAdmissionConflictError";
+  }
+}
+
+const DOWNLOAD_INTENT_UNIQUE_INDEX = "idx_download_jobs_blocking_intent";
+
 export class DownloadJobsRepository {
   constructor(private readonly db: KunaiDatabase) {}
 
@@ -148,9 +161,10 @@ export class DownloadJobsRepository {
       | "lastResolvedProviderId"
     >,
   ): void {
-    this.db
-      .query(
-        `
+    try {
+      this.db
+        .query(
+          `
           INSERT INTO download_jobs (
             id, title_id, external_ids_json, title_name, media_kind, content_type, season, episode, provider_id,
             mode, sub_lang, anime_lang, selected_source_id, selected_stream_id, selected_quality_label,
@@ -161,31 +175,41 @@ export class DownloadJobsRepository {
             created_at, updated_at, completed_at
           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', 0, ?, ?, NULL, NULL, NULL, NULL, ?, NULL, NULL, NULL, NULL, 0, 0, 3, NULL, NULL, NULL, NULL, 'pending', NULL, ?, ?, NULL)
         `,
-      )
-      .run(
-        input.id,
-        input.titleId,
-        input.externalIds ? JSON.stringify(input.externalIds) : null,
-        input.titleName,
-        input.mediaKind,
-        input.contentType ?? null,
-        input.season ?? null,
-        input.episode ?? null,
-        input.providerId,
-        input.mode ?? null,
-        input.subLang ?? null,
-        input.animeLang ?? null,
-        input.selectedSourceId ?? null,
-        input.selectedStreamId ?? null,
-        input.selectedQualityLabel ?? null,
-        input.streamUrl,
-        JSON.stringify(input.headers),
-        input.outputPath,
-        input.tempPath,
-        input.posterUrl ?? null,
-        input.createdAt,
-        input.updatedAt,
-      );
+        )
+        .run(
+          input.id,
+          input.titleId,
+          input.externalIds ? JSON.stringify(input.externalIds) : null,
+          input.titleName,
+          input.mediaKind,
+          input.contentType ?? null,
+          input.season ?? null,
+          input.episode ?? null,
+          input.providerId,
+          input.mode ?? null,
+          input.subLang ?? null,
+          input.animeLang ?? null,
+          input.selectedSourceId ?? null,
+          input.selectedStreamId ?? null,
+          input.selectedQualityLabel ?? null,
+          input.streamUrl,
+          JSON.stringify(input.headers),
+          input.outputPath,
+          input.tempPath,
+          input.posterUrl ?? null,
+          input.createdAt,
+          input.updatedAt,
+        );
+    } catch (error) {
+      if (
+        error instanceof SQLiteError &&
+        error.code === "SQLITE_CONSTRAINT_UNIQUE" &&
+        error.message.includes(`index '${DOWNLOAD_INTENT_UNIQUE_INDEX}'`)
+      ) {
+        throw new DownloadJobAdmissionConflictError();
+      }
+      throw error;
+    }
   }
 
   updateOfflineMetadata(
@@ -477,9 +501,10 @@ export class DownloadJobsRepository {
   }
 
   requeue(id: string, updatedAt: string): void {
-    this.db
-      .query(
-        `
+    try {
+      this.db
+        .query(
+          `
           UPDATE download_jobs
           SET status = 'queued',
               error_message = NULL,
@@ -489,8 +514,18 @@ export class DownloadJobsRepository {
               updated_at = ?
           WHERE id = ?
         `,
-      )
-      .run(updatedAt, id);
+        )
+        .run(updatedAt, id);
+    } catch (error) {
+      if (
+        error instanceof SQLiteError &&
+        error.code === "SQLITE_CONSTRAINT_UNIQUE" &&
+        error.message.includes(`index '${DOWNLOAD_INTENT_UNIQUE_INDEX}'`)
+      ) {
+        throw new DownloadJobAdmissionConflictError();
+      }
+      throw error;
+    }
   }
 
   abort(id: string, updatedAt: string): void {
@@ -526,24 +561,18 @@ export class DownloadJobsRepository {
     readonly episode?: number;
   }): DownloadJobRecord | undefined {
     const row = this.db
-      .query<DownloadJobRow, [string, number | null, number | null, number | null, number | null]>(
+      .query<DownloadJobRow, [string, number | null, number | null]>(
         `
           SELECT * FROM download_jobs
           WHERE title_id = ?
-            AND (? IS NULL OR season = ?)
-            AND (? IS NULL OR episode = ?)
+            AND season IS ?
+            AND episode IS ?
             AND status IN ('queued', 'running', 'completed', 'completed-with-notes', 'repairable')
           ORDER BY updated_at DESC
           LIMIT 1
         `,
       )
-      .get(
-        input.titleId,
-        input.season ?? null,
-        input.season ?? null,
-        input.episode ?? null,
-        input.episode ?? null,
-      );
+      .get(input.titleId, input.season ?? null, input.episode ?? null);
     return row === null ? undefined : mapRow(row);
   }
 

--- a/packages/storage/test/download-job-admission.test.ts
+++ b/packages/storage/test/download-job-admission.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, expect, test } from "bun:test";
+
+import {
+  dataMigrations,
+  DownloadJobsRepository,
+  openKunaiDatabase,
+  runMigrations,
+  type KunaiDatabase,
+} from "../src/index";
+import { createTempStoreRegistry } from "./helpers/temp-store";
+
+const stores = createTempStoreRegistry();
+
+afterEach(() => {
+  stores.cleanup();
+});
+
+function enqueueInput(
+  id: string,
+  overrides: Partial<Parameters<DownloadJobsRepository["enqueue"]>[0]> = {},
+): Parameters<DownloadJobsRepository["enqueue"]>[0] {
+  const now = "2026-08-24T00:00:00.000Z";
+  return {
+    id,
+    titleId: "tmdb:series",
+    titleName: "Example",
+    mediaKind: "series",
+    season: 1,
+    episode: 1,
+    providerId: "vidking",
+    streamUrl: "",
+    headers: {},
+    outputPath: `/tmp/${id}.mp4`,
+    tempPath: `/tmp/${id}.tmp`,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+test("two repositories cannot admit the same blocking episode intent", () => {
+  const directory = stores.dir("download-admission-two-repos");
+  const firstDb = stores.db(directory, "data");
+  const secondDb = openTrackedDatabase(directory);
+  const first = new DownloadJobsRepository(firstDb);
+  const second = new DownloadJobsRepository(secondDb);
+
+  first.enqueue(enqueueInput("first"));
+
+  expect(() => second.enqueue(enqueueInput("second"))).toThrow(
+    "A blocking download intent already exists",
+  );
+  expect(first.listByTitle("tmdb:series", 10)).toHaveLength(1);
+});
+
+test("constraint translation does not reread mutable winner state", () => {
+  class NoRereadDownloadJobsRepository extends DownloadJobsRepository {
+    override findBlockingEpisodeIntent(): never {
+      throw new Error("constraint translation must not reread the winning row");
+    }
+  }
+
+  const directory = stores.dir("download-admission-no-reread");
+  const first = new DownloadJobsRepository(stores.db(directory, "data"));
+  const second = new NoRereadDownloadJobsRepository(openTrackedDatabase(directory));
+
+  first.enqueue(enqueueInput("winner"));
+
+  expect(() => second.enqueue(enqueueInput("loser"))).toThrow(
+    "A blocking download intent already exists",
+  );
+});
+
+test("nullable movie and unknown-season coordinates are part of the durable identity", () => {
+  const repo = new DownloadJobsRepository(stores.store("download-admission-null", "data"));
+
+  repo.enqueue(
+    enqueueInput("movie", {
+      titleId: "tmdb:movie",
+      mediaKind: "movie",
+      season: undefined,
+      episode: undefined,
+    }),
+  );
+  expect(() =>
+    repo.enqueue(
+      enqueueInput("movie-duplicate", {
+        titleId: "tmdb:movie",
+        mediaKind: "movie",
+        season: undefined,
+        episode: undefined,
+      }),
+    ),
+  ).toThrow("A blocking download intent already exists");
+
+  repo.enqueue(enqueueInput("unknown-season", { season: undefined, episode: 4 }));
+  expect(() =>
+    repo.enqueue(enqueueInput("unknown-season-duplicate", { season: undefined, episode: 4 })),
+  ).toThrow("A blocking download intent already exists");
+
+  expect(() => repo.enqueue(enqueueInput("different-episode", { episode: 2 }))).not.toThrow();
+  expect(() =>
+    repo.enqueue(enqueueInput("different-title", { titleId: "tmdb:other", episode: 1 })),
+  ).not.toThrow();
+});
+
+test("failed and aborted rows release admission while completed rows keep it", () => {
+  const repo = new DownloadJobsRepository(stores.store("download-admission-status", "data"));
+
+  repo.enqueue(enqueueInput("failed"));
+  repo.fail("failed", "terminal", false, "2026-08-24T00:01:00.000Z", "terminal");
+  expect(() => repo.enqueue(enqueueInput("after-failed"))).not.toThrow();
+  expect(() => repo.requeue("failed", "2026-08-24T00:01:30.000Z")).toThrow(
+    "A blocking download intent already exists",
+  );
+
+  repo.abort("after-failed", "2026-08-24T00:02:00.000Z");
+  repo.enqueue(enqueueInput("completed"));
+  repo.complete("completed", "2026-08-24T00:03:00.000Z");
+  expect(() => repo.enqueue(enqueueInput("after-completed"))).toThrow(
+    "A blocking download intent already exists",
+  );
+});
+
+test("the admission migration preserves the best completed artifact and quarantines duplicates", () => {
+  const db = openKunaiDatabase(":memory:");
+  const migrationIndex = dataMigrations.findIndex(
+    (migration) => migration.id === "036_data_download_job_unique_intent",
+  );
+  expect(migrationIndex).toBeGreaterThan(0);
+  runMigrations(db, "data", dataMigrations.slice(0, migrationIndex));
+
+  const repo = new DownloadJobsRepository(db);
+  repo.enqueue(
+    enqueueInput("completed", {
+      outputPath: "/media/example-ready.mp4",
+      createdAt: "2026-08-24T00:00:00.000Z",
+      updatedAt: "2026-08-24T00:00:00.000Z",
+    }),
+  );
+  repo.complete("completed", "2026-08-24T00:01:00.000Z");
+  repo.enqueue(
+    enqueueInput("invalid-newer", {
+      outputPath: "/media/example-invalid.mp4",
+      createdAt: "2026-08-24T00:01:30.000Z",
+      updatedAt: "2026-08-24T00:01:30.000Z",
+    }),
+  );
+  repo.complete("invalid-newer", "2026-08-24T00:02:00.000Z");
+  repo.markArtifactValidated("invalid-newer", "invalid-file", "2026-08-24T00:02:30.000Z");
+  repo.enqueue(
+    enqueueInput("queued-newer", {
+      outputPath: "/media/example-queued.mp4",
+      createdAt: "2026-08-24T00:03:00.000Z",
+      updatedAt: "2026-08-24T00:03:00.000Z",
+    }),
+  );
+
+  runMigrations(db, "data");
+
+  expect(repo.get("completed")).toMatchObject({
+    status: "completed",
+    artifactStatus: "ready",
+    outputPath: "/media/example-ready.mp4",
+  });
+  expect(repo.get("queued-newer")).toMatchObject({
+    status: "aborted",
+    failureKind: "duplicate-intent-migrated",
+    outputPath: "/media/example-queued.mp4",
+  });
+  expect(repo.get("invalid-newer")).toMatchObject({
+    status: "aborted",
+    artifactStatus: "invalid-file",
+    failureKind: "duplicate-intent-migrated",
+    outputPath: "/media/example-invalid.mp4",
+  });
+  expect(repo.listByTitle("tmdb:series", 10)).toHaveLength(3);
+  expect(() => repo.enqueue(enqueueInput("post-migration"))).toThrow(
+    "A blocking download intent already exists",
+  );
+  db.close();
+});
+
+function openTrackedDatabase(directory: string): KunaiDatabase {
+  return stores.db(directory, "data");
+}

--- a/packages/storage/test/offline-asset-relocate.test.ts
+++ b/packages/storage/test/offline-asset-relocate.test.ts
@@ -1,6 +1,10 @@
 import { afterAll, expect, test } from "bun:test";
 
-import { DownloadJobsRepository, OfflineAssetsRepository } from "../src/index";
+import {
+  DownloadJobsRepository,
+  OfflineAssetsRepository,
+  type OfflineAssetInput,
+} from "../src/index";
 import { createTempStoreRegistry } from "./helpers/temp-store";
 
 const stores = createTempStoreRegistry();
@@ -18,15 +22,17 @@ function harness() {
   const jobs = new DownloadJobsRepository(db);
   const assets = new OfflineAssetsRepository(db);
 
-  function addAsset(titleId: string, overrides: Record<string, unknown> = {}) {
+  function addAsset(titleId: string, overrides: Partial<OfflineAssetInput> = {}) {
     const now = new Date().toISOString();
-    const originJobId = (overrides.originJobId as string | undefined) ?? `job-${titleId}`;
+    const originJobId = overrides.originJobId ?? `job-${titleId}`;
     if (!jobs.get(originJobId)) {
       jobs.enqueue({
         id: originJobId,
         titleId,
         titleName: "Obsession",
         mediaKind: "movie",
+        season: overrides.season ?? 1,
+        episode: overrides.episode ?? 1,
         providerId: "videasy",
         mode: "series",
         streamUrl: "",


### PR DESCRIPTION
## Summary

- removes the concurrent enqueue TOCTOU window
- adds the database uniqueness contract for active episode jobs
- prevents duplicate jobs from sharing one output path

Closes #137.

## Stack

Depends on #158.

## Verification

- concurrent admission and migration tests
- download service recovery regressions
- full repository gates

No release is performed by this PR.