### PR TITLE
fix(providers): fail closed on invalid AllManga identity bridge

### DIFF
--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -853,7 +853,7 @@ History and continuation use **canonical catalog ids** as the merge key (`anilis
 
 - **`externalIds.providerNativeIds`** — per-provider opaque show ids (e.g. AllAnime `bxCKT…`) stored in `history_progress.external_ids_json`. Written on playback upsert and backfilled immediately after anime remap (`persistProviderNativeMapping`).
 - **Read path** — `HistoryRepository.getLatestForTitleIdentity()` tries the canonical id first, then falls back to the session opaque id for legacy rows.
-- **AllAnime bridge** — `resolveAllMangaShowId` reads `providerNativeIds.allanime`, then the durable SQLite `provider_title_bridge` cache (TTL class `provider-metadata`), then in-process search bridge. Bridge results are persisted to both history metadata and the cache adapter injected through `ProviderRuntimeContext.titleBridge`.
+- **AllAnime bridge** — `resolveAllMangaShowId` reads `providerNativeIds.allanime`, then the durable SQLite `provider_title_bridge` cache (TTL class `provider-metadata`), then in-process search bridge. Bridge results are persisted to both history metadata and the cache adapter injected through `ProviderRuntimeContext.titleBridge`. Numeric catalog ids fail closed when no native mapping is available: a confirmed miss is `unsupported-title`, while an unchecked bridge caused by search transport failure stays a retryable `network-error`; neither value is sent to the provider-native show catalog.
 - **Legacy repair** — `HistoryIdentityConsolidator` runs once at CLI bootstrap (catalog-proof rows only; set `KUNAI_HISTORY_IDENTITY_DRY_RUN=1` to log without writing). Continue-watching dedupes display rows by catalog id without DB writes.
 
 ### Videasy identity, route caching and Wings transport

--- a/packages/providers/src/allmanga/direct.ts
+++ b/packages/providers/src/allmanga/direct.ts
@@ -50,7 +50,7 @@ import {
   searchAllManga,
 } from "./api-client";
 import { allanimeManifest, ALLANIME_PROVIDER_ID } from "./manifest";
-import { resolveAllMangaShowId } from "./resolve-show-id";
+import { AllMangaBridgeTransportError, resolveAllMangaShowId } from "./resolve-show-id";
 
 export { ALLANIME_PROVIDER_ID };
 
@@ -214,7 +214,14 @@ export const allmangaProviderModule: CoreProviderModule = {
   },
   async listEpisodes(input, context): Promise<readonly ProviderEpisodeOption[] | null> {
     const mode = resolveAnimeAudioIntent(input.preferredAudioLanguage ?? "original").catalogMode;
-    const showId = await resolveAllMangaShowId(input, context);
+    let showId: string | null;
+    try {
+      showId = await resolveAllMangaShowId(input, context);
+    } catch (error) {
+      if (error instanceof AllMangaBridgeTransportError) return null;
+      throw error;
+    }
+    if (!showId) return null;
     return fetchAllMangaEpisodeCatalog({
       context,
       apiUrl: ALLANIME_API_URL,
@@ -243,11 +250,36 @@ export const allmangaProviderModule: CoreProviderModule = {
     }
 
     // Provider-native opaque id; catalog ids (e.g. AniList) are bridged in resolveAllMangaShowId.
-    const showId = await resolveAllMangaShowId(input, context);
+    let showId: string | null;
+    try {
+      showId = await resolveAllMangaShowId(input, context);
+    } catch (error) {
+      if (context.signal?.aborted) {
+        return createExhaustedResult(input, context, ALLANIME_PROVIDER_ID, {
+          code: "cancelled",
+          message: "AllManga title bridge was cancelled",
+          retryable: false,
+        });
+      }
+      if (error instanceof AllMangaBridgeTransportError) {
+        return createExhaustedResult(input, context, ALLANIME_PROVIDER_ID, {
+          code: "network-error",
+          message: error.message,
+          retryable: true,
+        });
+      }
+      throw error;
+    }
     if (!showId) {
+      const rawId = input.title.id.replace(/^allanime:/, "").trim();
+      const anilistId = input.title.externalIds?.anilistId ?? input.title.anilistId;
       return createExhaustedResult(input, context, ALLANIME_PROVIDER_ID, {
         code: "unsupported-title",
-        message: "AllManga requires an internal show ID",
+        message: anilistId
+          ? `AllManga title bridge found no provider-native show for AniList ID ${anilistId}`
+          : /^\d+$/.test(rawId)
+            ? `AllManga title bridge requires an AniList ID for numeric catalog ID ${rawId}`
+            : "AllManga requires an internal show ID",
         retryable: false,
       });
     }

--- a/packages/providers/src/allmanga/resolve-show-id.ts
+++ b/packages/providers/src/allmanga/resolve-show-id.ts
@@ -15,6 +15,13 @@ const ANILIST_BRIDGE_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 const anilistBridgeCache = new TTLCache<string, string>(ANILIST_BRIDGE_CACHE_TTL_MS);
 
+export class AllMangaBridgeTransportError extends Error {
+  constructor(anilistId: string) {
+    super(`AllManga title bridge could not check AniList ID ${anilistId}`);
+    this.name = "AllMangaBridgeTransportError";
+  }
+}
+
 export function clearAllMangaAnilistBridgeCacheForTest(): void {
   anilistBridgeCache.clear();
 }
@@ -35,7 +42,7 @@ export function isCatalogIdPassedAsShowId(showId: string, anilistId?: string): b
 export async function resolveAllMangaShowId(
   input: Pick<ProviderResolveInput, "title" | "preferredAudioLanguage">,
   context: ProviderRuntimeContext,
-): Promise<string> {
+): Promise<string | null> {
   const rawId = input.title.id.replace(/^allanime:/, "").trim();
   const anilistId = input.title.externalIds?.anilistId ?? input.title.anilistId ?? undefined;
   const providerId = context.providerId ?? "allanime";
@@ -60,7 +67,7 @@ export async function resolveAllMangaShowId(
   }
 
   if (!anilistId) {
-    return rawId;
+    return null;
   }
 
   const bridged = await bridgeAllMangaShowIdFromAnilist(
@@ -80,7 +87,7 @@ export async function resolveAllMangaShowId(
     return bridged;
   }
 
-  return rawId;
+  return null;
 }
 
 async function bridgeAllMangaShowIdFromAnilist(
@@ -91,6 +98,7 @@ async function bridgeAllMangaShowIdFromAnilist(
 ): Promise<string | null> {
   const animeLang = resolveAnimeAudioIntent(preferredAudioLanguage).catalogMode;
   const queries = await buildAllMangaBridgeQueries(anilistId, displayTitle, context.signal);
+  let transportFailed = false;
 
   for (const query of queries) {
     const matches = await searchAllManga(
@@ -107,11 +115,16 @@ async function bridgeAllMangaShowIdFromAnilist(
     // Treating the two the same made a timeout look like a confirmed miss and
     // sent the caller on to the next query -- or out of the loop -- as though
     // the catalog had answered.
-    if (matches === null) continue;
+    if (matches === null) {
+      transportFailed = true;
+      continue;
+    }
 
     const idMatch = matches.find((result) => String(result.aniListId) === anilistId);
     if (idMatch?.id) return idMatch.id;
   }
+
+  if (transportFailed) throw new AllMangaBridgeTransportError(anilistId);
 
   return null;
 }

--- a/packages/providers/test/allmanga.test.ts
+++ b/packages/providers/test/allmanga.test.ts
@@ -96,6 +96,60 @@ describe("resolveAllMangaShowId", () => {
     expect(showId).toBe("bxCKTnota29uSRnZw");
   });
 
+  test("fails closed before catalog lookup when a numeric id has no AniList metadata", async () => {
+    using fetchMock = mockAllMangaBridgeFetch("unexpected");
+    const result = await allmangaProviderModule.resolve(
+      {
+        episode: { episode: 1 },
+        mediaKind: "anime",
+        intent: "play",
+        allowedRuntimes: ["direct-http"],
+        title: {
+          id: "20431",
+          kind: "anime",
+          title: "Hozuki's Coolheadedness",
+        },
+      },
+      TEST_CONTEXT,
+    );
+
+    expect(result.status).toBe("exhausted");
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toMatchObject({
+      providerId: "allanime",
+      code: "unsupported-title",
+      message: "AllManga title bridge requires an AniList ID for numeric catalog ID 20431",
+      retryable: false,
+    });
+    expect(fetchMock.requests).toEqual([]);
+  });
+
+  test("diagnoses a confirmed bridge miss without sending the AniList id to the catalog", async () => {
+    using fetchMock = mockAllMangaBridgeFetch("empty");
+    const result = await resolveCatalogAllMangaEpisode();
+
+    expect(result.status).toBe("exhausted");
+    expect(result.failures[0]).toMatchObject({
+      code: "unsupported-title",
+      message: "AllManga title bridge found no provider-native show for AniList ID 20431",
+      retryable: false,
+    });
+    expect(fetchMock.catalogRequests).toEqual([]);
+  });
+
+  test("diagnoses bridge transport failure before provider-native catalog lookup", async () => {
+    using fetchMock = mockAllMangaBridgeFetch("transport-error");
+    const result = await resolveCatalogAllMangaEpisode();
+
+    expect(result.status).toBe("exhausted");
+    expect(result.failures[0]).toMatchObject({
+      code: "network-error",
+      message: "AllManga title bridge could not check AniList ID 20431",
+      retryable: true,
+    });
+    expect(fetchMock.catalogRequests).toEqual([]);
+  });
+
   test("bridges catalog anilist ids to opaque show ids via search", async () => {
     clearAllMangaAnilistBridgeCacheForTest();
     const originalFetch = globalThis.fetch;
@@ -1320,6 +1374,70 @@ async function resolveEvidenceEpisode(
     },
     { now: nowFixture, signal: new AbortController().signal },
   );
+}
+
+async function resolveCatalogAllMangaEpisode(): Promise<ProviderResolveResult> {
+  return allmangaProviderModule.resolve(
+    {
+      episode: { episode: 1 },
+      mediaKind: "anime",
+      preferredAudioLanguage: "ja",
+      intent: "play",
+      allowedRuntimes: ["direct-http"],
+      title: {
+        id: "20431",
+        kind: "anime",
+        title: "Hozuki's Coolheadedness",
+        anilistId: "20431",
+        externalIds: { anilistId: "20431" },
+      },
+    },
+    TEST_CONTEXT,
+  );
+}
+
+function mockAllMangaBridgeFetch(
+  outcome: "empty" | "transport-error" | "unexpected",
+): Disposable & {
+  readonly requests: readonly string[];
+  readonly catalogRequests: readonly string[];
+} {
+  clearAllMangaAnilistBridgeCacheForTest();
+  const originalFetch = globalThis.fetch;
+  const requests: string[] = [];
+  const catalogRequests: string[] = [];
+  // SAFETY: This deterministic test stub implements the fetch call shape exercised here.
+  globalThis.fetch = (async (request, init) => {
+    const url = String(request);
+    requests.push(url);
+    if (outcome === "unexpected") {
+      return new Response("unexpected request", { status: 500 });
+    }
+    if (url.includes("graphql.anilist.co")) {
+      return jsonResponse({
+        data: {
+          Media: {
+            title: { romaji: "Hoozuki no Reitetsu" },
+          },
+        },
+      });
+    }
+
+    const body = String(init?.body ?? "");
+    if (body.includes("show(_id:$id)")) catalogRequests.push(body);
+    return outcome === "transport-error"
+      ? new Response("upstream unavailable", { status: 503 })
+      : jsonResponse({ data: { shows: { edges: [] } } });
+  }) as typeof fetch;
+
+  return {
+    requests,
+    catalogRequests,
+    [Symbol.dispose]() {
+      globalThis.fetch = originalFetch;
+      clearAllMangaAnilistBridgeCacheForTest();
+    },
+  };
 }
 
 async function mockAllMangaFetch(


### PR DESCRIPTION
## Summary

- stops raw AniList ids from being used as AllManga show ids when mapping fails
- returns the existing typed unsupported-title outcome
- avoids a doomed provider round trip and misleading empty catalog

Closes #136.

## Stack

Depends on #158.

## Verification

- bridge success and failure fixtures
- provider and CLI regression suites
- full repository gates

No release is performed by this PR.