### PR TITLE
fix(download): bound ffprobe validation

### DIFF
--- a/.docs/download-offline-onboarding.md
+++ b/.docs/download-offline-onboarding.md
@@ -1,6 +1,6 @@
 ---
 status: current
-lastReviewed: "2026-08-14"
+lastReviewed: "2026-08-24"
 ---
 
 # Kunai — Download, Offline Library, And Onboarding
@@ -70,7 +70,7 @@ Layering rule: UI asks services for capability/state; services do not render UI.
 - Progress is parsed from yt-dlp newline output and persisted for shell diagnostics/UI.
 - Download-only mode resolves a playable stream without launching mpv.
 - Selected poster URL and IntroDB/AniSkip timing are persisted at enqueue time when available.
-- Completed downloads persist local file size and, when `ffprobe` is available, playable duration after artifact validation.
+- Completed downloads persist local file size and, when `ffprobe` is available, playable duration after artifact validation. The optional probe has a 30-second deadline, then graceful termination and bounded force-kill cleanup; a probe timeout fails validation without publishing its temporary artifact or deleting a previously published file as corrupt.
 - Offline artwork caching is best-effort and post-completion; artwork failure must never fail or delay a completed download.
 - Thumbnail sidecars are written through a temporary file and renamed only after a non-empty image exists.
 - External subtitle/artwork sidecars are repairable metadata, not proof the video failed. If the video artifact validates but an expected sidecar is missing, the job becomes `repairable` and `/downloads` can retry just the sidecar path without re-running `yt-dlp`.

--- a/apps/cli/src/services/download/DownloadService.ts
+++ b/apps/cli/src/services/download/DownloadService.ts
@@ -27,7 +27,6 @@ import {
   buildYoutubeYtdlProfile,
   getYoutubeProviderConfig,
   runYtDlpProcess,
-  type YtDlpProcess,
 } from "@kunai/providers/youtube";
 import {
   externalIdsToAliases,
@@ -69,6 +68,10 @@ const STALLED_HEARTBEAT_MS = 90_000;
 const STDERR_MAX_BYTES = 64_000;
 const DEFAULT_ABORT_GRACE_MS = 2_500;
 const DEFAULT_INACTIVE_WAIT_MS = 5_000;
+const FFPROBE_DEADLINE_MS = 30_000;
+const FFPROBE_TERMINATION_GRACE_MS = 2_500;
+const FFPROBE_FORCE_WAIT_MS = 2_500;
+const FFPROBE_IO_CLEANUP_MS = 250;
 const YTDLP_HEADER_CRLF_PATTERN = /[\r\n]/g;
 
 /** Sanitized yt-dlp argv tail: validated stream URL, scrubbed headers, `--` before positional URL. */
@@ -171,9 +174,15 @@ export type DownloadEvent =
 
 type DownloadEventListener = (event: DownloadEvent) => void;
 
+type ManagedProcess = {
+  readonly exited: Promise<number>;
+  kill(signal?: NodeJS.Signals | number): void;
+};
+
 type ActiveDownloadProcess = {
-  readonly process: YtDlpProcess;
+  readonly process: ManagedProcess;
   readonly cancel?: (reason?: string) => void;
+  readonly releaseIo?: () => void;
   cancelRequested: boolean;
   cancelMode: "abort" | "pause";
   cancelReason?: string;
@@ -183,6 +192,25 @@ type ArtifactValidationResult = {
   readonly fileSize: number;
   readonly durationMs?: number;
 };
+
+export type DownloadFailureAnalysis = {
+  readonly failureKind: string;
+  readonly retryable: boolean;
+};
+
+class ArtifactValidationTimeoutError extends Error {
+  constructor() {
+    super(`artifact-validation-timeout: ffprobe exceeded ${FFPROBE_DEADLINE_MS}ms deadline`);
+    this.name = "ArtifactValidationTimeoutError";
+  }
+}
+
+type Deadline = {
+  readonly expired: Promise<void>;
+  cancel(): void;
+};
+
+type DeadlineFactory = (milliseconds: number) => Deadline;
 
 type DownloadSidecarResult = {
   readonly artifact: "subtitle" | "artwork";
@@ -237,6 +265,7 @@ export class DownloadService {
         intent: DownloadResolveIntent,
       ) => Promise<DownloadResolveResult | null>;
       readonly ffprobeAvailable?: boolean;
+      readonly ffprobeDeadline?: DeadlineFactory;
       readonly abortGraceMs?: number;
       readonly diagnostics?: Pick<DiagnosticsService, "record">;
       readonly onCompletedArtifact?: (job: DownloadJobRecord) => Promise<void> | void;
@@ -749,6 +778,7 @@ export class DownloadService {
       active.cancelRequested = true;
       active.cancelMode = "abort";
       active.cancelReason = "download aborted by user";
+      active.releaseIo?.();
       await this.terminateProcess(active.process, active.cancel);
       return;
     }
@@ -766,6 +796,7 @@ export class DownloadService {
   killActiveProcessesSync(): void {
     for (const active of this.activeProcesses.values()) {
       try {
+        active.releaseIo?.();
         active.process.kill("SIGKILL");
       } catch {
         // best effort — process may already be gone
@@ -794,6 +825,7 @@ export class DownloadService {
       active.cancelRequested = true;
       active.cancelMode = "pause";
       active.cancelReason = reason;
+      active.releaseIo?.();
     }
     await Promise.all(
       activeEntries.map(([, active]) =>
@@ -1011,7 +1043,7 @@ export class DownloadService {
     // The temp file is the only artifact yt-dlp owns. Validate it before
     // publication so an empty/invalid result can never replace a playable
     // last-known-good output at the stable path.
-    const validation = await this.validateCompletedArtifact(job.tempPath);
+    const validation = await this.validateCompletedArtifact(job.tempPath, job.id);
     await rename(job.tempPath, job.outputPath);
     this.persistValidatedArtifactMetadata(job.id, validation);
     return this.deps.repo.get(job.id) ?? job;
@@ -1092,16 +1124,22 @@ export class DownloadService {
   }
 
   private async terminateProcess(
-    proc: YtDlpProcess,
+    proc: ManagedProcess,
     cancel?: (reason?: string) => void,
-    waits: { readonly gracefulWaitMs?: number; readonly forceWaitMs?: number } = {},
+    waits: {
+      readonly gracefulWaitMs?: number;
+      readonly forceWaitMs?: number;
+      readonly deadline?: DeadlineFactory;
+    } = {},
   ): Promise<void> {
     const graceMs = this.deps.abortGraceMs ?? DEFAULT_ABORT_GRACE_MS;
     const gracefulWaitMs = waits.gracefulWaitMs ?? graceMs;
     const forceWaitMs = waits.forceWaitMs ?? graceMs;
     if (cancel) {
       cancel("download terminated");
-      await waitForExit(proc.exited, waits.gracefulWaitMs ?? graceMs + 2_500).catch(() => {});
+      await waitForExit(proc.exited, waits.gracefulWaitMs ?? graceMs + 2_500, waits.deadline).catch(
+        () => {},
+      );
       return;
     }
     try {
@@ -1110,7 +1148,7 @@ export class DownloadService {
       return;
     }
 
-    const exitedAfterTerm = await waitForExit(proc.exited, gracefulWaitMs);
+    const exitedAfterTerm = await waitForExit(proc.exited, gracefulWaitMs, waits.deadline);
     if (exitedAfterTerm) {
       return;
     }
@@ -1120,7 +1158,7 @@ export class DownloadService {
     } catch {
       return;
     }
-    await waitForExit(proc.exited, forceWaitMs).catch(() => {});
+    await waitForExit(proc.exited, forceWaitMs, waits.deadline).catch(() => {});
   }
 
   private async waitForInactive(jobIds: readonly string[], timeoutMs: number): Promise<void> {
@@ -1154,7 +1192,10 @@ export class DownloadService {
     });
   }
 
-  private async validateCompletedArtifact(outputPath: string): Promise<ArtifactValidationResult> {
+  private async validateCompletedArtifact(
+    outputPath: string,
+    ownedJobId?: string,
+  ): Promise<ArtifactValidationResult> {
     const fileStat = await stat(outputPath);
     if (!fileStat.isFile() || fileStat.size <= 0) {
       throw new Error("artifact-invalid: downloaded file is empty or not a regular file");
@@ -1175,7 +1216,58 @@ export class DownloadService {
       ],
       { stdin: "ignore", stdout: "pipe", stderr: "ignore" },
     );
-    const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
+    const deadline = this.deps.ffprobeDeadline ?? startDeadline;
+    const stdoutReader = proc.stdout.getReader();
+    const stdoutPromise = readUtf8Stream(stdoutReader);
+    const completion = Promise.all([proc.exited, stdoutPromise]);
+    let inheritedCancellation = false;
+    if (ownedJobId) {
+      const cancellation = this.cancellationRequests.get(ownedJobId);
+      this.activeProcesses.set(ownedJobId, {
+        process: proc,
+        releaseIo: () => {
+          void stdoutReader.cancel().catch(() => undefined);
+        },
+        cancelRequested: cancellation !== undefined,
+        cancelMode: cancellation?.mode ?? "abort",
+        cancelReason: cancellation?.reason,
+      });
+      inheritedCancellation = cancellation !== undefined;
+    }
+
+    let result: readonly [number, string] | undefined;
+    try {
+      if (inheritedCancellation) {
+        void completion.catch(() => undefined);
+        void stdoutReader.cancel().catch(() => undefined);
+        await this.terminateProcess(proc, undefined, {
+          gracefulWaitMs: FFPROBE_TERMINATION_GRACE_MS,
+          forceWaitMs: FFPROBE_FORCE_WAIT_MS,
+          deadline,
+        });
+        throw new Error("download aborted");
+      }
+      result = await settleBefore(completion, FFPROBE_DEADLINE_MS, deadline);
+      if (!result) {
+        await this.terminateProcess(proc, undefined, {
+          gracefulWaitMs: FFPROBE_TERMINATION_GRACE_MS,
+          forceWaitMs: FFPROBE_FORCE_WAIT_MS,
+          deadline,
+        });
+        await settleBefore(
+          stdoutReader.cancel().catch(() => undefined),
+          FFPROBE_IO_CLEANUP_MS,
+          deadline,
+        );
+        void completion.catch(() => undefined);
+        throw new ArtifactValidationTimeoutError();
+      }
+    } finally {
+      if (ownedJobId && this.activeProcesses.get(ownedJobId)?.process === proc) {
+        this.activeProcesses.delete(ownedJobId);
+      }
+    }
+    const [exitCode, stdout] = result;
     if (exitCode !== 0) {
       throw new Error("artifact-invalid: ffprobe could not inspect downloaded file");
     }
@@ -1448,8 +1540,28 @@ export class DownloadService {
       if (publishedOutput) {
         let validation: ArtifactValidationResult;
         try {
-          validation = await this.validateCompletedArtifact(runningJob.outputPath);
+          validation = await this.validateCompletedArtifact(runningJob.outputPath, runningJob.id);
         } catch (error) {
+          const cancellation = this.cancellationRequests.get(runningJob.id);
+          if (cancellation) {
+            if (cancellation.mode === "pause") {
+              this.deps.repo.pause(runningJob.id, cancellation.reason, now, now);
+            } else {
+              this.deps.repo.abort(runningJob.id, now);
+              this.emit({ type: "aborted", jobId: runningJob.id });
+            }
+            this.cancellationRequests.delete(runningJob.id);
+            continue;
+          }
+          if (error instanceof ArtifactValidationTimeoutError) {
+            this.deps.repo.fail(runningJob.id, error.message, false, now, "artifact-timeout");
+            this.emit({ type: "failed", jobId: runningJob.id, error: error.message });
+            this.deps.logger.warn("Interrupted download artifact validation timed out", {
+              jobId: runningJob.id,
+              error: error.message,
+            });
+            continue;
+          }
           if (publishedOutput.isFile()) {
             await rm(runningJob.outputPath, { force: true }).catch(() => {});
           } else {
@@ -1674,17 +1786,68 @@ function retryDelayMs(retryCount: number): number {
   return table[Math.min(retryCount, table.length - 1)] ?? 30_000;
 }
 
-async function waitForExit(exited: Promise<number>, timeoutMs: number): Promise<boolean> {
-  const marker = Symbol("timeout");
-  const result = await Promise.race([exited, Bun.sleep(timeoutMs).then(() => marker)]);
-  return result !== marker;
+async function settleBefore<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  deadlineFactory: DeadlineFactory = startDeadline,
+): Promise<T | undefined> {
+  const deadline = deadlineFactory(timeoutMs);
+  try {
+    const result = await Promise.race([
+      promise.then((value) => ({ settled: true as const, value })),
+      deadline.expired.then(() => ({ settled: false as const })),
+    ]);
+    return result.settled ? result.value : undefined;
+  } finally {
+    deadline.cancel();
+  }
 }
 
-export function analyzeDownloadFailure(message: string): {
-  failureKind: string;
-  retryable: boolean;
-} {
+async function waitForExit(
+  exited: Promise<number>,
+  timeoutMs: number,
+  deadline?: DeadlineFactory,
+): Promise<boolean> {
+  return (await settleBefore(exited, timeoutMs, deadline)) !== undefined;
+}
+
+function startDeadline(milliseconds: number): Deadline {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, milliseconds);
+    timer.unref?.();
+  });
+  return {
+    expired,
+    cancel() {
+      if (timer) clearTimeout(timer);
+    },
+  };
+}
+
+async function readUtf8Stream(reader: {
+  read(): Promise<{ readonly done: boolean; readonly value?: Uint8Array }>;
+  releaseLock(): void;
+}): Promise<string> {
+  const decoder = new TextDecoder();
+  let output = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      output += decoder.decode(value, { stream: true });
+    }
+    return output + decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export function analyzeDownloadFailure(message: string): DownloadFailureAnalysis {
   const normalized = message.toLowerCase();
+  if (normalized.includes("artifact-validation-timeout")) {
+    return { failureKind: "artifact-timeout", retryable: false };
+  }
   if (normalized.includes("artifact-invalid")) {
     return { failureKind: "artifact-invalid", retryable: false };
   }

--- a/apps/cli/test/unit/services/download/download-failure-classification.test.ts
+++ b/apps/cli/test/unit/services/download/download-failure-classification.test.ts
@@ -3,6 +3,15 @@ import { describe, expect, test } from "bun:test";
 import { analyzeDownloadFailure } from "@/services/download/DownloadService";
 
 describe("download failure classification", () => {
+  test("classifies an artifact probe deadline separately from corrupt media", () => {
+    expect(
+      analyzeDownloadFailure("artifact-validation-timeout: ffprobe exceeded 30000ms deadline"),
+    ).toEqual({
+      failureKind: "artifact-timeout",
+      retryable: false,
+    });
+  });
+
   test("retries rate limits and request timeouts", () => {
     expect(analyzeDownloadFailure("HTTP Error 429: Too Many Requests")).toEqual({
       failureKind: "http-client",

--- a/apps/cli/test/unit/services/download/download-service.test.ts
+++ b/apps/cli/test/unit/services/download/download-service.test.ts
@@ -423,6 +423,7 @@ describe("DownloadService", () => {
         stdout: streamOf("[download] 100% of 1.2GiB\n"),
         stderr: streamOf(""),
         exited: Promise.resolve(0),
+        // SAFETY: Bun.spawn is intercepted; this fixture implements every process member the service reads.
       } as never;
     });
 
@@ -449,6 +450,181 @@ describe("DownloadService", () => {
         }),
       }),
     );
+  });
+
+  test("bounds ffprobe and releases queue ownership after forced termination", async () => {
+    const waits: number[] = [];
+    const service = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      ffprobeAvailable: true,
+      downloadPath: tempDir,
+      ffprobeDeadline: (milliseconds) => {
+        waits.push(milliseconds);
+        return { expired: Promise.resolve(), cancel() {} };
+      },
+    });
+    whichSpy.mockImplementation((name: string) => (name === "ffprobe" ? "/usr/bin/ffprobe" : null));
+
+    let markProbeStarted!: () => void;
+    const probeStarted = new Promise<void>((resolve) => {
+      markProbeStarted = resolve;
+    });
+    const probe = createHangingProbe("SIGKILL");
+    spawnSpy.mockImplementation((command: string[]) => {
+      if (command[0] === "ffprobe") {
+        markProbeStarted();
+        return probe.process;
+      }
+      const outputIndex = command.indexOf("-o");
+      const outputPath = outputIndex >= 0 ? command[outputIndex + 1] : undefined;
+      if (outputPath) writeFileSync(outputPath, "video-bytes");
+      // SAFETY: Bun.spawn is intercepted; this fixture implements every process member the service reads.
+      return {
+        stdout: streamOf("[download] 100% of 1.2GiB\n"),
+        stderr: streamOf(""),
+        exited: Promise.resolve(0),
+      } as never;
+    });
+
+    const job = await service.enqueue({
+      title: { id: "tmdb:1", type: "series", name: "Deadline" },
+      episode: { season: 1, episode: 1, name: "Episode 1" },
+      stream: { url: "https://secret.example/master.m3u8", headers: {}, timestamp: 0 },
+      providerId: "vidking",
+    });
+    const processing = service.processQueue();
+    await probeStarted;
+    await processing;
+
+    const reloaded = repo.get(job.id);
+    expect(waits).toEqual([30_000, 2_500, 2_500, 250]);
+    expect(probe.killSignals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(probe.stdoutCancelled).toBe(true);
+    expect(repo.listRunning(10)).toEqual([]);
+    expect(reloaded?.status).toBe("failed");
+    expect(reloaded?.failureKind).toBe("artifact-timeout");
+    expect(reloaded?.errorMessage).toBe(
+      "artifact-validation-timeout: ffprobe exceeded 30000ms deadline",
+    );
+    expect(reloaded?.errorMessage).not.toContain(job.tempPath);
+    expect(reloaded?.errorMessage).not.toContain("secret.example");
+  });
+
+  test("cancels ffprobe stdout so abort can release the running lease", async () => {
+    const service = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      ffprobeAvailable: true,
+      downloadPath: tempDir,
+      ffprobeDeadline: () => ({
+        expired: new Promise<never>(() => {}),
+        cancel() {},
+      }),
+    });
+    whichSpy.mockImplementation((name: string) => (name === "ffprobe" ? "/usr/bin/ffprobe" : null));
+
+    let markProbeStarted!: () => void;
+    const probeStarted = new Promise<void>((resolve) => {
+      markProbeStarted = resolve;
+    });
+    const probe = createHangingProbe("SIGTERM");
+    spawnSpy.mockImplementation((command: string[]) => {
+      if (command[0] === "ffprobe") {
+        markProbeStarted();
+        return probe.process;
+      }
+      const outputIndex = command.indexOf("-o");
+      const outputPath = outputIndex >= 0 ? command[outputIndex + 1] : undefined;
+      if (outputPath) writeFileSync(outputPath, "video-bytes");
+      // SAFETY: Bun.spawn is intercepted; this fixture implements every process member the service reads.
+      return {
+        stdout: streamOf("[download] 100% of 1.2GiB\n"),
+        stderr: streamOf(""),
+        exited: Promise.resolve(0),
+      } as never;
+    });
+
+    const job = await service.enqueue({
+      title: { id: "tmdb:2", type: "series", name: "Cancelled Probe" },
+      episode: { season: 1, episode: 1, name: "Episode 1" },
+      stream: { url: "https://example.com/master.m3u8", headers: {}, timestamp: 0 },
+      providerId: "vidking",
+    });
+    const processing = service.processQueue();
+    await probeStarted;
+
+    await service.abort(job.id);
+    await processing;
+
+    expect(probe.stdoutCancelled).toBe(true);
+    expect(probe.killSignals).toEqual(["SIGTERM"]);
+    expect(repo.listRunning(10)).toEqual([]);
+    expect(repo.get(job.id)?.status).toBe("aborted");
+  });
+
+  test("terminates ffprobe immediately when abort wins before process registration", async () => {
+    const waits: number[] = [];
+    let service!: DownloadService;
+    let aborting: Promise<void> | undefined;
+    service = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      ffprobeAvailable: true,
+      downloadPath: tempDir,
+      ffprobeDeadline: (milliseconds) => {
+        waits.push(milliseconds);
+        return { expired: Promise.resolve(), cancel() {} };
+      },
+    });
+    whichSpy.mockImplementation((name: string) => (name === "ffprobe" ? "/usr/bin/ffprobe" : null));
+
+    let releaseStdoutCancel!: () => void;
+    const stdoutCancel = new Promise<void>((resolve) => {
+      releaseStdoutCancel = resolve;
+    });
+    const probe = createHangingProbe("SIGKILL", { stdoutCancel });
+    let jobId = "";
+    spawnSpy.mockImplementation((command: string[]) => {
+      if (command[0] === "ffprobe") {
+        aborting = service.abort(jobId);
+        return probe.process;
+      }
+      const outputIndex = command.indexOf("-o");
+      const outputPath = outputIndex >= 0 ? command[outputIndex + 1] : undefined;
+      if (outputPath) writeFileSync(outputPath, "video-bytes");
+      // SAFETY: Bun.spawn is intercepted; this fixture implements every process member the service reads.
+      return {
+        stdout: streamOf("[download] 100% of 1.2GiB\n"),
+        stderr: streamOf(""),
+        exited: Promise.resolve(0),
+        kill() {},
+      } as never;
+    });
+
+    const job = await service.enqueue({
+      title: { id: "tmdb:3", type: "series", name: "Pre-registration Abort" },
+      episode: { season: 1, episode: 1, name: "Episode 1" },
+      stream: { url: "https://example.com/master.m3u8", headers: {}, timestamp: 0 },
+      providerId: "vidking",
+    });
+    jobId = job.id;
+
+    const processing = service.processQueue();
+    await probe.stdoutCancelStarted;
+    const killedBeforeStdoutSettled = probe.killSignals.length > 0;
+    releaseStdoutCancel();
+    await processing;
+    await aborting;
+
+    expect(killedBeforeStdoutSettled).toBe(true);
+    expect(waits).not.toContain(30_000);
+    expect(probe.stdoutCancelled).toBe(true);
+    expect(probe.killSignals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(repo.get(job.id)?.status).toBe("aborted");
   });
 
   test("carries poster metadata and caches poster artwork without ffmpeg", async () => {
@@ -1328,6 +1504,115 @@ describe("DownloadService", () => {
     updateFileSizeSpy.mockRestore();
   });
 
+  test("preserves a published artifact when recovery ffprobe reaches its deadline", async () => {
+    const enqueueService = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      downloadPath: tempDir,
+    });
+    const job = await enqueueService.enqueue({
+      title: { id: "tmdb:7", type: "movie", name: "Probe Timeout" },
+      stream: { url: "https://secret.example/master.m3u8", headers: {}, timestamp: 0 },
+      providerId: "vidking",
+      mode: "series",
+    });
+    expect(repo.markRunning(job.id, "2026-04-29T00:01:00.000Z")).toBe(true);
+    writeFileSync(job.outputPath, "published-media-that-must-survive");
+
+    const probe = createHangingProbe("SIGKILL");
+    whichSpy.mockImplementation((name: string) => (name === "ffprobe" ? "/usr/bin/ffprobe" : null));
+    spawnSpy.mockImplementation(() => probe.process);
+    const recoveryService = buildService({
+      repo,
+      downloadsEnabled: false,
+      ytDlpAvailable: false,
+      ffprobeAvailable: true,
+      downloadPath: tempDir,
+      ffprobeDeadline: () => ({ expired: Promise.resolve(), cancel() {} }),
+    });
+
+    await recoveryService.processQueue();
+
+    const recovered = repo.get(job.id);
+    expect(probe.killSignals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(existsSync(job.outputPath)).toBe(true);
+    expect(await Bun.file(job.outputPath).text()).toBe("published-media-that-must-survive");
+    expect(recovered?.status).toBe("failed");
+    expect(recovered?.failureKind).toBe("artifact-timeout");
+    expect(recovered?.errorMessage).toBe(
+      "artifact-validation-timeout: ffprobe exceeded 30000ms deadline",
+    );
+    expect(recovered?.errorMessage).not.toContain(job.outputPath);
+    expect(recovered?.errorMessage).not.toContain("secret.example");
+  });
+
+  test("shutdown owns a recovery ffprobe and preserves its published artifact", async () => {
+    const enqueueService = buildService({
+      repo,
+      downloadsEnabled: true,
+      ytDlpAvailable: true,
+      downloadPath: tempDir,
+    });
+    const job = await enqueueService.enqueue({
+      title: { id: "tmdb:8", type: "movie", name: "Recovery Shutdown" },
+      stream: { url: "https://example.com/master.m3u8", headers: {}, timestamp: 0 },
+      providerId: "vidking",
+      mode: "series",
+    });
+    expect(repo.markRunning(job.id, "2026-04-29T00:01:00.000Z")).toBe(true);
+    writeFileSync(job.outputPath, "published-media-that-must-survive-shutdown");
+
+    let expireProbe!: () => void;
+    let deadlineCount = 0;
+    const probeDeadline = new Promise<void>((resolve) => {
+      expireProbe = resolve;
+    });
+    const probe = createHangingProbe("SIGTERM");
+    whichSpy.mockImplementation((name: string) => (name === "ffprobe" ? "/usr/bin/ffprobe" : null));
+    let markProbeStarted!: () => void;
+    const probeStarted = new Promise<void>((resolve) => {
+      markProbeStarted = resolve;
+    });
+    spawnSpy.mockImplementation(() => {
+      markProbeStarted();
+      return probe.process;
+    });
+    const recoveryService = buildService({
+      repo,
+      downloadsEnabled: false,
+      ytDlpAvailable: false,
+      ffprobeAvailable: true,
+      downloadPath: tempDir,
+      ffprobeDeadline: () => {
+        deadlineCount += 1;
+        return {
+          expired: deadlineCount === 1 ? probeDeadline : Promise.resolve(),
+          cancel() {},
+        };
+      },
+    });
+
+    const processing = recoveryService.processQueue();
+    await probeStarted;
+    await recoveryService.pauseActiveJobsForShutdown("download paused by recovery shutdown");
+    const killedBeforeDeadline = probe.killSignals.length > 0;
+    expireProbe();
+    await processing;
+
+    const recovered = repo.get(job.id);
+    expect(killedBeforeDeadline).toBe(true);
+    expect(probe.stdoutCancelled).toBe(true);
+    expect(probe.killSignals).toEqual(["SIGTERM"]);
+    expect(existsSync(job.outputPath)).toBe(true);
+    expect(await Bun.file(job.outputPath).text()).toBe(
+      "published-media-that-must-survive-shutdown",
+    );
+    expect(recovered?.status).toBe("queued");
+    expect(recovered?.failureKind).toBe("interrupted");
+    expect(recovered?.errorMessage).toBe("download paused by recovery shutdown");
+  });
+
   test("does not recover a freshly heartbeating job owned by another process", async () => {
     const enqueueService = buildService({
       repo,
@@ -1479,6 +1764,7 @@ function buildService({
   resolveDownloadStream,
   abortGraceMs,
   ffprobeAvailable = false,
+  ffprobeDeadline,
   diagnostics,
   configService,
   titleAliases = { upsertAliases() {} },
@@ -1490,6 +1776,7 @@ function buildService({
   resolveDownloadStream?: ConstructorParameters<typeof DownloadService>[0]["resolveDownloadStream"];
   abortGraceMs?: number;
   ffprobeAvailable?: boolean;
+  ffprobeDeadline?: ConstructorParameters<typeof DownloadService>[0]["ffprobeDeadline"];
   diagnostics?: ConstructorParameters<typeof DownloadService>[0]["diagnostics"];
   configService?: ConfigService;
   titleAliases?: ConstructorParameters<typeof DownloadService>[0]["titleAliases"];
@@ -1520,6 +1807,7 @@ function buildService({
     },
     resolveDownloadStream,
     abortGraceMs,
+    ffprobeDeadline,
   });
 }
 
@@ -1530,6 +1818,46 @@ function streamOf(text: string): ReadableStream<Uint8Array> {
       controller.close();
     },
   });
+}
+
+function createHangingProbe(
+  exitOn: "SIGTERM" | "SIGKILL",
+  options: { readonly stdoutCancel?: Promise<void> } = {},
+) {
+  let resolveExit!: (code: number) => void;
+  let markStdoutCancelStarted!: () => void;
+  let stdoutCancelled = false;
+  const killSignals: Array<NodeJS.Signals | number | undefined> = [];
+  const exited = new Promise<number>((resolve) => {
+    resolveExit = resolve;
+  });
+  const stdoutCancelStarted = new Promise<void>((resolve) => {
+    markStdoutCancelStarted = resolve;
+  });
+  // SAFETY: Bun.spawn is intercepted; this fixture implements stdout, stderr, exited, and kill used here.
+  const process = {
+    stdout: new ReadableStream<Uint8Array>({
+      cancel() {
+        stdoutCancelled = true;
+        markStdoutCancelStarted();
+        return options.stdoutCancel;
+      },
+    }),
+    stderr: streamOf(""),
+    exited,
+    kill(signal?: NodeJS.Signals | number) {
+      killSignals.push(signal);
+      if (signal === exitOn) resolveExit(signal === "SIGTERM" ? 143 : 137);
+    },
+  } as never;
+  return {
+    process,
+    killSignals,
+    stdoutCancelStarted,
+    get stdoutCancelled() {
+      return stdoutCancelled;
+    },
+  };
 }
 
 /** Local signature kept so existing call sites read unchanged. */


### PR DESCRIPTION
## Summary

- adds a deadline to the remaining unbounded ffprobe process
- terminates wedged validation before the worker heartbeat recovery window
- preserves cleanup and classified failure behavior

Closes #127.

## Stack

Depends on #158.

## Verification

- ffprobe timeout, termination, and cleanup tests
- download recovery regressions
- full repository gates

No release is performed by this PR.