### PR TITLE
fix(installer): serialize native activation

### DIFF
--- a/.changeset/quiet-foxes-activate.md
+++ b/.changeset/quiet-foxes-activate.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Serialize native installer activation across the in-process updater and the Bash and PowerShell installers, preserving launcher and manifest consistency during concurrent upgrades and recovery failures.

--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -67,12 +67,17 @@ cross-language activation lock at `{dataDir}/locks/activation.lock`. The Bash,
 PowerShell, and TypeScript implementations exclusively create the same schema-1
 JSON record (`schemaVersion`, `scope`, `pid`, `version`, `execPath`, `ownerId`,
 `acquiredAt`, `hostname`, `processStartId`). A live local owner is waited on for
-a bounded interval; PID reuse is rejected when a process-start identity is
-available; a valid foreign-host owner is never declared dead from a local PID
-probe; and unreadable metadata receives a short grace period before reclaim.
-Stale/corrupt reclamation and release atomically rename the canonical file to a
-token-owned quarantine before validation, so no contender can delete a newer
-owner through a read/delete race.
+a bounded interval; fresh live-PID records receive a one-second grace before
+process-start validation so Windows contenders do not spawn a probe storm; PID
+reuse is then rejected when a process-start identity is available. A valid
+foreign-host owner is never declared dead from a local PID probe, and unreadable
+metadata receives a short grace period before reclaim.
+Stale/corrupt reclamation first publishes a unique token-owned reclaim claim.
+Claimants elect one reclaimer by lexical claim order, then that owner re-reads
+and atomically renames the canonical file to quarantine for validation. It
+publishes its successor lock before removing the claim, so the canonical path
+never becomes an acquisition window and no contender can delete a newer owner
+through a read/delete race. Release uses the same token-owned quarantine rule.
 
 The activation critical section contains only the shared launcher replacement
 and `install.json` publication. Artifact download, checksum verification,

--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -60,6 +60,49 @@ creation/verification slice. This builder slice does not close issue #132 and
 does not yet reduce user downloads: 0.3.0 release dispatch remains blocked until
 the installer/updater archive-consumption stack lands and is verified.
 
+## Native Installer Activation Gate
+
+Native install, in-process update, rollback, and uninstall share one short
+cross-language activation lock at `{dataDir}/locks/activation.lock`. The Bash,
+PowerShell, and TypeScript implementations exclusively create the same schema-1
+JSON record (`schemaVersion`, `scope`, `pid`, `version`, `execPath`, `ownerId`,
+`acquiredAt`, `hostname`, `processStartId`). A live local owner is waited on for
+a bounded interval; PID reuse is rejected when a process-start identity is
+available; a valid foreign-host owner is never declared dead from a local PID
+probe; and unreadable metadata receives a short grace period before reclaim.
+Stale/corrupt reclamation and release atomically rename the canonical file to a
+token-owned quarantine before validation, so no contender can delete a newer
+owner through a read/delete race.
+
+The activation critical section contains only the shared launcher replacement
+and `install.json` publication. Artifact download, checksum verification,
+versioned binary installation, and `version.json` publication remain under the
+independent per-version lock and must complete without holding the activation
+lock. If manifest publication fails after launcher replacement, the previous
+launcher is restored before the activation lock is released. The lifecycle lock
+also excludes new installs while uninstall is active. Its purge-safe guard at
+`{dataDir}.lifecycle.lock` remains outside the removable data root; uninstall
+holds that guard through the final root operation and never sweeps another
+owner's lock after releasing it.
+
+Run the focused cross-language contract before changing installer activation:
+
+```sh
+bun run --cwd apps/cli test:file -- \
+  test/unit/services/update/native-installer/activation-lock.test.ts \
+  test/unit/services/update/native-installer/install-latest.test.ts \
+  test/unit/services/update/native-installer/migrate-flat-install.test.ts \
+  test/unit/services/update/native-installer/rollback.test.ts \
+  test/unit/services/update/native-installer/native-uninstall.test.ts \
+  test/unit/services/update/native-installer/install-diagnostic.test.ts \
+  test/integration/install-scripts.test.ts \
+  test/integration/install-scripts-pwsh.test.ts
+```
+
+The PowerShell integration suite skips when `pwsh` is unavailable locally;
+Windows CI remains the required native-platform parity run. `kunai doctor`
+reports stale activation ownership without mutating the lock.
+
 ## Changelog Gate
 
 User-facing changes need a changeset before release:

--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -98,8 +98,15 @@ launcher is restored before the activation lock is released. The lifecycle lock
 also excludes new installs while uninstall is active. Its purge-safe guard at
 `{dataDir}.lifecycle.lock` remains outside the removable data root; uninstall
 holds that guard through the final root operation and never sweeps another
-owner's lock after releasing it. Both lifecycle paths use a schema-1 `lifecycle`
-record with the same normalized `hostname` and `processStartId` identity fields.
+owner's lock after releasing it. Lifecycle acquisition first takes the shared
+activation lock and holds it while inspecting or reclaiming lifecycle residue,
+through purge, and until the external guard is released. This lock order makes
+stale-guard classification and replacement a single-winner operation; uninstall
+must not acquire activation a second time inside the lifecycle critical section.
+If purge already removed the activation path, owner-aware release is a safe
+no-op; other cleanup errors remain visible. Both lifecycle paths use a schema-1
+`lifecycle` record with the same normalized `hostname` and `processStartId`
+identity fields.
 A valid foreign-host lifecycle owner blocks without a local PID probe. On the
 same host, a dead PID or a mismatched available process-start identity is stale;
 an unavailable identity fails closed while the PID is live. Pre-schema records

--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -72,12 +72,22 @@ process-start validation so Windows contenders do not spawn a probe storm; PID
 reuse is then rejected when a process-start identity is available. A valid
 foreign-host owner is never declared dead from a local PID probe, and unreadable
 metadata receives a short grace period before reclaim.
+The acquisition deadline starts before ownership identity is collected or a
+same-process contender waits its turn. Every retry sleeps for at most the real
+time remaining; failed reclaim attempts return to that same deadline instead of
+hot-looping. Poll values at or below zero are clamped to one millisecond in all
+three implementations. A zero timeout still permits one uncontended exclusive
+create, but never waits. External process-start probes are bounded where the
+runtime must launch a helper process.
 Stale/corrupt reclamation first publishes a unique token-owned reclaim claim.
 Claimants elect one reclaimer by lexical claim order, then that owner re-reads
 and atomically renames the canonical file to quarantine for validation. It
 publishes its successor lock before removing the claim, so the canonical path
 never becomes an acquisition window and no contender can delete a newer owner
 through a read/delete race. Release uses the same token-owned quarantine rule.
+TypeScript release cleanup and Bash quarantine restoration report failures and
+leave the evidence in place; neither path treats failed cleanup as a successful
+release or reclaim.
 
 The activation critical section contains only the shared launcher replacement
 and `install.json` publication. Artifact download, checksum verification,
@@ -88,13 +98,25 @@ launcher is restored before the activation lock is released. The lifecycle lock
 also excludes new installs while uninstall is active. Its purge-safe guard at
 `{dataDir}.lifecycle.lock` remains outside the removable data root; uninstall
 holds that guard through the final root operation and never sweeps another
-owner's lock after releasing it.
+owner's lock after releasing it. Both lifecycle paths use a schema-1 `lifecycle`
+record with the same normalized `hostname` and `processStartId` identity fields.
+A valid foreign-host lifecycle owner blocks without a local PID probe. On the
+same host, a dead PID or a mismatched available process-start identity is stale;
+an unavailable identity fails closed while the PID is live. Pre-schema records
+remain compatible through legacy local-PID liveness. Empty, unreadable, or
+incomplete schema-intent lifecycle records block for a 250-millisecond
+partial-write grace, then become recoverable if unchanged or aged past that
+grace, so a writer cannot be deleted mid-publication and crash residue does not
+block forever.
+TypeScript likewise surfaces failure to remove an owner-matching lifecycle
+guard; pruning the empty compatibility lock directory remains best-effort.
 
 Run the focused cross-language contract before changing installer activation:
 
 ```sh
 bun run --cwd apps/cli test:file -- \
   test/unit/services/update/native-installer/activation-lock.test.ts \
+  test/unit/services/update/native-installer/version-lock.test.ts \
   test/unit/services/update/native-installer/install-latest.test.ts \
   test/unit/services/update/native-installer/migrate-flat-install.test.ts \
   test/unit/services/update/native-installer/rollback.test.ts \

--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -85,6 +85,12 @@ and atomically renames the canonical file to quarantine for validation. It
 publishes its successor lock before removing the claim, so the canonical path
 never becomes an acquisition window and no contender can delete a newer owner
 through a read/delete race. Release uses the same token-owned quarantine rule.
+Claims publish through uniquely named `.reclaim-tmp.*` files outside the
+`.reclaim.*` election namespace. Current and legacy temp names never enter
+election; dead-owner or aged-corrupt temp residue is cleaned without removing a
+live writer. PowerShell compares raw observations, process-start identities,
+and owner tokens with ordinal case-sensitive equality, and its successor-create
+retry checks the same acquisition stopwatch before each create and sleep.
 TypeScript release cleanup and Bash quarantine restoration report failures and
 leave the evidence in place; neither path treats failed cleanup as a successful
 release or reclaim.

--- a/apps/cli/src/services/update/native-installer/activation-lock.ts
+++ b/apps/cli/src/services/update/native-installer/activation-lock.ts
@@ -5,7 +5,12 @@ import { dirname, join } from "node:path";
 
 import { parseCanonicalVersion } from "../version";
 import { activationLockPath, type InstallLayoutPaths } from "./install-layout";
-import { isProcessAlive, normalizedHostname, processStartId } from "./lock-owner-identity";
+import {
+  isProcessAlive,
+  normalizedHostname,
+  processStartId,
+  type ProcessStartIdLookup,
+} from "./lock-owner-identity";
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_POLL_MS = 50;
@@ -33,6 +38,8 @@ export type ActivationLockOptions = {
   readonly timeoutMs?: number;
   readonly pollMs?: number;
   readonly corruptGraceMs?: number;
+  /** Test seam for deterministic PID-reuse coverage. */
+  readonly processStartIdLookup?: ProcessStartIdLookup;
 };
 
 export type ActivationLockInspection =
@@ -120,6 +127,7 @@ type OwnerState = "active" | "stale" | "foreign-host";
 function ownerState(
   content: ActivationLockContent,
   processProbeBudgetMs: number = Number.POSITIVE_INFINITY,
+  processStartIdLookup: ProcessStartIdLookup = processStartId,
 ): OwnerState {
   if (content.hostname.trim().toLowerCase() !== normalizedHostname()) return "foreign-host";
   if (!isProcessAlive(content.pid)) return "stale";
@@ -127,7 +135,7 @@ function ownerState(
   const startIdentityDue =
     !Number.isFinite(acquiredAtMs) || Date.now() - acquiredAtMs >= PROCESS_START_ID_GRACE_MS;
   if (content.processStartId && startIdentityDue) {
-    const currentStartId = processStartId(content.pid, processProbeBudgetMs);
+    const currentStartId = processStartIdLookup(content.pid, processProbeBudgetMs);
     if (currentStartId && currentStartId !== content.processStartId) return "stale";
   }
   return "active";
@@ -137,6 +145,7 @@ async function reclaimClaimOwnerState(
   path: string,
   content: ActivationLockContent,
   processProbeBudgetMs: number = Number.POSITIVE_INFINITY,
+  processStartIdLookup: ProcessStartIdLookup = processStartId,
 ): Promise<OwnerState> {
   if (content.hostname.trim().toLowerCase() !== normalizedHostname()) return "foreign-host";
   if (!isProcessAlive(content.pid)) return "stale";
@@ -151,7 +160,7 @@ async function reclaimClaimOwnerState(
     return "active";
   }
   if (content.processStartId) {
-    const currentStartId = processStartId(content.pid, processProbeBudgetMs);
+    const currentStartId = processStartIdLookup(content.pid, processProbeBudgetMs);
     if (currentStartId && currentStartId !== content.processStartId) return "stale";
   }
   return "active";
@@ -180,6 +189,7 @@ async function quarantineForReclaim(
   ownerId: string,
   successorRaw: string,
   deadlineAt: number,
+  processStartIdLookup: ProcessStartIdLookup,
 ): Promise<boolean> {
   const quarantinePath = `${path}.quarantine.${ownerId}.${randomUUID()}`;
   try {
@@ -192,7 +202,11 @@ async function quarantineForReclaim(
   const quarantined = await readActivationLock(quarantinePath);
   const unchanged = quarantined.raw === observed.raw;
   const stillReclaimable = quarantined.content
-    ? ownerState(quarantined.content, Math.max(0, deadlineAt - Date.now())) === "stale"
+    ? ownerState(
+        quarantined.content,
+        Math.max(0, deadlineAt - Date.now()),
+        processStartIdLookup,
+      ) === "stale"
     : quarantined.raw !== null;
   if (!unchanged || !stillReclaimable) {
     await restoreQuarantinedLock(quarantinePath, path);
@@ -245,6 +259,7 @@ function reclaimClaimTempPrefix(path: string): string {
 async function listReclaimClaims(
   path: string,
   deadlineAt: number = Number.POSITIVE_INFINITY,
+  processStartIdLookup: ProcessStartIdLookup = processStartId,
 ): Promise<string[]> {
   const prefix = reclaimClaimPrefix(path);
   const tempPrefix = reclaimClaimTempPrefix(path);
@@ -266,6 +281,7 @@ async function listReclaimClaims(
             claimPath,
             temp.content,
             Math.max(0, deadlineAt - Date.now()),
+            processStartIdLookup,
           )) === "stale"
         : tempStat !== null && Date.now() - tempStat.mtimeMs >= DEFAULT_CORRUPT_GRACE_MS;
       if (reclaimable) await rm(claimPath, { force: true }).catch(() => {});
@@ -279,6 +295,7 @@ async function listReclaimClaims(
         claimPath,
         claim.content,
         Math.max(0, deadlineAt - Date.now()),
+        processStartIdLookup,
       )) === "stale"
     ) {
       // Claim paths include a UUID and are never reused, so deleting a dead
@@ -350,11 +367,12 @@ async function tryAcquireActivationLockFromFilesystem(
 ): Promise<ActivationLockAcquireResult> {
   const pollMs = Math.max(1, options.pollMs ?? DEFAULT_POLL_MS);
   const corruptGraceMs = Math.max(0, options.corruptGraceMs ?? DEFAULT_CORRUPT_GRACE_MS);
+  const processStartIdLookup = options.processStartIdLookup ?? processStartId;
   const ownerId = `${process.pid}-${randomUUID()}`;
   // Resolve this once before timestamping the record. On Windows the fallback
   // PowerShell query is comparatively expensive; acquisition-age grace starts
   // when the lock is ready to publish, not while that identity is being read.
-  const ownProcessStartId = processStartId(process.pid, Math.max(1, deadlineAt - Date.now()));
+  const ownProcessStartId = processStartIdLookup(process.pid, Math.max(1, deadlineAt - Date.now()));
   const content: ActivationLockContent = {
     schemaVersion: 1,
     scope: "activation",
@@ -393,18 +411,31 @@ async function tryAcquireActivationLockFromFilesystem(
   const reclaimObserved = async (observed: LockRead, allowCorrupt: boolean): Promise<boolean> => {
     const claimPath = await createReclaimClaim(path, ownerId, contentRaw);
     try {
-      const claims = await listReclaimClaims(path, deadlineAt);
+      const claims = await listReclaimClaims(path, deadlineAt, processStartIdLookup);
       if (claims[0] !== claimPath) return false;
       const current = await readActivationLock(path);
       if (current.raw !== observed.raw) return false;
       if (current.content) {
-        if (ownerState(current.content, Math.max(0, deadlineAt - Date.now())) !== "stale") {
+        if (
+          ownerState(
+            current.content,
+            Math.max(0, deadlineAt - Date.now()),
+            processStartIdLookup,
+          ) !== "stale"
+        ) {
           return false;
         }
       } else if (!allowCorrupt || current.raw === null) {
         return false;
       }
-      return await quarantineForReclaim(path, current, ownerId, contentRaw, deadlineAt);
+      return await quarantineForReclaim(
+        path,
+        current,
+        ownerId,
+        contentRaw,
+        deadlineAt,
+        processStartIdLookup,
+      );
     } finally {
       await rm(claimPath, { force: true }).catch(() => {});
     }
@@ -422,13 +453,15 @@ async function tryAcquireActivationLockFromFilesystem(
       return holderPid === undefined ? { acquired: false } : { acquired: false, holderPid };
     }
     attempted = true;
-    if ((await listReclaimClaims(path, deadlineAt)).length > 0) {
+    if ((await listReclaimClaims(path, deadlineAt, processStartIdLookup)).length > 0) {
       if (!(await sleepForRetry())) return { acquired: false, holderPid };
       continue;
     }
     try {
       await writeFile(path, contentRaw, { flag: "wx", mode: 0o600 });
-      if ((await listReclaimClaims(path, deadlineAt)).length === 0) return acquiredResult();
+      if ((await listReclaimClaims(path, deadlineAt, processStartIdLookup)).length === 0) {
+        return acquiredResult();
+      }
       await quarantineForRelease(path, ownerId);
       continue;
     } catch (error) {
@@ -449,7 +482,10 @@ async function tryAcquireActivationLockFromFilesystem(
       corruptRaw = null;
       corruptSince = 0;
       holderPid = observed.content.pid;
-      if (ownerState(observed.content, Math.max(0, deadlineAt - Date.now())) === "stale") {
+      if (
+        ownerState(observed.content, Math.max(0, deadlineAt - Date.now()), processStartIdLookup) ===
+        "stale"
+      ) {
         if (await reclaimObserved(observed, false)) return acquiredResult();
       }
     } else if (observed.raw !== corruptRaw) {

--- a/apps/cli/src/services/update/native-installer/activation-lock.ts
+++ b/apps/cli/src/services/update/native-installer/activation-lock.ts
@@ -1,11 +1,11 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { link, mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
-import { hostname as getHostname } from "node:os";
 import { dirname, join } from "node:path";
 
 import { parseCanonicalVersion } from "../version";
 import { activationLockPath, type InstallLayoutPaths } from "./install-layout";
+import { isProcessAlive, normalizedHostname, processStartId } from "./lock-owner-identity";
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_POLL_MS = 50;
@@ -51,15 +51,31 @@ type LockRead = {
 
 const localAcquisitionTails = new Map<string, Promise<void>>();
 
-async function serializeLocalAcquisition<T>(path: string, fn: () => Promise<T>): Promise<T> {
-  const previous = localAcquisitionTails.get(path) ?? Promise.resolve();
+async function serializeLocalAcquisition(
+  path: string,
+  deadlineAt: number,
+  fn: () => Promise<ActivationLockAcquireResult>,
+): Promise<ActivationLockAcquireResult> {
+  const queued = localAcquisitionTails.get(path);
+  const previous = queued ?? Promise.resolve();
   let release!: () => void;
   const current = new Promise<void>((resolve) => {
     release = resolve;
   });
   const tail = previous.then(() => current);
   localAcquisitionTails.set(path, tail);
-  await previous;
+  const remainingMs = deadlineAt - Date.now();
+  const ready = queued
+    ? await Promise.race([
+        previous.then(() => true),
+        Bun.sleep(Math.max(0, remainingMs)).then(() => false),
+      ])
+    : true;
+  if (!ready) {
+    release();
+    if (localAcquisitionTails.get(path) === tail) localAcquisitionTails.delete(path);
+    return { acquired: false };
+  }
   try {
     return await fn();
   } finally {
@@ -68,78 +84,7 @@ async function serializeLocalAcquisition<T>(path: string, fn: () => Promise<T>):
   }
 }
 
-function isProcessAlive(pid: number): boolean {
-  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "EPERM";
-  }
-}
-
 const ISO_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
-
-function localHostname(): string {
-  return getHostname().trim().toLowerCase();
-}
-
-function lookupProcessStartId(pid: number): string | null {
-  if (process.platform === "win32") {
-    try {
-      const powershell = Bun.which("powershell.exe") ?? Bun.which("pwsh.exe") ?? Bun.which("pwsh");
-      if (!powershell) return null;
-      const result = Bun.spawnSync([
-        powershell,
-        "-NoLogo",
-        "-NoProfile",
-        "-NonInteractive",
-        "-Command",
-        `$process = Get-Process -Id ${pid} -ErrorAction Stop; [Console]::Out.Write($process.StartTime.ToUniversalTime().Ticks)`,
-      ]);
-      if (result.exitCode !== 0) return null;
-      const ticks = result.stdout.toString().trim();
-      return /^\d+$/.test(ticks) ? `windows-ticks:${ticks}` : null;
-    } catch {
-      return null;
-    }
-  }
-  if (process.platform === "linux") {
-    try {
-      const procStat = readFileSync(`/proc/${pid}/stat`, "utf8");
-      const afterName = procStat
-        .slice(procStat.lastIndexOf(") ") + 2)
-        .trim()
-        .split(/\s+/);
-      const startTicks = afterName[19];
-      return startTicks ? `linux-proc:${startTicks}` : null;
-    } catch {
-      return null;
-    }
-  }
-  if (process.platform === "darwin") {
-    try {
-      const result = Bun.spawnSync(["ps", "-o", "lstart=", "-p", String(pid)]);
-      if (result.exitCode !== 0) return null;
-      const value = result.stdout.toString().trim().replace(/\s+/g, " ");
-      return value ? `darwin-ps:${value}` : null;
-    } catch {
-      return null;
-    }
-  }
-  return null;
-}
-
-let cachedOwnProcessStartId: string | null | undefined;
-
-function processStartId(pid: number): string | null {
-  if (pid === process.pid && cachedOwnProcessStartId !== undefined) {
-    return cachedOwnProcessStartId;
-  }
-  const value = lookupProcessStartId(pid);
-  if (pid === process.pid) cachedOwnProcessStartId = value;
-  return value;
-}
 
 function parseLockContent(raw: string): ActivationLockContent | null {
   try {
@@ -173,7 +118,7 @@ function parseLockContent(raw: string): ActivationLockContent | null {
 type OwnerState = "active" | "stale" | "foreign-host";
 
 function ownerState(content: ActivationLockContent): OwnerState {
-  if (content.hostname.trim().toLowerCase() !== localHostname()) return "foreign-host";
+  if (content.hostname.trim().toLowerCase() !== normalizedHostname()) return "foreign-host";
   if (!isProcessAlive(content.pid)) return "stale";
   const acquiredAtMs = Date.parse(content.acquiredAt);
   const startIdentityDue =
@@ -189,7 +134,7 @@ async function reclaimClaimOwnerState(
   path: string,
   content: ActivationLockContent,
 ): Promise<OwnerState> {
-  if (content.hostname.trim().toLowerCase() !== localHostname()) return "foreign-host";
+  if (content.hostname.trim().toLowerCase() !== normalizedHostname()) return "foreign-host";
   if (!isProcessAlive(content.pid)) return "stale";
 
   // A reclaim claim is normally present for only a few file operations. Avoid
@@ -230,6 +175,7 @@ async function quarantineForReclaim(
   observed: LockRead,
   ownerId: string,
   successorRaw: string,
+  deadlineAt: number,
 ): Promise<boolean> {
   const quarantinePath = `${path}.quarantine.${ownerId}.${randomUUID()}`;
   try {
@@ -252,17 +198,24 @@ async function quarantineForReclaim(
   try {
     await rm(quarantinePath, { force: true });
     for (let attempt = 0; attempt < 20; attempt += 1) {
+      if (Date.now() >= deadlineAt) return false;
       try {
         await writeFile(path, successorRaw, { flag: "wx", mode: 0o600 });
         return true;
       } catch (error) {
         if (errorCode(error) !== "EEXIST") throw error;
-        await Bun.sleep(1);
+        await Bun.sleep(Math.min(1, Math.max(0, deadlineAt - Date.now())));
       }
     }
     return false;
   } catch (error) {
-    await restoreQuarantinedLock(quarantinePath, path).catch(() => {});
+    try {
+      await restoreQuarantinedLock(quarantinePath, path);
+    } catch (restoreError) {
+      throw new Error(`Could not restore quarantined activation lock at ${path}`, {
+        cause: restoreError,
+      });
+    }
     throw error;
   }
 }
@@ -344,8 +297,10 @@ export async function tryAcquireActivationLock(
   if (!canonical) throw new Error(`Invalid activation lock version: ${version}`);
 
   const path = activationLockPath(layout);
-  return serializeLocalAcquisition(path, () =>
-    tryAcquireActivationLockFromFilesystem(path, canonical, options),
+  const timeoutMs = Math.max(0, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  const deadlineAt = Date.now() + timeoutMs;
+  return serializeLocalAcquisition(path, deadlineAt, () =>
+    tryAcquireActivationLockFromFilesystem(path, canonical, options, deadlineAt),
   );
 }
 
@@ -353,15 +308,15 @@ async function tryAcquireActivationLockFromFilesystem(
   path: string,
   canonical: string,
   options: ActivationLockOptions,
+  deadlineAt: number,
 ): Promise<ActivationLockAcquireResult> {
-  const timeoutMs = Math.max(0, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
   const pollMs = Math.max(1, options.pollMs ?? DEFAULT_POLL_MS);
   const corruptGraceMs = Math.max(0, options.corruptGraceMs ?? DEFAULT_CORRUPT_GRACE_MS);
   const ownerId = `${process.pid}-${randomUUID()}`;
   // Resolve this once before timestamping the record. On Windows the fallback
   // PowerShell query is comparatively expensive; acquisition-age grace starts
   // when the lock is ready to publish, not while that identity is being read.
-  const ownProcessStartId = processStartId(process.pid);
+  const ownProcessStartId = processStartId(process.pid, Math.max(1, deadlineAt - Date.now()));
   const content: ActivationLockContent = {
     schemaVersion: 1,
     scope: "activation",
@@ -370,14 +325,14 @@ async function tryAcquireActivationLockFromFilesystem(
     execPath: options.execPath ?? process.execPath,
     ownerId,
     acquiredAt: new Date().toISOString(),
-    hostname: localHostname(),
+    hostname: normalizedHostname(),
     processStartId: ownProcessStartId,
   };
   const contentRaw = `${JSON.stringify(content)}\n`;
-  const startedAt = Date.now();
   let corruptRaw: string | null = null;
   let corruptSince = 0;
   let holderPid: number | undefined;
+  let attempted = false;
 
   await mkdir(dirname(path), { recursive: true });
 
@@ -388,7 +343,11 @@ async function tryAcquireActivationLockFromFilesystem(
       if (current.content?.ownerId === ownerId) {
         // Rename first, then validate the moved inode. A read-then-delete
         // release could otherwise remove a successor created in between.
-        await quarantineForRelease(path, ownerId).catch(() => {});
+        try {
+          await quarantineForRelease(path, ownerId);
+        } catch (error) {
+          throw new Error(`Could not release activation lock at ${path}`, { cause: error });
+        }
       }
     },
   });
@@ -405,22 +364,32 @@ async function tryAcquireActivationLockFromFilesystem(
       } else if (!allowCorrupt || current.raw === null) {
         return false;
       }
-      return await quarantineForReclaim(path, current, ownerId, contentRaw);
+      return await quarantineForReclaim(path, current, ownerId, contentRaw, deadlineAt);
     } finally {
       await rm(claimPath, { force: true }).catch(() => {});
     }
   };
 
+  const sleepForRetry = async (): Promise<boolean> => {
+    const remainingMs = deadlineAt - Date.now();
+    if (remainingMs <= 0) return false;
+    await Bun.sleep(Math.min(pollMs, remainingMs));
+    return Date.now() < deadlineAt;
+  };
+
   while (true) {
+    if (attempted && Date.now() >= deadlineAt) {
+      return holderPid === undefined ? { acquired: false } : { acquired: false, holderPid };
+    }
+    attempted = true;
     if ((await listReclaimClaims(path)).length > 0) {
-      if (Date.now() - startedAt >= timeoutMs) return { acquired: false, holderPid };
-      await Bun.sleep(Math.min(pollMs, Math.max(1, timeoutMs - (Date.now() - startedAt))));
+      if (!(await sleepForRetry())) return { acquired: false, holderPid };
       continue;
     }
     try {
       await writeFile(path, contentRaw, { flag: "wx", mode: 0o600 });
       if ((await listReclaimClaims(path)).length === 0) return acquiredResult();
-      await quarantineForRelease(path, ownerId).catch(() => {});
+      await quarantineForRelease(path, ownerId);
       continue;
     } catch (error) {
       if (errorCode(error) !== "EEXIST") {
@@ -432,8 +401,7 @@ async function tryAcquireActivationLockFromFilesystem(
 
     const observed = await readActivationLock(path);
     if (observed.raw === null) {
-      if (Date.now() - startedAt >= timeoutMs) return { acquired: false };
-      await Bun.sleep(Math.min(pollMs, Math.max(1, timeoutMs - (Date.now() - startedAt))));
+      if (!(await sleepForRetry())) return { acquired: false };
       continue;
     }
 
@@ -443,7 +411,6 @@ async function tryAcquireActivationLockFromFilesystem(
       holderPid = observed.content.pid;
       if (ownerState(observed.content) === "stale") {
         if (await reclaimObserved(observed, false)) return acquiredResult();
-        continue;
       }
     } else if (observed.raw !== corruptRaw) {
       corruptRaw = observed.raw;
@@ -453,13 +420,11 @@ async function tryAcquireActivationLockFromFilesystem(
       if (await reclaimObserved(observed, true)) return acquiredResult();
       corruptRaw = null;
       corruptSince = 0;
-      continue;
     }
 
-    if (Date.now() - startedAt >= timeoutMs) {
+    if (!(await sleepForRetry())) {
       return holderPid === undefined ? { acquired: false } : { acquired: false, holderPid };
     }
-    await Bun.sleep(Math.min(pollMs, Math.max(1, timeoutMs - (Date.now() - startedAt))));
   }
 }
 

--- a/apps/cli/src/services/update/native-installer/activation-lock.ts
+++ b/apps/cli/src/services/update/native-installer/activation-lock.ts
@@ -117,14 +117,17 @@ function parseLockContent(raw: string): ActivationLockContent | null {
 
 type OwnerState = "active" | "stale" | "foreign-host";
 
-function ownerState(content: ActivationLockContent): OwnerState {
+function ownerState(
+  content: ActivationLockContent,
+  processProbeBudgetMs: number = Number.POSITIVE_INFINITY,
+): OwnerState {
   if (content.hostname.trim().toLowerCase() !== normalizedHostname()) return "foreign-host";
   if (!isProcessAlive(content.pid)) return "stale";
   const acquiredAtMs = Date.parse(content.acquiredAt);
   const startIdentityDue =
     !Number.isFinite(acquiredAtMs) || Date.now() - acquiredAtMs >= PROCESS_START_ID_GRACE_MS;
   if (content.processStartId && startIdentityDue) {
-    const currentStartId = processStartId(content.pid);
+    const currentStartId = processStartId(content.pid, processProbeBudgetMs);
     if (currentStartId && currentStartId !== content.processStartId) return "stale";
   }
   return "active";
@@ -133,6 +136,7 @@ function ownerState(content: ActivationLockContent): OwnerState {
 async function reclaimClaimOwnerState(
   path: string,
   content: ActivationLockContent,
+  processProbeBudgetMs: number = Number.POSITIVE_INFINITY,
 ): Promise<OwnerState> {
   if (content.hostname.trim().toLowerCase() !== normalizedHostname()) return "foreign-host";
   if (!isProcessAlive(content.pid)) return "stale";
@@ -147,7 +151,7 @@ async function reclaimClaimOwnerState(
     return "active";
   }
   if (content.processStartId) {
-    const currentStartId = processStartId(content.pid);
+    const currentStartId = processStartId(content.pid, processProbeBudgetMs);
     if (currentStartId && currentStartId !== content.processStartId) return "stale";
   }
   return "active";
@@ -188,7 +192,7 @@ async function quarantineForReclaim(
   const quarantined = await readActivationLock(quarantinePath);
   const unchanged = quarantined.raw === observed.raw;
   const stillReclaimable = quarantined.content
-    ? ownerState(quarantined.content) === "stale"
+    ? ownerState(quarantined.content, Math.max(0, deadlineAt - Date.now())) === "stale"
     : quarantined.raw !== null;
   if (!unchanged || !stillReclaimable) {
     await restoreQuarantinedLock(quarantinePath, path);
@@ -238,7 +242,10 @@ function reclaimClaimTempPrefix(path: string): string {
   return `${path}.reclaim-tmp.`;
 }
 
-async function listReclaimClaims(path: string): Promise<string[]> {
+async function listReclaimClaims(
+  path: string,
+  deadlineAt: number = Number.POSITIVE_INFINITY,
+): Promise<string[]> {
   const prefix = reclaimClaimPrefix(path);
   const tempPrefix = reclaimClaimTempPrefix(path);
   const names = await readdir(dirname(path)).catch(() => [] as string[]);
@@ -255,14 +262,25 @@ async function listReclaimClaims(path: string): Promise<string[]> {
       const temp = await readActivationLock(claimPath);
       const tempStat = await stat(claimPath).catch(() => null);
       const reclaimable = temp.content
-        ? (await reclaimClaimOwnerState(claimPath, temp.content)) === "stale"
+        ? (await reclaimClaimOwnerState(
+            claimPath,
+            temp.content,
+            Math.max(0, deadlineAt - Date.now()),
+          )) === "stale"
         : tempStat !== null && Date.now() - tempStat.mtimeMs >= DEFAULT_CORRUPT_GRACE_MS;
       if (reclaimable) await rm(claimPath, { force: true }).catch(() => {});
       continue;
     }
     if (!claimPath.startsWith(prefix)) continue;
     const claim = await readActivationLock(claimPath);
-    if (claim.content && (await reclaimClaimOwnerState(claimPath, claim.content)) === "stale") {
+    if (
+      claim.content &&
+      (await reclaimClaimOwnerState(
+        claimPath,
+        claim.content,
+        Math.max(0, deadlineAt - Date.now()),
+      )) === "stale"
+    ) {
       // Claim paths include a UUID and are never reused, so deleting a dead
       // claimant cannot remove a successor's claim.
       await rm(claimPath, { force: true }).catch(() => {});
@@ -375,12 +393,14 @@ async function tryAcquireActivationLockFromFilesystem(
   const reclaimObserved = async (observed: LockRead, allowCorrupt: boolean): Promise<boolean> => {
     const claimPath = await createReclaimClaim(path, ownerId, contentRaw);
     try {
-      const claims = await listReclaimClaims(path);
+      const claims = await listReclaimClaims(path, deadlineAt);
       if (claims[0] !== claimPath) return false;
       const current = await readActivationLock(path);
       if (current.raw !== observed.raw) return false;
       if (current.content) {
-        if (ownerState(current.content) !== "stale") return false;
+        if (ownerState(current.content, Math.max(0, deadlineAt - Date.now())) !== "stale") {
+          return false;
+        }
       } else if (!allowCorrupt || current.raw === null) {
         return false;
       }
@@ -402,13 +422,13 @@ async function tryAcquireActivationLockFromFilesystem(
       return holderPid === undefined ? { acquired: false } : { acquired: false, holderPid };
     }
     attempted = true;
-    if ((await listReclaimClaims(path)).length > 0) {
+    if ((await listReclaimClaims(path, deadlineAt)).length > 0) {
       if (!(await sleepForRetry())) return { acquired: false, holderPid };
       continue;
     }
     try {
       await writeFile(path, contentRaw, { flag: "wx", mode: 0o600 });
-      if ((await listReclaimClaims(path)).length === 0) return acquiredResult();
+      if ((await listReclaimClaims(path, deadlineAt)).length === 0) return acquiredResult();
       await quarantineForRelease(path, ownerId);
       continue;
     } catch (error) {
@@ -429,7 +449,7 @@ async function tryAcquireActivationLockFromFilesystem(
       corruptRaw = null;
       corruptSince = 0;
       holderPid = observed.content.pid;
-      if (ownerState(observed.content) === "stale") {
+      if (ownerState(observed.content, Math.max(0, deadlineAt - Date.now())) === "stale") {
         if (await reclaimObserved(observed, false)) return acquiredResult();
       }
     } else if (observed.raw !== corruptRaw) {

--- a/apps/cli/src/services/update/native-installer/activation-lock.ts
+++ b/apps/cli/src/services/update/native-installer/activation-lock.ts
@@ -245,7 +245,8 @@ async function listReclaimClaims(path: string): Promise<string[]> {
   const claims: string[] = [];
   for (const name of names) {
     const claimPath = join(dirname(path), name);
-    const isLegacyTemp = claimPath.startsWith(prefix) && claimPath.includes(".tmp.");
+    const isLegacyTemp =
+      claimPath.startsWith(prefix) && claimPath.slice(prefix.length).includes(".tmp.");
     if (claimPath.startsWith(tempPrefix) || isLegacyTemp) {
       // Temp records never participate in election. Old releases wrote them
       // below `.reclaim.*`; a crash during that write otherwise left an

--- a/apps/cli/src/services/update/native-installer/activation-lock.ts
+++ b/apps/cli/src/services/update/native-installer/activation-lock.ts
@@ -1,0 +1,330 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { link, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { hostname as getHostname } from "node:os";
+
+import { parseCanonicalVersion } from "../version";
+import { activationLockPath, type InstallLayoutPaths } from "./install-layout";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_POLL_MS = 50;
+const DEFAULT_CORRUPT_GRACE_MS = 250;
+
+export type ActivationLockContent = {
+  readonly schemaVersion: 1;
+  readonly scope: "activation";
+  readonly pid: number;
+  readonly version: string;
+  readonly execPath: string;
+  readonly ownerId: string;
+  readonly acquiredAt: string;
+  readonly hostname: string;
+  readonly processStartId: string | null;
+};
+
+export type ActivationLockAcquireResult =
+  | { readonly acquired: true; readonly release: () => Promise<void> }
+  | { readonly acquired: false; readonly holderPid?: number };
+
+export type ActivationLockOptions = {
+  readonly execPath?: string;
+  readonly timeoutMs?: number;
+  readonly pollMs?: number;
+  readonly corruptGraceMs?: number;
+};
+
+export type ActivationLockInspection =
+  | { readonly status: "missing" }
+  | { readonly status: "active"; readonly content: ActivationLockContent }
+  | {
+      readonly status: "stale";
+      readonly content: ActivationLockContent | null;
+      readonly reason: "dead-owner" | "invalid-metadata";
+    };
+
+type LockRead = {
+  readonly content: ActivationLockContent | null;
+  readonly raw: string | null;
+};
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+const ISO_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+
+function localHostname(): string {
+  return getHostname().trim().toLowerCase();
+}
+
+function processStartId(pid: number): string | null {
+  if (process.platform === "linux") {
+    try {
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const afterName = stat
+        .slice(stat.lastIndexOf(") ") + 2)
+        .trim()
+        .split(/\s+/);
+      const startTicks = afterName[19];
+      return startTicks ? `linux-proc:${startTicks}` : null;
+    } catch {
+      return null;
+    }
+  }
+  if (process.platform === "darwin") {
+    try {
+      const result = Bun.spawnSync(["ps", "-o", "lstart=", "-p", String(pid)]);
+      if (result.exitCode !== 0) return null;
+      const value = result.stdout.toString().trim().replace(/\s+/g, " ");
+      return value ? `darwin-ps:${value}` : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function parseLockContent(raw: string): ActivationLockContent | null {
+  try {
+    const value = JSON.parse(raw) as Record<string, unknown>;
+    if (
+      value.schemaVersion !== 1 ||
+      value.scope !== "activation" ||
+      !Number.isSafeInteger(value.pid) ||
+      (value.pid as number) <= 0 ||
+      typeof value.version !== "string" ||
+      !parseCanonicalVersion(value.version) ||
+      typeof value.execPath !== "string" ||
+      !value.execPath ||
+      typeof value.ownerId !== "string" ||
+      !value.ownerId ||
+      typeof value.acquiredAt !== "string" ||
+      !ISO_UTC_PATTERN.test(value.acquiredAt) ||
+      typeof value.hostname !== "string" ||
+      !value.hostname.trim() ||
+      (value.processStartId !== null &&
+        (typeof value.processStartId !== "string" || !value.processStartId))
+    ) {
+      return null;
+    }
+    return value as ActivationLockContent;
+  } catch {
+    return null;
+  }
+}
+
+type OwnerState = "active" | "stale" | "foreign-host";
+
+function ownerState(content: ActivationLockContent): OwnerState {
+  if (content.hostname.trim().toLowerCase() !== localHostname()) return "foreign-host";
+  if (!isProcessAlive(content.pid)) return "stale";
+  if (content.processStartId) {
+    const currentStartId = processStartId(content.pid);
+    if (currentStartId && currentStartId !== content.processStartId) return "stale";
+  }
+  return "active";
+}
+
+function errorCode(error: unknown): string | undefined {
+  return (error as NodeJS.ErrnoException).code;
+}
+
+async function restoreQuarantinedLock(quarantinePath: string, lockPath: string): Promise<void> {
+  try {
+    // A hard link restores only when the canonical path is still absent. It
+    // cannot overwrite an owner that acquired after the quarantine rename.
+    await link(quarantinePath, lockPath);
+    await rm(quarantinePath, { force: true });
+  } catch (error) {
+    if (errorCode(error) !== "EEXIST") throw error;
+    // A new canonical owner won. Keep the quarantine for diagnostics rather
+    // than ever replacing or deleting that owner.
+  }
+}
+
+async function quarantineForReclaim(
+  path: string,
+  observed: LockRead,
+  ownerId: string,
+): Promise<boolean> {
+  const quarantinePath = `${path}.quarantine.${ownerId}.${randomUUID()}`;
+  try {
+    await rename(path, quarantinePath);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return false;
+    throw error;
+  }
+
+  const quarantined = await readActivationLock(quarantinePath);
+  const unchanged = quarantined.raw === observed.raw;
+  const stillReclaimable = quarantined.content
+    ? ownerState(quarantined.content) === "stale"
+    : quarantined.raw !== null;
+  if (!unchanged || !stillReclaimable) {
+    await restoreQuarantinedLock(quarantinePath, path);
+    return false;
+  }
+
+  try {
+    await rm(quarantinePath, { force: true });
+    return true;
+  } catch (error) {
+    await restoreQuarantinedLock(quarantinePath, path).catch(() => {});
+    throw error;
+  }
+}
+
+async function readActivationLock(path: string): Promise<LockRead> {
+  if (!existsSync(path)) return { content: null, raw: null };
+  try {
+    const raw = await readFile(path, "utf8");
+    return { content: parseLockContent(raw), raw };
+  } catch {
+    return { content: null, raw: "" };
+  }
+}
+
+/** Inspect activation ownership without mutating or reclaiming the lock. */
+export async function inspectActivationLock(
+  layout: Pick<InstallLayoutPaths, "locksDir">,
+): Promise<ActivationLockInspection> {
+  const observed = await readActivationLock(activationLockPath(layout));
+  if (observed.raw === null) return { status: "missing" };
+  if (!observed.content) {
+    return { status: "stale", content: null, reason: "invalid-metadata" };
+  }
+  if (ownerState(observed.content) === "stale") {
+    return { status: "stale", content: observed.content, reason: "dead-owner" };
+  }
+  return { status: "active", content: observed.content };
+}
+
+/**
+ * Acquire the cross-language launcher/manifest activation lock.
+ *
+ * Bash, PowerShell, and TypeScript all use exclusive file creation at the same
+ * path and the same JSON record. A short corrupt grace period prevents another
+ * contender from reclaiming the file while its owner is still writing it.
+ */
+export async function tryAcquireActivationLock(
+  layout: Pick<InstallLayoutPaths, "locksDir">,
+  version: string,
+  options: ActivationLockOptions = {},
+): Promise<ActivationLockAcquireResult> {
+  const canonical = parseCanonicalVersion(version);
+  if (!canonical) throw new Error(`Invalid activation lock version: ${version}`);
+
+  const path = activationLockPath(layout);
+  const timeoutMs = Math.max(0, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  const pollMs = Math.max(1, options.pollMs ?? DEFAULT_POLL_MS);
+  const corruptGraceMs = Math.max(0, options.corruptGraceMs ?? DEFAULT_CORRUPT_GRACE_MS);
+  const ownerId = `${process.pid}-${randomUUID()}`;
+  const content: ActivationLockContent = {
+    schemaVersion: 1,
+    scope: "activation",
+    pid: process.pid,
+    version: canonical,
+    execPath: options.execPath ?? process.execPath,
+    ownerId,
+    acquiredAt: new Date().toISOString(),
+    hostname: localHostname(),
+    processStartId: processStartId(process.pid),
+  };
+  const startedAt = Date.now();
+  let corruptRaw: string | null = null;
+  let corruptSince = 0;
+  let holderPid: number | undefined;
+
+  await mkdir(layout.locksDir, { recursive: true });
+
+  while (true) {
+    try {
+      await writeFile(path, `${JSON.stringify(content)}\n`, { flag: "wx", mode: 0o600 });
+      return {
+        acquired: true,
+        release: async () => {
+          const current = await readActivationLock(path);
+          if (current.content?.ownerId === ownerId) {
+            // Rename first, then validate the moved inode. A read-then-delete
+            // release could otherwise remove a successor created in between.
+            await quarantineForRelease(path, ownerId).catch(() => {});
+          }
+        },
+      };
+    } catch (error) {
+      if (errorCode(error) !== "EEXIST") {
+        throw new Error(`Could not create activation lock at ${path}`, { cause: error });
+      }
+      // Another owner won exclusive creation. Inspect before deciding whether
+      // it is live, dead, or a partially-written/corrupt record.
+    }
+
+    const observed = await readActivationLock(path);
+    if (observed.raw === null) {
+      if (Date.now() - startedAt >= timeoutMs) return { acquired: false };
+      await Bun.sleep(Math.min(pollMs, Math.max(1, timeoutMs - (Date.now() - startedAt))));
+      continue;
+    }
+
+    if (observed.content) {
+      corruptRaw = null;
+      corruptSince = 0;
+      holderPid = observed.content.pid;
+      if (ownerState(observed.content) === "stale") {
+        await quarantineForReclaim(path, observed, ownerId);
+        continue;
+      }
+    } else if (observed.raw !== corruptRaw) {
+      corruptRaw = observed.raw;
+      corruptSince = Date.now();
+      holderPid = undefined;
+    } else if (Date.now() - corruptSince >= corruptGraceMs) {
+      await quarantineForReclaim(path, observed, ownerId);
+      corruptRaw = null;
+      corruptSince = 0;
+      continue;
+    }
+
+    if (Date.now() - startedAt >= timeoutMs) {
+      return holderPid === undefined ? { acquired: false } : { acquired: false, holderPid };
+    }
+    await Bun.sleep(Math.min(pollMs, Math.max(1, timeoutMs - (Date.now() - startedAt))));
+  }
+}
+
+async function quarantineForRelease(path: string, ownerId: string): Promise<void> {
+  const quarantinePath = `${path}.quarantine.${ownerId}.${randomUUID()}`;
+  try {
+    await rename(path, quarantinePath);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return;
+    throw error;
+  }
+  const moved = await readActivationLock(quarantinePath);
+  if (moved.content?.ownerId === ownerId) {
+    await rm(quarantinePath, { force: true });
+    return;
+  }
+  await restoreQuarantinedLock(quarantinePath, path);
+}
+
+export async function withActivationLock<T>(
+  layout: Pick<InstallLayoutPaths, "locksDir">,
+  version: string,
+  fn: () => Promise<T>,
+  options: ActivationLockOptions = {},
+): Promise<T | null> {
+  const lock = await tryAcquireActivationLock(layout, version, options);
+  if (!lock.acquired) return null;
+  try {
+    return await fn();
+  } finally {
+    await lock.release();
+  }
+}

--- a/apps/cli/src/services/update/native-installer/activation-lock.ts
+++ b/apps/cli/src/services/update/native-installer/activation-lock.ts
@@ -234,12 +234,31 @@ function reclaimClaimPrefix(path: string): string {
   return `${path}.reclaim.`;
 }
 
+function reclaimClaimTempPrefix(path: string): string {
+  return `${path}.reclaim-tmp.`;
+}
+
 async function listReclaimClaims(path: string): Promise<string[]> {
   const prefix = reclaimClaimPrefix(path);
+  const tempPrefix = reclaimClaimTempPrefix(path);
   const names = await readdir(dirname(path)).catch(() => [] as string[]);
   const claims: string[] = [];
   for (const name of names) {
     const claimPath = join(dirname(path), name);
+    const isLegacyTemp = claimPath.startsWith(prefix) && claimPath.includes(".tmp.");
+    if (claimPath.startsWith(tempPrefix) || isLegacyTemp) {
+      // Temp records never participate in election. Old releases wrote them
+      // below `.reclaim.*`; a crash during that write otherwise left an
+      // invalid, permanently blocking claim. Preserve live/fresh writers, but
+      // clean dead-owner records and invalid residue after corrupt grace.
+      const temp = await readActivationLock(claimPath);
+      const tempStat = await stat(claimPath).catch(() => null);
+      const reclaimable = temp.content
+        ? (await reclaimClaimOwnerState(claimPath, temp.content)) === "stale"
+        : tempStat !== null && Date.now() - tempStat.mtimeMs >= DEFAULT_CORRUPT_GRACE_MS;
+      if (reclaimable) await rm(claimPath, { force: true }).catch(() => {});
+      continue;
+    }
     if (!claimPath.startsWith(prefix)) continue;
     const claim = await readActivationLock(claimPath);
     if (claim.content && (await reclaimClaimOwnerState(claimPath, claim.content)) === "stale") {
@@ -255,7 +274,7 @@ async function listReclaimClaims(path: string): Promise<string[]> {
 
 async function createReclaimClaim(path: string, ownerId: string, raw: string): Promise<string> {
   const claimPath = `${reclaimClaimPrefix(path)}${ownerId}`;
-  const tempPath = `${claimPath}.tmp.${randomUUID()}`;
+  const tempPath = `${reclaimClaimTempPrefix(path)}${ownerId}.${randomUUID()}`;
   await writeFile(tempPath, raw, { flag: "wx", mode: 0o600 });
   try {
     await rename(tempPath, claimPath);

--- a/apps/cli/src/services/update/native-installer/activation-lock.ts
+++ b/apps/cli/src/services/update/native-installer/activation-lock.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
-import { link, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { link, mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { hostname as getHostname } from "node:os";
+import { dirname, join } from "node:path";
 
 import { parseCanonicalVersion } from "../version";
 import { activationLockPath, type InstallLayoutPaths } from "./install-layout";
@@ -9,6 +10,7 @@ import { activationLockPath, type InstallLayoutPaths } from "./install-layout";
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_POLL_MS = 50;
 const DEFAULT_CORRUPT_GRACE_MS = 250;
+const PROCESS_START_ID_GRACE_MS = 1_000;
 
 export type ActivationLockContent = {
   readonly schemaVersion: 1;
@@ -47,6 +49,25 @@ type LockRead = {
   readonly raw: string | null;
 };
 
+const localAcquisitionTails = new Map<string, Promise<void>>();
+
+async function serializeLocalAcquisition<T>(path: string, fn: () => Promise<T>): Promise<T> {
+  const previous = localAcquisitionTails.get(path) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const tail = previous.then(() => current);
+  localAcquisitionTails.set(path, tail);
+  await previous;
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (localAcquisitionTails.get(path) === tail) localAcquisitionTails.delete(path);
+  }
+}
+
 function isProcessAlive(pid: number): boolean {
   if (!Number.isSafeInteger(pid) || pid <= 0) return false;
   try {
@@ -63,12 +84,31 @@ function localHostname(): string {
   return getHostname().trim().toLowerCase();
 }
 
-function processStartId(pid: number): string | null {
+function lookupProcessStartId(pid: number): string | null {
+  if (process.platform === "win32") {
+    try {
+      const powershell = Bun.which("powershell.exe") ?? Bun.which("pwsh.exe") ?? Bun.which("pwsh");
+      if (!powershell) return null;
+      const result = Bun.spawnSync([
+        powershell,
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `$process = Get-Process -Id ${pid} -ErrorAction Stop; [Console]::Out.Write($process.StartTime.ToUniversalTime().Ticks)`,
+      ]);
+      if (result.exitCode !== 0) return null;
+      const ticks = result.stdout.toString().trim();
+      return /^\d+$/.test(ticks) ? `windows-ticks:${ticks}` : null;
+    } catch {
+      return null;
+    }
+  }
   if (process.platform === "linux") {
     try {
-      const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
-      const afterName = stat
-        .slice(stat.lastIndexOf(") ") + 2)
+      const procStat = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const afterName = procStat
+        .slice(procStat.lastIndexOf(") ") + 2)
         .trim()
         .split(/\s+/);
       const startTicks = afterName[19];
@@ -88,6 +128,17 @@ function processStartId(pid: number): string | null {
     }
   }
   return null;
+}
+
+let cachedOwnProcessStartId: string | null | undefined;
+
+function processStartId(pid: number): string | null {
+  if (pid === process.pid && cachedOwnProcessStartId !== undefined) {
+    return cachedOwnProcessStartId;
+  }
+  const value = lookupProcessStartId(pid);
+  if (pid === process.pid) cachedOwnProcessStartId = value;
+  return value;
 }
 
 function parseLockContent(raw: string): ActivationLockContent | null {
@@ -124,6 +175,32 @@ type OwnerState = "active" | "stale" | "foreign-host";
 function ownerState(content: ActivationLockContent): OwnerState {
   if (content.hostname.trim().toLowerCase() !== localHostname()) return "foreign-host";
   if (!isProcessAlive(content.pid)) return "stale";
+  const acquiredAtMs = Date.parse(content.acquiredAt);
+  const startIdentityDue =
+    !Number.isFinite(acquiredAtMs) || Date.now() - acquiredAtMs >= PROCESS_START_ID_GRACE_MS;
+  if (content.processStartId && startIdentityDue) {
+    const currentStartId = processStartId(content.pid);
+    if (currentStartId && currentStartId !== content.processStartId) return "stale";
+  }
+  return "active";
+}
+
+async function reclaimClaimOwnerState(
+  path: string,
+  content: ActivationLockContent,
+): Promise<OwnerState> {
+  if (content.hostname.trim().toLowerCase() !== localHostname()) return "foreign-host";
+  if (!isProcessAlive(content.pid)) return "stale";
+
+  // A reclaim claim is normally present for only a few file operations. Avoid
+  // launching an expensive Windows process-start probe for every contender's
+  // fresh claim; that creates an O(contenders²) PowerShell storm. Dead PIDs are
+  // still reclaimed immediately, while an aged live-PID claim receives the
+  // full PID-reuse check before it can block future attempts indefinitely.
+  const claimStat = await stat(path).catch(() => null);
+  if (!claimStat || Date.now() - claimStat.mtimeMs < PROCESS_START_ID_GRACE_MS) {
+    return "active";
+  }
   if (content.processStartId) {
     const currentStartId = processStartId(content.pid);
     if (currentStartId && currentStartId !== content.processStartId) return "stale";
@@ -152,6 +229,7 @@ async function quarantineForReclaim(
   path: string,
   observed: LockRead,
   ownerId: string,
+  successorRaw: string,
 ): Promise<boolean> {
   const quarantinePath = `${path}.quarantine.${ownerId}.${randomUUID()}`;
   try {
@@ -173,7 +251,16 @@ async function quarantineForReclaim(
 
   try {
     await rm(quarantinePath, { force: true });
-    return true;
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      try {
+        await writeFile(path, successorRaw, { flag: "wx", mode: 0o600 });
+        return true;
+      } catch (error) {
+        if (errorCode(error) !== "EEXIST") throw error;
+        await Bun.sleep(1);
+      }
+    }
+    return false;
   } catch (error) {
     await restoreQuarantinedLock(quarantinePath, path).catch(() => {});
     throw error;
@@ -188,6 +275,42 @@ async function readActivationLock(path: string): Promise<LockRead> {
   } catch {
     return { content: null, raw: "" };
   }
+}
+
+function reclaimClaimPrefix(path: string): string {
+  return `${path}.reclaim.`;
+}
+
+async function listReclaimClaims(path: string): Promise<string[]> {
+  const prefix = reclaimClaimPrefix(path);
+  const names = await readdir(dirname(path)).catch(() => [] as string[]);
+  const claims: string[] = [];
+  for (const name of names) {
+    const claimPath = join(dirname(path), name);
+    if (!claimPath.startsWith(prefix)) continue;
+    const claim = await readActivationLock(claimPath);
+    if (claim.content && (await reclaimClaimOwnerState(claimPath, claim.content)) === "stale") {
+      // Claim paths include a UUID and are never reused, so deleting a dead
+      // claimant cannot remove a successor's claim.
+      await rm(claimPath, { force: true }).catch(() => {});
+      continue;
+    }
+    claims.push(claimPath);
+  }
+  return claims.sort();
+}
+
+async function createReclaimClaim(path: string, ownerId: string, raw: string): Promise<string> {
+  const claimPath = `${reclaimClaimPrefix(path)}${ownerId}`;
+  const tempPath = `${claimPath}.tmp.${randomUUID()}`;
+  await writeFile(tempPath, raw, { flag: "wx", mode: 0o600 });
+  try {
+    await rename(tempPath, claimPath);
+  } catch (error) {
+    await rm(tempPath, { force: true }).catch(() => {});
+    throw error;
+  }
+  return claimPath;
 }
 
 /** Inspect activation ownership without mutating or reclaiming the lock. */
@@ -221,10 +344,24 @@ export async function tryAcquireActivationLock(
   if (!canonical) throw new Error(`Invalid activation lock version: ${version}`);
 
   const path = activationLockPath(layout);
+  return serializeLocalAcquisition(path, () =>
+    tryAcquireActivationLockFromFilesystem(path, canonical, options),
+  );
+}
+
+async function tryAcquireActivationLockFromFilesystem(
+  path: string,
+  canonical: string,
+  options: ActivationLockOptions,
+): Promise<ActivationLockAcquireResult> {
   const timeoutMs = Math.max(0, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
   const pollMs = Math.max(1, options.pollMs ?? DEFAULT_POLL_MS);
   const corruptGraceMs = Math.max(0, options.corruptGraceMs ?? DEFAULT_CORRUPT_GRACE_MS);
   const ownerId = `${process.pid}-${randomUUID()}`;
+  // Resolve this once before timestamping the record. On Windows the fallback
+  // PowerShell query is comparatively expensive; acquisition-age grace starts
+  // when the lock is ready to publish, not while that identity is being read.
+  const ownProcessStartId = processStartId(process.pid);
   const content: ActivationLockContent = {
     schemaVersion: 1,
     scope: "activation",
@@ -234,29 +371,57 @@ export async function tryAcquireActivationLock(
     ownerId,
     acquiredAt: new Date().toISOString(),
     hostname: localHostname(),
-    processStartId: processStartId(process.pid),
+    processStartId: ownProcessStartId,
   };
+  const contentRaw = `${JSON.stringify(content)}\n`;
   const startedAt = Date.now();
   let corruptRaw: string | null = null;
   let corruptSince = 0;
   let holderPid: number | undefined;
 
-  await mkdir(layout.locksDir, { recursive: true });
+  await mkdir(dirname(path), { recursive: true });
+
+  const acquiredResult = (): ActivationLockAcquireResult => ({
+    acquired: true,
+    release: async () => {
+      const current = await readActivationLock(path);
+      if (current.content?.ownerId === ownerId) {
+        // Rename first, then validate the moved inode. A read-then-delete
+        // release could otherwise remove a successor created in between.
+        await quarantineForRelease(path, ownerId).catch(() => {});
+      }
+    },
+  });
+
+  const reclaimObserved = async (observed: LockRead, allowCorrupt: boolean): Promise<boolean> => {
+    const claimPath = await createReclaimClaim(path, ownerId, contentRaw);
+    try {
+      const claims = await listReclaimClaims(path);
+      if (claims[0] !== claimPath) return false;
+      const current = await readActivationLock(path);
+      if (current.raw !== observed.raw) return false;
+      if (current.content) {
+        if (ownerState(current.content) !== "stale") return false;
+      } else if (!allowCorrupt || current.raw === null) {
+        return false;
+      }
+      return await quarantineForReclaim(path, current, ownerId, contentRaw);
+    } finally {
+      await rm(claimPath, { force: true }).catch(() => {});
+    }
+  };
 
   while (true) {
+    if ((await listReclaimClaims(path)).length > 0) {
+      if (Date.now() - startedAt >= timeoutMs) return { acquired: false, holderPid };
+      await Bun.sleep(Math.min(pollMs, Math.max(1, timeoutMs - (Date.now() - startedAt))));
+      continue;
+    }
     try {
-      await writeFile(path, `${JSON.stringify(content)}\n`, { flag: "wx", mode: 0o600 });
-      return {
-        acquired: true,
-        release: async () => {
-          const current = await readActivationLock(path);
-          if (current.content?.ownerId === ownerId) {
-            // Rename first, then validate the moved inode. A read-then-delete
-            // release could otherwise remove a successor created in between.
-            await quarantineForRelease(path, ownerId).catch(() => {});
-          }
-        },
-      };
+      await writeFile(path, contentRaw, { flag: "wx", mode: 0o600 });
+      if ((await listReclaimClaims(path)).length === 0) return acquiredResult();
+      await quarantineForRelease(path, ownerId).catch(() => {});
+      continue;
     } catch (error) {
       if (errorCode(error) !== "EEXIST") {
         throw new Error(`Could not create activation lock at ${path}`, { cause: error });
@@ -277,7 +442,7 @@ export async function tryAcquireActivationLock(
       corruptSince = 0;
       holderPid = observed.content.pid;
       if (ownerState(observed.content) === "stale") {
-        await quarantineForReclaim(path, observed, ownerId);
+        if (await reclaimObserved(observed, false)) return acquiredResult();
         continue;
       }
     } else if (observed.raw !== corruptRaw) {
@@ -285,7 +450,7 @@ export async function tryAcquireActivationLock(
       corruptSince = Date.now();
       holderPid = undefined;
     } else if (Date.now() - corruptSince >= corruptGraceMs) {
-      await quarantineForReclaim(path, observed, ownerId);
+      if (await reclaimObserved(observed, true)) return acquiredResult();
       corruptRaw = null;
       corruptSince = 0;
       continue;

--- a/apps/cli/src/services/update/native-installer/index.ts
+++ b/apps/cli/src/services/update/native-installer/index.ts
@@ -1,8 +1,10 @@
 export {
+  activationLockPath,
   DEFAULT_DL_BASE,
   VERSION_RETENTION_COUNT,
   getInstallLayoutPaths,
   isVersionedExecPath,
+  lifecycleGuardPath,
   lockFilePath,
   parseVersionFromExecPath,
   removeStagingAndPruneParents,
@@ -12,6 +14,15 @@ export {
   versionMetadataPath,
   type InstallLayoutPaths,
 } from "./install-layout";
+export {
+  inspectActivationLock,
+  tryAcquireActivationLock,
+  withActivationLock,
+  type ActivationLockAcquireResult,
+  type ActivationLockContent,
+  type ActivationLockInspection,
+  type ActivationLockOptions,
+} from "./activation-lock";
 export {
   installLatest,
   checkInstall,

--- a/apps/cli/src/services/update/native-installer/install-diagnostic.ts
+++ b/apps/cli/src/services/update/native-installer/install-diagnostic.ts
@@ -4,7 +4,12 @@ import { win32 } from "node:path";
 import { inspectInstallManifest, type InstallManifest } from "../install-manifest";
 import { detectInstallMethod } from "../install-method";
 import { findKunaiPathCandidates } from "../path-candidates";
-import { getInstallLayoutPaths } from "./install-layout";
+import { inspectActivationLock } from "./activation-lock";
+import {
+  activationLockPath,
+  getInstallLayoutPaths,
+  type InstallLayoutPaths,
+} from "./install-layout";
 
 export type InstallDiagnostic = {
   readonly level: "info" | "warn" | "error";
@@ -17,6 +22,8 @@ export type GetInstallDiagnosticsInput = {
   readonly pathExt?: string;
   readonly platform?: NodeJS.Platform;
   readonly fileExists?: (path: string) => boolean;
+  /** Test seam for inspecting an isolated install root. */
+  readonly layout?: InstallLayoutPaths;
   /** Test seam only. Production uses read-only `inspectInstallManifest`. */
   readonly readManifest?: () => Promise<InstallManifest | null>;
 };
@@ -47,6 +54,13 @@ export async function getInstallDiagnostics(
   const platform = input.platform ?? process.platform;
   const pathValue = input.pathValue ?? process.env.PATH ?? "";
   const manifest = await loadManifestForDiagnostics(input.readManifest);
+  const diagnosticLayout =
+    input.layout ??
+    getInstallLayoutPaths({
+      launcherPath: manifest?.method === "binary" ? manifest.launcherPath : undefined,
+      platform,
+    });
+  const activationLock = await inspectActivationLock(diagnosticLayout);
   const detected = detectInstallMethod({ fileExists, platform });
   const pathCandidates = findKunaiPathCandidates({
     pathValue,
@@ -55,6 +69,17 @@ export async function getInstallDiagnostics(
     fileExists,
   });
   const messages: InstallDiagnostic[] = [];
+
+  if (activationLock.status === "stale") {
+    const path = activationLockPath(diagnosticLayout);
+    messages.push({
+      level: "warn",
+      code: "stale-activation-lock",
+      message: activationLock.content
+        ? `Stale installer activation lock at ${path} (owner pid ${activationLock.content.pid} is not running).`
+        : `Stale installer activation lock at ${path} (metadata is unreadable).`,
+    });
+  }
 
   const pathWinner = pathCandidates[0];
   if (pathWinner) {
@@ -74,7 +99,7 @@ export async function getInstallDiagnostics(
   }
 
   if (manifest?.method === "binary") {
-    const layout = getInstallLayoutPaths({ launcherPath: manifest.launcherPath, platform });
+    const layout = diagnosticLayout;
     if (manifest.versionedPath && !fileExists(manifest.versionedPath)) {
       messages.push({
         level: "error",

--- a/apps/cli/src/services/update/native-installer/install-latest.ts
+++ b/apps/cli/src/services/update/native-installer/install-latest.ts
@@ -12,6 +12,7 @@ import {
 } from "../platform-assets";
 import { pickChecksum, verifyChecksum } from "../self-replace";
 import { normalizeRequestedVersion, parseCanonicalVersion } from "../version";
+import { withActivationLock } from "./activation-lock";
 import { cleanupOldVersions } from "./cleanup-versions";
 import {
   DEFAULT_BINARY_DOWNLOAD_POLICY,
@@ -27,7 +28,13 @@ import {
   versionBinaryPath,
   type InstallLayoutPaths,
 } from "./install-layout";
-import { atomicInstallBinaryFromFile, updateLauncher } from "./launcher";
+import {
+  atomicInstallBinaryFromFile,
+  captureLauncherSnapshot,
+  discardLauncherSnapshot,
+  restoreLauncherSnapshot,
+  updateLauncher,
+} from "./launcher";
 import { isMuslEnvironmentSync } from "./musl";
 import {
   beginInstallTransaction,
@@ -160,30 +167,60 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
           installedAt: new Date().toISOString(),
         });
 
-        const launcherPath = manifest?.launcherPath ?? layout.launcherPath;
-        await updateLauncher({
-          launcherPath,
-          versionPath,
-        });
+        const activated = await withActivationLock(layout, resolved, async () => {
+          // Another version may have activated while this version downloaded.
+          // Re-read shared state only after winning the cross-version lock.
+          const activeManifest = await readInstallManifest(layout.configDir);
+          const launcherPath = activeManifest?.launcherPath ?? layout.launcherPath;
+          const launcherSnapshot = await captureLauncherSnapshot(launcherPath);
+          let preserveSnapshot = false;
 
-        await writeInstallManifest(
-          {
-            method: "binary",
-            activeVersion: resolved,
-            launcherPath,
-            versionedPath: versionPath,
-            downloadBaseUrl: dlBase,
-            target: releaseTarget?.id ?? `${os}-${arch}`,
-            artifactSha256: downloaded.sha256,
-            ...(manifest?.activeVersion && manifest.activeVersion !== resolved
-              ? { previousVersion: manifest.activeVersion }
-              : {}),
-          },
-          layout.configDir,
-        );
+          try {
+            await updateLauncher({
+              launcherPath,
+              versionPath,
+            });
+            await writeInstallManifest(
+              {
+                method: "binary",
+                activeVersion: resolved,
+                launcherPath,
+                versionedPath: versionPath,
+                downloadBaseUrl: dlBase,
+                target: releaseTarget?.id ?? `${os}-${arch}`,
+                artifactSha256: downloaded.sha256,
+                ...(activeManifest?.activeVersion && activeManifest.activeVersion !== resolved
+                  ? { previousVersion: activeManifest.activeVersion }
+                  : {}),
+              },
+              layout.configDir,
+            );
+          } catch (manifestError) {
+            try {
+              await restoreLauncherSnapshot(launcherSnapshot);
+            } catch (restoreError) {
+              preserveSnapshot = true;
+              const recoveryFailure = new Error(
+                "Install manifest commit and launcher restoration both failed",
+                { cause: restoreError },
+              );
+              Object.assign(recoveryFailure, { errors: [manifestError, restoreError] });
+              throw recoveryFailure;
+            }
+            throw manifestError;
+          } finally {
+            if (!preserveSnapshot) {
+              await discardLauncherSnapshot(launcherSnapshot).catch(() => {});
+            }
+          }
+        });
 
         await finishInstallTransaction(layout, transaction.id);
         await removeStagingAndPruneParents(staging, layout.stagingRoot);
+
+        if (activated === null) {
+          return { status: "skipped" as const, reason: "lock-contention" as const };
+        }
 
         void cleanupOldVersions(layout);
 

--- a/apps/cli/src/services/update/native-installer/install-layout.ts
+++ b/apps/cli/src/services/update/native-installer/install-layout.ts
@@ -194,6 +194,19 @@ export function lockFilePath(
   return joinerForLayoutPath(layout.locksDir)(layout.locksDir, `${canonical}.lock`);
 }
 
+/** Shared launcher/manifest activation lock: `{dataDir}/locks/activation.lock`. */
+export function activationLockPath(layout: Pick<InstallLayoutPaths, "locksDir">): string {
+  return joinerForLayoutPath(layout.locksDir)(layout.locksDir, "activation.lock");
+}
+
+/**
+ * Purge-safe uninstall guard, intentionally outside `{dataDir}` so removing
+ * the managed data root cannot drop serialization before uninstall finishes.
+ */
+export function lifecycleGuardPath(layout: Pick<InstallLayoutPaths, "dataDir">): string {
+  return `${layout.dataDir}.lifecycle.lock`;
+}
+
 /** Per-version metadata sidecar: `{dataDir}/versions/{semver}/version.json`. */
 export function versionMetadataPath(
   layout: Pick<InstallLayoutPaths, "versionsDir">,

--- a/apps/cli/src/services/update/native-installer/launcher.ts
+++ b/apps/cli/src/services/update/native-installer/launcher.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import {
   chmod,
   copyFile,
+  lstat,
   mkdir,
   readdir,
   readlink,
@@ -158,6 +159,88 @@ export async function updateLauncher(input: {
   await rm(tmpLink, { force: true }).catch(() => {});
   await symlink(input.versionPath, tmpLink);
   await rename(tmpLink, input.launcherPath);
+}
+
+export type LauncherSnapshot =
+  | { readonly kind: "missing"; readonly launcherPath: string; readonly platform: NodeJS.Platform }
+  | {
+      readonly kind: "symlink";
+      readonly launcherPath: string;
+      readonly platform: NodeJS.Platform;
+      readonly target: string;
+    }
+  | {
+      readonly kind: "file";
+      readonly launcherPath: string;
+      readonly platform: NodeJS.Platform;
+      readonly backupPath: string;
+    };
+
+/** Capture the exact pre-activation launcher until its manifest commit succeeds. */
+export async function captureLauncherSnapshot(
+  launcherPath: string,
+  platform: NodeJS.Platform = process.platform,
+): Promise<LauncherSnapshot> {
+  try {
+    await lstat(launcherPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { kind: "missing", launcherPath, platform };
+    }
+    throw error;
+  }
+
+  if (platform !== "win32") {
+    try {
+      return { kind: "symlink", launcherPath, platform, target: await readlink(launcherPath) };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EINVAL") throw error;
+    }
+  }
+
+  const backupPath = `${launcherPath}.activation-backup.${process.pid}.${Date.now()}`;
+  await copyFile(launcherPath, backupPath);
+  return { kind: "file", launcherPath, platform, backupPath };
+}
+
+/** Restore a launcher snapshot without consuming its last-known-good backup. */
+export async function restoreLauncherSnapshot(snapshot: LauncherSnapshot): Promise<void> {
+  if (snapshot.kind === "missing") {
+    await rm(snapshot.launcherPath, { force: true });
+    return;
+  }
+  if (snapshot.kind === "symlink") {
+    const candidate = `${snapshot.launcherPath}.restore.${process.pid}.${Date.now()}`;
+    await rm(candidate, { force: true }).catch(() => {});
+    try {
+      await symlink(snapshot.target, candidate);
+      await rename(candidate, snapshot.launcherPath);
+    } finally {
+      await rm(candidate, { force: true }).catch(() => {});
+    }
+    return;
+  }
+  if (snapshot.platform === "win32") {
+    await updateWindowsLauncher({
+      launcherPath: snapshot.launcherPath,
+      versionPath: snapshot.backupPath,
+    });
+    return;
+  }
+  const candidate = `${snapshot.launcherPath}.restore.${process.pid}.${Date.now()}`;
+  await rm(candidate, { force: true }).catch(() => {});
+  try {
+    await copyFile(snapshot.backupPath, candidate);
+    await rename(candidate, snapshot.launcherPath);
+  } finally {
+    await rm(candidate, { force: true }).catch(() => {});
+  }
+}
+
+export async function discardLauncherSnapshot(snapshot: LauncherSnapshot): Promise<void> {
+  if (snapshot.kind === "file") {
+    await rm(snapshot.backupPath, { force: true });
+  }
 }
 
 export type LauncherOwnership = "managed" | "unmanaged" | "missing";

--- a/apps/cli/src/services/update/native-installer/lock-owner-identity.ts
+++ b/apps/cli/src/services/update/native-installer/lock-owner-identity.ts
@@ -1,7 +1,10 @@
 import { readFileSync } from "node:fs";
 import { hostname } from "node:os";
 
-const PROCESS_PROBE_TIMEOUT_MS = 250;
+// Windows PowerShell startup can exceed 250 ms on a cold CI runner. Give the
+// first self-identity lookup enough time to succeed so its positive result is
+// cached; callers with a shorter deadline still clamp this bound below.
+const PROCESS_PROBE_TIMEOUT_MS = 1_000;
 
 export function normalizedHostname(): string {
   return hostname().trim().toLowerCase();

--- a/apps/cli/src/services/update/native-installer/lock-owner-identity.ts
+++ b/apps/cli/src/services/update/native-installer/lock-owner-identity.ts
@@ -7,6 +7,8 @@ import { hostname } from "node:os";
 const PROCESS_PROBE_TIMEOUT_MS = 2_000;
 const OWN_PROCESS_PROBE_RETRY_DELAY_MS = 1_000;
 
+export type ProcessStartIdLookup = (pid: number, timeoutMs?: number) => string | null;
+
 export function normalizedHostname(): string {
   return hostname().trim().toLowerCase();
 }

--- a/apps/cli/src/services/update/native-installer/lock-owner-identity.ts
+++ b/apps/cli/src/services/update/native-installer/lock-owner-identity.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from "node:fs";
+import { hostname } from "node:os";
+
+const PROCESS_PROBE_TIMEOUT_MS = 250;
+
+export function normalizedHostname(): string {
+  return hostname().trim().toLowerCase();
+}
+
+export function isProcessAlive(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function boundedSpawn(command: string[], timeoutMs: number) {
+  return Bun.spawnSync({
+    cmd: command,
+    stdout: "pipe",
+    stderr: "ignore",
+    timeout: Math.max(1, Math.min(PROCESS_PROBE_TIMEOUT_MS, timeoutMs)),
+  });
+}
+
+let cachedOwnProcessStartId: string | null | undefined;
+
+export function processStartId(
+  pid: number,
+  timeoutMs: number = PROCESS_PROBE_TIMEOUT_MS,
+): string | null {
+  if (pid === process.pid && cachedOwnProcessStartId !== undefined) {
+    return cachedOwnProcessStartId;
+  }
+
+  let value: string | null = null;
+  if (process.platform === "win32") {
+    try {
+      const powershell = Bun.which("powershell.exe") ?? Bun.which("pwsh.exe") ?? Bun.which("pwsh");
+      if (powershell) {
+        const result = boundedSpawn(
+          [
+            powershell,
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            `$process = Get-Process -Id ${pid} -ErrorAction Stop; [Console]::Out.Write($process.StartTime.ToUniversalTime().Ticks)`,
+          ],
+          timeoutMs,
+        );
+        const ticks = result.exitCode === 0 ? result.stdout.toString().trim() : "";
+        value = /^\d+$/.test(ticks) ? `windows-ticks:${ticks}` : null;
+      }
+    } catch {
+      value = null;
+    }
+  } else if (process.platform === "linux") {
+    try {
+      const procStat = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const afterName = procStat
+        .slice(procStat.lastIndexOf(") ") + 2)
+        .trim()
+        .split(/\s+/);
+      const startTicks = afterName[19];
+      value = startTicks ? `linux-proc:${startTicks}` : null;
+    } catch {
+      value = null;
+    }
+  } else if (process.platform === "darwin") {
+    try {
+      const result = boundedSpawn(["ps", "-o", "lstart=", "-p", String(pid)], timeoutMs);
+      const start =
+        result.exitCode === 0 ? result.stdout.toString().trim().replace(/\s+/g, " ") : "";
+      value = start ? `darwin-ps:${start}` : null;
+    } catch {
+      value = null;
+    }
+  }
+
+  // A short caller deadline can make a helper probe time out. Cache only a
+  // positive identity so a later normal-budget acquisition can retry.
+  if (pid === process.pid && value !== null) cachedOwnProcessStartId = value;
+  return value;
+}

--- a/apps/cli/src/services/update/native-installer/lock-owner-identity.ts
+++ b/apps/cli/src/services/update/native-installer/lock-owner-identity.ts
@@ -1,10 +1,11 @@
 import { readFileSync } from "node:fs";
 import { hostname } from "node:os";
 
-// Windows PowerShell startup can exceed 250 ms on a cold CI runner. Give the
-// first self-identity lookup enough time to succeed so its positive result is
-// cached; callers with a shorter deadline still clamp this bound below.
-const PROCESS_PROBE_TIMEOUT_MS = 1_000;
+// Windows PowerShell startup can exceed one second on a loaded runner. Normal
+// lifecycle operations allow one bounded probe and cache its positive result;
+// short activation deadlines skip optional self-identity enrichment entirely.
+const PROCESS_PROBE_TIMEOUT_MS = 2_000;
+const OWN_PROCESS_PROBE_RETRY_DELAY_MS = 1_000;
 
 export function normalizedHostname(): string {
   return hostname().trim().toLowerCase();
@@ -30,6 +31,7 @@ function boundedSpawn(command: string[], timeoutMs: number) {
 }
 
 let cachedOwnProcessStartId: string | null | undefined;
+let retryOwnProcessStartIdAfter = 0;
 
 export function processStartId(
   pid: number,
@@ -37,6 +39,17 @@ export function processStartId(
 ): string | null {
   if (pid === process.pid && cachedOwnProcessStartId !== undefined) {
     return cachedOwnProcessStartId;
+  }
+  if (process.platform === "win32" && timeoutMs < PROCESS_PROBE_TIMEOUT_MS) {
+    return null;
+  }
+  if (pid === process.pid) {
+    // Nullable processStartId is part of the cross-language lock schema. A
+    // short acquisition must reach its filesystem attempt instead of spending
+    // the entire deadline starting PowerShell solely to enrich its own record.
+    if (Date.now() < retryOwnProcessStartIdAfter) {
+      return null;
+    }
   }
 
   let value: string | null = null;
@@ -84,8 +97,16 @@ export function processStartId(
     }
   }
 
-  // A short caller deadline can make a helper probe time out. Cache only a
-  // positive identity so a later normal-budget acquisition can retry.
-  if (pid === process.pid && value !== null) cachedOwnProcessStartId = value;
+  // Cache a positive identity for the process lifetime. A failed normal-budget
+  // probe gets only a short negative backoff so a later operation can retry.
+  if (pid === process.pid) {
+    if (value !== null) {
+      cachedOwnProcessStartId = value;
+    } else {
+      // Avoid a queued acquisition storm when a loaded Windows runner cannot
+      // start PowerShell within the normal probe budget.
+      retryOwnProcessStartIdAfter = Date.now() + OWN_PROCESS_PROBE_RETRY_DELAY_MS;
+    }
+  }
   return value;
 }

--- a/apps/cli/src/services/update/native-installer/migrate-flat-install.ts
+++ b/apps/cli/src/services/update/native-installer/migrate-flat-install.ts
@@ -1,15 +1,24 @@
 import { existsSync } from "node:fs";
 import { copyFile, mkdir, rename } from "node:fs/promises";
 
-import type { InstallManifest } from "../install-manifest";
-import { writeInstallManifest } from "../install-manifest";
+import {
+  readInstallManifest,
+  writeInstallManifest,
+  type InstallManifest,
+} from "../install-manifest";
 import { parseCanonicalVersion } from "../version";
+import { withActivationLock } from "./activation-lock";
 import {
   getInstallLayoutPaths,
   versionBinaryPath,
   type InstallLayoutPaths,
 } from "./install-layout";
-import { updateLauncher } from "./launcher";
+import {
+  captureLauncherSnapshot,
+  discardLauncherSnapshot,
+  restoreLauncherSnapshot,
+  updateLauncher,
+} from "./launcher";
 
 export type MigrateFlatResult =
   | { readonly migrated: false }
@@ -60,20 +69,55 @@ export async function migrateFlatInstall(input: {
     }
   }
 
-  await updateLauncher({ launcherPath: layout.launcherPath, versionPath: targetPath });
+  const activated = await withActivationLock(layout, version, async () => {
+    // A manual installer may have completed while the legacy binary was copied.
+    // Re-evaluate shared state only after winning activation ownership.
+    const activeManifest = await readInstallManifest(layout.configDir);
+    if (
+      activeManifest?.versionedPath ||
+      (activeManifest?.method && activeManifest.method !== "binary")
+    ) {
+      return { migrated: false } as const;
+    }
 
-  const downloadBaseUrl =
-    manifest?.downloadBaseUrl ?? "https://github.com/KitsuneKode/kunai/releases";
-  await writeInstallManifest(
-    {
-      method: "binary",
-      activeVersion: version,
-      launcherPath: layout.launcherPath,
-      versionedPath: targetPath,
-      downloadBaseUrl,
-    },
-    layout.configDir,
-  );
+    const launcherPath = activeManifest?.launcherPath ?? layout.launcherPath;
+    const launcherSnapshot = await captureLauncherSnapshot(launcherPath);
 
-  return { migrated: true, versionPath: targetPath };
+    let preserveBackup = false;
+    try {
+      await updateLauncher({ launcherPath, versionPath: targetPath });
+
+      const downloadBaseUrl =
+        activeManifest?.downloadBaseUrl ?? "https://github.com/KitsuneKode/kunai/releases";
+      await writeInstallManifest(
+        {
+          method: "binary",
+          activeVersion: version,
+          launcherPath,
+          versionedPath: targetPath,
+          downloadBaseUrl,
+        },
+        layout.configDir,
+      );
+
+      return { migrated: true, versionPath: targetPath } as const;
+    } catch (manifestError) {
+      try {
+        await restoreLauncherSnapshot(launcherSnapshot);
+      } catch (restoreError) {
+        preserveBackup = launcherSnapshot.kind === "file";
+        const recoveryFailure = new Error(
+          "Flat-install manifest commit and launcher restoration both failed",
+          { cause: restoreError },
+        );
+        Object.assign(recoveryFailure, { errors: [manifestError, restoreError] });
+        throw recoveryFailure;
+      }
+      throw manifestError;
+    } finally {
+      if (!preserveBackup) await discardLauncherSnapshot(launcherSnapshot).catch(() => {});
+    }
+  });
+
+  return activated ?? { migrated: false };
 }

--- a/apps/cli/src/services/update/native-installer/native-uninstall.ts
+++ b/apps/cli/src/services/update/native-installer/native-uninstall.ts
@@ -7,6 +7,7 @@ import {
   readInstallManifest,
   type InstallManifest,
 } from "../install-manifest";
+import { tryAcquireActivationLock } from "./activation-lock";
 import { getInstallLayoutPaths, type InstallLayoutPaths } from "./install-layout";
 import {
   inspectLauncherOwnership,
@@ -37,6 +38,8 @@ export type NativeUninstallOptions = {
   readonly preservePaths?: readonly string[];
   /** Test seam for simulating partial removal failures. */
   readonly rmImpl?: typeof rm;
+  /** Test/embedding seam; production uses the shared lock default. */
+  readonly activationLockTimeoutMs?: number;
 };
 
 type RmFn = typeof rm;
@@ -161,12 +164,29 @@ export async function nativeUninstall(
     ]);
   }
 
+  const activation = await tryAcquireActivationLock(layout, manifest.activeVersion, {
+    timeoutMs: options.activationLockTimeoutMs,
+  });
+  if (!activation.acquired) {
+    await lifecycle.release();
+    return blocked([
+      layout.launcherPath,
+      layout.versionsDir,
+      layout.configDir,
+      layout.dataDir,
+      layout.cacheDir,
+    ]);
+  }
+
   const transaction = await beginInstallTransaction(layout, {
     kind: "uninstall",
     version: manifest.activeVersion,
+  }).catch(async (error: unknown) => {
+    await activation.release();
+    await lifecycle.release();
+    throw error;
   });
 
-  let lifecycleReleased = false;
   try {
     // 1. Launcher + owned copy-asides
     if (ownership === "managed") {
@@ -195,13 +215,6 @@ export async function nativeUninstall(
     }
     const transactionsOk = await tryRemove(layout.transactionsDir, removed, failed, rmImpl);
 
-    if (existsSync(layout.locksDir)) {
-      for (const entry of await readdir(layout.locksDir).catch(() => [] as string[])) {
-        if (entry === "lifecycle.lock") continue;
-        await tryRemove(join(layout.locksDir, entry), removed, failed, rmImpl, false);
-      }
-    }
-
     const lifecyclePartial = failed.length > 0 || !versionsOk || !stagingOk || !transactionsOk;
 
     // 3. Manifest last — only when lifecycle cleanup fully succeeded.
@@ -215,7 +228,10 @@ export async function nativeUninstall(
     //    user roots survive (purge of configDir would otherwise wipe the manifest).
     const preserveSet = new Set(options.preservePaths ?? []);
     if (options.purge && !lifecyclePartial) {
-      for (const root of [layout.configDir, layout.dataDir, layout.cacheDir]) {
+      // Remove dataDir last: it contains the compatibility lifecycle and
+      // activation files. The purge-safe lifecycle guard lives beside it and
+      // remains held until every root operation has completed.
+      for (const root of [layout.configDir, layout.cacheDir, layout.dataDir]) {
         if (preserveSet.has(root)) {
           preserved.push(root);
           continue;
@@ -237,17 +253,6 @@ export async function nativeUninstall(
       await finishInstallTransaction(layout, transaction.id).catch(() => {});
     }
 
-    // Release lifecycle lock before removing the locks directory.
-    await lifecycle.release();
-    lifecycleReleased = true;
-    if (existsSync(layout.locksDir)) {
-      const remaining = await readdir(layout.locksDir).catch(() => [] as string[]);
-      for (const entry of remaining) {
-        await tryRemove(join(layout.locksDir, entry), removed, failed, rmImpl, false);
-      }
-      await tryRemove(layout.locksDir, removed, failed, rmImpl);
-    }
-
     return {
       status: failed.length > 0 ? "partial" : "removed",
       removed: [...new Set(removed)],
@@ -255,8 +260,7 @@ export async function nativeUninstall(
       failed,
     };
   } finally {
-    if (!lifecycleReleased) {
-      await lifecycle.release();
-    }
+    await activation.release();
+    await lifecycle.release();
   }
 }

--- a/apps/cli/src/services/update/native-installer/native-uninstall.ts
+++ b/apps/cli/src/services/update/native-installer/native-uninstall.ts
@@ -7,7 +7,6 @@ import {
   readInstallManifest,
   type InstallManifest,
 } from "../install-manifest";
-import { tryAcquireActivationLock } from "./activation-lock";
 import { getInstallLayoutPaths, type InstallLayoutPaths } from "./install-layout";
 import {
   inspectLauncherOwnership,
@@ -113,9 +112,6 @@ export async function nativeUninstall(
   }
 
   // Active locks / transactions block before any mutation — force never deletes live locks.
-  if (options.force) {
-    await cleanupStaleLocks(layout);
-  }
   if (await hasActiveVersionLocks(layout)) {
     return blocked([
       layout.launcherPath,
@@ -153,22 +149,9 @@ export async function nativeUninstall(
   const lifecycle = await tryAcquireLifecycleLock(layout, {
     force: options.force,
     execPath: process.execPath,
+    activationLockTimeoutMs: options.activationLockTimeoutMs,
   });
   if (!lifecycle.acquired) {
-    return blocked([
-      layout.launcherPath,
-      layout.versionsDir,
-      layout.configDir,
-      layout.dataDir,
-      layout.cacheDir,
-    ]);
-  }
-
-  const activation = await tryAcquireActivationLock(layout, manifest.activeVersion, {
-    timeoutMs: options.activationLockTimeoutMs,
-  });
-  if (!activation.acquired) {
-    await lifecycle.release();
     return blocked([
       layout.launcherPath,
       layout.versionsDir,
@@ -182,7 +165,6 @@ export async function nativeUninstall(
     kind: "uninstall",
     version: manifest.activeVersion,
   }).catch(async (error: unknown) => {
-    await activation.release();
     await lifecycle.release();
     throw error;
   });
@@ -260,7 +242,6 @@ export async function nativeUninstall(
       failed,
     };
   } finally {
-    await activation.release();
     await lifecycle.release();
   }
 }

--- a/apps/cli/src/services/update/native-installer/rollback.ts
+++ b/apps/cli/src/services/update/native-installer/rollback.ts
@@ -8,6 +8,7 @@ import {
   type InstallManifest,
 } from "../install-manifest";
 import { parseCanonicalVersion } from "../version";
+import { withActivationLock } from "./activation-lock";
 import {
   getInstallLayoutPaths,
   versionBinaryPath,
@@ -67,6 +68,8 @@ export type RollbackOptions = {
   readonly to?: string;
   readonly dryRun?: boolean;
   readonly layout?: InstallLayoutPaths;
+  /** Test/embedding seam; production uses the shared lock default. */
+  readonly activationLockTimeoutMs?: number;
 };
 
 async function listInstalledVersions(
@@ -284,8 +287,7 @@ export async function executeRollback(
     };
   }
 
-  const { candidate, fromVersion } = plan;
-  const previousLauncherTarget = await readLauncherTarget(layout.launcherPath);
+  const { candidate } = plan;
 
   try {
     const locked = await withVersionLock(
@@ -307,45 +309,70 @@ export async function executeRollback(
             );
           }
 
-          await updateLauncher({
-            launcherPath: layout.launcherPath,
-            versionPath: candidate.versionPath,
-          });
+          const activated = await withActivationLock(
+            layout,
+            candidate.version,
+            async () => {
+              const manifest = (await readInstallManifest(layout.configDir)) as InstallManifest;
+              if (manifest.activeVersion === candidate.version) {
+                return {
+                  status: "refused" as const,
+                  code: "already-active" as const,
+                  reason: `Version ${candidate.version} is already active`,
+                };
+              }
+              const previousLauncherTarget =
+                (await readLauncherTarget(manifest.launcherPath)) ??
+                manifest.versionedPath ??
+                versionBinaryPath(layout, manifest.activeVersion);
 
-          const manifest = (await readInstallManifest(layout.configDir)) as InstallManifest;
-          try {
-            await writeInstallManifest(
-              {
-                method: "binary",
-                activeVersion: candidate.version,
-                previousVersion: fromVersion,
+              await updateLauncher({
                 launcherPath: manifest.launcherPath,
-                versionedPath: candidate.versionPath,
-                downloadBaseUrl: manifest.downloadBaseUrl,
-                target: candidate.target,
-                artifactSha256: candidate.artifactSha256,
-                managedPaths: manifest.managedPaths,
-                ...(manifest.observedProvenance
-                  ? { observedProvenance: manifest.observedProvenance }
-                  : {}),
-              },
-              layout.configDir,
-            );
-          } catch (manifestError) {
-            await restoreLauncher(
-              layout.launcherPath,
-              previousLauncherTarget ?? versionBinaryPath(layout, fromVersion),
-              process.platform,
-            );
-            throw manifestError;
+                versionPath: candidate.versionPath,
+              });
+
+              try {
+                await writeInstallManifest(
+                  {
+                    method: "binary",
+                    activeVersion: candidate.version,
+                    previousVersion: manifest.activeVersion,
+                    launcherPath: manifest.launcherPath,
+                    versionedPath: candidate.versionPath,
+                    downloadBaseUrl: manifest.downloadBaseUrl,
+                    target: candidate.target,
+                    artifactSha256: candidate.artifactSha256,
+                    managedPaths: manifest.managedPaths,
+                    ...(manifest.observedProvenance
+                      ? { observedProvenance: manifest.observedProvenance }
+                      : {}),
+                  },
+                  layout.configDir,
+                );
+              } catch (manifestError) {
+                await restoreLauncher(
+                  manifest.launcherPath,
+                  previousLauncherTarget,
+                  process.platform,
+                );
+                throw manifestError;
+              }
+
+              return {
+                status: "rolled-back" as const,
+                fromVersion: manifest.activeVersion,
+                toVersion: candidate.version,
+              };
+            },
+            { timeoutMs: options.activationLockTimeoutMs },
+          );
+
+          if (activated === null) {
+            throw new Error(`Activation lock held while rolling back to ${candidate.version}`);
           }
 
           await finishInstallTransaction(layout, transaction.id);
-          return {
-            status: "rolled-back" as const,
-            fromVersion,
-            toVersion: candidate.version,
-          };
+          return activated;
         } catch (error) {
           await finishInstallTransaction(layout, transaction.id).catch(() => {});
           throw error;
@@ -365,7 +392,7 @@ export async function executeRollback(
     return locked;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    if (/locked|Install lock held/i.test(message)) {
+    if (/locked|(?:Install|Activation) lock held/i.test(message)) {
       return {
         status: "refused",
         code: "locked",

--- a/apps/cli/src/services/update/native-installer/version-lock.ts
+++ b/apps/cli/src/services/update/native-installer/version-lock.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, rm, rmdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, rmdir, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { parseCanonicalVersion } from "../version";
@@ -10,6 +10,7 @@ import {
   lockFilePath,
   type InstallLayoutPaths,
 } from "./install-layout";
+import { isProcessAlive, normalizedHostname, processStartId } from "./lock-owner-identity";
 
 export type VersionLockContent = {
   readonly pid: number;
@@ -17,6 +18,10 @@ export type VersionLockContent = {
   readonly execPath: string;
   readonly acquiredAt: string;
   readonly ownerId?: string;
+  readonly schemaVersion?: number;
+  readonly scope?: string;
+  readonly hostname?: string;
+  readonly processStartId?: string | null;
 };
 
 export type LockAcquireResult =
@@ -32,15 +37,7 @@ export type VersionLockInspection =
       readonly detail: string;
     };
 
-function isProcessAlive(pid: number): boolean {
-  if (pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
+const LIFECYCLE_CORRUPT_GRACE_MS = 250;
 
 export async function readLockContent(path: string): Promise<VersionLockContent | null> {
   if (!existsSync(path)) return null;
@@ -62,6 +59,56 @@ async function isLockStale(path: string): Promise<boolean> {
   }
   // Unreadable/invalid: reclaim immediately (matches inspect "stale").
   return true;
+}
+
+function isModernLifecycleContent(content: VersionLockContent): boolean {
+  return (
+    content.schemaVersion === 1 &&
+    content.scope === "lifecycle" &&
+    Number.isSafeInteger(content.pid) &&
+    content.pid > 0 &&
+    content.version === LIFECYCLE_LOCK_VERSION &&
+    typeof content.execPath === "string" &&
+    content.execPath.length > 0 &&
+    typeof content.ownerId === "string" &&
+    content.ownerId.length > 0 &&
+    typeof content.acquiredAt === "string" &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(content.acquiredAt) &&
+    typeof content.hostname === "string" &&
+    content.hostname.trim().length > 0 &&
+    (content.processStartId === null ||
+      (typeof content.processStartId === "string" && content.processStartId.length > 0))
+  );
+}
+
+/**
+ * Schema-1 lifecycle identities are host-scoped. Foreign owners fail closed;
+ * local owners are stale only when their PID is dead or its start ID changed.
+ * Pre-schema records retain the legacy local-PID behavior for upgrades.
+ */
+async function isLifecycleLockStale(path: string): Promise<boolean> {
+  const content = await readLockContent(path);
+  if (!content) {
+    const metadata = await stat(path).catch(() => null);
+    return metadata === null || Date.now() - metadata.mtimeMs >= LIFECYCLE_CORRUPT_GRACE_MS;
+  }
+  const hasModernIdentity =
+    content.schemaVersion !== undefined ||
+    content.scope !== undefined ||
+    content.hostname !== undefined ||
+    content.processStartId !== undefined;
+  if (!hasModernIdentity) return !isProcessAlive(content.pid);
+  if (!isModernLifecycleContent(content)) {
+    const metadata = await stat(path).catch(() => null);
+    return metadata === null || Date.now() - metadata.mtimeMs >= LIFECYCLE_CORRUPT_GRACE_MS;
+  }
+  if (content.hostname?.trim().toLowerCase() !== normalizedHostname()) return false;
+  if (!isProcessAlive(content.pid)) return true;
+  if (content.processStartId) {
+    const currentStartId = processStartId(content.pid);
+    if (currentStartId && currentStartId !== content.processStartId) return true;
+  }
+  return false;
 }
 
 /** Read-only lock inspection — never deletes or reclaims lock files. */
@@ -105,7 +152,7 @@ export async function tryAcquireVersionLock(
   const lifecyclePath = lifecycleLockPath(layout);
   const lifecyclePaths = [lifecycleGuardPath(layout), lifecyclePath];
   for (const guardPath of lifecyclePaths) {
-    if (existsSync(guardPath) && !(await isLockStale(guardPath))) {
+    if (existsSync(guardPath) && !(await isLifecycleLockStale(guardPath))) {
       const existing = await readLockContent(guardPath);
       return { acquired: false, holderPid: existing?.pid };
     }
@@ -137,7 +184,7 @@ export async function tryAcquireVersionLock(
   // Close the check/create race with lifecycle acquisition: if uninstall won
   // its lock after our first check, relinquish this version lock and refuse.
   for (const guardPath of lifecyclePaths) {
-    if (existsSync(guardPath) && !(await isLockStale(guardPath))) {
+    if (existsSync(guardPath) && !(await isLifecycleLockStale(guardPath))) {
       const existing = await readLockContent(guardPath);
       const current = await readLockContent(path);
       if (current?.pid === process.pid) {
@@ -225,7 +272,7 @@ export async function cleanupStaleLocks(layout: InstallLayoutPaths): Promise<voi
   for (const entry of await readdir(layout.locksDir).catch(() => [] as string[])) {
     if (entry === LIFECYCLE_LOCK_NAME) {
       const path = join(layout.locksDir, LIFECYCLE_LOCK_NAME);
-      if (await isLockStale(path)) {
+      if (await isLifecycleLockStale(path)) {
         await rm(path, { force: true }).catch(() => {});
       }
       continue;
@@ -286,16 +333,20 @@ export async function tryAcquireLifecycleLock(
   const ownerId = `${process.pid}-${randomUUID()}`;
 
   const content: VersionLockContent = {
+    schemaVersion: 1,
+    scope: "lifecycle",
     pid: process.pid,
     version: LIFECYCLE_LOCK_VERSION,
     execPath: options.execPath ?? process.execPath,
     acquiredAt: new Date().toISOString(),
     ownerId,
+    hostname: normalizedHostname(),
+    processStartId: processStartId(process.pid),
   };
 
   const acquiredPaths: string[] = [];
   for (const path of paths) {
-    if (existsSync(path) && !(await isLockStale(path))) {
+    if (existsSync(path) && !(await isLifecycleLockStale(path))) {
       const existing = await readLockContent(path);
       for (const acquiredPath of acquiredPaths) {
         await rm(acquiredPath, { force: true }).catch(() => {});
@@ -338,7 +389,11 @@ export async function tryAcquireLifecycleLock(
       for (const path of [...acquiredPaths].reverse()) {
         const current = await readLockContent(path);
         if (current?.ownerId === ownerId) {
-          await rm(path, { force: true }).catch(() => {});
+          try {
+            await rm(path, { force: true });
+          } catch (error) {
+            throw new Error(`Could not release lifecycle lock at ${path}`, { cause: error });
+          }
           if (path === lifecycleLockPath(layout)) {
             // The external purge-safe guard is still held at this point, so no
             // new install can acquire ownership while we remove an empty

--- a/apps/cli/src/services/update/native-installer/version-lock.ts
+++ b/apps/cli/src/services/update/native-installer/version-lock.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, rmdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { parseCanonicalVersion } from "../version";
@@ -339,6 +339,13 @@ export async function tryAcquireLifecycleLock(
         const current = await readLockContent(path);
         if (current?.ownerId === ownerId) {
           await rm(path, { force: true }).catch(() => {});
+          if (path === lifecycleLockPath(layout)) {
+            // The external purge-safe guard is still held at this point, so no
+            // new install can acquire ownership while we remove an empty
+            // compatibility lock directory. rmdir fails safely if any lock or
+            // diagnostic quarantine remains.
+            await rmdir(layout.locksDir).catch(() => {});
+          }
         }
       }
     },

--- a/apps/cli/src/services/update/native-installer/version-lock.ts
+++ b/apps/cli/src/services/update/native-installer/version-lock.ts
@@ -11,7 +11,12 @@ import {
   lockFilePath,
   type InstallLayoutPaths,
 } from "./install-layout";
-import { isProcessAlive, normalizedHostname, processStartId } from "./lock-owner-identity";
+import {
+  isProcessAlive,
+  normalizedHostname,
+  processStartId,
+  type ProcessStartIdLookup,
+} from "./lock-owner-identity";
 
 export type VersionLockContent = {
   readonly pid: number;
@@ -28,6 +33,12 @@ export type VersionLockContent = {
 export type LockAcquireResult =
   | { readonly acquired: true; readonly release: () => Promise<void> }
   | { readonly acquired: false; readonly holderPid?: number };
+
+export type VersionLockOptions = {
+  readonly execPath?: string;
+  /** Test seam for deterministic PID-reuse coverage. */
+  readonly processStartIdLookup?: ProcessStartIdLookup;
+};
 
 export type VersionLockInspection =
   | { readonly status: "missing" }
@@ -87,7 +98,10 @@ function isModernLifecycleContent(content: VersionLockContent): boolean {
  * local owners are stale only when their PID is dead or its start ID changed.
  * Pre-schema records retain the legacy local-PID behavior for upgrades.
  */
-async function isLifecycleLockStale(path: string): Promise<boolean> {
+async function isLifecycleLockStale(
+  path: string,
+  processStartIdLookup: ProcessStartIdLookup = processStartId,
+): Promise<boolean> {
   const content = await readLockContent(path);
   if (!content) {
     const metadata = await stat(path).catch(() => null);
@@ -106,7 +120,7 @@ async function isLifecycleLockStale(path: string): Promise<boolean> {
   if (content.hostname?.trim().toLowerCase() !== normalizedHostname()) return false;
   if (!isProcessAlive(content.pid)) return true;
   if (content.processStartId) {
-    const currentStartId = processStartId(content.pid);
+    const currentStartId = processStartIdLookup(content.pid);
     if (currentStartId && currentStartId !== content.processStartId) return true;
   }
   return false;
@@ -145,15 +159,17 @@ export async function inspectVersionLock(
 export async function tryAcquireVersionLock(
   layout: InstallLayoutPaths,
   version: string,
-  execPath: string = process.execPath,
+  options: VersionLockOptions = {},
 ): Promise<LockAcquireResult> {
+  const execPath = options.execPath ?? process.execPath;
+  const processStartIdLookup = options.processStartIdLookup ?? processStartId;
   const path = lockFilePath(layout, version);
   await mkdir(layout.locksDir, { recursive: true });
 
   const lifecyclePath = lifecycleLockPath(layout);
   const lifecyclePaths = [lifecycleGuardPath(layout), lifecyclePath];
   for (const guardPath of lifecyclePaths) {
-    if (existsSync(guardPath) && !(await isLifecycleLockStale(guardPath))) {
+    if (existsSync(guardPath) && !(await isLifecycleLockStale(guardPath, processStartIdLookup))) {
       const existing = await readLockContent(guardPath);
       return { acquired: false, holderPid: existing?.pid };
     }
@@ -185,7 +201,7 @@ export async function tryAcquireVersionLock(
   // Close the check/create race with lifecycle acquisition: if uninstall won
   // its lock after our first check, relinquish this version lock and refuse.
   for (const guardPath of lifecyclePaths) {
-    if (existsSync(guardPath) && !(await isLifecycleLockStale(guardPath))) {
+    if (existsSync(guardPath) && !(await isLifecycleLockStale(guardPath, processStartIdLookup))) {
       const existing = await readLockContent(guardPath);
       const current = await readLockContent(path);
       if (current?.pid === process.pid) {
@@ -213,7 +229,7 @@ export async function withVersionLock<T>(
   fn: () => Promise<T>,
   options: { readonly requireLock?: boolean; readonly execPath?: string } = {},
 ): Promise<T | null> {
-  const lock = await tryAcquireVersionLock(layout, version, options.execPath);
+  const lock = await tryAcquireVersionLock(layout, version, { execPath: options.execPath });
   if (!lock.acquired) {
     if (options.requireLock) {
       throw new Error(
@@ -251,7 +267,7 @@ export async function lockCurrentVersion(
   const path = lockFilePath(layout, version);
   if (lifetimeLockPath === path) return;
 
-  const lock = await tryAcquireVersionLock(layout, version, execPath);
+  const lock = await tryAcquireVersionLock(layout, version, { execPath });
   if (!lock.acquired) return;
 
   lifetimeLockPath = path;

--- a/apps/cli/src/services/update/native-installer/version-lock.ts
+++ b/apps/cli/src/services/update/native-installer/version-lock.ts
@@ -1,15 +1,22 @@
+import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { parseCanonicalVersion } from "../version";
-import { getInstallLayoutPaths, lockFilePath, type InstallLayoutPaths } from "./install-layout";
+import {
+  getInstallLayoutPaths,
+  lifecycleGuardPath,
+  lockFilePath,
+  type InstallLayoutPaths,
+} from "./install-layout";
 
 export type VersionLockContent = {
   readonly pid: number;
   readonly version: string;
   readonly execPath: string;
   readonly acquiredAt: string;
+  readonly ownerId?: string;
 };
 
 export type LockAcquireResult =
@@ -95,6 +102,15 @@ export async function tryAcquireVersionLock(
   const path = lockFilePath(layout, version);
   await mkdir(layout.locksDir, { recursive: true });
 
+  const lifecyclePath = lifecycleLockPath(layout);
+  const lifecyclePaths = [lifecycleGuardPath(layout), lifecyclePath];
+  for (const guardPath of lifecyclePaths) {
+    if (existsSync(guardPath) && !(await isLockStale(guardPath))) {
+      const existing = await readLockContent(guardPath);
+      return { acquired: false, holderPid: existing?.pid };
+    }
+  }
+
   if (existsSync(path) && !(await isLockStale(path))) {
     const existing = await readLockContent(path);
     return { acquired: false, holderPid: existing?.pid };
@@ -116,6 +132,19 @@ export async function tryAcquireVersionLock(
   } catch {
     const existing = await readLockContent(path);
     return { acquired: false, holderPid: existing?.pid };
+  }
+
+  // Close the check/create race with lifecycle acquisition: if uninstall won
+  // its lock after our first check, relinquish this version lock and refuse.
+  for (const guardPath of lifecyclePaths) {
+    if (existsSync(guardPath) && !(await isLockStale(guardPath))) {
+      const existing = await readLockContent(guardPath);
+      const current = await readLockContent(path);
+      if (current?.pid === process.pid) {
+        await rm(path, { force: true }).catch(() => {});
+      }
+      return { acquired: false, holderPid: existing?.pid };
+    }
   }
 
   return {
@@ -253,35 +282,64 @@ export async function tryAcquireLifecycleLock(
     return { acquired: false };
   }
 
-  const path = lifecycleLockPath(layout);
-  if (existsSync(path) && !(await isLockStale(path))) {
-    const existing = await readLockContent(path);
-    return { acquired: false, holderPid: existing?.pid };
-  }
-  if (existsSync(path)) {
-    await rm(path, { force: true }).catch(() => {});
-  }
+  const paths = [lifecycleGuardPath(layout), lifecycleLockPath(layout)];
+  const ownerId = `${process.pid}-${randomUUID()}`;
 
   const content: VersionLockContent = {
     pid: process.pid,
     version: LIFECYCLE_LOCK_VERSION,
     execPath: options.execPath ?? process.execPath,
     acquiredAt: new Date().toISOString(),
+    ownerId,
   };
 
-  try {
-    await writeFile(path, `${JSON.stringify(content)}\n`, { flag: "wx" });
-  } catch {
-    const existing = await readLockContent(path);
-    return { acquired: false, holderPid: existing?.pid };
+  const acquiredPaths: string[] = [];
+  for (const path of paths) {
+    if (existsSync(path) && !(await isLockStale(path))) {
+      const existing = await readLockContent(path);
+      for (const acquiredPath of acquiredPaths) {
+        await rm(acquiredPath, { force: true }).catch(() => {});
+      }
+      return { acquired: false, holderPid: existing?.pid };
+    }
+    if (existsSync(path)) {
+      await rm(path, { force: true }).catch(() => {});
+    }
+    try {
+      await writeFile(path, `${JSON.stringify(content)}\n`, { flag: "wx" });
+      acquiredPaths.push(path);
+    } catch {
+      const existing = await readLockContent(path);
+      for (const acquiredPath of acquiredPaths) {
+        const current = await readLockContent(acquiredPath);
+        if (current?.ownerId === ownerId) {
+          await rm(acquiredPath, { force: true }).catch(() => {});
+        }
+      }
+      return { acquired: false, holderPid: existing?.pid };
+    }
+  }
+
+  // Close the inverse race with version-lock acquisition. One side must see
+  // the other after both exclusive creates and back out before mutation.
+  if (await hasActiveVersionLocks(layout)) {
+    for (const path of acquiredPaths) {
+      const current = await readLockContent(path);
+      if (current?.ownerId === ownerId) {
+        await rm(path, { force: true }).catch(() => {});
+      }
+    }
+    return { acquired: false };
   }
 
   return {
     acquired: true,
     release: async () => {
-      const current = await readLockContent(path);
-      if (current?.pid === process.pid) {
-        await rm(path, { force: true }).catch(() => {});
+      for (const path of [...acquiredPaths].reverse()) {
+        const current = await readLockContent(path);
+        if (current?.ownerId === ownerId) {
+          await rm(path, { force: true }).catch(() => {});
+        }
       }
     },
   };

--- a/apps/cli/src/services/update/native-installer/version-lock.ts
+++ b/apps/cli/src/services/update/native-installer/version-lock.ts
@@ -4,6 +4,7 @@ import { mkdir, readFile, rm, rmdir, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { parseCanonicalVersion } from "../version";
+import { tryAcquireActivationLock } from "./activation-lock";
 import {
   getInstallLayoutPaths,
   lifecycleGuardPath,
@@ -316,93 +317,168 @@ export async function hasActiveVersionLocks(
  */
 export async function tryAcquireLifecycleLock(
   layout: InstallLayoutPaths,
-  options: { readonly force?: boolean; readonly execPath?: string } = {},
+  options: {
+    readonly force?: boolean;
+    readonly execPath?: string;
+    readonly activationLockTimeoutMs?: number;
+    /** Test seam for deterministic lifecycle cleanup failures. */
+    readonly rmImpl?: typeof rm;
+  } = {},
 ): Promise<LockAcquireResult> {
-  await mkdir(layout.locksDir, { recursive: true });
-
-  // Force may reclaim stale residue, but never a live lock.
-  if (options.force) {
-    await cleanupStaleLocks(layout);
+  // The activation lock is the cross-language election primitive. Acquire it
+  // before inspecting or reclaiming lifecycle residue so two contenders can
+  // never act on the same stale observation. It remains held until the
+  // external purge-safe guard has been released.
+  const activation = await tryAcquireActivationLock(layout, LIFECYCLE_LOCK_VERSION, {
+    execPath: options.execPath,
+    timeoutMs: options.activationLockTimeoutMs,
+  });
+  if (!activation.acquired) {
+    return { acquired: false, holderPid: activation.holderPid };
   }
 
-  if (await hasActiveVersionLocks(layout)) {
-    return { acquired: false };
-  }
-
-  const paths = [lifecycleGuardPath(layout), lifecycleLockPath(layout)];
-  const ownerId = `${process.pid}-${randomUUID()}`;
-
-  const content: VersionLockContent = {
-    schemaVersion: 1,
-    scope: "lifecycle",
-    pid: process.pid,
-    version: LIFECYCLE_LOCK_VERSION,
-    execPath: options.execPath ?? process.execPath,
-    acquiredAt: new Date().toISOString(),
-    ownerId,
-    hostname: normalizedHostname(),
-    processStartId: processStartId(process.pid),
+  const releaseActivationAndReturn = async (
+    result: Extract<LockAcquireResult, { readonly acquired: false }>,
+  ): Promise<LockAcquireResult> => {
+    await activation.release();
+    return result;
   };
 
-  const acquiredPaths: string[] = [];
-  for (const path of paths) {
-    if (existsSync(path) && !(await isLifecycleLockStale(path))) {
-      const existing = await readLockContent(path);
-      for (const acquiredPath of acquiredPaths) {
-        await rm(acquiredPath, { force: true }).catch(() => {});
-      }
-      return { acquired: false, holderPid: existing?.pid };
+  try {
+    await mkdir(layout.locksDir, { recursive: true });
+
+    // Force may reclaim stale residue, but never a live lock.
+    if (options.force) {
+      await cleanupStaleLocks(layout);
     }
-    if (existsSync(path)) {
-      await rm(path, { force: true }).catch(() => {});
+
+    if (await hasActiveVersionLocks(layout)) {
+      return await releaseActivationAndReturn({ acquired: false });
     }
-    try {
-      await writeFile(path, `${JSON.stringify(content)}\n`, { flag: "wx" });
-      acquiredPaths.push(path);
-    } catch {
-      const existing = await readLockContent(path);
-      for (const acquiredPath of acquiredPaths) {
+
+    const paths = [lifecycleGuardPath(layout), lifecycleLockPath(layout)];
+    const ownerId = `${process.pid}-${randomUUID()}`;
+    const lifecycleRm = options.rmImpl ?? rm;
+
+    const content: VersionLockContent = {
+      schemaVersion: 1,
+      scope: "lifecycle",
+      pid: process.pid,
+      version: LIFECYCLE_LOCK_VERSION,
+      execPath: options.execPath ?? process.execPath,
+      acquiredAt: new Date().toISOString(),
+      ownerId,
+      hostname: normalizedHostname(),
+      processStartId: processStartId(process.pid),
+    };
+
+    const acquiredPaths: string[] = [];
+    const backOutAcquiredPaths = async (): Promise<void> => {
+      for (const acquiredPath of [...acquiredPaths].reverse()) {
         const current = await readLockContent(acquiredPath);
-        if (current?.ownerId === ownerId) {
-          await rm(acquiredPath, { force: true }).catch(() => {});
+        if (current?.ownerId !== ownerId) continue;
+        try {
+          await lifecycleRm(acquiredPath, { force: true });
+        } catch (error) {
+          throw new Error(`Could not back out lifecycle lock at ${acquiredPath}`, { cause: error });
         }
       }
-      return { acquired: false, holderPid: existing?.pid };
-    }
-  }
+    };
 
-  // Close the inverse race with version-lock acquisition. One side must see
-  // the other after both exclusive creates and back out before mutation.
-  if (await hasActiveVersionLocks(layout)) {
-    for (const path of acquiredPaths) {
-      const current = await readLockContent(path);
-      if (current?.ownerId === ownerId) {
-        await rm(path, { force: true }).catch(() => {});
+    for (const path of paths) {
+      if (existsSync(path) && !(await isLifecycleLockStale(path))) {
+        const existing = await readLockContent(path);
+        await backOutAcquiredPaths();
+        return await releaseActivationAndReturn({
+          acquired: false,
+          holderPid: existing?.pid,
+        });
+      }
+      if (existsSync(path)) {
+        await lifecycleRm(path, { force: true }).catch(() => {});
+      }
+      try {
+        await writeFile(path, `${JSON.stringify(content)}\n`, { flag: "wx" });
+        acquiredPaths.push(path);
+      } catch {
+        const existing = await readLockContent(path);
+        await backOutAcquiredPaths();
+        return await releaseActivationAndReturn({
+          acquired: false,
+          holderPid: existing?.pid,
+        });
       }
     }
-    return { acquired: false };
-  }
 
-  return {
-    acquired: true,
-    release: async () => {
-      for (const path of [...acquiredPaths].reverse()) {
-        const current = await readLockContent(path);
-        if (current?.ownerId === ownerId) {
-          try {
-            await rm(path, { force: true });
-          } catch (error) {
-            throw new Error(`Could not release lifecycle lock at ${path}`, { cause: error });
+    // Close the inverse race with version-lock acquisition. One side must see
+    // the other after both exclusive creates and back out before mutation.
+    if (await hasActiveVersionLocks(layout)) {
+      await backOutAcquiredPaths();
+      return await releaseActivationAndReturn({ acquired: false });
+    }
+
+    return {
+      acquired: true,
+      release: async () => {
+        let lifecycleReleaseError: unknown;
+        try {
+          for (const path of [...acquiredPaths].reverse()) {
+            const current = await readLockContent(path);
+            if (current?.ownerId === ownerId) {
+              try {
+                await lifecycleRm(path, { force: true });
+              } catch (error) {
+                throw new Error(`Could not release lifecycle lock at ${path}`, { cause: error });
+              }
+              if (path === lifecycleLockPath(layout)) {
+                // The external purge-safe guard and activation ownership are
+                // both still held here. rmdir fails safely if any diagnostic
+                // quarantine or unrelated lock remains.
+                await rmdir(layout.locksDir).catch(() => {});
+              }
+            }
           }
-          if (path === lifecycleLockPath(layout)) {
-            // The external purge-safe guard is still held at this point, so no
-            // new install can acquire ownership while we remove an empty
-            // compatibility lock directory. rmdir fails safely if any lock or
-            // diagnostic quarantine remains.
-            await rmdir(layout.locksDir).catch(() => {});
-          }
+        } catch (error) {
+          lifecycleReleaseError = error;
         }
-      }
-    },
-  };
+
+        try {
+          // Purge may already have removed the activation path. Its owner-aware
+          // release treats a missing path as success but surfaces real I/O
+          // failures while a matching lock still exists.
+          await activation.release();
+        } catch (activationReleaseError) {
+          if (lifecycleReleaseError) {
+            const lifecycleDetail =
+              lifecycleReleaseError instanceof Error
+                ? lifecycleReleaseError.message
+                : String(lifecycleReleaseError);
+            throw new Error(
+              `Could not release lifecycle lock (${lifecycleDetail}) and activation lock`,
+              { cause: activationReleaseError },
+            );
+          }
+          throw activationReleaseError;
+        }
+
+        // Activation ownership is the last entry in locksDir under the normal
+        // uninstall path, so the directory can become empty only after its
+        // release. Purge may already have removed the directory.
+        await rmdir(layout.locksDir).catch(() => {});
+
+        if (lifecycleReleaseError) throw lifecycleReleaseError;
+      },
+    };
+  } catch (error) {
+    try {
+      await activation.release();
+    } catch (activationReleaseError) {
+      const acquisitionDetail = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Lifecycle acquisition failed (${acquisitionDetail}) and activation ownership could not be released`,
+        { cause: activationReleaseError },
+      );
+    }
+    throw error;
+  }
 }

--- a/apps/cli/test/integration/helpers/installer-script-harness.ts
+++ b/apps/cli/test/integration/helpers/installer-script-harness.ts
@@ -114,19 +114,41 @@ export function seedActivationLock(
   return path;
 }
 
-export function seedLifecycleLock(dataDir: string, pid: number): string {
+export function seedLifecycleLock(
+  dataDir: string,
+  input:
+    | number
+    | {
+        readonly pid: number;
+        readonly hostname?: string;
+        readonly processStartId?: string | null;
+        readonly legacy?: boolean;
+        readonly external?: boolean;
+      },
+): string {
+  const options = typeof input === "number" ? { pid: input } : input;
   const locksDir = join(dataDir, "locks");
-  const path = join(locksDir, "lifecycle.lock");
-  mkdirSync(locksDir, { recursive: true });
-  writeFileSync(
-    path,
-    `${JSON.stringify({
-      pid,
-      version: "0.0.0",
-      execPath: "/tmp/kunai-uninstall",
-      acquiredAt: "2026-08-24T00:00:00.000Z",
-    })}\n`,
-  );
+  const path = options.external ? `${dataDir}.lifecycle.lock` : join(locksDir, "lifecycle.lock");
+  mkdirSync(options.external ? join(dataDir, "..") : locksDir, { recursive: true });
+  const content = options.legacy
+    ? {
+        pid: options.pid,
+        version: "0.0.0",
+        execPath: "/tmp/kunai-uninstall",
+        acquiredAt: "2026-08-24T00:00:00.000Z",
+      }
+    : {
+        schemaVersion: 1,
+        scope: "lifecycle",
+        pid: options.pid,
+        version: "0.0.0",
+        execPath: "/tmp/kunai-uninstall",
+        ownerId: `lifecycle-fixture-${options.pid}`,
+        acquiredAt: "2026-08-24T00:00:00.000Z",
+        hostname: options.hostname ?? hostname().trim().toLowerCase(),
+        processStartId: options.processStartId ?? null,
+      };
+  writeFileSync(path, `${JSON.stringify(content)}\n`);
   return path;
 }
 

--- a/apps/cli/test/integration/helpers/installer-script-harness.ts
+++ b/apps/cli/test/integration/helpers/installer-script-harness.ts
@@ -1,5 +1,5 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { hostname, tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 
 import { removeTempDir } from "../../support/remove-temp-dir";
@@ -80,6 +80,54 @@ export function createInstallerSandbox(name: string) {
     } as NodeJS.ProcessEnv,
     cleanup: () => removeTempDir(root),
   };
+}
+
+export function seedActivationLock(
+  dataDir: string,
+  input: {
+    readonly pid: number;
+    readonly version?: string;
+    readonly ownerId?: string;
+    readonly execPath?: string;
+    readonly hostname?: string;
+    readonly processStartId?: string | null;
+    readonly schemaVersion?: number;
+  },
+): string {
+  const locksDir = join(dataDir, "locks");
+  const path = join(locksDir, "activation.lock");
+  mkdirSync(locksDir, { recursive: true });
+  writeFileSync(
+    path,
+    `${JSON.stringify({
+      schemaVersion: input.schemaVersion ?? 1,
+      scope: "activation",
+      pid: input.pid,
+      version: input.version ?? "1.0.0",
+      execPath: input.execPath ?? "/tmp/installer-owner",
+      ownerId: input.ownerId ?? `fixture-${input.pid}`,
+      acquiredAt: "2020-01-01T00:00:00.000Z",
+      hostname: input.hostname ?? hostname().trim().toLowerCase(),
+      processStartId: input.processStartId ?? null,
+    })}\n`,
+  );
+  return path;
+}
+
+export function seedLifecycleLock(dataDir: string, pid: number): string {
+  const locksDir = join(dataDir, "locks");
+  const path = join(locksDir, "lifecycle.lock");
+  mkdirSync(locksDir, { recursive: true });
+  writeFileSync(
+    path,
+    `${JSON.stringify({
+      pid,
+      version: "0.0.0",
+      execPath: "/tmp/kunai-uninstall",
+      acquiredAt: "2026-08-24T00:00:00.000Z",
+    })}\n`,
+  );
+  return path;
 }
 
 /** Route definition for the local release fixture HTTP server. */

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   realpathSync,
+  rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -15,6 +17,8 @@ import { join } from "node:path";
 import {
   createInstallerSandbox,
   installCommandShim,
+  seedActivationLock,
+  seedLifecycleLock,
   windowsShellEnvDefaults,
   withCommandPath,
   withReleaseFixture,
@@ -22,6 +26,14 @@ import {
 
 const REPO_ROOT = join(import.meta.dirname, "../../../..");
 const INSTALL_PS1 = join(REPO_ROOT, "install.ps1");
+
+async function waitForPaths(paths: readonly string[]): Promise<void> {
+  const deadline = Date.now() + 8_000;
+  while (paths.some((path) => !existsSync(path))) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${paths.join(", ")}`);
+    await Bun.sleep(10);
+  }
+}
 
 function pwshAvailable(): boolean {
   const result = spawnSync("pwsh", ["-NoProfile", "-Command", "exit 0"], {
@@ -335,6 +347,24 @@ describePwsh("install.ps1 release asset failures", () => {
 });
 
 describePwsh("install.ps1 lifecycle contract", () => {
+  test("does not start a download while uninstall owns the lifecycle lock", async () => {
+    const sandbox = createInstallerSandbox("install-ps1-lifecycle-lock");
+    seedLifecycleLock(sandbox.dataDir, process.pid);
+    try {
+      await withReleaseFixture({}, async (baseUrl, evidence) => {
+        const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+          ...sandbox.env,
+          KUNAI_DL_BASE: baseUrl,
+        });
+        expect(result.status).not.toBe(0);
+        expect(`${result.stderr}${result.stdout}`).toMatch(/lifecycle|uninstall/i);
+        expect(evidence.requests).toEqual([]);
+      });
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
   test.each(["../1.2.3", "1.2.3-beta", "01.2.3", "1.2"])(
     "rejects invalid version %s before creating directories",
     (version) => {
@@ -531,6 +561,266 @@ describePwsh("install.ps1 lifecycle contract", () => {
       sandbox.cleanup();
     }
   });
+
+  test("different versions download concurrently and serialize launcher plus manifest activation", async () => {
+    const asset = hostWindowsAsset();
+    const versions = ["9.8.7", "9.8.8"] as const;
+    const bodies = {
+      "9.8.7": "MZ-version-9.8.7",
+      "9.8.8": "MZ-version-9.8.8",
+    } as const;
+    const sandbox = createInstallerSandbox("install-ps1-activation-concurrency");
+    const activationPath = seedActivationLock(sandbox.dataDir, { pid: process.pid });
+    try {
+      const routes = Object.fromEntries(
+        versions.flatMap((version) => {
+          const digest = createHash("sha256").update(bodies[version]).digest("hex");
+          return [
+            [`/download/v${version}/${asset}`, { body: bodies[version] }],
+            [`/download/v${version}/SHA256SUMS`, { body: `${digest}  ${asset}\n` }],
+          ];
+        }),
+      );
+      await withReleaseFixture(routes, async (baseUrl) => {
+        const installs = versions.map((version) =>
+          runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", version], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          }),
+        );
+        await waitForPaths(
+          versions.map((version) => join(sandbox.dataDir, "versions", version, "version.json")),
+        );
+        const launcherBeforeRelease = existsSync(join(sandbox.binDir, "kunai.exe"));
+        const manifestBeforeRelease = existsSync(join(sandbox.configDir, "install.json"));
+        rmSync(activationPath, { force: true });
+
+        const results = await Promise.all(installs);
+        expect(results.map((result) => result.status)).toEqual([0, 0]);
+        expect(launcherBeforeRelease).toBe(false);
+        expect(manifestBeforeRelease).toBe(false);
+
+        const manifest = JSON.parse(
+          readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
+        ) as { activeVersion: string; versionedPath: string };
+        expect(versions).toContain(manifest.activeVersion as (typeof versions)[number]);
+        expect(manifest.versionedPath).toBe(
+          join(sandbox.dataDir, "versions", manifest.activeVersion, "kunai.exe"),
+        );
+        expect(readFileSync(join(sandbox.binDir, "kunai.exe"))).toEqual(
+          readFileSync(manifest.versionedPath),
+        );
+        expect(existsSync(activationPath)).toBe(false);
+      });
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("reclaims a dead activation owner", async () => {
+    const asset = hostWindowsAsset();
+    const body = "MZ-stale-owner-reclaimed";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-ps1-activation-stale");
+    const activationPath = seedActivationLock(sandbox.dataDir, { pid: 2_147_483_646 });
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+          expect(result.status).toBe(0);
+          expect(existsSync(activationPath)).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("does not reclaim a foreign-host activation owner", async () => {
+    const asset = hostWindowsAsset();
+    const body = "MZ-foreign-owner";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-ps1-activation-foreign");
+    const activationPath = seedActivationLock(sandbox.dataDir, {
+      pid: 2_147_483_646,
+      hostname: "another-host.example",
+    });
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "40",
+            KUNAI_ACTIVATION_LOCK_POLL_MS: "5",
+          });
+          expect(result.status).not.toBe(0);
+          expect(JSON.parse(readFileSync(activationPath, "utf8")).hostname).toBe(
+            "another-host.example",
+          );
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("reclaims schema-invalid activation metadata after the corrupt grace", async () => {
+    const asset = hostWindowsAsset();
+    const body = "MZ-corrupt-owner";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-ps1-activation-corrupt-schema");
+    const activationPath = seedActivationLock(sandbox.dataDir, {
+      pid: process.pid,
+      schemaVersion: 2,
+    });
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_ACTIVATION_LOCK_CORRUPT_GRACE_MS: "10",
+            KUNAI_ACTIVATION_LOCK_POLL_MS: "2",
+          });
+          expect(result.status).toBe(0);
+          expect(existsSync(activationPath)).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("bounds activation contention after completing the version download", async () => {
+    const asset = hostWindowsAsset();
+    const body = "MZ-activation-timeout";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-ps1-activation-timeout");
+    const activationPath = seedActivationLock(sandbox.dataDir, { pid: process.pid });
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "40",
+            KUNAI_ACTIVATION_LOCK_POLL_MS: "5",
+          });
+          expect(result.status).not.toBe(0);
+          expect(`${result.stderr}${result.stdout}`).toContain("Activation lock held");
+          expect(existsSync(join(sandbox.dataDir, "versions", "9.8.7", "version.json"))).toBe(true);
+          expect(existsSync(activationPath)).toBe(true);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("releases the activation lock when manifest publication fails", async () => {
+    const asset = hostWindowsAsset();
+    const body = "MZ-manifest-failure";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-ps1-activation-failure");
+    const activationPath = seedActivationLock(sandbox.dataDir, { pid: 2_147_483_646 });
+    writeFileSync(sandbox.configDir, "not-a-directory");
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+          expect(result.status).not.toBe(0);
+          expect(existsSync(activationPath)).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  const testPosixPwsh = process.platform === "win32" ? test.skip : test;
+  testPosixPwsh(
+    "restores the previous launcher when manifest commit fails after replacement",
+    async () => {
+      const asset = hostWindowsAsset();
+      const body = "MZ-replacement";
+      const digest = createHash("sha256").update(body).digest("hex");
+      const sandbox = createInstallerSandbox("install-ps1-activation-restore");
+      mkdirSync(join(sandbox.dataDir, "versions", "1.0.0"), { recursive: true });
+      mkdirSync(sandbox.binDir, { recursive: true });
+      mkdirSync(sandbox.configDir, { recursive: true });
+      const previousPath = join(sandbox.dataDir, "versions", "1.0.0", "kunai.exe");
+      const launcher = join(sandbox.binDir, "kunai.exe");
+      writeFileSync(previousPath, "MZ-previous");
+      writeFileSync(launcher, "MZ-previous");
+      const manifestPath = join(sandbox.configDir, "install.json");
+      const oldManifest = `${JSON.stringify(
+        {
+          schemaVersion: 1,
+          method: "binary",
+          activeVersion: "1.0.0",
+          preferredChannel: "stable",
+          launcherPath: launcher,
+          versionedPath: previousPath,
+          managedPaths: [sandbox.dataDir, sandbox.cacheDir],
+          downloadBaseUrl: "https://example.test/releases",
+          installedAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+        null,
+        2,
+      )}\n`;
+      writeFileSync(manifestPath, oldManifest);
+      chmodSync(sandbox.configDir, 0o555);
+      try {
+        await withReleaseFixture(
+          {
+            [`/download/v2.0.0/${asset}`]: { body },
+            "/download/v2.0.0/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+          },
+          async (baseUrl) => {
+            const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "2.0.0"], {
+              ...sandbox.env,
+              KUNAI_DL_BASE: baseUrl,
+            });
+            expect(result.status).not.toBe(0);
+            expect(readFileSync(launcher, "utf8")).toBe("MZ-previous");
+            expect(readFileSync(manifestPath, "utf8")).toBe(oldManifest);
+            expect(existsSync(join(sandbox.dataDir, "locks", "activation.lock"))).toBe(false);
+          },
+        );
+      } finally {
+        chmodSync(sandbox.configDir, 0o755);
+        sandbox.cleanup();
+      }
+    },
+  );
 });
 
 const describeWindows = process.platform === "win32" && pwshAvailable() ? describe : describe.skip;

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -27,6 +27,12 @@ import {
 const REPO_ROOT = join(import.meta.dirname, "../../../..");
 const INSTALL_PS1 = join(REPO_ROOT, "install.ps1");
 
+function impossibleProcessStartId(): string {
+  if (process.platform === "win32") return "windows-ticks:0";
+  if (process.platform === "darwin") return "darwin-ps:impossible";
+  return "linux-proc:0";
+}
+
 async function waitForPaths(paths: readonly string[]): Promise<void> {
   const deadline = Date.now() + 8_000;
   while (paths.some((path) => !existsSync(path))) {
@@ -367,6 +373,86 @@ describePwsh("install.ps1 lifecycle contract", () => {
     }
   });
 
+  test("fails closed on a foreign-host lifecycle guard before download", async () => {
+    const sandbox = createInstallerSandbox("install-ps1-lifecycle-foreign");
+    const path = seedLifecycleLock(sandbox.dataDir, {
+      pid: 2_147_483_646,
+      hostname: " Another-Host.Example ",
+      external: true,
+    });
+    try {
+      await withReleaseFixture({}, async (baseUrl, evidence) => {
+        const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+          ...sandbox.env,
+          KUNAI_DL_BASE: baseUrl,
+        });
+        expect(result.status).not.toBe(0);
+        expect(`${result.stderr}${result.stdout}`).toMatch(/lifecycle|uninstall/i);
+        expect(evidence.requests).toEqual([]);
+        expect(existsSync(path)).toBe(true);
+      });
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("reclaims a same-host lifecycle guard whose pid start identity was reused", async () => {
+    const asset = hostWindowsAsset();
+    const body = "MZ-lifecycle-reused-pid";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-ps1-lifecycle-reused");
+    seedLifecycleLock(sandbox.dataDir, {
+      pid: process.pid,
+      processStartId: impossibleProcessStartId(),
+      external: true,
+    });
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+          expect(result.status).toBe(0);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("gives an unchanged partial lifecycle guard bounded grace before recovery", async () => {
+    const asset = hostWindowsAsset();
+    const body = "MZ-lifecycle-partial";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-ps1-lifecycle-partial");
+    mkdirSync(sandbox.dataDir, { recursive: true });
+    writeFileSync(`${sandbox.dataDir}.lifecycle.lock`, "");
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const startedAt = performance.now();
+          const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+          expect(result.status).toBe(0);
+          expect(performance.now() - startedAt).toBeGreaterThanOrEqual(400);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
   test.each(["../1.2.3", "1.2.3-beta", "01.2.3", "1.2"])(
     "rejects invalid version %s before creating directories",
     (version) => {
@@ -697,7 +783,7 @@ describePwsh("install.ps1 lifecycle contract", () => {
             ...sandbox.env,
             KUNAI_DL_BASE: baseUrl,
             KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "40",
-            KUNAI_ACTIVATION_LOCK_POLL_MS: "5",
+            KUNAI_ACTIVATION_LOCK_POLL_MS: "0",
           });
           expect(result.status).not.toBe(0);
           expect(JSON.parse(readFileSync(activationPath, "utf8")).hostname).toBe(
@@ -764,6 +850,37 @@ describePwsh("install.ps1 lifecycle contract", () => {
           expect(`${result.stderr}${result.stdout}`).toContain("Activation lock held");
           expect(existsSync(join(sandbox.dataDir, "versions", "9.8.7", "version.json"))).toBe(true);
           expect(existsSync(activationPath)).toBe(true);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("bounds activation contention by real elapsed time when poll exceeds timeout", async () => {
+    const asset = hostWindowsAsset();
+    const body = "MZ-activation-real-deadline";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-ps1-activation-real-deadline");
+    seedActivationLock(sandbox.dataDir, { pid: process.pid });
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const install = runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "40",
+            KUNAI_ACTIVATION_LOCK_POLL_MS: "500",
+          });
+          await waitForPaths([join(sandbox.dataDir, "versions", "9.8.7", "version.json")]);
+          const activationStartedAt = performance.now();
+          const result = await install;
+          expect(result.status).not.toBe(0);
+          expect(performance.now() - activationStartedAt).toBeLessThan(300);
         },
       );
     } finally {

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -168,11 +168,13 @@ describePwsh("install.ps1 dry-run", () => {
     }
   });
 
-  test("rejects lifecycle switches — use kunai upgrade / kunai uninstall instead", () => {
+  test("rejects -Uninstall — use kunai uninstall instead", () => {
     const uninstall = runInstallPs1(["-Uninstall"]);
     expect(uninstall.status).not.toBe(0);
     expect(`${uninstall.stderr}${uninstall.stdout}`).toMatch(/Uninstall|parameter/i);
+  });
 
+  test("rejects -Upgrade — use kunai upgrade instead", () => {
     const upgrade = runInstallPs1(["-Upgrade"]);
     expect(upgrade.status).not.toBe(0);
     expect(`${upgrade.stderr}${upgrade.stdout}`).toMatch(/Upgrade|parameter/i);

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -1093,7 +1093,12 @@ describePwsh("install.ps1 lifecycle contract", () => {
     }
   });
 
-  const testPosixPwsh = process.platform === "win32" ? test.skip : test;
+  // A read-only config directory is what makes the manifest commit fail here.
+  // Windows ignores POSIX mode bits and root bypasses them, so on either the
+  // write succeeds and the test asserts a failure that never happened. Skip
+  // where the precondition cannot hold rather than weaken the fixture.
+  const canDenyWriteByMode = process.platform !== "win32" && (process.getuid?.() ?? 0) !== 0;
+  const testPosixPwsh = canDenyWriteByMode ? test : test.skip;
   testPosixPwsh(
     "restores the previous launcher when manifest commit fails after replacement",
     async () => {

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -9,6 +9,7 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -70,6 +71,30 @@ function runInstallPs1(
     encoding: "utf8",
     env,
   });
+}
+
+function runActivationProtocolProbe(body: string): {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+} {
+  const root = mkdtempSync(join(tmpdir(), "kunai-pwsh-activation-probe-"));
+  const probePath = join(root, "probe.ps1");
+  const source = readFileSync(INSTALL_PS1, "utf8");
+  const protocolEnd = source.indexOf("function New-LauncherSnapshot");
+  if (protocolEnd < 0) throw new Error("Could not isolate install.ps1 activation protocol");
+  writeFileSync(probePath, `${source.slice(0, protocolEnd)}\n${body}\n`);
+  try {
+    return spawnSync("pwsh", ["-NoProfile", "-File", probePath], {
+      encoding: "utf8",
+      env: {
+        ...DEFAULT_SHELL_ENV,
+        KUNAI_DATA_DIR: join(root, "data"),
+      },
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 }
 
 function installPwshCommandShim(
@@ -173,6 +198,69 @@ describePwsh("install.ps1 dry-run", () => {
     } finally {
       sandbox.cleanup();
     }
+  });
+});
+
+describePwsh("install.ps1 activation identity", () => {
+  test("treats a case-only raw successor as changed during reclaim", () => {
+    const result = runActivationProtocolProbe(String.raw`
+      $lockPath = Join-Path $env:KUNAI_DATA_DIR 'locks/activation.lock'
+      New-Item -ItemType Directory -Force -Path (Split-Path $lockPath) | Out-Null
+      $record = [ordered]@{
+        schemaVersion = 1
+        scope = 'activation'
+        pid = 2147483646
+        version = '1.0.0'
+        execPath = 'old-installer'
+        ownerId = 'case-owner'
+        acquiredAt = '2020-01-01T00:00:00.000Z'
+        hostname = (Get-ActivationLockHostname)
+        processStartId = $null
+      }
+      $observedRaw = (($record | ConvertTo-Json -Compress) + [Environment]::NewLine)
+      $actualRaw = $observedRaw.Replace('case-owner', 'CASE-OWNER')
+      [System.IO.File]::WriteAllText($lockPath, $actualRaw, (New-Object System.Text.UTF8Encoding $false))
+      $successorBytes = (New-Object System.Text.UTF8Encoding $false).GetBytes(
+        $observedRaw.Replace('case-owner', 'successor-owner')
+      )
+      $timer = [System.Diagnostics.Stopwatch]::StartNew()
+      $reclaimed = Move-ActivationLockToQuarantine $lockPath $observedRaw $false 'probe-owner' $successorBytes $timer
+      $remaining = [System.IO.File]::ReadAllText($lockPath)
+      Write-Output ("{0}|{1}" -f $reclaimed, $remaining.Contains('CASE-OWNER'))
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("False|True");
+  });
+
+  test("does not release a case-only different owner token", () => {
+    const result = runActivationProtocolProbe(String.raw`
+      $lockPath = Join-Path $env:KUNAI_DATA_DIR 'locks/activation.lock'
+      New-Item -ItemType Directory -Force -Path (Split-Path $lockPath) | Out-Null
+      $record = [ordered]@{
+        schemaVersion = 1
+        scope = 'activation'
+        pid = $PID
+        version = '1.0.0'
+        execPath = 'current-installer'
+        ownerId = 'CaseOwner'
+        acquiredAt = '2020-01-01T00:00:00.000Z'
+        hostname = (Get-ActivationLockHostname)
+        processStartId = $null
+      }
+      [System.IO.File]::WriteAllText(
+        $lockPath,
+        (($record | ConvertTo-Json -Compress) + [Environment]::NewLine),
+        (New-Object System.Text.UTF8Encoding $false)
+      )
+      Release-ActivationLock $lockPath 'caseowner'
+      $remaining = Read-ActivationLock $lockPath
+      $owner = if ($null -eq $remaining) { 'missing' } else { [string]$remaining.ownerId }
+      Write-Output ("{0}|{1}" -f (Test-Path -LiteralPath $lockPath), $owner)
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("True|CaseOwner");
   });
 });
 
@@ -756,6 +844,79 @@ describePwsh("install.ps1 lifecycle contract", () => {
           );
           expect(result.status).toBe(0);
           expect(existsSync(activationPath)).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("does not elect an orphaned reclaim temp as an activation claim", async () => {
+    const asset = hostWindowsAsset();
+    const body = "MZ-orphan-reclaim-temp";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-ps1-orphan-reclaim-temp");
+    const orphanPath = join(
+      sandbox.dataDir,
+      "locks",
+      "activation.lock.reclaim.crashed-owner.tmp.orphan",
+    );
+    mkdirSync(join(sandbox.dataDir, "locks"), { recursive: true });
+    writeFileSync(orphanPath, "{partial");
+    const abandoned = new Date(Date.now() - 5_000);
+    utimesSync(orphanPath, abandoned, abandoned);
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "60",
+            KUNAI_ACTIVATION_LOCK_POLL_MS: "2",
+          });
+          expect(result.status).toBe(0);
+          expect(existsSync(orphanPath)).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("timeout zero does not enter reclaim retry for a dead owner", async () => {
+    const asset = hostWindowsAsset();
+    const body = "MZ-zero-timeout-reclaim";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-ps1-zero-timeout-reclaim");
+    const activationPath = seedActivationLock(sandbox.dataDir, {
+      pid: 2_147_483_646,
+      ownerId: "dead-owner-must-remain",
+    });
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const install = runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "0",
+            KUNAI_ACTIVATION_LOCK_POLL_MS: "1",
+          });
+          await waitForPaths([join(sandbox.dataDir, "versions", "9.8.7", "version.json")]);
+          const activationStartedAt = performance.now();
+          const result = await install;
+          expect(result.status).not.toBe(0);
+          expect(performance.now() - activationStartedAt).toBeLessThan(300);
+          expect(JSON.parse(readFileSync(activationPath, "utf8")).ownerId).toBe(
+            "dead-owner-must-remain",
+          );
         },
       );
     } finally {

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -202,6 +202,19 @@ describePwsh("install.ps1 dry-run", () => {
 });
 
 describePwsh("install.ps1 activation identity", () => {
+  test("caps an activation poll to the remaining deadline", () => {
+    const result = runActivationProtocolProbe(String.raw`
+      $script:ActivationLockTimeoutMs = 40
+      $script:ActivationLockPollMs = 10000
+      $timer = [System.Diagnostics.Stopwatch]::StartNew()
+      Wait-ActivationLockPoll $timer
+      Write-Output $timer.ElapsedMilliseconds
+    `);
+
+    expect(result.status).toBe(0);
+    expect(Number(result.stdout.trim())).toBeLessThan(1_000);
+  });
+
   test("treats a case-only raw successor as changed during reclaim", () => {
     const result = runActivationProtocolProbe(String.raw`
       $lockPath = Join-Path $env:KUNAI_DATA_DIR 'locks/activation.lock'
@@ -910,10 +923,8 @@ describePwsh("install.ps1 lifecycle contract", () => {
             KUNAI_ACTIVATION_LOCK_POLL_MS: "1",
           });
           await waitForPaths([join(sandbox.dataDir, "versions", "9.8.7", "version.json")]);
-          const activationStartedAt = performance.now();
           const result = await install;
           expect(result.status).not.toBe(0);
-          expect(performance.now() - activationStartedAt).toBeLessThan(300);
           expect(JSON.parse(readFileSync(activationPath, "utf8")).ownerId).toBe(
             "dead-owner-must-remain",
           );
@@ -1035,13 +1046,15 @@ describePwsh("install.ps1 lifecycle contract", () => {
             ...sandbox.env,
             KUNAI_DL_BASE: baseUrl,
             KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "40",
-            KUNAI_ACTIVATION_LOCK_POLL_MS: "500",
+            // Keep the mutation signal far above ordinary Windows scheduling
+            // noise: an unbounded poll would sleep for ten seconds.
+            KUNAI_ACTIVATION_LOCK_POLL_MS: "10000",
           });
           await waitForPaths([join(sandbox.dataDir, "versions", "9.8.7", "version.json")]);
           const activationStartedAt = performance.now();
           const result = await install;
           expect(result.status).not.toBe(0);
-          expect(performance.now() - activationStartedAt).toBeLessThan(300);
+          expect(performance.now() - activationStartedAt).toBeLessThan(5_000);
         },
       );
     } finally {

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -212,7 +212,9 @@ describePwsh("install.ps1 activation identity", () => {
     `);
 
     expect(result.status).toBe(0);
-    expect(Number(result.stdout.trim())).toBeLessThan(1_000);
+    const elapsedMs = Number(result.stdout.trim());
+    expect(elapsedMs).toBeGreaterThanOrEqual(10);
+    expect(elapsedMs).toBeLessThan(1_000);
   });
 
   test("treats a case-only raw successor as changed during reclaim", () => {

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -12,7 +12,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 
 import {
   createInstallerSandbox,
@@ -82,8 +82,10 @@ function installPwshCommandShim(
 async function runInstallPs1Async(
   args: string[],
   env: NodeJS.ProcessEnv = DEFAULT_SHELL_ENV,
+  cwd?: string,
 ): Promise<{ status: number; stdout: string; stderr: string }> {
   const proc = Bun.spawn(["pwsh", "-NoProfile", "-File", INSTALL_PS1, ...args], {
+    cwd,
     env,
     stdout: "pipe",
     stderr: "pipe",
@@ -634,6 +636,38 @@ describePwsh("install.ps1 lifecycle contract", () => {
             ...sandbox.env,
             KUNAI_DL_BASE: baseUrl,
           });
+          expect(result.status).toBe(0);
+          expect(existsSync(activationPath)).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("elects its reclaim claim across lexical path aliases", async () => {
+    const asset = hostWindowsAsset();
+    const body = "MZ-relative-lock-path";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-ps1-activation-relative-path");
+    const activationPath = seedActivationLock(sandbox.dataDir, { pid: 2_147_483_646 });
+    const sandboxRoot = dirname(sandbox.dataDir);
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallPs1Async(
+            ["-Yes", "-SkipDeps", "-Version", "9.8.7"],
+            {
+              ...sandbox.env,
+              KUNAI_DATA_DIR: basename(sandbox.dataDir),
+              KUNAI_DL_BASE: baseUrl,
+            },
+            sandboxRoot,
+          );
           expect(result.status).toBe(0);
           expect(existsSync(activationPath)).toBe(false);
         },

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -1,7 +1,18 @@
 import { expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 
@@ -12,12 +23,22 @@ import {
   createInstallerSandbox,
   hostInstallShAsset,
   installCommandShim,
+  seedActivationLock,
+  seedLifecycleLock,
   withoutKunaiPathOverrides,
   withReleaseFixture,
 } from "./helpers/installer-script-harness";
 
 const REPO_ROOT = join(import.meta.dirname, "../../../..");
 const INSTALL_SH = join(REPO_ROOT, "install.sh");
+
+async function waitForPaths(paths: readonly string[]): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (paths.some((path) => !existsSync(path))) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${paths.join(", ")}`);
+    await Bun.sleep(10);
+  }
+}
 
 function runInstallSh(
   args: string[],
@@ -382,6 +403,24 @@ describe("install.sh release asset failures", () => {
 });
 
 describe("install.sh lifecycle contract", () => {
+  test("does not start a download while uninstall owns the lifecycle lock", async () => {
+    const sandbox = createInstallerSandbox("install-sh-lifecycle-lock");
+    seedLifecycleLock(sandbox.dataDir, process.pid);
+    try {
+      await withReleaseFixture({}, async (baseUrl, evidence) => {
+        const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+          ...sandbox.env,
+          KUNAI_DL_BASE: baseUrl,
+        });
+        expect(result.status).not.toBe(0);
+        expect(`${result.stderr}${result.stdout}`).toMatch(/lifecycle|uninstall/i);
+        expect(evidence.requests).toEqual([]);
+      });
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
   test.each(["../1.2.3", "1.2.3-beta", "01.2.3", "1.2", "v1.2.3-rc.1"])(
     "rejects invalid version %s before creating directories",
     (version) => {
@@ -490,7 +529,6 @@ describe("install.sh lifecycle contract", () => {
           expect(existsSync(join(sandbox.binDir, "kunai"))).toBe(false);
           // Staging txn dirs must be cleaned on failure.
           if (existsSync(join(sandbox.cacheDir, "staging"))) {
-            const { readdirSync } = await import("node:fs");
             const leftover = readdirSync(join(sandbox.cacheDir, "staging"), {
               recursive: true,
             }) as string[];
@@ -535,7 +573,6 @@ describe("install.sh lifecycle contract", () => {
           );
           expect(existsSync(join(sandbox.binDir, "kunai"))).toBe(false);
           if (existsSync(join(sandbox.cacheDir, "staging"))) {
-            const { readdirSync } = await import("node:fs");
             const leftover = readdirSync(join(sandbox.cacheDir, "staging"), {
               recursive: true,
             }) as string[];
@@ -576,7 +613,6 @@ describe("install.sh lifecycle contract", () => {
           expect(existsSync(join(sandbox.binDir, "kunai"))).toBe(false);
           // Staging txn dirs must be cleaned; empty staging root is ok.
           if (existsSync(join(sandbox.cacheDir, "staging"))) {
-            const { readdirSync } = await import("node:fs");
             const leftover = readdirSync(join(sandbox.cacheDir, "staging"), {
               recursive: true,
             }) as string[];
@@ -643,6 +679,318 @@ describe("install.sh lifecycle contract", () => {
         },
       );
     } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("different versions download concurrently and serialize launcher plus manifest activation", async () => {
+    const asset = hostInstallShAsset();
+    const versions = ["9.8.7", "9.8.8"] as const;
+    const bodies = {
+      "9.8.7": "#!/bin/sh\necho version-9.8.7\n",
+      "9.8.8": "#!/bin/sh\necho version-9.8.8\n",
+    } as const;
+    const sandbox = createInstallerSandbox("install-sh-activation-concurrency");
+    const activationPath = seedActivationLock(sandbox.dataDir, { pid: process.pid });
+    try {
+      const routes = Object.fromEntries(
+        versions.flatMap((version) => {
+          const digest = createHash("sha256").update(bodies[version]).digest("hex");
+          return [
+            [`/download/v${version}/${asset}`, { body: bodies[version] }],
+            [`/download/v${version}/SHA256SUMS`, { body: `${digest}  ${asset}\n` }],
+          ];
+        }),
+      );
+      await withReleaseFixture(routes, async (baseUrl) => {
+        const installs = versions.map((version) =>
+          runInstallShAsync(["--yes", "--skip-deps", "--version", version], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          }),
+        );
+        await waitForPaths(
+          versions.map((version) => join(sandbox.dataDir, "versions", version, "version.json")),
+        );
+        const launcherBeforeRelease = existsSync(join(sandbox.binDir, "kunai"));
+        const manifestBeforeRelease = existsSync(join(sandbox.configDir, "install.json"));
+        rmSync(activationPath, { force: true });
+
+        const results = await Promise.all(installs);
+        expect(results.map((result) => result.status)).toEqual([0, 0]);
+        expect(launcherBeforeRelease).toBe(false);
+        expect(manifestBeforeRelease).toBe(false);
+
+        const manifest = JSON.parse(
+          readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
+        ) as { activeVersion: string; versionedPath: string };
+        expect(versions).toContain(manifest.activeVersion as (typeof versions)[number]);
+        expect(manifest.versionedPath).toBe(
+          join(sandbox.dataDir, "versions", manifest.activeVersion, "kunai"),
+        );
+        expect(readlinkSync(join(sandbox.binDir, "kunai"))).toBe(manifest.versionedPath);
+        expect(existsSync(activationPath)).toBe(false);
+      });
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("reclaims a dead activation owner", async () => {
+    const asset = hostInstallShAsset();
+    const body = "#!/bin/sh\necho stale-owner-reclaimed\n";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-activation-stale");
+    const activationPath = seedActivationLock(sandbox.dataDir, { pid: 2_147_483_646 });
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+          expect(result.status).toBe(0);
+          expect(existsSync(activationPath)).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("does not reclaim a foreign-host activation owner", async () => {
+    const asset = hostInstallShAsset();
+    const body = "#!/bin/sh\necho foreign-owner\n";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-activation-foreign");
+    const activationPath = seedActivationLock(sandbox.dataDir, {
+      pid: 2_147_483_646,
+      hostname: "another-host.example",
+    });
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "40",
+            KUNAI_ACTIVATION_LOCK_POLL_MS: "5",
+          });
+          expect(result.status).not.toBe(0);
+          expect(JSON.parse(readFileSync(activationPath, "utf8")).hostname).toBe(
+            "another-host.example",
+          );
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("reclaims schema-invalid activation metadata after the corrupt grace", async () => {
+    const asset = hostInstallShAsset();
+    const body = "#!/bin/sh\necho corrupt-owner\n";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-activation-corrupt-schema");
+    const activationPath = seedActivationLock(sandbox.dataDir, {
+      pid: process.pid,
+      schemaVersion: 2,
+    });
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_ACTIVATION_LOCK_CORRUPT_GRACE_MS: "10",
+            KUNAI_ACTIVATION_LOCK_POLL_MS: "2",
+          });
+          expect(result.status).toBe(0);
+          expect(existsSync(activationPath)).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("bounds activation contention after completing the version download", async () => {
+    const asset = hostInstallShAsset();
+    const body = "#!/bin/sh\necho activation-timeout\n";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-activation-timeout");
+    const activationPath = seedActivationLock(sandbox.dataDir, { pid: process.pid });
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "40",
+            KUNAI_ACTIVATION_LOCK_POLL_MS: "5",
+          });
+          expect(result.status).not.toBe(0);
+          expect(`${result.stderr}${result.stdout}`).toContain("Activation lock held");
+          expect(existsSync(join(sandbox.dataDir, "versions", "9.8.7", "version.json"))).toBe(true);
+          expect(existsSync(activationPath)).toBe(true);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("releases the activation lock when manifest publication fails", async () => {
+    const asset = hostInstallShAsset();
+    const body = "#!/bin/sh\necho manifest-failure\n";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-activation-failure");
+    const activationPath = seedActivationLock(sandbox.dataDir, { pid: 2_147_483_646 });
+    writeFileSync(sandbox.configDir, "not-a-directory");
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+          expect(result.status).not.toBe(0);
+          expect(existsSync(activationPath)).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("restores the previous launcher when manifest commit fails after replacement", async () => {
+    const asset = hostInstallShAsset();
+    const body = "#!/bin/sh\necho replacement\n";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-activation-restore");
+    mkdirSync(join(sandbox.dataDir, "versions", "1.0.0"), { recursive: true });
+    mkdirSync(sandbox.binDir, { recursive: true });
+    mkdirSync(sandbox.configDir, { recursive: true });
+    const previousPath = join(sandbox.dataDir, "versions", "1.0.0", "kunai");
+    const launcher = join(sandbox.binDir, "kunai");
+    writeFileSync(previousPath, "#!/bin/sh\necho previous\n", { mode: 0o755 });
+    symlinkSync(previousPath, launcher);
+    const manifestPath = join(sandbox.configDir, "install.json");
+    const oldManifest = `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        method: "binary",
+        activeVersion: "1.0.0",
+        preferredChannel: "stable",
+        launcherPath: launcher,
+        versionedPath: previousPath,
+        managedPaths: [sandbox.dataDir, sandbox.cacheDir],
+        downloadBaseUrl: "https://example.test/releases",
+        installedAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      null,
+      2,
+    )}\n`;
+    writeFileSync(manifestPath, oldManifest);
+    chmodSync(sandbox.configDir, 0o555);
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v2.0.0/${asset}`]: { body },
+          "/download/v2.0.0/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "2.0.0"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+          expect(result.status).not.toBe(0);
+          expect(readlinkSync(launcher)).toBe(previousPath);
+          expect(readFileSync(manifestPath, "utf8")).toBe(oldManifest);
+          expect(existsSync(join(sandbox.dataDir, "locks", "activation.lock"))).toBe(false);
+        },
+      );
+    } finally {
+      chmodSync(sandbox.configDir, 0o755);
+      sandbox.cleanup();
+    }
+  });
+
+  test("retains a flat-launcher backup when restoration itself fails", async () => {
+    const asset = hostInstallShAsset();
+    const body = "#!/bin/sh\necho replacement\n";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-activation-restore-failure");
+    mkdirSync(sandbox.binDir, { recursive: true });
+    mkdirSync(sandbox.configDir, { recursive: true });
+    const launcher = join(sandbox.binDir, "kunai");
+    writeFileSync(launcher, "#!/bin/sh\necho legacy-flat\n", { mode: 0o755 });
+    writeFileSync(
+      join(sandbox.configDir, "install.json"),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        method: "binary",
+        activeVersion: "1.0.0",
+        preferredChannel: "stable",
+        launcherPath: launcher,
+        managedPaths: [sandbox.dataDir, sandbox.cacheDir],
+        downloadBaseUrl: "https://example.test/releases",
+        installedAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      })}\n`,
+    );
+    const shimDir = join(sandbox.root, "shims");
+    mkdirSync(shimDir, { recursive: true });
+    const realMv = Bun.which("mv");
+    if (!realMv) throw new Error("mv is required for installer integration tests");
+    installCommandShim(
+      shimDir,
+      "mv",
+      `#!/bin/sh\ncase " $* " in *.activation-backup.*) exit 73 ;; esac\nexec "${realMv}" "$@"\n`,
+    );
+    chmodSync(sandbox.configDir, 0o555);
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v2.0.0/${asset}`]: { body },
+          "/download/v2.0.0/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "2.0.0"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            PATH: `${shimDir}${delimiter}${sandbox.env.PATH ?? ""}`,
+          });
+          expect(result.status).not.toBe(0);
+          expect(result.stderr).toContain("Launcher restoration failed");
+          expect(
+            readdirSync(sandbox.binDir).some((name) => name.includes("activation-backup")),
+          ).toBe(true);
+        },
+      );
+    } finally {
+      chmodSync(sandbox.configDir, 0o755);
       sandbox.cleanup();
     }
   });

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -1135,7 +1135,7 @@ describe("install.sh lifecycle contract", () => {
     installCommandShim(
       shimDir,
       "mv",
-      `#!/bin/sh\n"${realMv}" "$@" || exit $?\ncase "\${2:-}" in *.release.*) "${realSed}" -i 's/"ownerId":"[^"]*"/"ownerId":"injected-other-owner"/' "\${2}" ;; esac\n`,
+      `#!/bin/sh\n"${realMv}" "$@" || exit $?\ncase "\${2:-}" in *.release.*) mutated="\${2}.mutated"; "${realSed}" 's/"ownerId":"[^"]*"/"ownerId":"injected-other-owner"/' "\${2}" >"$mutated" || exit $?; "${realMv}" "$mutated" "\${2}" ;; esac\n`,
     );
     installCommandShim(
       shimDir,

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -65,6 +65,29 @@ async function runInstallShAsync(
   return { status, stdout, stderr };
 }
 
+async function runInstallShWithin(
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number,
+): Promise<{ status: number; stdout: string; stderr: string } | null> {
+  const proc = Bun.spawn(["bash", INSTALL_SH, ...args], {
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const output = Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]).then(([stdout, stderr, status]) => ({ status, stdout, stderr }));
+  const result = await Promise.race([output, Bun.sleep(timeoutMs).then(() => null)]);
+  if (result === null) {
+    proc.kill();
+    await proc.exited;
+  }
+  return result;
+}
+
 type DarwinSysctlFixture = "missing" | "failing" | "0" | "1" | "unexpected";
 
 function runInstallShForDarwin(
@@ -416,6 +439,86 @@ describe("install.sh lifecycle contract", () => {
         expect(`${result.stderr}${result.stdout}`).toMatch(/lifecycle|uninstall/i);
         expect(evidence.requests).toEqual([]);
       });
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("fails closed on a foreign-host lifecycle guard before download", async () => {
+    const sandbox = createInstallerSandbox("install-sh-lifecycle-foreign");
+    const path = seedLifecycleLock(sandbox.dataDir, {
+      pid: 2_147_483_646,
+      hostname: " Another-Host.Example ",
+      external: true,
+    });
+    try {
+      await withReleaseFixture({}, async (baseUrl, evidence) => {
+        const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+          ...sandbox.env,
+          KUNAI_DL_BASE: baseUrl,
+        });
+        expect(result.status).not.toBe(0);
+        expect(`${result.stderr}${result.stdout}`).toMatch(/lifecycle|uninstall/i);
+        expect(evidence.requests).toEqual([]);
+        expect(existsSync(path)).toBe(true);
+      });
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("reclaims a same-host lifecycle guard whose pid start identity was reused", async () => {
+    const asset = hostInstallShAsset();
+    const body = "#!/bin/sh\necho lifecycle-reused-pid\n";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-lifecycle-reused");
+    seedLifecycleLock(sandbox.dataDir, {
+      pid: process.pid,
+      processStartId: "linux-proc:0",
+      external: true,
+    });
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+          expect(result.status).toBe(0);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("gives an unchanged partial lifecycle guard bounded grace before recovery", async () => {
+    const asset = hostInstallShAsset();
+    const body = "#!/bin/sh\necho lifecycle-partial\n";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-lifecycle-partial");
+    mkdirSync(sandbox.dataDir, { recursive: true });
+    writeFileSync(`${sandbox.dataDir}.lifecycle.lock`, "");
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const startedAt = performance.now();
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+          expect(result.status).toBe(0);
+          expect(performance.now() - startedAt).toBeGreaterThanOrEqual(400);
+        },
+      );
     } finally {
       sandbox.cleanup();
     }
@@ -849,6 +952,178 @@ describe("install.sh lifecycle contract", () => {
           expect(`${result.stderr}${result.stdout}`).toContain("Activation lock held");
           expect(existsSync(join(sandbox.dataDir, "versions", "9.8.7", "version.json"))).toBe(true);
           expect(existsSync(activationPath)).toBe(true);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("bounds activation contention by real elapsed time when poll exceeds timeout", async () => {
+    const asset = hostInstallShAsset();
+    const body = "#!/bin/sh\necho activation-real-deadline\n";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-activation-real-deadline");
+    seedActivationLock(sandbox.dataDir, { pid: process.pid });
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const install = runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "40",
+            KUNAI_ACTIVATION_LOCK_POLL_MS: "500",
+          });
+          await waitForPaths([join(sandbox.dataDir, "versions", "9.8.7", "version.json")]);
+          const activationStartedAt = performance.now();
+          const result = await install;
+          expect(result.status).not.toBe(0);
+          expect(performance.now() - activationStartedAt).toBeLessThan(300);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("a failed reclaim with zero poll observes the activation deadline instead of hot-looping", async () => {
+    const asset = hostInstallShAsset();
+    const body = "#!/bin/sh\necho reclaim-deadline\n";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-reclaim-deadline");
+    seedActivationLock(sandbox.dataDir, { pid: 2_147_483_646 });
+    const shimDir = join(sandbox.root, "shims");
+    mkdirSync(shimDir, { recursive: true });
+    const realMv = Bun.which("mv");
+    if (!realMv) throw new Error("mv is required for installer integration tests");
+    installCommandShim(
+      shimDir,
+      "mv",
+      `#!/bin/sh\ncase " $* " in *.reclaim.*) exit 73 ;; esac\nexec "${realMv}" "$@"\n`,
+    );
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallShWithin(
+            ["--yes", "--skip-deps", "--version", "9.8.7"],
+            {
+              ...sandbox.env,
+              KUNAI_DL_BASE: baseUrl,
+              KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "40",
+              KUNAI_ACTIVATION_LOCK_POLL_MS: "0",
+              PATH: `${shimDir}${delimiter}${sandbox.env.PATH ?? ""}`,
+            },
+            500,
+          );
+          expect(result).not.toBeNull();
+          expect(result?.status).not.toBe(0);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("fails closed when an injected hard-link failure prevents quarantine restore", async () => {
+    const asset = hostInstallShAsset();
+    const body = "#!/bin/sh\necho quarantine-restore\n";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-quarantine-restore-failure");
+    seedActivationLock(sandbox.dataDir, { pid: 2_147_483_646 });
+    const shimDir = join(sandbox.root, "shims");
+    mkdirSync(shimDir, { recursive: true });
+    const realMv = Bun.which("mv");
+    const realLn = Bun.which("ln");
+    if (!realMv || !realLn) throw new Error("mv and ln are required for installer tests");
+    installCommandShim(
+      shimDir,
+      "mv",
+      `#!/bin/sh\n"${realMv}" "$@" || exit $?\ncase "\${2:-}" in *.quarantine.*) printf ' ' >>"\${2}" ;; esac\n`,
+    );
+    installCommandShim(
+      shimDir,
+      "ln",
+      `#!/bin/sh\ncase " $* " in *.quarantine.*activation.lock*) exit 74 ;; esac\nexec "${realLn}" "$@"\n`,
+    );
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "100",
+            KUNAI_ACTIVATION_LOCK_POLL_MS: "5",
+            PATH: `${shimDir}${delimiter}${sandbox.env.PATH ?? ""}`,
+          });
+          expect(result.status).not.toBe(0);
+          expect(`${result.stderr}${result.stdout}`).toMatch(/quarantine|activation lock/i);
+          expect(existsSync(join(sandbox.configDir, "install.json"))).toBe(false);
+          expect(
+            readdirSync(join(sandbox.dataDir, "locks")).some((name) =>
+              name.includes("activation.lock.quarantine"),
+            ),
+          ).toBe(true);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("surfaces an injected hard-link failure while releasing quarantined ownership", async () => {
+    const asset = hostInstallShAsset();
+    const body = "#!/bin/sh\necho release-quarantine-restore\n";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-release-quarantine-failure");
+    const shimDir = join(sandbox.root, "shims");
+    mkdirSync(shimDir, { recursive: true });
+    const realMv = Bun.which("mv");
+    const realLn = Bun.which("ln");
+    const realSed = Bun.which("sed");
+    if (!realMv || !realLn || !realSed) {
+      throw new Error("mv, ln, and sed are required for installer tests");
+    }
+    installCommandShim(
+      shimDir,
+      "mv",
+      `#!/bin/sh\n"${realMv}" "$@" || exit $?\ncase "\${2:-}" in *.release.*) "${realSed}" -i 's/"ownerId":"[^"]*"/"ownerId":"injected-other-owner"/' "\${2}" ;; esac\n`,
+    );
+    installCommandShim(
+      shimDir,
+      "ln",
+      `#!/bin/sh\ncase " $* " in *.release.*activation.lock*) exit 74 ;; esac\nexec "${realLn}" "$@"\n`,
+    );
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            PATH: `${shimDir}${delimiter}${sandbox.env.PATH ?? ""}`,
+          });
+          expect(result.status).not.toBe(0);
+          expect(`${result.stderr}${result.stdout}`).toMatch(/restore activation lock quarantine/i);
+          expect(
+            readdirSync(join(sandbox.dataDir, "locks")).some((name) =>
+              name.includes("activation.lock.quarantine"),
+            ),
+          ).toBe(true);
         },
       );
     } finally {

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -11,6 +11,7 @@ import {
   readdirSync,
   rmSync,
   symlinkSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -858,6 +859,42 @@ describe("install.sh lifecycle contract", () => {
           });
           expect(result.status).toBe(0);
           expect(existsSync(activationPath)).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("does not elect an orphaned reclaim temp as an activation claim", async () => {
+    const asset = hostInstallShAsset();
+    const body = "#!/bin/sh\necho orphan-reclaim-temp\n";
+    const digest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-orphan-reclaim-temp");
+    const orphanPath = join(
+      sandbox.dataDir,
+      "locks",
+      "activation.lock.reclaim.crashed-owner.tmp.orphan",
+    );
+    mkdirSync(join(sandbox.dataDir, "locks"), { recursive: true });
+    writeFileSync(orphanPath, "{partial");
+    const abandoned = new Date(Date.now() - 5_000);
+    utimesSync(orphanPath, abandoned, abandoned);
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${asset}`]: { body },
+          "/download/v9.8.7/SHA256SUMS": { body: `${digest}  ${asset}\n` },
+        },
+        async (baseUrl) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "60",
+            KUNAI_ACTIVATION_LOCK_POLL_MS: "2",
+          });
+          expect(result.status).toBe(0);
+          expect(existsSync(orphanPath)).toBe(false);
         },
       );
     } finally {

--- a/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
@@ -76,11 +76,46 @@ describe("activation lock", () => {
 
     const second = await tryAcquireActivationLock(layout, "2.0.0", {
       timeoutMs: 30,
-      pollMs: 5,
+      pollMs: 0,
     });
     expect(second).toMatchObject({ acquired: false, holderPid: process.pid });
     expect(existsSync(activationLockPath(layout))).toBe(true);
 
+    if (first.acquired) await first.release();
+  });
+
+  test("timeout zero still makes one immediate uncontended acquisition attempt", async () => {
+    const layout = await makeLayout();
+    const lock = await tryAcquireActivationLock(layout, "1.0.1", {
+      timeoutMs: 0,
+      pollMs: 0,
+    });
+    expect(lock.acquired).toBe(true);
+    if (lock.acquired) await lock.release();
+  });
+
+  test("includes local acquisition queue time in the caller's deadline", async () => {
+    const layout = await makeLayout();
+    const path = activationLockPath(layout);
+    await writeFile(path, "{not-json\n");
+
+    const firstPromise = tryAcquireActivationLock(layout, "1.0.0", {
+      timeoutMs: 500,
+      pollMs: 5,
+      corruptGraceMs: 150,
+    });
+    await Bun.sleep(10);
+    const startedAt = performance.now();
+    const second = await tryAcquireActivationLock(layout, "2.0.0", {
+      timeoutMs: 30,
+      pollMs: 5,
+    });
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(second.acquired).toBe(false);
+    expect(elapsedMs).toBeLessThan(100);
+
+    const first = await firstPromise;
     if (first.acquired) await first.release();
   });
 
@@ -385,4 +420,24 @@ describe("activation lock", () => {
     ).rejects.toThrow("activation failed");
     expect(existsSync(activationLockPath(layout))).toBe(false);
   });
+
+  test.skipIf(process.platform === "win32")(
+    "surfaces an injected release cleanup failure and preserves ownership",
+    async () => {
+      const layout = await makeLayout();
+      const path = activationLockPath(layout);
+      const lock = await tryAcquireActivationLock(layout, "4.1.0");
+      expect(lock.acquired).toBe(true);
+      if (!lock.acquired) return;
+
+      try {
+        await chmod(layout.locksDir, 0o500);
+        await expect(lock.release()).rejects.toThrow(/release activation lock/i);
+        expect(existsSync(path)).toBe(true);
+      } finally {
+        await chmod(layout.locksDir, 0o700);
+        await lock.release();
+      }
+    },
+  );
 });

--- a/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
@@ -290,6 +290,24 @@ describe("activation lock", () => {
     if (aged.acquired) await aged.release();
   });
 
+  test("ignores and cleans a crashed reclaim temp without electing it as a claim", async () => {
+    const layout = await makeLayout();
+    const path = activationLockPath(layout);
+    const orphanTempPath = `${path}.reclaim.crashed-owner.tmp.orphan`;
+    await writeFile(orphanTempPath, "{partial");
+    const abandoned = new Date(Date.now() - 5_000);
+    await utimes(orphanTempPath, abandoned, abandoned);
+
+    const lock = await tryAcquireActivationLock(layout, "2.1.0", {
+      timeoutMs: 40,
+      pollMs: 5,
+    });
+
+    expect(lock.acquired).toBe(true);
+    expect(existsSync(orphanTempPath)).toBe(false);
+    if (lock.acquired) await lock.release();
+  });
+
   test("never reclaims a valid lock owned by another hostname", async () => {
     const layout = await makeLayout();
     const path = activationLockPath(layout);

--- a/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import { hostname, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -14,6 +14,12 @@ import {
 } from "@/services/update/native-installer/install-layout";
 
 const made: string[] = [];
+
+function impossibleProcessStartId(): string {
+  if (process.platform === "win32") return "windows-ticks:0";
+  if (process.platform === "darwin") return "darwin-ps:impossible";
+  return "linux-proc:0";
+}
 
 afterEach(async () => {
   for (const root of made.splice(0)) {
@@ -212,6 +218,43 @@ describe("activation lock", () => {
     expect(existsSync(violationPath)).toBe(false);
   });
 
+  test("defers process-start validation for a fresh live reclaim claim", async () => {
+    const layout = await makeLayout();
+    const path = activationLockPath(layout);
+    const claimPath = `${path}.reclaim.reused-pid-claim`;
+    await writeFile(
+      claimPath,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        scope: "activation",
+        pid: process.pid,
+        version: "1.0.0",
+        execPath: "/tmp/previous-installer",
+        ownerId: "reused-pid-claim",
+        acquiredAt: "2020-01-01T00:00:00.000Z",
+        hostname: hostname().toLowerCase(),
+        processStartId: impossibleProcessStartId(),
+      })}\n`,
+    );
+
+    const fresh = await tryAcquireActivationLock(layout, "2.0.0", {
+      timeoutMs: 20,
+      pollMs: 5,
+    });
+    expect(fresh.acquired).toBe(false);
+    expect(existsSync(claimPath)).toBe(true);
+
+    const staleTime = new Date(Date.now() - 5_000);
+    await utimes(claimPath, staleTime, staleTime);
+    const aged = await tryAcquireActivationLock(layout, "2.0.0", {
+      timeoutMs: 100,
+      pollMs: 5,
+    });
+    expect(aged.acquired).toBe(true);
+    expect(existsSync(claimPath)).toBe(false);
+    if (aged.acquired) await aged.release();
+  });
+
   test("never reclaims a valid lock owned by another hostname", async () => {
     const layout = await makeLayout();
     const path = activationLockPath(layout);
@@ -238,6 +281,32 @@ describe("activation lock", () => {
     expect(JSON.parse(await readFile(path, "utf8")).ownerId).toBe("remote-owner");
   });
 
+  test("defers process-start validation for a newly published live lock", async () => {
+    const layout = await makeLayout();
+    const path = activationLockPath(layout);
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        scope: "activation",
+        pid: process.pid,
+        version: "1.0.0",
+        execPath: "/tmp/current-installer",
+        ownerId: "fresh-live-owner",
+        acquiredAt: new Date().toISOString(),
+        hostname: hostname().toLowerCase(),
+        processStartId: impossibleProcessStartId(),
+      })}\n`,
+    );
+
+    const lock = await tryAcquireActivationLock(layout, "2.0.0", {
+      timeoutMs: 20,
+      pollMs: 5,
+    });
+    expect(lock).toEqual({ acquired: false, holderPid: process.pid });
+    expect(JSON.parse(await readFile(path, "utf8")).ownerId).toBe("fresh-live-owner");
+  });
+
   test("reclaims a reused local pid when the process-start identity differs", async () => {
     const layout = await makeLayout();
     const path = activationLockPath(layout);
@@ -252,7 +321,7 @@ describe("activation lock", () => {
         ownerId: "reused-pid-owner",
         acquiredAt: "2020-01-01T00:00:00.000Z",
         hostname: hostname().toLowerCase(),
-        processStartId: "linux-proc:0",
+        processStartId: impossibleProcessStartId(),
       })}\n`,
     );
 
@@ -264,27 +333,30 @@ describe("activation lock", () => {
     if (lock.acquired) await lock.release();
   });
 
-  test("does not hot-loop when exclusive creation fails while the lock path is absent", async () => {
-    const layout = await makeLayout();
-    await chmod(layout.locksDir, 0o500);
-    const acquisition = tryAcquireActivationLock(layout, "5.0.0", {
-      timeoutMs: 30,
-      pollMs: 5,
-    });
-    const outcome = await Promise.race([
-      acquisition.then(
-        () => "settled",
-        () => "settled",
-      ),
-      Bun.sleep(150).then(() => "hung"),
-    ]);
-    await chmod(layout.locksDir, 0o700);
-    if (outcome === "hung") {
-      const eventual = await acquisition;
-      if (eventual.acquired) await eventual.release();
-    }
-    expect(outcome).toBe("settled");
-  });
+  test.skipIf(process.platform === "win32")(
+    "does not hot-loop when exclusive creation fails while the lock path is absent",
+    async () => {
+      const layout = await makeLayout();
+      await chmod(layout.locksDir, 0o500);
+      const acquisition = tryAcquireActivationLock(layout, "5.0.0", {
+        timeoutMs: 30,
+        pollMs: 5,
+      });
+      const outcome = await Promise.race([
+        acquisition.then(
+          () => "settled",
+          () => "settled",
+        ),
+        Bun.sleep(150).then(() => "hung"),
+      ]);
+      await chmod(layout.locksDir, 0o700);
+      if (outcome === "hung") {
+        const eventual = await acquisition;
+        if (eventual.acquired) await eventual.release();
+      }
+      expect(outcome).toBe("settled");
+    },
+  );
 
   test("reclaims persistently corrupt metadata after the partial-write grace period", async () => {
     const layout = await makeLayout();

--- a/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
@@ -148,6 +148,42 @@ describe("activation lock", () => {
     if (lock.acquired) await lock.release();
   });
 
+  test("elects reclaim claims when a parent directory contains the legacy temp marker", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai.tmp.activation-lock-"));
+    made.push(root);
+    const layout = getInstallLayoutPaths({
+      dataDir: join(root, "data"),
+      cacheDir: join(root, "cache"),
+      configDir: join(root, "config"),
+      launcherPath: join(root, "bin", "kunai"),
+      platform: "linux",
+    });
+    await mkdir(layout.locksDir, { recursive: true });
+    const path = activationLockPath(layout);
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        scope: "activation",
+        pid: 2_147_483_646,
+        version: "1.0.0",
+        execPath: "/tmp/dead-installer",
+        ownerId: "dead-owner",
+        acquiredAt: "2020-01-01T00:00:00.000Z",
+        hostname: hostname().toLowerCase(),
+        processStartId: null,
+      })}\n`,
+    );
+
+    const lock = await tryAcquireActivationLock(layout, "2.0.0", {
+      timeoutMs: 100,
+      pollMs: 5,
+    });
+
+    expect(lock.acquired).toBe(true);
+    if (lock.acquired) await lock.release();
+  });
+
   test("only one of eight stale-lock reclaimers enters activation at a time", async () => {
     const layout = await makeLayout();
     const path = activationLockPath(layout);

--- a/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
@@ -184,8 +184,9 @@ describe("activation lock", () => {
     );
 
     const lock = await tryAcquireActivationLock(layout, "2.0.0", {
-      timeoutMs: 100,
+      timeoutMs: RECLAIM_TEST_TIMEOUT_MS,
       pollMs: 5,
+      processStartIdLookup: () => null,
     });
 
     expect(lock.acquired).toBe(true);
@@ -365,7 +366,7 @@ describe("activation lock", () => {
     const staleTime = new Date(Date.now() - 5_000);
     await utimes(claimPath, staleTime, staleTime);
     const aged = await tryAcquireActivationLock(layout, "2.0.0", {
-      timeoutMs: 100,
+      timeoutMs: RECLAIM_TEST_TIMEOUT_MS,
       pollMs: 5,
       processStartIdLookup: () => knownCurrentProcessStartId(),
     });
@@ -383,8 +384,9 @@ describe("activation lock", () => {
     await utimes(orphanTempPath, abandoned, abandoned);
 
     const lock = await tryAcquireActivationLock(layout, "2.1.0", {
-      timeoutMs: 40,
+      timeoutMs: RECLAIM_TEST_TIMEOUT_MS,
       pollMs: 5,
+      processStartIdLookup: () => null,
     });
 
     expect(lock.acquired).toBe(true);
@@ -534,9 +536,10 @@ describe("activation lock", () => {
     await writeFile(path, "{not-json\n");
 
     const lock = await tryAcquireActivationLock(layout, "3.0.0", {
-      timeoutMs: 100,
+      timeoutMs: RECLAIM_TEST_TIMEOUT_MS,
       pollMs: 5,
       corruptGraceMs: 15,
+      processStartIdLookup: () => null,
     });
     expect(lock.acquired).toBe(true);
     const content = JSON.parse(await readFile(path, "utf8")) as { version: string };

--- a/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { chmod, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, utimes, writeFile } from "node:fs/promises";
 import { hostname, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -14,6 +14,7 @@ import {
 } from "@/services/update/native-installer/install-layout";
 
 const made: string[] = [];
+const RECLAIM_TEST_TIMEOUT_MS = process.platform === "win32" ? 1_000 : 100;
 
 function impossibleProcessStartId(): string {
   if (process.platform === "win32") return "windows-ticks:0";
@@ -144,8 +145,9 @@ describe("activation lock", () => {
     );
 
     const lock = await tryAcquireActivationLock(layout, "2.0.0", {
-      timeoutMs: 100,
+      timeoutMs: RECLAIM_TEST_TIMEOUT_MS,
       pollMs: 5,
+      processStartIdLookup: () => null,
     });
     expect(lock.acquired).toBe(true);
     const content = JSON.parse(await readFile(path, "utf8")) as { version: string };
@@ -235,6 +237,7 @@ describe("activation lock", () => {
     const path = activationLockPath(layout);
     const criticalPath = join(dirname(path), "activation-critical-section");
     const violationPath = join(dirname(path), "activation-overlap-detected");
+    const startPath = join(dirname(path), "activation-workers-start");
     await writeFile(
       path,
       `${JSON.stringify({
@@ -255,8 +258,16 @@ describe("activation lock", () => {
       "../../../../../src/services/update/native-installer/activation-lock.ts",
     );
     const worker = `
+      import { existsSync } from "node:fs";
       import { mkdir, rm, writeFile } from "node:fs/promises";
+      import { join } from "node:path";
       import { withActivationLock } from ${JSON.stringify(modulePath)};
+      const workerId = process.env.KUNAI_TEST_WORKER_ID;
+      const readyPath = join(process.env.KUNAI_TEST_LOCKS_DIR, \`activation-worker-ready-\${workerId}\`);
+      const enteredPath = join(process.env.KUNAI_TEST_LOCKS_DIR, \`activation-worker-entered-\${workerId}\`);
+      const releasePath = join(process.env.KUNAI_TEST_LOCKS_DIR, \`activation-worker-release-\${workerId}\`);
+      await writeFile(readyPath, "ready");
+      while (!existsSync(process.env.KUNAI_TEST_START_PATH)) await Bun.sleep(5);
       const result = await withActivationLock(
         { locksDir: process.env.KUNAI_TEST_LOCKS_DIR },
         process.env.KUNAI_TEST_VERSION,
@@ -268,10 +279,11 @@ describe("activation lock", () => {
           } catch {
             await writeFile(process.env.KUNAI_TEST_VIOLATION_PATH, "overlap");
           }
-          await Bun.sleep(20);
+          await writeFile(enteredPath, "entered");
+          while (!existsSync(releasePath)) await Bun.sleep(5);
           if (ownsSentinel) await rm(process.env.KUNAI_TEST_CRITICAL_PATH, { recursive: true });
         },
-        { timeoutMs: 2_000, pollMs: 1 },
+        { timeoutMs: process.platform === "win32" ? 5_000 : 2_000, pollMs: 1 },
       );
       process.exit(result === null ? 2 : 0);
     `;
@@ -282,6 +294,8 @@ describe("activation lock", () => {
           ...process.env,
           KUNAI_TEST_LOCKS_DIR: layout.locksDir,
           KUNAI_TEST_VERSION: `3.0.${index}`,
+          KUNAI_TEST_WORKER_ID: String(index),
+          KUNAI_TEST_START_PATH: startPath,
           KUNAI_TEST_CRITICAL_PATH: criticalPath,
           KUNAI_TEST_VIOLATION_PATH: violationPath,
         },
@@ -289,6 +303,33 @@ describe("activation lock", () => {
         stderr: "pipe",
       }),
     );
+
+    const waitForWorkerCount = async (prefix: string, expected: number): Promise<void> => {
+      const deadlineAt = Date.now() + 5_000;
+      while (Date.now() < deadlineAt) {
+        const count = (await readdir(layout.locksDir)).filter((name) =>
+          name.startsWith(prefix),
+        ).length;
+        if (count >= expected) return;
+        await Bun.sleep(5);
+      }
+      throw new Error(`Timed out waiting for ${expected} ${prefix} handshakes`);
+    };
+
+    await waitForWorkerCount("activation-worker-ready-", 8);
+    await writeFile(startPath, "start");
+    const released = new Set<string>();
+    for (let enteredCount = 1; enteredCount <= 8; enteredCount += 1) {
+      await waitForWorkerCount("activation-worker-entered-", enteredCount);
+      expect(existsSync(violationPath)).toBe(false);
+      const entered = (await readdir(layout.locksDir)).filter((name) =>
+        name.startsWith("activation-worker-entered-"),
+      );
+      const next = entered.find((name) => !released.has(name));
+      if (!next) throw new Error("Missing newly entered activation worker");
+      released.add(next);
+      await writeFile(join(layout.locksDir, next.replace("entered", "release")), "release");
+    }
     const statuses = await Promise.all(processes.map((process) => process.exited));
 
     expect(statuses).toEqual([0, 0, 0, 0, 0, 0, 0, 0]);
@@ -454,7 +495,7 @@ describe("activation lock", () => {
     );
 
     const lock = await tryAcquireActivationLock(layout, "2.0.0", {
-      timeoutMs: 100,
+      timeoutMs: RECLAIM_TEST_TIMEOUT_MS,
       pollMs: 5,
       processStartIdLookup: () => knownCurrentProcessStartId(),
     });

--- a/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { hostname, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  tryAcquireActivationLock,
+  withActivationLock,
+} from "@/services/update/native-installer/activation-lock";
+import {
+  activationLockPath,
+  getInstallLayoutPaths,
+} from "@/services/update/native-installer/install-layout";
+
+const made: string[] = [];
+
+afterEach(async () => {
+  for (const root of made.splice(0)) {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+async function makeLayout() {
+  const root = await mkdtemp(join(tmpdir(), "kunai-activation-lock-"));
+  made.push(root);
+  const layout = getInstallLayoutPaths({
+    dataDir: join(root, "data"),
+    cacheDir: join(root, "cache"),
+    configDir: join(root, "config"),
+    launcherPath: join(root, "bin", "kunai"),
+    platform: "linux",
+  });
+  await mkdir(layout.locksDir, { recursive: true });
+  return layout;
+}
+
+describe("activation lock", () => {
+  test("stores cross-language ownership metadata and releases only its own lock", async () => {
+    const layout = await makeLayout();
+    const lock = await tryAcquireActivationLock(layout, "1.2.3", {
+      execPath: "/tmp/kunai-updater",
+    });
+
+    expect(lock.acquired).toBe(true);
+    const path = activationLockPath(layout);
+    const content = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+    expect(content).toMatchObject({
+      schemaVersion: 1,
+      scope: "activation",
+      pid: process.pid,
+      version: "1.2.3",
+      execPath: "/tmp/kunai-updater",
+    });
+    expect(content.ownerId).toBeString();
+    expect(content.acquiredAt).toBeString();
+    expect(content.hostname).toBe(hostname().toLowerCase());
+    expect(content.processStartId === null || typeof content.processStartId === "string").toBe(
+      true,
+    );
+
+    if (lock.acquired) await lock.release();
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test("times out without disturbing a live owner", async () => {
+    const layout = await makeLayout();
+    const first = await tryAcquireActivationLock(layout, "1.0.0");
+    expect(first.acquired).toBe(true);
+
+    const second = await tryAcquireActivationLock(layout, "2.0.0", {
+      timeoutMs: 30,
+      pollMs: 5,
+    });
+    expect(second).toMatchObject({ acquired: false, holderPid: process.pid });
+    expect(existsSync(activationLockPath(layout))).toBe(true);
+
+    if (first.acquired) await first.release();
+  });
+
+  test("reclaims a lock whose owner process is dead", async () => {
+    const layout = await makeLayout();
+    const path = activationLockPath(layout);
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        scope: "activation",
+        pid: 2_147_483_646,
+        version: "1.0.0",
+        execPath: "/tmp/dead-installer",
+        ownerId: "dead-owner",
+        acquiredAt: "2020-01-01T00:00:00.000Z",
+        hostname: hostname().toLowerCase(),
+        processStartId: null,
+      })}\n`,
+    );
+
+    const lock = await tryAcquireActivationLock(layout, "2.0.0", {
+      timeoutMs: 100,
+      pollMs: 5,
+    });
+    expect(lock.acquired).toBe(true);
+    const content = JSON.parse(await readFile(path, "utf8")) as { version: string };
+    expect(content.version).toBe("2.0.0");
+
+    if (lock.acquired) await lock.release();
+  });
+
+  test("only one of eight stale-lock reclaimers enters activation at a time", async () => {
+    const layout = await makeLayout();
+    const path = activationLockPath(layout);
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        scope: "activation",
+        pid: 2_147_483_646,
+        version: "1.0.0",
+        execPath: "/tmp/dead-installer",
+        ownerId: "dead-owner",
+        acquiredAt: "2020-01-01T00:00:00.000Z",
+        hostname: hostname().toLowerCase(),
+        processStartId: null,
+      })}\n`,
+    );
+
+    let inside = 0;
+    let maximumInside = 0;
+    const results = await Promise.all(
+      Array.from({ length: 8 }, async (_, index) => {
+        const lock = await tryAcquireActivationLock(layout, `2.0.${index}`, {
+          timeoutMs: 2_000,
+          pollMs: 1,
+        });
+        if (!lock.acquired) return false;
+        inside += 1;
+        maximumInside = Math.max(maximumInside, inside);
+        await Bun.sleep(15);
+        inside -= 1;
+        await lock.release();
+        return true;
+      }),
+    );
+
+    expect(results).toEqual([true, true, true, true, true, true, true, true]);
+    expect(maximumInside).toBe(1);
+  });
+
+  test("serializes eight separate processes reclaiming the same stale lock", async () => {
+    const layout = await makeLayout();
+    const path = activationLockPath(layout);
+    const criticalPath = join(dirname(path), "activation-critical-section");
+    const violationPath = join(dirname(path), "activation-overlap-detected");
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        scope: "activation",
+        pid: 2_147_483_646,
+        version: "1.0.0",
+        execPath: "/tmp/dead-installer",
+        ownerId: "dead-owner",
+        acquiredAt: "2020-01-01T00:00:00.000Z",
+        hostname: hostname().toLowerCase(),
+        processStartId: null,
+      })}\n`,
+    );
+
+    const modulePath = join(
+      import.meta.dir,
+      "../../../../../src/services/update/native-installer/activation-lock.ts",
+    );
+    const worker = `
+      import { mkdir, rm, writeFile } from "node:fs/promises";
+      import { withActivationLock } from ${JSON.stringify(modulePath)};
+      const result = await withActivationLock(
+        { locksDir: process.env.KUNAI_TEST_LOCKS_DIR },
+        process.env.KUNAI_TEST_VERSION,
+        async () => {
+          let ownsSentinel = false;
+          try {
+            await mkdir(process.env.KUNAI_TEST_CRITICAL_PATH);
+            ownsSentinel = true;
+          } catch {
+            await writeFile(process.env.KUNAI_TEST_VIOLATION_PATH, "overlap");
+          }
+          await Bun.sleep(20);
+          if (ownsSentinel) await rm(process.env.KUNAI_TEST_CRITICAL_PATH, { recursive: true });
+        },
+        { timeoutMs: 2_000, pollMs: 1 },
+      );
+      process.exit(result === null ? 2 : 0);
+    `;
+    const processes = Array.from({ length: 8 }, (_, index) =>
+      Bun.spawn([process.execPath, "-e", worker], {
+        cwd: join(import.meta.dir, "../../../../.."),
+        env: {
+          ...process.env,
+          KUNAI_TEST_LOCKS_DIR: layout.locksDir,
+          KUNAI_TEST_VERSION: `3.0.${index}`,
+          KUNAI_TEST_CRITICAL_PATH: criticalPath,
+          KUNAI_TEST_VIOLATION_PATH: violationPath,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      }),
+    );
+    const statuses = await Promise.all(processes.map((process) => process.exited));
+
+    expect(statuses).toEqual([0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(existsSync(violationPath)).toBe(false);
+  });
+
+  test("never reclaims a valid lock owned by another hostname", async () => {
+    const layout = await makeLayout();
+    const path = activationLockPath(layout);
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        scope: "activation",
+        pid: 2_147_483_646,
+        version: "1.0.0",
+        execPath: "/tmp/remote-installer",
+        ownerId: "remote-owner",
+        acquiredAt: "2026-08-24T00:00:00.000Z",
+        hostname: "another-host.example",
+        processStartId: null,
+      })}\n`,
+    );
+
+    const lock = await tryAcquireActivationLock(layout, "2.0.0", {
+      timeoutMs: 30,
+      pollMs: 5,
+    });
+    expect(lock).toEqual({ acquired: false, holderPid: 2_147_483_646 });
+    expect(JSON.parse(await readFile(path, "utf8")).ownerId).toBe("remote-owner");
+  });
+
+  test("reclaims a reused local pid when the process-start identity differs", async () => {
+    const layout = await makeLayout();
+    const path = activationLockPath(layout);
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        scope: "activation",
+        pid: process.pid,
+        version: "1.0.0",
+        execPath: "/tmp/previous-installer",
+        ownerId: "reused-pid-owner",
+        acquiredAt: "2020-01-01T00:00:00.000Z",
+        hostname: hostname().toLowerCase(),
+        processStartId: "linux-proc:0",
+      })}\n`,
+    );
+
+    const lock = await tryAcquireActivationLock(layout, "2.0.0", {
+      timeoutMs: 100,
+      pollMs: 5,
+    });
+    expect(lock.acquired).toBe(true);
+    if (lock.acquired) await lock.release();
+  });
+
+  test("does not hot-loop when exclusive creation fails while the lock path is absent", async () => {
+    const layout = await makeLayout();
+    await chmod(layout.locksDir, 0o500);
+    const acquisition = tryAcquireActivationLock(layout, "5.0.0", {
+      timeoutMs: 30,
+      pollMs: 5,
+    });
+    const outcome = await Promise.race([
+      acquisition.then(
+        () => "settled",
+        () => "settled",
+      ),
+      Bun.sleep(150).then(() => "hung"),
+    ]);
+    await chmod(layout.locksDir, 0o700);
+    if (outcome === "hung") {
+      const eventual = await acquisition;
+      if (eventual.acquired) await eventual.release();
+    }
+    expect(outcome).toBe("settled");
+  });
+
+  test("reclaims persistently corrupt metadata after the partial-write grace period", async () => {
+    const layout = await makeLayout();
+    const path = activationLockPath(layout);
+    await writeFile(path, "{not-json\n");
+
+    const lock = await tryAcquireActivationLock(layout, "3.0.0", {
+      timeoutMs: 100,
+      pollMs: 5,
+      corruptGraceMs: 15,
+    });
+    expect(lock.acquired).toBe(true);
+    const content = JSON.parse(await readFile(path, "utf8")) as { version: string };
+    expect(content.version).toBe("3.0.0");
+
+    if (lock.acquired) await lock.release();
+  });
+
+  test("releases the lock when activation throws", async () => {
+    const layout = await makeLayout();
+
+    await expect(
+      withActivationLock(layout, "4.0.0", async () => {
+        throw new Error("activation failed");
+      }),
+    ).rejects.toThrow("activation failed");
+    expect(existsSync(activationLockPath(layout))).toBe(false);
+  });
+});

--- a/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
@@ -14,6 +14,7 @@ import {
 } from "@/services/update/native-installer/install-layout";
 
 const made: string[] = [];
+const WINDOWS_IDENTITY_TIMEOUT_MS = 3_000;
 
 function impossibleProcessStartId(): string {
   if (process.platform === "win32") return "windows-ticks:0";
@@ -207,7 +208,7 @@ describe("activation lock", () => {
     const results = await Promise.all(
       Array.from({ length: 8 }, async (_, index) => {
         const lock = await tryAcquireActivationLock(layout, `2.0.${index}`, {
-          timeoutMs: 2_000,
+          timeoutMs: process.platform === "win32" ? 5_000 : 2_000,
           pollMs: 1,
         });
         if (!lock.acquired) return false;
@@ -318,7 +319,7 @@ describe("activation lock", () => {
     const staleTime = new Date(Date.now() - 5_000);
     await utimes(claimPath, staleTime, staleTime);
     const aged = await tryAcquireActivationLock(layout, "2.0.0", {
-      timeoutMs: 100,
+      timeoutMs: process.platform === "win32" ? WINDOWS_IDENTITY_TIMEOUT_MS : 100,
       pollMs: 5,
     });
     expect(aged.acquired).toBe(true);
@@ -396,6 +397,38 @@ describe("activation lock", () => {
     expect(JSON.parse(await readFile(path, "utf8")).ownerId).toBe("fresh-live-owner");
   });
 
+  test.skipIf(process.platform !== "win32")(
+    "keeps a short deadline while conservatively retaining an aged live Windows owner",
+    async () => {
+      const layout = await makeLayout();
+      const path = activationLockPath(layout);
+      await writeFile(
+        path,
+        `${JSON.stringify({
+          schemaVersion: 1,
+          scope: "activation",
+          pid: process.pid,
+          version: "1.0.0",
+          execPath: process.execPath,
+          ownerId: "aged-live-owner",
+          acquiredAt: "2020-01-01T00:00:00.000Z",
+          hostname: hostname().toLowerCase(),
+          processStartId: impossibleProcessStartId(),
+        })}\n`,
+      );
+
+      const startedAt = performance.now();
+      const lock = await tryAcquireActivationLock(layout, "2.0.0", {
+        timeoutMs: 40,
+        pollMs: 5,
+      });
+
+      expect(lock).toEqual({ acquired: false, holderPid: process.pid });
+      expect(performance.now() - startedAt).toBeLessThan(1_000);
+      expect(JSON.parse(await readFile(path, "utf8")).ownerId).toBe("aged-live-owner");
+    },
+  );
+
   test("reclaims a reused local pid when the process-start identity differs", async () => {
     const layout = await makeLayout();
     const path = activationLockPath(layout);
@@ -415,7 +448,7 @@ describe("activation lock", () => {
     );
 
     const lock = await tryAcquireActivationLock(layout, "2.0.0", {
-      timeoutMs: 100,
+      timeoutMs: process.platform === "win32" ? WINDOWS_IDENTITY_TIMEOUT_MS : 100,
       pollMs: 5,
     });
     expect(lock.acquired).toBe(true);

--- a/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
@@ -14,12 +14,17 @@ import {
 } from "@/services/update/native-installer/install-layout";
 
 const made: string[] = [];
-const WINDOWS_IDENTITY_TIMEOUT_MS = 3_000;
 
 function impossibleProcessStartId(): string {
   if (process.platform === "win32") return "windows-ticks:0";
   if (process.platform === "darwin") return "darwin-ps:impossible";
   return "linux-proc:0";
+}
+
+function knownCurrentProcessStartId(): string {
+  if (process.platform === "win32") return "windows-ticks:1";
+  if (process.platform === "darwin") return "darwin-ps:known-current";
+  return "linux-proc:1";
 }
 
 afterEach(async () => {
@@ -319,8 +324,9 @@ describe("activation lock", () => {
     const staleTime = new Date(Date.now() - 5_000);
     await utimes(claimPath, staleTime, staleTime);
     const aged = await tryAcquireActivationLock(layout, "2.0.0", {
-      timeoutMs: process.platform === "win32" ? WINDOWS_IDENTITY_TIMEOUT_MS : 100,
+      timeoutMs: 100,
       pollMs: 5,
+      processStartIdLookup: () => knownCurrentProcessStartId(),
     });
     expect(aged.acquired).toBe(true);
     expect(existsSync(claimPath)).toBe(false);
@@ -448,8 +454,9 @@ describe("activation lock", () => {
     );
 
     const lock = await tryAcquireActivationLock(layout, "2.0.0", {
-      timeoutMs: process.platform === "win32" ? WINDOWS_IDENTITY_TIMEOUT_MS : 100,
+      timeoutMs: 100,
       pollMs: 5,
+      processStartIdLookup: () => knownCurrentProcessStartId(),
     });
     expect(lock.acquired).toBe(true);
     if (lock.acquired) await lock.release();

--- a/apps/cli/test/unit/services/update/native-installer/install-diagnostic.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/install-diagnostic.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { hostname, tmpdir } from "node:os";
+import { join } from "node:path";
 
 import type { InstallManifest } from "@/services/update/install-manifest";
 import { getInstallDiagnostics } from "@/services/update/native-installer/install-diagnostic";
+import {
+  activationLockPath,
+  getInstallLayoutPaths,
+} from "@/services/update/native-installer/install-layout";
 
 const binaryManifest: InstallManifest = {
   schemaVersion: 1,
@@ -64,5 +71,49 @@ describe("getInstallDiagnostics", () => {
     expect(diagnostics[2]?.message).toBe(
       "Native launcher /home/k/.local/bin/kunai is shadowed by /usr/local/bin/kunai.",
     );
+  });
+
+  test("reports a stale shared activation lock without reclaiming it", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai-install-diagnostic-lock-"));
+    const layout = getInstallLayoutPaths({
+      dataDir: join(root, "data"),
+      cacheDir: join(root, "cache"),
+      configDir: join(root, "config"),
+      launcherPath: join(root, "bin", "kunai"),
+      platform: "linux",
+    });
+    await mkdir(layout.locksDir, { recursive: true });
+    const path = activationLockPath(layout);
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        scope: "activation",
+        pid: 2_147_483_646,
+        version: "1.0.0",
+        execPath: "/tmp/dead-installer",
+        ownerId: "dead-owner",
+        acquiredAt: "2020-01-01T00:00:00.000Z",
+        hostname: hostname().trim().toLowerCase(),
+        processStartId: null,
+      })}\n`,
+    );
+
+    try {
+      const diagnostics = await getInstallDiagnostics({
+        layout,
+        pathValue: "",
+        fileExists: () => false,
+        readManifest: async () => null,
+      });
+      expect(diagnostics).toContainEqual({
+        level: "warn",
+        code: "stale-activation-lock",
+        message: `Stale installer activation lock at ${path} (owner pid 2147483646 is not running).`,
+      });
+      expect(await Bun.file(path).exists()).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/cli/test/unit/services/update/native-installer/install-latest.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/install-latest.test.ts
@@ -1,12 +1,24 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, readlink, rm, symlink, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { existsSync } from "node:fs";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readlink,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { hostname, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import { readInstallManifest, writeInstallManifest } from "@/services/update/install-manifest";
+import { tryAcquireActivationLock } from "@/services/update/native-installer/activation-lock";
 import { installLatest } from "@/services/update/native-installer/install-latest";
 import {
+  activationLockPath,
   getInstallLayoutPaths,
   versionBinaryPath,
   versionMetadataPath,
@@ -53,6 +65,14 @@ function hostAssetName(): string {
 
 function sumsFor(assetName: string, digest: string): string {
   return `${digest}  ${assetName}\n`;
+}
+
+async function waitForPath(path: string): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!existsSync(path)) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${path}`);
+    await Bun.sleep(5);
+  }
 }
 
 async function seedLauncher(launcherPath: string, versionPath: string): Promise<void> {
@@ -151,4 +171,182 @@ describe("installLatest", () => {
     expect(meta.artifactSha256).toBe(digest);
     expect(await verifyStoredVersion(layout, "3.1.4")).toMatchObject({ status: "verified" });
   });
+
+  test("downloads and installs the version before waiting to activate shared state", async () => {
+    const { layout } = await makeLayout();
+    const held = await tryAcquireActivationLock(layout, "1.0.0");
+    expect(held.acquired).toBe(true);
+
+    const assetName = hostAssetName();
+    const bytes = new TextEncoder().encode("WAITING-TO-ACTIVATE");
+    const digest = sha256Hex(bytes);
+    const install = installLatest({
+      version: "2.0.0",
+      force: true,
+      layout,
+      dlBase: "https://example.test/releases",
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.includes("SHA256SUMS")) {
+          return new Response(sumsFor(assetName, digest), { status: 200 });
+        }
+        if (url.includes(assetName)) return new Response(bytes, { status: 200 });
+        return new Response("missing", { status: 404 });
+      },
+    });
+
+    const versionPath = versionBinaryPath(layout, "2.0.0");
+    await waitForPath(versionMetadataPath(layout, "2.0.0"));
+    expect(await Bun.file(versionPath).text()).toBe("WAITING-TO-ACTIVATE");
+    expect(existsSync(layout.launcherPath)).toBe(false);
+    expect(await readInstallManifest(layout.configDir)).toBeNull();
+
+    if (held.acquired) await held.release();
+    expect(await install).toMatchObject({ status: "installed", version: "2.0.0" });
+    await expectLauncherPointsTo(layout.launcherPath, versionPath);
+    expect((await readInstallManifest(layout.configDir))?.activeVersion).toBe("2.0.0");
+  });
+
+  test("releases a reclaimed activation lock when manifest publication fails", async () => {
+    const { layout } = await makeLayout();
+    const path = activationLockPath(layout);
+    await mkdir(layout.locksDir, { recursive: true });
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        scope: "activation",
+        pid: 2_147_483_646,
+        version: "1.0.0",
+        execPath: "/tmp/dead-installer",
+        ownerId: "dead-owner",
+        acquiredAt: "2020-01-01T00:00:00.000Z",
+        hostname: hostname().trim().toLowerCase(),
+        processStartId: null,
+      })}\n`,
+    );
+    await rm(layout.configDir, { recursive: true, force: true });
+    await writeFile(layout.configDir, "not-a-directory");
+
+    const assetName = hostAssetName();
+    const bytes = new TextEncoder().encode("MANIFEST-WILL-FAIL");
+    const digest = sha256Hex(bytes);
+    const result = await installLatest({
+      version: "4.0.0",
+      force: true,
+      layout,
+      dlBase: "https://example.test/releases",
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.includes("SHA256SUMS")) {
+          return new Response(sumsFor(assetName, digest), { status: 200 });
+        }
+        if (url.includes(assetName)) return new Response(bytes, { status: 200 });
+        return new Response("missing", { status: 404 });
+      },
+    });
+
+    expect(result.status).toBe("failed");
+    expect(existsSync(path)).toBe(false);
+  });
+
+  const testPosix = process.platform === "win32" ? test.skip : test;
+  testPosix(
+    "restores the previous launcher when manifest commit fails after replacement",
+    async () => {
+      const { layout } = await makeLayout();
+      const previousPath = versionBinaryPath(layout, "1.0.0");
+      await mkdir(dirname(previousPath), { recursive: true });
+      await writeFile(previousPath, "OLD-BINARY");
+      await seedLauncher(layout.launcherPath, previousPath);
+      await writeInstallManifest(
+        {
+          method: "binary",
+          activeVersion: "1.0.0",
+          launcherPath: layout.launcherPath,
+          versionedPath: previousPath,
+          downloadBaseUrl: "https://example.test/releases",
+          artifactSha256: sha256Hex("OLD-BINARY"),
+        },
+        layout.configDir,
+      );
+      const beforeManifest = await readFile(join(layout.configDir, "install.json"), "utf8");
+      await chmod(layout.configDir, 0o555);
+
+      const assetName = hostAssetName();
+      const bytes = new TextEncoder().encode("NEW-BINARY");
+      const digest = sha256Hex(bytes);
+      let result;
+      try {
+        result = await installLatest({
+          version: "2.0.0",
+          force: true,
+          layout,
+          dlBase: "https://example.test/releases",
+          fetchImpl: async (input) => {
+            const url = String(input);
+            if (url.includes("SHA256SUMS")) {
+              return new Response(sumsFor(assetName, digest), { status: 200 });
+            }
+            if (url.includes(assetName)) return new Response(bytes, { status: 200 });
+            return new Response("missing", { status: 404 });
+          },
+        });
+      } finally {
+        await chmod(layout.configDir, 0o755);
+      }
+
+      expect(result?.status).toBe("failed");
+      await expectLauncherPointsTo(layout.launcherPath, previousPath);
+      expect(await readFile(join(layout.configDir, "install.json"), "utf8")).toBe(beforeManifest);
+      expect(existsSync(activationLockPath(layout))).toBe(false);
+    },
+  );
+
+  testPosix(
+    "restores a legacy flat launcher when manifest commit fails after replacement",
+    async () => {
+      const { layout } = await makeLayout();
+      await writeFile(layout.launcherPath, "LEGACY-FLAT-BINARY", { mode: 0o755 });
+      await writeInstallManifest(
+        {
+          method: "binary",
+          activeVersion: "1.0.0",
+          launcherPath: layout.launcherPath,
+          downloadBaseUrl: "https://example.test/releases",
+        },
+        layout.configDir,
+      );
+      const beforeManifest = await readFile(join(layout.configDir, "install.json"), "utf8");
+      await chmod(layout.configDir, 0o555);
+
+      const assetName = hostAssetName();
+      const bytes = new TextEncoder().encode("NEW-BINARY");
+      const digest = sha256Hex(bytes);
+      let result;
+      try {
+        result = await installLatest({
+          version: "2.0.0",
+          force: true,
+          layout,
+          dlBase: "https://example.test/releases",
+          fetchImpl: async (input) => {
+            const url = String(input);
+            if (url.includes("SHA256SUMS")) {
+              return new Response(sumsFor(assetName, digest), { status: 200 });
+            }
+            if (url.includes(assetName)) return new Response(bytes, { status: 200 });
+            return new Response("missing", { status: 404 });
+          },
+        });
+      } finally {
+        await chmod(layout.configDir, 0o755);
+      }
+
+      expect(result?.status).toBe("failed");
+      expect(await readFile(layout.launcherPath, "utf8")).toBe("LEGACY-FLAT-BINARY");
+      expect(await readFile(join(layout.configDir, "install.json"), "utf8")).toBe(beforeManifest);
+      expect(existsSync(activationLockPath(layout))).toBe(false);
+    },
+  );
 });

--- a/apps/cli/test/unit/services/update/native-installer/migrate-flat-install.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/migrate-flat-install.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, expect, test } from "bun:test";
+import { chmod, lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { readInstallManifest, writeInstallManifest } from "@/services/update/install-manifest";
+import { tryAcquireActivationLock } from "@/services/update/native-installer/activation-lock";
+import {
+  activationLockPath,
+  getInstallLayoutPaths,
+  versionBinaryPath,
+} from "@/services/update/native-installer/install-layout";
+import { migrateFlatInstall } from "@/services/update/native-installer/migrate-flat-install";
+
+import { describePosixOnly as describe } from "../../../../helpers/platform-gates";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+async function seedFlatInstall() {
+  const root = await mkdtemp(join(tmpdir(), "kunai-flat-migration-lock-"));
+  roots.push(root);
+  const layout = getInstallLayoutPaths({
+    dataDir: join(root, "data"),
+    cacheDir: join(root, "cache"),
+    configDir: join(root, "config"),
+    launcherPath: join(root, "bin", "kunai"),
+    platform: "linux",
+  });
+  await mkdir(dirname(layout.launcherPath), { recursive: true });
+  await writeFile(layout.launcherPath, "flat-launcher", { mode: 0o755 });
+  await writeInstallManifest(
+    {
+      method: "binary",
+      activeVersion: "1.2.3",
+      launcherPath: layout.launcherPath,
+      downloadBaseUrl: "https://example.test/releases",
+    },
+    layout.configDir,
+  );
+  const manifest = await readInstallManifest(layout.configDir);
+  if (!manifest) throw new Error("Expected seeded flat install manifest");
+  return { layout, manifest };
+}
+
+async function waitForPath(path: string): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!(await Bun.file(path).exists())) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${path}`);
+    await Bun.sleep(5);
+  }
+}
+
+describe("migrateFlatInstall activation", () => {
+  test("copies the version outside the activation lock and waits before shared publication", async () => {
+    const { layout, manifest } = await seedFlatInstall();
+    const lock = await tryAcquireActivationLock(layout, "9.9.9");
+    expect(lock.acquired).toBe(true);
+
+    const migration = migrateFlatInstall({
+      manifest,
+      currentVersion: "1.2.3",
+      execPath: layout.launcherPath,
+      layout,
+    });
+    await waitForPath(versionBinaryPath(layout, "1.2.3"));
+    await Bun.sleep(20);
+    expect((await lstat(layout.launcherPath)).isFile()).toBe(true);
+
+    if (lock.acquired) await lock.release();
+    expect(await migration).toEqual({
+      migrated: true,
+      versionPath: versionBinaryPath(layout, "1.2.3"),
+    });
+  });
+
+  test("restores the flat launcher before releasing when manifest commit fails", async () => {
+    const { layout, manifest } = await seedFlatInstall();
+    await chmod(layout.configDir, 0o500);
+    try {
+      await expect(
+        migrateFlatInstall({
+          manifest,
+          currentVersion: "1.2.3",
+          execPath: layout.launcherPath,
+          layout,
+        }),
+      ).rejects.toThrow();
+    } finally {
+      await chmod(layout.configDir, 0o700);
+    }
+
+    expect((await lstat(layout.launcherPath)).isFile()).toBe(true);
+    expect(await readFile(layout.launcherPath, "utf8")).toBe("flat-launcher");
+    expect(await Bun.file(activationLockPath(layout)).exists()).toBe(false);
+  });
+});

--- a/apps/cli/test/unit/services/update/native-installer/native-uninstall.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/native-uninstall.test.ts
@@ -211,6 +211,7 @@ describe("nativeUninstall residue and preservation", () => {
     await seedManagedUnixInstall(layout);
     const guardPath = `${layout.dataDir}.lifecycle.lock`;
     const guardedRemovals: string[] = [];
+    const activationGuardedRemovals: string[] = [];
     const originalRm = rm;
     const rmSpy = async (path: Parameters<typeof rm>[0], options?: Parameters<typeof rm>[1]) => {
       if (
@@ -218,6 +219,9 @@ describe("nativeUninstall residue and preservation", () => {
         (path === layout.configDir || path === layout.dataDir || path === layout.cacheDir)
       ) {
         if (existsSync(guardPath)) guardedRemovals.push(path);
+        if (existsSync(join(layout.locksDir, "activation.lock"))) {
+          activationGuardedRemovals.push(path);
+        }
       }
       return originalRm(path, options);
     };
@@ -231,6 +235,7 @@ describe("nativeUninstall residue and preservation", () => {
 
     expect(result.status).toBe("removed");
     expect(guardedRemovals).toEqual([layout.configDir, layout.cacheDir, layout.dataDir]);
+    expect(activationGuardedRemovals).toEqual([layout.configDir, layout.cacheDir, layout.dataDir]);
     expect(existsSync(guardPath)).toBe(false);
   });
 });

--- a/apps/cli/test/unit/services/update/native-installer/native-uninstall.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/native-uninstall.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import { writeInstallManifest } from "@/services/update/install-manifest";
+import { tryAcquireActivationLock } from "@/services/update/native-installer/activation-lock";
 import {
   getInstallLayoutPaths,
   versionBinaryPath,
@@ -159,7 +160,8 @@ describe("nativeUninstall residue and preservation", () => {
     expect(existsSync(layout.versionsDir)).toBe(false);
     expect(existsSync(layout.stagingRoot)).toBe(false);
     expect(existsSync(layout.transactionsDir)).toBe(false);
-    expect(existsSync(layout.locksDir)).toBe(false);
+    expect(existsSync(layout.locksDir)).toBe(true);
+    expect(await readdir(layout.locksDir)).toEqual([]);
     expect(existsSync(join(layout.configDir, "install.json"))).toBe(false);
 
     expect(existsSync(user.configJson)).toBe(true);
@@ -176,7 +178,7 @@ describe("nativeUninstall residue and preservation", () => {
     expect(result.removed).toContain(layout.versionsDir);
     expect(result.removed).toContain(layout.stagingRoot);
     expect(result.removed).toContain(layout.transactionsDir);
-    expect(result.removed).toContain(layout.locksDir);
+    expect(result.removed).not.toContain(layout.locksDir);
     expect(result.removed).toContain(join(layout.configDir, "install.json"));
     expect(result.failed).toEqual([]);
     expect(abandoned.id).toBeTruthy();
@@ -204,6 +206,34 @@ describe("nativeUninstall residue and preservation", () => {
     expect(result.removed).toContain(layout.cacheDir);
     expect(result.preserved).toContain(dirname(user.externalDownloads));
   });
+
+  test("--purge keeps its external lifecycle guard through the final root removal", async () => {
+    const { layout } = await makeRoot();
+    await seedManagedUnixInstall(layout);
+    const guardPath = `${layout.dataDir}.lifecycle.lock`;
+    const guardedRemovals: string[] = [];
+    const originalRm = rm;
+    const rmSpy = async (path: Parameters<typeof rm>[0], options?: Parameters<typeof rm>[1]) => {
+      if (
+        typeof path === "string" &&
+        (path === layout.configDir || path === layout.dataDir || path === layout.cacheDir)
+      ) {
+        if (existsSync(guardPath)) guardedRemovals.push(path);
+      }
+      return originalRm(path, options);
+    };
+
+    const result = await nativeUninstall({
+      layout,
+      platform: "linux",
+      purge: true,
+      rmImpl: rmSpy,
+    });
+
+    expect(result.status).toBe("removed");
+    expect(guardedRemovals).toEqual([layout.configDir, layout.cacheDir, layout.dataDir]);
+    expect(existsSync(guardPath)).toBe(false);
+  });
 });
 
 describe("nativeUninstall refusal", () => {
@@ -226,6 +256,40 @@ describe("nativeUninstall refusal", () => {
 
     if (lock.acquired) await lock.release();
     await rm(root, { recursive: true, force: true }).catch(() => {});
+  });
+
+  test("active launcher activation blocks uninstall without mutation", async () => {
+    const { layout } = await makeRoot();
+    const { path } = await seedManagedUnixInstall(layout);
+    const beforeManifest = await readFile(join(layout.configDir, "install.json"), "utf8");
+
+    const activation = await tryAcquireActivationLock(layout, "9.9.9");
+    expect(activation.acquired).toBe(true);
+    try {
+      const result = await nativeUninstall({
+        layout,
+        platform: "linux",
+        activationLockTimeoutMs: 30,
+      });
+      expect(result.status).toBe("blocked");
+      expect(existsSync(layout.launcherPath)).toBe(true);
+      expect(existsSync(path)).toBe(true);
+      expect(await readFile(join(layout.configDir, "install.json"), "utf8")).toBe(beforeManifest);
+    } finally {
+      if (activation.acquired) await activation.release();
+    }
+  });
+
+  test("transaction-start failure releases lifecycle and activation ownership", async () => {
+    const { layout } = await makeRoot();
+    await seedManagedUnixInstall(layout);
+    await rm(layout.transactionsDir, { recursive: true, force: true });
+    await writeFile(layout.transactionsDir, "not-a-directory");
+
+    await expect(nativeUninstall({ layout, platform: "linux" })).rejects.toThrow();
+    expect(existsSync(join(layout.locksDir, "activation.lock"))).toBe(false);
+    expect(existsSync(join(layout.locksDir, "lifecycle.lock"))).toBe(false);
+    expect(existsSync(layout.launcherPath)).toBe(true);
   });
 
   test("active transaction blocks without mutation", async () => {

--- a/apps/cli/test/unit/services/update/native-installer/native-uninstall.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/native-uninstall.test.ts
@@ -160,8 +160,7 @@ describe("nativeUninstall residue and preservation", () => {
     expect(existsSync(layout.versionsDir)).toBe(false);
     expect(existsSync(layout.stagingRoot)).toBe(false);
     expect(existsSync(layout.transactionsDir)).toBe(false);
-    expect(existsSync(layout.locksDir)).toBe(true);
-    expect(await readdir(layout.locksDir)).toEqual([]);
+    expect(existsSync(layout.locksDir)).toBe(false);
     expect(existsSync(join(layout.configDir, "install.json"))).toBe(false);
 
     expect(existsSync(user.configJson)).toBe(true);

--- a/apps/cli/test/unit/services/update/native-installer/rollback.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/rollback.test.ts
@@ -16,6 +16,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
 
 import { readInstallManifest, writeInstallManifest } from "@/services/update/install-manifest";
+import { tryAcquireActivationLock } from "@/services/update/native-installer/activation-lock";
 import {
   getInstallLayoutPaths,
   versionBinaryPath,
@@ -372,6 +373,26 @@ describePosixOnly("executeRollback activation and refusal", () => {
       expect(existsSync(previousPath)).toBe(true);
     } finally {
       await chmod(layout.configDir, 0o755);
+    }
+  });
+
+  test("refuses shared activation contention without changing launcher or manifest", async () => {
+    const { layout } = await makeRoot();
+    await seedVerifiedVersion(layout, "1.0.0", "old");
+    const activePath = await seedVerifiedVersion(layout, "2.0.0", "new");
+    await symlink(activePath, layout.launcherPath);
+    await seedBinaryManifest(layout, "2.0.0", "1.0.0");
+    const beforeManifest = await readFile(join(layout.configDir, "install.json"), "utf8");
+
+    const activation = await tryAcquireActivationLock(layout, "9.9.9");
+    expect(activation.acquired).toBe(true);
+    try {
+      const result = await executeRollback(layout, { activationLockTimeoutMs: 30 });
+      expect(result).toMatchObject({ status: "refused", code: "locked" });
+      expect(await readlink(layout.launcherPath)).toBe(activePath);
+      expect(await readFile(join(layout.configDir, "install.json"), "utf8")).toBe(beforeManifest);
+    } finally {
+      if (activation.acquired) await activation.release();
     }
   });
 });

--- a/apps/cli/test/unit/services/update/native-installer/version-lock.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/version-lock.test.ts
@@ -4,7 +4,11 @@ import { chmod, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/
 import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { getInstallLayoutPaths } from "@/services/update/native-installer/install-layout";
+import {
+  activationLockPath,
+  getInstallLayoutPaths,
+  lifecycleGuardPath,
+} from "@/services/update/native-installer/install-layout";
 import {
   inspectVersionLock,
   lifecycleLockPath,
@@ -322,6 +326,102 @@ describe("version lock", () => {
     if (recovered.acquired) await recovered.release();
 
     await rm(root, { recursive: true, force: true });
+  });
+
+  test("two contenders serialize reclaim of an aged corrupt lifecycle guard", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai-lock-racing-lifecycle-reclaim-"));
+    const layout = getInstallLayoutPaths({
+      dataDir: join(root, "data"),
+      cacheDir: join(root, "cache"),
+      configDir: join(root, "config"),
+      launcherPath: join(root, "bin", "kunai"),
+      platform: "linux",
+    });
+    const guardPath = lifecycleGuardPath(layout);
+    await mkdir(root, { recursive: true });
+    await writeFile(guardPath, "");
+    const abandoned = new Date(Date.now() - 1_000);
+    await utimes(guardPath, abandoned, abandoned);
+
+    const contentionOptions = {
+      force: true,
+      activationLockTimeoutMs: 40,
+    };
+    const contenders = await Promise.all([
+      tryAcquireLifecycleLock(layout, contentionOptions),
+      tryAcquireLifecycleLock(layout, contentionOptions),
+    ]);
+    const winners = contenders.filter((result) => result.acquired);
+
+    try {
+      expect(winners).toHaveLength(1);
+      expect(existsSync(activationLockPath(layout))).toBe(true);
+      expect(existsSync(guardPath)).toBe(true);
+      const external = JSON.parse(await readFile(guardPath, "utf8")) as { ownerId?: string };
+      const internal = JSON.parse(await readFile(lifecycleLockPath(layout), "utf8")) as {
+        ownerId?: string;
+      };
+      expect(external.ownerId).toBeString();
+      expect(internal.ownerId).toBe(external.ownerId);
+    } finally {
+      await Promise.all(
+        contenders.map(async (result) => {
+          if (result.acquired) await result.release();
+        }),
+      );
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("backout surfaces lifecycle guard cleanup failure before releasing activation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai-lock-lifecycle-backout-failure-"));
+    const layout = getInstallLayoutPaths({
+      dataDir: join(root, "data"),
+      cacheDir: join(root, "cache"),
+      configDir: join(root, "config"),
+      launcherPath: join(root, "bin", "kunai"),
+      platform: "linux",
+    });
+    const guardPath = lifecycleGuardPath(layout);
+    await mkdir(layout.locksDir, { recursive: true });
+    await writeFile(
+      lifecycleLockPath(layout),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        scope: "lifecycle",
+        pid: process.pid,
+        version: "0.0.0",
+        execPath: process.execPath,
+        ownerId: "existing-owner",
+        acquiredAt: new Date().toISOString(),
+        hostname: hostname().trim().toLowerCase(),
+        processStartId: null,
+      })}\n`,
+    );
+
+    let activationHeldDuringBackout = false;
+    const injectedRm: typeof rm = async (path, options) => {
+      if (path === guardPath) {
+        activationHeldDuringBackout = existsSync(activationLockPath(layout));
+        throw new Error("injected lifecycle guard removal failure");
+      }
+      return await rm(path, options);
+    };
+    const acquisitionOptions = {
+      activationLockTimeoutMs: 40,
+      rmImpl: injectedRm,
+    };
+
+    try {
+      await expect(tryAcquireLifecycleLock(layout, acquisitionOptions)).rejects.toThrow(
+        /back out lifecycle lock/i,
+      );
+      expect(activationHeldDuringBackout).toBe(true);
+      expect(existsSync(guardPath)).toBe(true);
+      expect(existsSync(activationLockPath(layout))).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   test.skipIf(process.platform === "win32")(

--- a/apps/cli/test/unit/services/update/native-installer/version-lock.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/version-lock.test.ts
@@ -233,7 +233,11 @@ describe("version lock", () => {
       })}\n`,
     );
 
-    const version = await tryAcquireVersionLock(layout, "1.2.3");
+    const version = await tryAcquireVersionLock(layout, "1.2.3", {
+      execPath: process.execPath,
+      processStartIdLookup: () =>
+        process.platform === "win32" ? "windows-ticks:1" : "linux-proc:1",
+    });
     expect(version.acquired).toBe(true);
     if (version.acquired) await version.release();
 

--- a/apps/cli/test/unit/services/update/native-installer/version-lock.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/version-lock.test.ts
@@ -10,6 +10,7 @@ import {
   lockCurrentVersion,
   releaseCurrentVersionLock,
   tryAcquireVersionLock,
+  tryAcquireLifecycleLock,
 } from "@/services/update/native-installer/version-lock";
 
 describe("version lock", () => {
@@ -108,6 +109,53 @@ describe("version lock", () => {
     expect(source).not.toMatch(/process\.once\(\s*"SIG/);
     expect(source).not.toMatch(/process\.on\(\s*"SIG/);
     expect(source).not.toMatch(/process\.exit\(/);
+  });
+
+  test("a live lifecycle lock prevents a new version install from bypassing uninstall", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai-lock-lifecycle-"));
+    const layout = getInstallLayoutPaths({
+      dataDir: join(root, "data"),
+      cacheDir: join(root, "cache"),
+      configDir: join(root, "config"),
+      launcherPath: join(root, "bin", "kunai"),
+      platform: "linux",
+    });
+
+    const lifecycle = await tryAcquireLifecycleLock(layout);
+    expect(lifecycle.acquired).toBe(true);
+    expect(existsSync(`${layout.dataDir}.lifecycle.lock`)).toBe(true);
+    const version = await tryAcquireVersionLock(layout, "1.2.3");
+    expect(version.acquired).toBe(false);
+
+    if (lifecycle.acquired) await lifecycle.release();
+    expect(existsSync(`${layout.dataDir}.lifecycle.lock`)).toBe(false);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("an external purge-safe lifecycle guard blocks a new version install", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai-lock-external-lifecycle-"));
+    const layout = getInstallLayoutPaths({
+      dataDir: join(root, "data"),
+      cacheDir: join(root, "cache"),
+      configDir: join(root, "config"),
+      launcherPath: join(root, "bin", "kunai"),
+      platform: "linux",
+    });
+    await mkdir(root, { recursive: true });
+    await writeFile(
+      `${layout.dataDir}.lifecycle.lock`,
+      `${JSON.stringify({
+        pid: process.pid,
+        version: "0.0.0",
+        execPath: process.execPath,
+        acquiredAt: new Date().toISOString(),
+      })}\n`,
+    );
+
+    const version = await tryAcquireVersionLock(layout, "1.2.3");
+    expect(version).toMatchObject({ acquired: false, holderPid: process.pid });
+
+    await rm(root, { recursive: true, force: true });
   });
 });
 

--- a/apps/cli/test/unit/services/update/native-installer/version-lock.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/version-lock.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { chmod, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { getInstallLayoutPaths } from "@/services/update/native-installer/install-layout";
 import {
   inspectVersionLock,
+  lifecycleLockPath,
   lockCurrentVersion,
   releaseCurrentVersionLock,
   tryAcquireVersionLock,
@@ -124,6 +125,19 @@ describe("version lock", () => {
     const lifecycle = await tryAcquireLifecycleLock(layout);
     expect(lifecycle.acquired).toBe(true);
     expect(existsSync(`${layout.dataDir}.lifecycle.lock`)).toBe(true);
+    const content = JSON.parse(
+      await readFile(`${layout.dataDir}.lifecycle.lock`, "utf8"),
+    ) as Record<string, unknown>;
+    expect(content).toMatchObject({
+      schemaVersion: 1,
+      scope: "lifecycle",
+      pid: process.pid,
+      hostname: hostname().trim().toLowerCase(),
+    });
+    expect(content.ownerId).toBeString();
+    expect(content.processStartId === null || typeof content.processStartId === "string").toBe(
+      true,
+    );
     const version = await tryAcquireVersionLock(layout, "1.2.3");
     expect(version.acquired).toBe(false);
 
@@ -157,6 +171,185 @@ describe("version lock", () => {
 
     await rm(root, { recursive: true, force: true });
   });
+
+  test("a foreign-host lifecycle guard fails closed even when its pid is dead locally", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai-lock-foreign-lifecycle-"));
+    const layout = getInstallLayoutPaths({
+      dataDir: join(root, "data"),
+      cacheDir: join(root, "cache"),
+      configDir: join(root, "config"),
+      launcherPath: join(root, "bin", "kunai"),
+      platform: "linux",
+    });
+    await mkdir(root, { recursive: true });
+    await writeFile(
+      `${layout.dataDir}.lifecycle.lock`,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        scope: "lifecycle",
+        pid: 2_147_483_646,
+        version: "0.0.0",
+        execPath: "/remote/kunai",
+        ownerId: "remote-owner",
+        acquiredAt: "2026-08-24T00:00:00.000Z",
+        hostname: " Another-Host.Example ",
+        processStartId: null,
+      })}\n`,
+    );
+
+    const version = await tryAcquireVersionLock(layout, "1.2.3");
+    expect(version).toEqual({ acquired: false, holderPid: 2_147_483_646 });
+    expect(existsSync(`${layout.dataDir}.lifecycle.lock`)).toBe(true);
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("a same-host lifecycle guard with a reused pid is stale", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai-lock-reused-lifecycle-"));
+    const layout = getInstallLayoutPaths({
+      dataDir: join(root, "data"),
+      cacheDir: join(root, "cache"),
+      configDir: join(root, "config"),
+      launcherPath: join(root, "bin", "kunai"),
+      platform: "linux",
+    });
+    await mkdir(root, { recursive: true });
+    await writeFile(
+      `${layout.dataDir}.lifecycle.lock`,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        scope: "lifecycle",
+        pid: process.pid,
+        version: "0.0.0",
+        execPath: process.execPath,
+        ownerId: "reused-owner",
+        acquiredAt: "2020-01-01T00:00:00.000Z",
+        hostname: hostname().trim().toLowerCase(),
+        processStartId: process.platform === "win32" ? "windows-ticks:0" : "linux-proc:0",
+      })}\n`,
+    );
+
+    const version = await tryAcquireVersionLock(layout, "1.2.3");
+    expect(version.acquired).toBe(true);
+    if (version.acquired) await version.release();
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("legacy lifecycle records keep local live-pid compatibility", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai-lock-legacy-lifecycle-"));
+    const layout = getInstallLayoutPaths({
+      dataDir: join(root, "data"),
+      cacheDir: join(root, "cache"),
+      configDir: join(root, "config"),
+      launcherPath: join(root, "bin", "kunai"),
+      platform: "linux",
+    });
+    await mkdir(root, { recursive: true });
+    await writeFile(
+      `${layout.dataDir}.lifecycle.lock`,
+      `${JSON.stringify({
+        pid: process.pid,
+        version: "0.0.0",
+        execPath: process.execPath,
+        acquiredAt: new Date().toISOString(),
+      })}\n`,
+    );
+
+    expect(await tryAcquireVersionLock(layout, "1.2.3")).toEqual({
+      acquired: false,
+      holderPid: process.pid,
+    });
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("a partial lifecycle guard blocks during grace and becomes recoverable when abandoned", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai-lock-partial-lifecycle-"));
+    const layout = getInstallLayoutPaths({
+      dataDir: join(root, "data"),
+      cacheDir: join(root, "cache"),
+      configDir: join(root, "config"),
+      launcherPath: join(root, "bin", "kunai"),
+      platform: "linux",
+    });
+    const guardPath = `${layout.dataDir}.lifecycle.lock`;
+    await mkdir(root, { recursive: true });
+    await writeFile(guardPath, "");
+
+    expect((await tryAcquireVersionLock(layout, "1.2.3")).acquired).toBe(false);
+
+    const abandoned = new Date(Date.now() - 1_000);
+    await utimes(guardPath, abandoned, abandoned);
+    const recovered = await tryAcquireVersionLock(layout, "1.2.3");
+    expect(recovered.acquired).toBe(true);
+    if (recovered.acquired) await recovered.release();
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("an incomplete schema-1 lifecycle record receives corrupt grace", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kunai-lock-invalid-lifecycle-"));
+    const layout = getInstallLayoutPaths({
+      dataDir: join(root, "data"),
+      cacheDir: join(root, "cache"),
+      configDir: join(root, "config"),
+      launcherPath: join(root, "bin", "kunai"),
+      platform: "linux",
+    });
+    const guardPath = `${layout.dataDir}.lifecycle.lock`;
+    await mkdir(root, { recursive: true });
+    await writeFile(
+      guardPath,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        scope: "lifecycle",
+        version: "0.0.0",
+        execPath: process.execPath,
+        ownerId: "partial-owner",
+        acquiredAt: new Date().toISOString(),
+        hostname: hostname().trim().toLowerCase(),
+        processStartId: null,
+      })}\n`,
+    );
+
+    expect((await tryAcquireVersionLock(layout, "1.2.3")).acquired).toBe(false);
+
+    const abandoned = new Date(Date.now() - 1_000);
+    await utimes(guardPath, abandoned, abandoned);
+    const recovered = await tryAcquireVersionLock(layout, "1.2.3");
+    expect(recovered.acquired).toBe(true);
+    if (recovered.acquired) await recovered.release();
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test.skipIf(process.platform === "win32")(
+    "surfaces failure to remove an owner-matching lifecycle guard",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "kunai-lock-release-lifecycle-"));
+      const layout = getInstallLayoutPaths({
+        dataDir: join(root, "data"),
+        cacheDir: join(root, "cache"),
+        configDir: join(root, "config"),
+        launcherPath: join(root, "bin", "kunai"),
+        platform: "linux",
+      });
+      const lifecycle = await tryAcquireLifecycleLock(layout);
+      expect(lifecycle.acquired).toBe(true);
+      if (!lifecycle.acquired) return;
+
+      try {
+        await chmod(layout.locksDir, 0o500);
+        await expect(lifecycle.release()).rejects.toThrow(/release lifecycle lock/i);
+        expect(existsSync(lifecycleLockPath(layout))).toBe(true);
+      } finally {
+        await chmod(layout.locksDir, 0o700);
+        await lifecycle.release();
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 describe("version lock inspection", () => {

--- a/install.ps1
+++ b/install.ps1
@@ -569,6 +569,34 @@ function Test-ActivationOwnerStale($Content) {
   return $false
 }
 
+function Get-ActivationReclaimClaims([string]$LockPath) {
+  $directory = Split-Path $LockPath
+  $leaf = Split-Path $LockPath -Leaf
+  $claims = [System.Collections.Generic.List[string]]::new()
+  foreach ($item in @(Get-ChildItem -LiteralPath $directory -Filter "$leaf.reclaim.*" -File -ErrorAction SilentlyContinue)) {
+    $state = Read-ActivationLockState $item.FullName
+    if ($null -ne $state -and $null -ne $state.Content -and (Test-ActivationOwnerStale $state.Content)) {
+      # Claim paths contain a GUID owner token and are never reused.
+      Remove-Item -LiteralPath $item.FullName -Force -ErrorAction SilentlyContinue
+      continue
+    }
+    $claims.Add($item.FullName)
+  }
+  return @($claims | Sort-Object)
+}
+
+function New-ActivationReclaimClaim([string]$LockPath, [string]$OwnerId, [byte[]]$Bytes) {
+  $claimPath = "$LockPath.reclaim.$OwnerId"
+  $tempPath = "$claimPath.tmp.$([Guid]::NewGuid().ToString('N'))"
+  [System.IO.File]::WriteAllBytes($tempPath, $Bytes)
+  try { [System.IO.File]::Move($tempPath, $claimPath) }
+  catch {
+    Remove-Item -LiteralPath $tempPath -Force -ErrorAction SilentlyContinue
+    throw
+  }
+  return $claimPath
+}
+
 function Restore-ActivationQuarantine([string]$QuarantinePath, [string]$LockPath) {
   try {
     # Hard-link creation is exclusive and therefore cannot overwrite a newer
@@ -592,7 +620,8 @@ function Move-ActivationLockToQuarantine(
   [string]$LockPath,
   [string]$ObservedRaw,
   [bool]$AllowCorrupt,
-  [string]$OwnerId
+  [string]$OwnerId,
+  [byte[]]$SuccessorBytes
 ) {
   $quarantinePath = "$LockPath.quarantine.$OwnerId.$([Guid]::NewGuid().ToString('N'))"
   try { [System.IO.File]::Move($LockPath, $quarantinePath) }
@@ -614,7 +643,51 @@ function Move-ActivationLockToQuarantine(
     return $false
   }
   Remove-Item -LiteralPath $quarantinePath -Force -ErrorAction Stop
-  return $true
+  for ($attempt = 0; $attempt -lt 20; $attempt++) {
+    $stream = $null
+    try {
+      $stream = [System.IO.File]::Open(
+        $LockPath,
+        [System.IO.FileMode]::CreateNew,
+        [System.IO.FileAccess]::Write,
+        [System.IO.FileShare]::None
+      )
+      $stream.Write($SuccessorBytes, 0, $SuccessorBytes.Length)
+      $stream.Flush()
+      $stream.Dispose()
+      return $true
+    }
+    catch [System.IO.IOException] {
+      if ($null -ne $stream) { $stream.Dispose() }
+      Start-Sleep -Milliseconds 1
+    }
+  }
+  return $false
+}
+
+function Invoke-ActivationReclaim(
+  [string]$LockPath,
+  [string]$ObservedRaw,
+  [bool]$AllowCorrupt,
+  [string]$OwnerId,
+  [byte[]]$SuccessorBytes
+) {
+  $claimPath = New-ActivationReclaimClaim $LockPath $OwnerId $SuccessorBytes
+  try {
+    $claims = @(Get-ActivationReclaimClaims $LockPath)
+    if ($claims.Count -eq 0) { return $false }
+    # FullName may expand a Windows 8.3 path that LockPath retained. Election is
+    # scoped to one lock directory, so compare the unique token-owned leaf.
+    $electedLeaf = [System.IO.Path]::GetFileName([string]$claims[0])
+    $claimLeaf = [System.IO.Path]::GetFileName($claimPath)
+    if (-not [string]::Equals($electedLeaf, $claimLeaf, [StringComparison]::Ordinal)) { return $false }
+    $current = Read-ActivationLockState $LockPath
+    if ($null -eq $current -or [string]$current.Raw -ne $ObservedRaw) { return $false }
+    return Move-ActivationLockToQuarantine $LockPath $ObservedRaw $AllowCorrupt $OwnerId $SuccessorBytes
+  }
+  finally {
+    Remove-Item -LiteralPath $claimPath -Force -ErrorAction SilentlyContinue
+  }
 }
 
 function Acquire-ActivationLock([string]$Ver, [string]$LockPath) {
@@ -638,6 +711,13 @@ function Acquire-ActivationLock([string]$Ver, [string]$LockPath) {
   $holder = $null
 
   while ($true) {
+    if (@(Get-ActivationReclaimClaims $LockPath).Count -gt 0) {
+      if ($timer.ElapsedMilliseconds -ge $ActivationLockTimeoutMs) {
+        throw "Activation reclamation is already in progress for version $Ver"
+      }
+      Start-Sleep -Milliseconds ([Math]::Max(1, $ActivationLockPollMs))
+      continue
+    }
     $stream = $null
     try {
       $stream = [System.IO.File]::Open(
@@ -649,7 +729,9 @@ function Acquire-ActivationLock([string]$Ver, [string]$LockPath) {
       $stream.Write($bytes, 0, $bytes.Length)
       $stream.Flush()
       $stream.Dispose()
-      return $ownerId
+      if (@(Get-ActivationReclaimClaims $LockPath).Count -eq 0) { return $ownerId }
+      Release-ActivationLock $LockPath $ownerId
+      continue
     }
     catch [System.IO.IOException] {
       if ($null -ne $stream) { $stream.Dispose() }
@@ -676,8 +758,9 @@ function Acquire-ActivationLock([string]$Ver, [string]$LockPath) {
       $corruptSinceMs = 0L
       $holder = [int]$content.pid
       if (Test-ActivationOwnerStale $content) {
-        Move-ActivationLockToQuarantine $LockPath ([string]$observed.Raw) $false $ownerId | Out-Null
-        continue
+        if (Invoke-ActivationReclaim $LockPath ([string]$observed.Raw) $false $ownerId $bytes) {
+          return $ownerId
+        }
       }
     }
     else {
@@ -688,10 +771,9 @@ function Acquire-ActivationLock([string]$Ver, [string]$LockPath) {
         $holder = $null
       }
       elseif (($timer.ElapsedMilliseconds - $corruptSinceMs) -ge $ActivationLockCorruptGraceMs) {
-        Move-ActivationLockToQuarantine $LockPath $raw $true $ownerId | Out-Null
+        if (Invoke-ActivationReclaim $LockPath $raw $true $ownerId $bytes) { return $ownerId }
         $corruptRaw = $null
         $corruptSinceMs = 0L
-        continue
       }
     }
 

--- a/install.ps1
+++ b/install.ps1
@@ -60,6 +60,9 @@ $DownloadRetryBaseMs = if ($env:KUNAI_DOWNLOAD_RETRY_BASE_MS) { [int]$env:KUNAI_
 $ActivationLockTimeoutMs = if ($env:KUNAI_ACTIVATION_LOCK_TIMEOUT_MS) { [int]$env:KUNAI_ACTIVATION_LOCK_TIMEOUT_MS } else { 10000 }
 $ActivationLockPollMs = if ($env:KUNAI_ACTIVATION_LOCK_POLL_MS) { [int]$env:KUNAI_ACTIVATION_LOCK_POLL_MS } else { 50 }
 $ActivationLockCorruptGraceMs = if ($env:KUNAI_ACTIVATION_LOCK_CORRUPT_GRACE_MS) { [int]$env:KUNAI_ACTIVATION_LOCK_CORRUPT_GRACE_MS } else { 250 }
+$ActivationLockTimeoutMs = [Math]::Max(0, $ActivationLockTimeoutMs)
+$ActivationLockPollMs = [Math]::Max(1, $ActivationLockPollMs)
+$ActivationLockCorruptGraceMs = [Math]::Max(0, $ActivationLockCorruptGraceMs)
 
 function Write-Utf8File([string]$Path, [string]$Content) {
   $encoding = New-Object System.Text.UTF8Encoding $false
@@ -408,21 +411,60 @@ function Write-VersionMetadata {
   Move-Item -Force -Path $tmp -Destination $Path
 }
 
+function Test-LifecycleLockActive([string]$LockPath) {
+  $script:LifecycleHolderPid = $null
+  $raw = try { Get-Content -LiteralPath $LockPath -Raw -ErrorAction Stop } catch { '' }
+  $candidate = $null
+  try { $candidate = $raw | ConvertFrom-Json } catch { $candidate = $null }
+  $validPid = $null -ne $candidate -and
+    ($candidate.pid -is [int] -or $candidate.pid -is [long]) -and [int64]$candidate.pid -gt 0
+  $properties = if ($null -ne $candidate) { @($candidate.PSObject.Properties.Name) } else { @() }
+  $modernIntent = $properties -contains 'schemaVersion' -or $properties -contains 'scope' -or
+    $properties -contains 'hostname' -or $properties -contains 'processStartId'
+  $validModern = $validPid -and $modernIntent -and
+    [int64]$candidate.schemaVersion -eq 1 -and [string]$candidate.scope -eq 'lifecycle' -and
+    $candidate.version -is [string] -and [string]$candidate.version -eq '0.0.0' -and
+    $candidate.execPath -is [string] -and -not [string]::IsNullOrWhiteSpace([string]$candidate.execPath) -and
+    $candidate.ownerId -is [string] -and -not [string]::IsNullOrWhiteSpace([string]$candidate.ownerId) -and
+    $raw -match '"acquiredAt"\s*:\s*"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z"' -and
+    $candidate.hostname -is [string] -and -not [string]::IsNullOrWhiteSpace([string]$candidate.hostname) -and
+    ($properties -contains 'processStartId') -and
+    ($null -eq $candidate.processStartId -or
+      ($candidate.processStartId -is [string] -and
+        -not [string]::IsNullOrWhiteSpace([string]$candidate.processStartId)))
+
+  if (-not $validPid -or ($modernIntent -and -not $validModern)) {
+    Start-Sleep -Milliseconds 250
+    $reread = try { Get-Content -LiteralPath $LockPath -Raw -ErrorAction Stop } catch { '' }
+    # A changing record is still being published. An unchanged invalid record
+    # has exhausted its bounded grace and is abandoned crash residue.
+    return $reread -ne $raw
+  }
+
+  $script:LifecycleHolderPid = [int]$candidate.pid
+  if (-not $modernIntent) {
+    return $null -ne (Get-Process -Id $script:LifecycleHolderPid -ErrorAction SilentlyContinue)
+  }
+  $ownerHost = ([string]$candidate.hostname).Trim().ToLowerInvariant()
+  if ($ownerHost -ne (Get-ActivationLockHostname)) { return $true }
+  $process = Get-Process -Id $script:LifecycleHolderPid -ErrorAction SilentlyContinue
+  if ($null -eq $process) { return $false }
+  if (-not [string]::IsNullOrWhiteSpace([string]$candidate.processStartId)) {
+    $currentStart = Get-ActivationProcessStartId $script:LifecycleHolderPid
+    if ($currentStart -and $currentStart -ne [string]$candidate.processStartId) { return $false }
+  }
+  return $true
+}
+
 function Acquire-VersionLock([string]$Ver, [string]$LockPath) {
   New-Item -ItemType Directory -Force -Path (Split-Path $LockPath) | Out-Null
   $lifecyclePath = Join-Path (Split-Path $LockPath) 'lifecycle.lock'
   $lifecycleGuardPath = "$DataDir.lifecycle.lock"
   foreach ($lifecycleCandidate in @($lifecycleGuardPath, $lifecyclePath)) {
     if (Test-Path -LiteralPath $lifecycleCandidate) {
-      try {
-        $lifecycle = Get-Content -LiteralPath $lifecycleCandidate -Raw | ConvertFrom-Json
-        $lifecyclePid = [int]$lifecycle.pid
-        if ($lifecyclePid -gt 0 -and $null -ne (Get-Process -Id $lifecyclePid -ErrorAction SilentlyContinue)) {
-          throw "Install lifecycle lock held by pid $lifecyclePid; uninstall is in progress"
-        }
-      }
-      catch {
-        if ($_.Exception.Message -match 'lifecycle lock held') { throw }
+      if (Test-LifecycleLockActive $lifecycleCandidate) {
+        $detail = if ($null -ne $script:LifecycleHolderPid) { " by pid $($script:LifecycleHolderPid)" } else { '' }
+        throw "Install lifecycle lock held$detail; uninstall is in progress"
       }
     }
   }
@@ -457,16 +499,10 @@ function Acquire-VersionLock([string]$Ver, [string]$LockPath) {
   # Close the race with lifecycle acquisition before download or mutation.
   foreach ($lifecycleCandidate in @($lifecycleGuardPath, $lifecyclePath)) {
     if (Test-Path -LiteralPath $lifecycleCandidate) {
-      try {
-        $lifecycle = Get-Content -LiteralPath $lifecycleCandidate -Raw | ConvertFrom-Json
-        $lifecyclePid = [int]$lifecycle.pid
-        if ($lifecyclePid -gt 0 -and $null -ne (Get-Process -Id $lifecyclePid -ErrorAction SilentlyContinue)) {
-          Release-VersionLock $LockPath
-          throw "Install lifecycle lock held by pid $lifecyclePid; uninstall is in progress"
-        }
-      }
-      catch {
-        if ($_.Exception.Message -match 'lifecycle lock held') { throw }
+      if (Test-LifecycleLockActive $lifecycleCandidate) {
+        Release-VersionLock $LockPath
+        $detail = if ($null -ne $script:LifecycleHolderPid) { " by pid $($script:LifecycleHolderPid)" } else { '' }
+        throw "Install lifecycle lock held$detail; uninstall is in progress"
       }
     }
   }
@@ -563,7 +599,12 @@ function Test-ActivationOwnerStale($Content) {
   $process = Get-Process -Id ([int]$Content.pid) -ErrorAction SilentlyContinue
   if ($null -eq $process) { return $true }
   if (-not [string]::IsNullOrWhiteSpace([string]$Content.processStartId)) {
-    $currentStart = Get-ActivationProcessStartId ([int]$Content.pid)
+    $currentStart = if ($OnWindows) {
+      "windows-ticks:$($process.StartTime.ToUniversalTime().Ticks)"
+    }
+    else {
+      Get-ActivationProcessStartId ([int]$Content.pid)
+    }
     if ($currentStart -and $currentStart -ne [string]$Content.processStartId) { return $true }
   }
   return $false
@@ -575,6 +616,11 @@ function Get-ActivationReclaimClaims([string]$LockPath) {
   $claims = [System.Collections.Generic.List[string]]::new()
   foreach ($item in @(Get-ChildItem -LiteralPath $directory -Filter "$leaf.reclaim.*" -File -ErrorAction SilentlyContinue)) {
     $state = Read-ActivationLockState $item.FullName
+    if ($null -ne $state -and $null -ne $state.Content -and
+      ([DateTime]::UtcNow - $item.LastWriteTimeUtc).TotalMilliseconds -lt 1000) {
+      $claims.Add($item.FullName)
+      continue
+    }
     if ($null -ne $state -and $null -ne $state.Content -and (Test-ActivationOwnerStale $state.Content)) {
       # Claim paths contain a GUID owner token and are never reused.
       Remove-Item -LiteralPath $item.FullName -Force -ErrorAction SilentlyContinue
@@ -690,7 +736,14 @@ function Invoke-ActivationReclaim(
   }
 }
 
+function Wait-ActivationLockPoll([System.Diagnostics.Stopwatch]$Timer) {
+  $remaining = $ActivationLockTimeoutMs - $Timer.ElapsedMilliseconds
+  if ($remaining -le 0) { return }
+  Start-Sleep -Milliseconds ([Math]::Max(1, [Math]::Min($ActivationLockPollMs, $remaining)))
+}
+
 function Acquire-ActivationLock([string]$Ver, [string]$LockPath) {
+  $timer = [System.Diagnostics.Stopwatch]::StartNew()
   New-Item -ItemType Directory -Force -Path (Split-Path $LockPath) | Out-Null
   $ownerId = "$PID-$([Guid]::NewGuid().ToString('N'))"
   $record = [ordered]@{
@@ -705,17 +758,22 @@ function Acquire-ActivationLock([string]$Ver, [string]$LockPath) {
     processStartId = (Get-ActivationProcessStartId $PID)
   }
   $bytes = (New-Object System.Text.UTF8Encoding $false).GetBytes((($record | ConvertTo-Json -Compress) + "`n"))
-  $timer = [System.Diagnostics.Stopwatch]::StartNew()
   $corruptRaw = $null
   $corruptSinceMs = 0L
   $holder = $null
+  $attempted = $false
 
   while ($true) {
+    if ($attempted -and $timer.ElapsedMilliseconds -ge $ActivationLockTimeoutMs) {
+      $detail = if ($null -ne $holder) { " by pid $holder" } else { '' }
+      throw "Activation lock held$detail while activating version $Ver"
+    }
+    $attempted = $true
     if (@(Get-ActivationReclaimClaims $LockPath).Count -gt 0) {
       if ($timer.ElapsedMilliseconds -ge $ActivationLockTimeoutMs) {
         throw "Activation reclamation is already in progress for version $Ver"
       }
-      Start-Sleep -Milliseconds ([Math]::Max(1, $ActivationLockPollMs))
+      Wait-ActivationLockPoll $timer
       continue
     }
     $stream = $null
@@ -739,7 +797,7 @@ function Acquire-ActivationLock([string]$Ver, [string]$LockPath) {
         if ($timer.ElapsedMilliseconds -ge $ActivationLockTimeoutMs) {
           throw "Could not create activation lock at $LockPath"
         }
-        Start-Sleep -Milliseconds ([Math]::Max(1, $ActivationLockPollMs))
+        Wait-ActivationLockPoll $timer
         continue
       }
     }
@@ -749,7 +807,7 @@ function Acquire-ActivationLock([string]$Ver, [string]$LockPath) {
       if ($timer.ElapsedMilliseconds -ge $ActivationLockTimeoutMs) {
         throw "Activation lock held while activating version $Ver"
       }
-      Start-Sleep -Milliseconds ([Math]::Max(1, $ActivationLockPollMs))
+      Wait-ActivationLockPoll $timer
       continue
     }
     $content = $observed.Content
@@ -781,7 +839,7 @@ function Acquire-ActivationLock([string]$Ver, [string]$LockPath) {
       $detail = if ($null -ne $holder) { " by pid $holder" } else { '' }
       throw "Activation lock held$detail while activating version $Ver"
     }
-    Start-Sleep -Milliseconds ([Math]::Max(1, $ActivationLockPollMs))
+    Wait-ActivationLockPoll $timer
   }
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -57,6 +57,9 @@ $DownloadMaxBytes = if ($env:KUNAI_DOWNLOAD_MAX_BYTES) { [long]$env:KUNAI_DOWNLO
 $DownloadChecksumMaxBytes = if ($env:KUNAI_DOWNLOAD_CHECKSUM_MAX_BYTES) { [long]$env:KUNAI_DOWNLOAD_CHECKSUM_MAX_BYTES } else { 1048576 }
 $DownloadMaxAttempts = if ($env:KUNAI_DOWNLOAD_MAX_ATTEMPTS) { [int]$env:KUNAI_DOWNLOAD_MAX_ATTEMPTS } else { 3 }
 $DownloadRetryBaseMs = if ($env:KUNAI_DOWNLOAD_RETRY_BASE_MS) { [int]$env:KUNAI_DOWNLOAD_RETRY_BASE_MS } else { 1000 }
+$ActivationLockTimeoutMs = if ($env:KUNAI_ACTIVATION_LOCK_TIMEOUT_MS) { [int]$env:KUNAI_ACTIVATION_LOCK_TIMEOUT_MS } else { 10000 }
+$ActivationLockPollMs = if ($env:KUNAI_ACTIVATION_LOCK_POLL_MS) { [int]$env:KUNAI_ACTIVATION_LOCK_POLL_MS } else { 50 }
+$ActivationLockCorruptGraceMs = if ($env:KUNAI_ACTIVATION_LOCK_CORRUPT_GRACE_MS) { [int]$env:KUNAI_ACTIVATION_LOCK_CORRUPT_GRACE_MS } else { 250 }
 
 function Write-Utf8File([string]$Path, [string]$Content) {
   $encoding = New-Object System.Text.UTF8Encoding $false
@@ -407,6 +410,22 @@ function Write-VersionMetadata {
 
 function Acquire-VersionLock([string]$Ver, [string]$LockPath) {
   New-Item -ItemType Directory -Force -Path (Split-Path $LockPath) | Out-Null
+  $lifecyclePath = Join-Path (Split-Path $LockPath) 'lifecycle.lock'
+  $lifecycleGuardPath = "$DataDir.lifecycle.lock"
+  foreach ($lifecycleCandidate in @($lifecycleGuardPath, $lifecyclePath)) {
+    if (Test-Path -LiteralPath $lifecycleCandidate) {
+      try {
+        $lifecycle = Get-Content -LiteralPath $lifecycleCandidate -Raw | ConvertFrom-Json
+        $lifecyclePid = [int]$lifecycle.pid
+        if ($lifecyclePid -gt 0 -and $null -ne (Get-Process -Id $lifecyclePid -ErrorAction SilentlyContinue)) {
+          throw "Install lifecycle lock held by pid $lifecyclePid; uninstall is in progress"
+        }
+      }
+      catch {
+        if ($_.Exception.Message -match 'lifecycle lock held') { throw }
+      }
+    }
+  }
   if (Test-Path -LiteralPath $LockPath) {
     try {
       $existing = Get-Content -LiteralPath $LockPath -Raw | ConvertFrom-Json
@@ -434,6 +453,23 @@ function Acquire-VersionLock([string]$Ver, [string]$LockPath) {
     acquiredAt = (Get-IsoNow)
   }
   Write-Utf8File $LockPath (($content | ConvertTo-Json -Compress) + "`n")
+
+  # Close the race with lifecycle acquisition before download or mutation.
+  foreach ($lifecycleCandidate in @($lifecycleGuardPath, $lifecyclePath)) {
+    if (Test-Path -LiteralPath $lifecycleCandidate) {
+      try {
+        $lifecycle = Get-Content -LiteralPath $lifecycleCandidate -Raw | ConvertFrom-Json
+        $lifecyclePid = [int]$lifecycle.pid
+        if ($lifecyclePid -gt 0 -and $null -ne (Get-Process -Id $lifecyclePid -ErrorAction SilentlyContinue)) {
+          Release-VersionLock $LockPath
+          throw "Install lifecycle lock held by pid $lifecyclePid; uninstall is in progress"
+        }
+      }
+      catch {
+        if ($_.Exception.Message -match 'lifecycle lock held') { throw }
+      }
+    }
+  }
 }
 
 function Release-VersionLock([string]$LockPath) {
@@ -446,6 +482,261 @@ function Release-VersionLock([string]$LockPath) {
   }
   catch {
     Remove-Item -LiteralPath $LockPath -Force -ErrorAction SilentlyContinue
+  }
+}
+
+function Get-ActivationLockHostname {
+  return ([System.Net.Dns]::GetHostName()).Trim().ToLowerInvariant()
+}
+
+function Get-ActivationProcessStartId([int]$ProcessId) {
+  if ($ProcessId -le 0) { return $null }
+  if ($OnWindows) {
+    try {
+      $process = Get-Process -Id $ProcessId -ErrorAction Stop
+      return "windows-ticks:$($process.StartTime.ToUniversalTime().Ticks)"
+    }
+    catch { return $null }
+  }
+  if (Test-Path -LiteralPath "/proc/$ProcessId/stat" -PathType Leaf) {
+    try {
+      $stat = [System.IO.File]::ReadAllText("/proc/$ProcessId/stat")
+      $close = $stat.LastIndexOf(') ')
+      if ($close -lt 0) { return $null }
+      $fields = $stat.Substring($close + 2).Trim() -split '\s+'
+      if ($fields.Count -gt 19 -and $fields[19]) { return "linux-proc:$($fields[19])" }
+    }
+    catch { return $null }
+  }
+  if ($IsMacOS) {
+    try {
+      $value = (& ps -o lstart= -p $ProcessId 2>$null) -join ' '
+      $value = ($value -replace '\s+', ' ').Trim()
+      if ($value) { return "darwin-ps:$value" }
+    }
+    catch { return $null }
+  }
+  return $null
+}
+
+function Read-ActivationLockState([string]$LockPath) {
+  if (-not (Test-Path -LiteralPath $LockPath -PathType Leaf)) { return $null }
+  $raw = try { Get-Content -LiteralPath $LockPath -Raw } catch { '' }
+  $content = $null
+  try {
+    $candidate = $raw | ConvertFrom-Json
+    $hasProcessStart = $candidate.PSObject.Properties.Name -contains 'processStartId'
+    $validProcessStart = $hasProcessStart -and (
+      $null -eq $candidate.processStartId -or
+      ($candidate.processStartId -is [string] -and
+        -not [string]::IsNullOrWhiteSpace([string]$candidate.processStartId))
+    )
+    # PowerShell 7 converts ISO JSON strings to DateTime, so validate the wire
+    # representation to keep corrupt-record semantics identical to Bash/TS.
+    $validAcquiredAt = $raw -match '"acquiredAt"\s*:\s*"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z"'
+    if (
+      ($candidate.schemaVersion -is [int] -or $candidate.schemaVersion -is [long]) -and
+      [int64]$candidate.schemaVersion -eq 1 -and
+      $candidate.scope -is [string] -and [string]$candidate.scope -eq 'activation' -and
+      ($candidate.pid -is [int] -or $candidate.pid -is [long]) -and
+      [int64]$candidate.pid -gt 0 -and
+      $candidate.version -is [string] -and (Test-CanonicalVersion ([string]$candidate.version)) -and
+      $candidate.execPath -is [string] -and -not [string]::IsNullOrWhiteSpace([string]$candidate.execPath) -and
+      $candidate.ownerId -is [string] -and -not [string]::IsNullOrWhiteSpace([string]$candidate.ownerId) -and
+      $validAcquiredAt -and
+      $candidate.hostname -is [string] -and -not [string]::IsNullOrWhiteSpace([string]$candidate.hostname) -and
+      $validProcessStart
+    ) { $content = $candidate }
+  }
+  catch { $content = $null }
+  return [pscustomobject]@{ Raw = $raw; Content = $content }
+}
+
+function Read-ActivationLock([string]$LockPath) {
+  $state = Read-ActivationLockState $LockPath
+  if ($null -eq $state) { return $null }
+  return $state.Content
+}
+
+function Test-ActivationOwnerStale($Content) {
+  if ([string]$Content.hostname -ne (Get-ActivationLockHostname)) { return $false }
+  $process = Get-Process -Id ([int]$Content.pid) -ErrorAction SilentlyContinue
+  if ($null -eq $process) { return $true }
+  if (-not [string]::IsNullOrWhiteSpace([string]$Content.processStartId)) {
+    $currentStart = Get-ActivationProcessStartId ([int]$Content.pid)
+    if ($currentStart -and $currentStart -ne [string]$Content.processStartId) { return $true }
+  }
+  return $false
+}
+
+function Restore-ActivationQuarantine([string]$QuarantinePath, [string]$LockPath) {
+  try {
+    # Hard-link creation is exclusive and therefore cannot overwrite a newer
+    # canonical owner that won after the quarantine rename.
+    New-Item -ItemType HardLink -Path $LockPath -Target $QuarantinePath -ErrorAction Stop | Out-Null
+    Remove-Item -LiteralPath $QuarantinePath -Force -ErrorAction SilentlyContinue
+    return $true
+  }
+  catch {
+    if (Test-Path -LiteralPath $LockPath) {
+      # Preserve the quarantine for diagnostics when another owner already won.
+      return $false
+    }
+    # With no canonical successor, fail closed rather than abandoning a valid
+    # observed owner in quarantine and allowing activation to overlap it.
+    throw
+  }
+}
+
+function Move-ActivationLockToQuarantine(
+  [string]$LockPath,
+  [string]$ObservedRaw,
+  [bool]$AllowCorrupt,
+  [string]$OwnerId
+) {
+  $quarantinePath = "$LockPath.quarantine.$OwnerId.$([Guid]::NewGuid().ToString('N'))"
+  try { [System.IO.File]::Move($LockPath, $quarantinePath) }
+  catch [System.IO.IOException] { return $false }
+
+  $quarantined = Read-ActivationLockState $quarantinePath
+  if ($null -eq $quarantined -or [string]$quarantined.Raw -ne $ObservedRaw) {
+    Restore-ActivationQuarantine $quarantinePath $LockPath | Out-Null
+    return $false
+  }
+  if ($null -ne $quarantined.Content) {
+    if (-not (Test-ActivationOwnerStale $quarantined.Content)) {
+      Restore-ActivationQuarantine $quarantinePath $LockPath | Out-Null
+      return $false
+    }
+  }
+  elseif (-not $AllowCorrupt) {
+    Restore-ActivationQuarantine $quarantinePath $LockPath | Out-Null
+    return $false
+  }
+  Remove-Item -LiteralPath $quarantinePath -Force -ErrorAction Stop
+  return $true
+}
+
+function Acquire-ActivationLock([string]$Ver, [string]$LockPath) {
+  New-Item -ItemType Directory -Force -Path (Split-Path $LockPath) | Out-Null
+  $ownerId = "$PID-$([Guid]::NewGuid().ToString('N'))"
+  $record = [ordered]@{
+    schemaVersion = 1
+    scope         = 'activation'
+    pid           = $PID
+    version       = $Ver
+    execPath      = 'install.ps1'
+    ownerId       = $ownerId
+    acquiredAt    = (Get-IsoNow)
+    hostname      = (Get-ActivationLockHostname)
+    processStartId = (Get-ActivationProcessStartId $PID)
+  }
+  $bytes = (New-Object System.Text.UTF8Encoding $false).GetBytes((($record | ConvertTo-Json -Compress) + "`n"))
+  $timer = [System.Diagnostics.Stopwatch]::StartNew()
+  $corruptRaw = $null
+  $corruptSinceMs = 0L
+  $holder = $null
+
+  while ($true) {
+    $stream = $null
+    try {
+      $stream = [System.IO.File]::Open(
+        $LockPath,
+        [System.IO.FileMode]::CreateNew,
+        [System.IO.FileAccess]::Write,
+        [System.IO.FileShare]::None
+      )
+      $stream.Write($bytes, 0, $bytes.Length)
+      $stream.Flush()
+      $stream.Dispose()
+      return $ownerId
+    }
+    catch [System.IO.IOException] {
+      if ($null -ne $stream) { $stream.Dispose() }
+      if (-not (Test-Path -LiteralPath $LockPath)) {
+        if ($timer.ElapsedMilliseconds -ge $ActivationLockTimeoutMs) {
+          throw "Could not create activation lock at $LockPath"
+        }
+        Start-Sleep -Milliseconds ([Math]::Max(1, $ActivationLockPollMs))
+        continue
+      }
+    }
+
+    $observed = Read-ActivationLockState $LockPath
+    if ($null -eq $observed) {
+      if ($timer.ElapsedMilliseconds -ge $ActivationLockTimeoutMs) {
+        throw "Activation lock held while activating version $Ver"
+      }
+      Start-Sleep -Milliseconds ([Math]::Max(1, $ActivationLockPollMs))
+      continue
+    }
+    $content = $observed.Content
+    if ($null -ne $content) {
+      $corruptRaw = $null
+      $corruptSinceMs = 0L
+      $holder = [int]$content.pid
+      if (Test-ActivationOwnerStale $content) {
+        Move-ActivationLockToQuarantine $LockPath ([string]$observed.Raw) $false $ownerId | Out-Null
+        continue
+      }
+    }
+    else {
+      $raw = [string]$observed.Raw
+      if ($null -eq $corruptRaw -or $raw -ne $corruptRaw) {
+        $corruptRaw = $raw
+        $corruptSinceMs = $timer.ElapsedMilliseconds
+        $holder = $null
+      }
+      elseif (($timer.ElapsedMilliseconds - $corruptSinceMs) -ge $ActivationLockCorruptGraceMs) {
+        Move-ActivationLockToQuarantine $LockPath $raw $true $ownerId | Out-Null
+        $corruptRaw = $null
+        $corruptSinceMs = 0L
+        continue
+      }
+    }
+
+    if ($timer.ElapsedMilliseconds -ge $ActivationLockTimeoutMs) {
+      $detail = if ($null -ne $holder) { " by pid $holder" } else { '' }
+      throw "Activation lock held$detail while activating version $Ver"
+    }
+    Start-Sleep -Milliseconds ([Math]::Max(1, $ActivationLockPollMs))
+  }
+}
+
+function Release-ActivationLock([string]$LockPath, [string]$OwnerId) {
+  if ([string]::IsNullOrWhiteSpace($OwnerId)) { return }
+  $quarantinePath = "$LockPath.quarantine.$OwnerId.release.$([Guid]::NewGuid().ToString('N'))"
+  try { [System.IO.File]::Move($LockPath, $quarantinePath) }
+  catch [System.IO.IOException] { return }
+  $moved = Read-ActivationLock $quarantinePath
+  if ($null -ne $moved -and [string]$moved.ownerId -eq $OwnerId) {
+    Remove-Item -LiteralPath $quarantinePath -Force -ErrorAction SilentlyContinue
+  }
+  else {
+    Restore-ActivationQuarantine $quarantinePath $LockPath | Out-Null
+  }
+}
+
+function New-LauncherSnapshot([string]$LauncherPath) {
+  $backup = "$LauncherPath.activation-backup.$PID"
+  Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue
+  $exists = Test-Path -LiteralPath $LauncherPath -PathType Leaf
+  if ($exists) { Copy-Item -Force -Path $LauncherPath -Destination $backup }
+  return [pscustomobject]@{ Exists = $exists; BackupPath = $backup }
+}
+
+function Restore-LauncherSnapshot([string]$LauncherPath, $Snapshot) {
+  if ($Snapshot.Exists) {
+    Copy-Item -Force -Path $Snapshot.BackupPath -Destination $LauncherPath
+  }
+  else {
+    Remove-Item -LiteralPath $LauncherPath -Force -ErrorAction SilentlyContinue
+  }
+}
+
+function Remove-LauncherSnapshot($Snapshot) {
+  if ($null -ne $Snapshot) {
+    Remove-Item -LiteralPath $Snapshot.BackupPath -Force -ErrorAction SilentlyContinue
   }
 }
 
@@ -473,12 +764,9 @@ function Update-Launcher([string]$VersionPath, [string]$LauncherPath) {
   New-Item -ItemType Directory -Force -Path (Split-Path $LauncherPath) | Out-Null
   if (Test-Path -LiteralPath $LauncherPath) {
     $aside = "$LauncherPath.old.$([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())"
-    try {
-      Move-Item -Force -Path $LauncherPath -Destination $aside
-    }
-    catch {
-      Remove-Item -LiteralPath $LauncherPath -Force -ErrorAction SilentlyContinue
-    }
+    # Never delete the working launcher after a failed move-aside. The caller
+    # holds a durable snapshot and will restore it after any later failure.
+    Move-Item -Force -Path $LauncherPath -Destination $aside
   }
   Copy-Item -Force -Path $VersionPath -Destination $LauncherPath
   # Clearing the mark-of-the-web is meaningful only on Windows, and the cmdlet
@@ -739,11 +1027,16 @@ function Install-Binary {
   $txnId = ("{0:x}-{1}" -f [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds(), $PID)
   $txnPath = Join-Path $TransactionsDir "$txnId.json"
   $lockPath = Join-Path $LocksDir "$resolved.lock"
+  $activationLockPath = Join-Path $LocksDir 'activation.lock'
   $stagedBin = Join-Path $staging $asset
   $stagedSums = Join-Path $staging 'SHA256SUMS'
   $metadataPath = Join-Path (Join-Path $VersionsDir $resolved) 'version.json'
 
   $cleanupDone = $false
+  $activationOwnerId = $null
+  $launcherSnapshot = $null
+  $launcherActivated = $false
+  $preserveLauncherSnapshot = $false
   try {
     Acquire-VersionLock $resolved $lockPath
     New-Item -ItemType Directory -Force -Path $staging | Out-Null
@@ -797,11 +1090,41 @@ function Install-Binary {
     Write-VersionMetadata -Ver $resolved -Target $target -ArtifactName $asset -Sha256 $got `
       -SizeBytes $sizeBytes -SourceUrl $url -Path $metadataPath
 
-    Update-Launcher -VersionPath $versionPath -LauncherPath $BinPath
+    $activationOwnerId = Acquire-ActivationLock $resolved $activationLockPath
+    # Another version may have activated during this download. Read shared state
+    # under the cross-version lock before publishing the launcher and manifest.
+    $activationPrevious = Get-PreviousActiveVersion
+    $launcherSnapshot = New-LauncherSnapshot $BinPath
+    try {
+      # Update-Launcher can fail after moving the old launcher but before the
+      # replacement copy completes, so restoration is required from invocation.
+      $launcherActivated = $true
+      Update-Launcher -VersionPath $versionPath -LauncherPath $BinPath
 
-    $prevArg = ''
-    if ($previous -and $previous -ne $resolved) { $prevArg = $previous }
-    Write-Manifest 'binary' $resolved $BinPath $versionPath $target $got $prevArg
+      $prevArg = ''
+      if ($activationPrevious -and $activationPrevious -ne $resolved) { $prevArg = $activationPrevious }
+      Write-Manifest 'binary' $resolved $BinPath $versionPath $target $got $prevArg
+      $launcherActivated = $false
+    }
+    catch {
+      if ($launcherActivated) {
+        try {
+          Restore-LauncherSnapshot $BinPath $launcherSnapshot
+          $launcherActivated = $false
+        }
+        catch {
+          $launcherActivated = $false
+          $preserveLauncherSnapshot = $true
+          throw
+        }
+      }
+      throw
+    }
+    finally {
+      if (-not $preserveLauncherSnapshot) { Remove-LauncherSnapshot $launcherSnapshot }
+      Release-ActivationLock $activationLockPath $activationOwnerId
+      $activationOwnerId = $null
+    }
 
     Finish-InstallTransaction $txnPath
     Release-VersionLock $lockPath
@@ -820,6 +1143,12 @@ function Install-Binary {
   }
   catch {
     if (-not $cleanupDone) {
+      if ($launcherActivated -and $null -ne $launcherSnapshot) {
+        try { Restore-LauncherSnapshot $BinPath $launcherSnapshot }
+        catch { $preserveLauncherSnapshot = $true }
+      }
+      if (-not $preserveLauncherSnapshot) { Remove-LauncherSnapshot $launcherSnapshot }
+      Release-ActivationLock $activationLockPath $activationOwnerId
       Finish-InstallTransaction $txnPath
       Release-VersionLock $lockPath
       if (Test-Path -LiteralPath $staging) {

--- a/install.ps1
+++ b/install.ps1
@@ -573,7 +573,8 @@ function Read-ActivationLockState([string]$LockPath) {
     if (
       ($candidate.schemaVersion -is [int] -or $candidate.schemaVersion -is [long]) -and
       [int64]$candidate.schemaVersion -eq 1 -and
-      $candidate.scope -is [string] -and [string]$candidate.scope -eq 'activation' -and
+      $candidate.scope -is [string] -and
+      [string]::Equals([string]$candidate.scope, 'activation', [StringComparison]::Ordinal) -and
       ($candidate.pid -is [int] -or $candidate.pid -is [long]) -and
       [int64]$candidate.pid -gt 0 -and
       $candidate.version -is [string] -and (Test-CanonicalVersion ([string]$candidate.version)) -and
@@ -605,7 +606,11 @@ function Test-ActivationOwnerStale($Content) {
     else {
       Get-ActivationProcessStartId ([int]$Content.pid)
     }
-    if ($currentStart -and $currentStart -ne [string]$Content.processStartId) { return $true }
+    if ($currentStart -and -not [string]::Equals(
+        [string]$currentStart,
+        [string]$Content.processStartId,
+        [StringComparison]::Ordinal
+      )) { return $true }
   }
   return $false
 }
@@ -614,6 +619,22 @@ function Get-ActivationReclaimClaims([string]$LockPath) {
   $directory = Split-Path $LockPath
   $leaf = Split-Path $LockPath -Leaf
   $claims = [System.Collections.Generic.List[string]]::new()
+  foreach ($filter in @("$leaf.reclaim-tmp.*", "$leaf.reclaim.*.tmp.*")) {
+    foreach ($temp in @(Get-ChildItem -LiteralPath $directory -Filter $filter -File -ErrorAction SilentlyContinue)) {
+      # Temp publications never participate in election. The second pattern
+      # recovers crash residue written by older installers inside `.reclaim.*`.
+      $tempState = Read-ActivationLockState $temp.FullName
+      $reclaimable = if ($null -ne $tempState -and $null -ne $tempState.Content) {
+        Test-ActivationOwnerStale $tempState.Content
+      }
+      else {
+        ([DateTime]::UtcNow - $temp.LastWriteTimeUtc).TotalMilliseconds -ge $ActivationLockCorruptGraceMs
+      }
+      if ($reclaimable) {
+        Remove-Item -LiteralPath $temp.FullName -Force -ErrorAction SilentlyContinue
+      }
+    }
+  }
   foreach ($item in @(Get-ChildItem -LiteralPath $directory -Filter "$leaf.reclaim.*" -File -ErrorAction SilentlyContinue)) {
     $state = Read-ActivationLockState $item.FullName
     if ($null -ne $state -and $null -ne $state.Content -and
@@ -633,7 +654,7 @@ function Get-ActivationReclaimClaims([string]$LockPath) {
 
 function New-ActivationReclaimClaim([string]$LockPath, [string]$OwnerId, [byte[]]$Bytes) {
   $claimPath = "$LockPath.reclaim.$OwnerId"
-  $tempPath = "$claimPath.tmp.$([Guid]::NewGuid().ToString('N'))"
+  $tempPath = "$LockPath.reclaim-tmp.$OwnerId.$([Guid]::NewGuid().ToString('N'))"
   [System.IO.File]::WriteAllBytes($tempPath, $Bytes)
   try { [System.IO.File]::Move($tempPath, $claimPath) }
   catch {
@@ -667,14 +688,20 @@ function Move-ActivationLockToQuarantine(
   [string]$ObservedRaw,
   [bool]$AllowCorrupt,
   [string]$OwnerId,
-  [byte[]]$SuccessorBytes
+  [byte[]]$SuccessorBytes,
+  [System.Diagnostics.Stopwatch]$Timer
 ) {
+  if ($Timer.ElapsedMilliseconds -ge $ActivationLockTimeoutMs) { return $false }
   $quarantinePath = "$LockPath.quarantine.$OwnerId.$([Guid]::NewGuid().ToString('N'))"
   try { [System.IO.File]::Move($LockPath, $quarantinePath) }
   catch [System.IO.IOException] { return $false }
 
   $quarantined = Read-ActivationLockState $quarantinePath
-  if ($null -eq $quarantined -or [string]$quarantined.Raw -ne $ObservedRaw) {
+  if ($null -eq $quarantined -or -not [string]::Equals(
+      [string]$quarantined.Raw,
+      $ObservedRaw,
+      [StringComparison]::Ordinal
+    )) {
     Restore-ActivationQuarantine $quarantinePath $LockPath | Out-Null
     return $false
   }
@@ -688,8 +715,15 @@ function Move-ActivationLockToQuarantine(
     Restore-ActivationQuarantine $quarantinePath $LockPath | Out-Null
     return $false
   }
-  Remove-Item -LiteralPath $quarantinePath -Force -ErrorAction Stop
+  if ($Timer.ElapsedMilliseconds -ge $ActivationLockTimeoutMs) {
+    Restore-ActivationQuarantine $quarantinePath $LockPath | Out-Null
+    return $false
+  }
   for ($attempt = 0; $attempt -lt 20; $attempt++) {
+    if ($Timer.ElapsedMilliseconds -ge $ActivationLockTimeoutMs) {
+      Restore-ActivationQuarantine $quarantinePath $LockPath | Out-Null
+      return $false
+    }
     $stream = $null
     try {
       $stream = [System.IO.File]::Open(
@@ -701,13 +735,20 @@ function Move-ActivationLockToQuarantine(
       $stream.Write($SuccessorBytes, 0, $SuccessorBytes.Length)
       $stream.Flush()
       $stream.Dispose()
+      Remove-Item -LiteralPath $quarantinePath -Force -ErrorAction Stop
       return $true
     }
     catch [System.IO.IOException] {
       if ($null -ne $stream) { $stream.Dispose() }
-      Start-Sleep -Milliseconds 1
+      $remaining = $ActivationLockTimeoutMs - $Timer.ElapsedMilliseconds
+      if ($remaining -le 0) {
+        Restore-ActivationQuarantine $quarantinePath $LockPath | Out-Null
+        return $false
+      }
+      Start-Sleep -Milliseconds ([Math]::Min(1, $remaining))
     }
   }
+  Restore-ActivationQuarantine $quarantinePath $LockPath | Out-Null
   return $false
 }
 
@@ -716,8 +757,10 @@ function Invoke-ActivationReclaim(
   [string]$ObservedRaw,
   [bool]$AllowCorrupt,
   [string]$OwnerId,
-  [byte[]]$SuccessorBytes
+  [byte[]]$SuccessorBytes,
+  [System.Diagnostics.Stopwatch]$Timer
 ) {
+  if ($Timer.ElapsedMilliseconds -ge $ActivationLockTimeoutMs) { return $false }
   $claimPath = New-ActivationReclaimClaim $LockPath $OwnerId $SuccessorBytes
   try {
     $claims = @(Get-ActivationReclaimClaims $LockPath)
@@ -728,8 +771,12 @@ function Invoke-ActivationReclaim(
     $claimLeaf = [System.IO.Path]::GetFileName($claimPath)
     if (-not [string]::Equals($electedLeaf, $claimLeaf, [StringComparison]::Ordinal)) { return $false }
     $current = Read-ActivationLockState $LockPath
-    if ($null -eq $current -or [string]$current.Raw -ne $ObservedRaw) { return $false }
-    return Move-ActivationLockToQuarantine $LockPath $ObservedRaw $AllowCorrupt $OwnerId $SuccessorBytes
+    if ($null -eq $current -or -not [string]::Equals(
+        [string]$current.Raw,
+        $ObservedRaw,
+        [StringComparison]::Ordinal
+      )) { return $false }
+    return Move-ActivationLockToQuarantine $LockPath $ObservedRaw $AllowCorrupt $OwnerId $SuccessorBytes $Timer
   }
   finally {
     Remove-Item -LiteralPath $claimPath -Force -ErrorAction SilentlyContinue
@@ -816,20 +863,24 @@ function Acquire-ActivationLock([string]$Ver, [string]$LockPath) {
       $corruptSinceMs = 0L
       $holder = [int]$content.pid
       if (Test-ActivationOwnerStale $content) {
-        if (Invoke-ActivationReclaim $LockPath ([string]$observed.Raw) $false $ownerId $bytes) {
+        if (Invoke-ActivationReclaim $LockPath ([string]$observed.Raw) $false $ownerId $bytes $timer) {
           return $ownerId
         }
       }
     }
     else {
       $raw = [string]$observed.Raw
-      if ($null -eq $corruptRaw -or $raw -ne $corruptRaw) {
+      if ($null -eq $corruptRaw -or -not [string]::Equals(
+          $raw,
+          [string]$corruptRaw,
+          [StringComparison]::Ordinal
+        )) {
         $corruptRaw = $raw
         $corruptSinceMs = $timer.ElapsedMilliseconds
         $holder = $null
       }
       elseif (($timer.ElapsedMilliseconds - $corruptSinceMs) -ge $ActivationLockCorruptGraceMs) {
-        if (Invoke-ActivationReclaim $LockPath $raw $true $ownerId $bytes) { return $ownerId }
+        if (Invoke-ActivationReclaim $LockPath $raw $true $ownerId $bytes $timer) { return $ownerId }
         $corruptRaw = $null
         $corruptSinceMs = 0L
       }
@@ -849,7 +900,11 @@ function Release-ActivationLock([string]$LockPath, [string]$OwnerId) {
   try { [System.IO.File]::Move($LockPath, $quarantinePath) }
   catch [System.IO.IOException] { return }
   $moved = Read-ActivationLock $quarantinePath
-  if ($null -ne $moved -and [string]$moved.ownerId -eq $OwnerId) {
+  if ($null -ne $moved -and [string]::Equals(
+      [string]$moved.ownerId,
+      $OwnerId,
+      [StringComparison]::Ordinal
+    )) {
     Remove-Item -LiteralPath $quarantinePath -Force -ErrorAction SilentlyContinue
   }
   else {

--- a/install.sh
+++ b/install.sh
@@ -61,6 +61,11 @@ Linux) HOST_OS="linux" ;;
 *) HOST_OS="unknown" ;;
 esac
 
+[[ "$ACTIVATION_LOCK_TIMEOUT_MS" =~ ^[0-9]+$ ]] || ACTIVATION_LOCK_TIMEOUT_MS=10000
+[[ "$ACTIVATION_LOCK_POLL_MS" =~ ^[0-9]+$ ]] || ACTIVATION_LOCK_POLL_MS=50
+[[ "$ACTIVATION_LOCK_CORRUPT_GRACE_MS" =~ ^[0-9]+$ ]] || ACTIVATION_LOCK_CORRUPT_GRACE_MS=250
+((ACTIVATION_LOCK_POLL_MS > 0)) || ACTIVATION_LOCK_POLL_MS=1
+
 if [[ "$HOST_OS" == "darwin" ]]; then
 	CONFIG_DIR="${KUNAI_CONFIG_DIR:-$HOME/Library/Application Support/kunai}"
 	DATA_DIR="${KUNAI_DATA_DIR:-$HOME/Library/Application Support/kunai}"
@@ -490,6 +495,66 @@ JSON
 	mv -f "$tmp" "$path"
 }
 
+read_lifecycle_lock() {
+	local raw="$1" process_start_raw
+	LIFECYCLE_READ_SCHEMA="$(printf '%s\n' "$raw" | sed -n 's/.*"schemaVersion"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -1)"
+	LIFECYCLE_READ_SCOPE="$(printf '%s\n' "$raw" | sed -n 's/.*"scope"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+	LIFECYCLE_READ_PID="$(printf '%s\n' "$raw" | sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -1)"
+	LIFECYCLE_READ_VERSION="$(printf '%s\n' "$raw" | sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+	LIFECYCLE_READ_EXEC_PATH="$(printf '%s\n' "$raw" | sed -n 's/.*"execPath"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+	LIFECYCLE_READ_OWNER="$(printf '%s\n' "$raw" | sed -n 's/.*"ownerId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+	LIFECYCLE_READ_ACQUIRED_AT="$(printf '%s\n' "$raw" | sed -n 's/.*"acquiredAt"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+	LIFECYCLE_READ_HOSTNAME="$(printf '%s\n' "$raw" | sed -n 's/.*"hostname"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1 | tr '[:upper:]' '[:lower:]')"
+	LIFECYCLE_READ_PROCESS_START="$(printf '%s\n' "$raw" | sed -n 's/.*"processStartId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+	process_start_raw="$(printf '%s\n' "$raw" | sed -n 's/.*"processStartId"[[:space:]]*:[[:space:]]*\([^,}]*\).*/\1/p' | head -1)"
+	[[ "$LIFECYCLE_READ_PID" =~ ^[1-9][0-9]*$ ]] || return 2
+	if [[ -z "$LIFECYCLE_READ_SCHEMA$LIFECYCLE_READ_SCOPE$LIFECYCLE_READ_HOSTNAME$process_start_raw" ]]; then
+		LIFECYCLE_READ_MODERN=0
+		return 0
+	fi
+	LIFECYCLE_READ_MODERN=1
+	[[ "$LIFECYCLE_READ_SCHEMA" == 1 && "$LIFECYCLE_READ_SCOPE" == lifecycle ]] || return 2
+	[[ "$LIFECYCLE_READ_VERSION" == 0.0.0 ]] || return 2
+	[[ -n "$LIFECYCLE_READ_EXEC_PATH" && -n "$LIFECYCLE_READ_OWNER" ]] || return 2
+	[[ "$LIFECYCLE_READ_ACQUIRED_AT" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z$ ]] || return 2
+	[[ -n "$LIFECYCLE_READ_HOSTNAME" ]] || return 2
+	[[ "$process_start_raw" == null || -n "$LIFECYCLE_READ_PROCESS_START" ]] || return 2
+}
+
+lifecycle_lock_blocks() {
+	local lock_path="$1" raw reread status local_hostname current_start
+	raw="$(cat "$lock_path" 2>/dev/null || true)"
+	if read_lifecycle_lock "$raw"; then
+		status=0
+	else
+		status=$?
+	fi
+	if ((status == 2)); then
+		activation_lock_sleep 250
+		reread="$(cat "$lock_path" 2>/dev/null || true)"
+		[[ "$reread" == "$raw" ]] || return 0
+		if ! read_lifecycle_lock "$reread"; then
+			return 1
+		fi
+	fi
+	if [[ "$LIFECYCLE_READ_MODERN" == 1 ]]; then
+		local_hostname="$(activation_lock_hostname)"
+		[[ "$LIFECYCLE_READ_HOSTNAME" == "$local_hostname" ]] || return 0
+		if kill -0 "$LIFECYCLE_READ_PID" 2>/dev/null || ps -p "$LIFECYCLE_READ_PID" >/dev/null 2>&1; then
+			if [[ -n "$LIFECYCLE_READ_PROCESS_START" ]]; then
+				current_start="$(activation_lock_process_start_id "$LIFECYCLE_READ_PID")"
+				[[ -n "$current_start" && "$current_start" != "$LIFECYCLE_READ_PROCESS_START" ]] && return 1
+			fi
+			return 0
+		fi
+		return 1
+	fi
+	if kill -0 "$LIFECYCLE_READ_PID" 2>/dev/null || ps -p "$LIFECYCLE_READ_PID" >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
 acquire_version_lock() {
 	local version="$1" lock_path="$2"
 	local lifecycle_path lifecycle_guard_path lifecycle_candidate holder
@@ -498,8 +563,8 @@ acquire_version_lock() {
 	lifecycle_guard_path="${DATA_DIR}.lifecycle.lock"
 	for lifecycle_candidate in "$lifecycle_guard_path" "$lifecycle_path"; do
 		if [[ -f "$lifecycle_candidate" ]]; then
-			holder="$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' "$lifecycle_candidate" | head -1)"
-			if [[ -n "$holder" ]] && kill -0 "$holder" 2>/dev/null; then
+			if lifecycle_lock_blocks "$lifecycle_candidate"; then
+				holder="$LIFECYCLE_READ_PID"
 				err "Install lifecycle lock held by pid $holder; uninstall is in progress"
 				return 1
 			fi
@@ -520,8 +585,8 @@ JSON
 	# first check, relinquish our version lock before any download or mutation.
 	for lifecycle_candidate in "$lifecycle_guard_path" "$lifecycle_path"; do
 		if [[ -f "$lifecycle_candidate" ]]; then
-			holder="$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' "$lifecycle_candidate" | head -1)"
-			if [[ -n "$holder" ]] && kill -0 "$holder" 2>/dev/null; then
+			if lifecycle_lock_blocks "$lifecycle_candidate"; then
+				holder="$LIFECYCLE_READ_PID"
 				release_version_lock "$lock_path"
 				err "Install lifecycle lock held by pid $holder; uninstall is in progress"
 				return 1
@@ -546,10 +611,36 @@ activation_lock_sleep() {
 	sleep "$seconds"
 }
 
+activation_lock_now_ms() {
+	local value seconds
+	value="$(date +%s%3N 2>/dev/null || true)"
+	if [[ "$value" =~ ^[0-9]+$ ]]; then
+		printf '%s' "$value"
+		return
+	fi
+	if have perl; then
+		perl -MTime::HiRes=time -e 'printf "%.0f", time() * 1000'
+		return
+	fi
+	seconds="$(date +%s)"
+	printf '%s000' "$seconds"
+}
+
+activation_lock_poll_until() {
+	local deadline="$1" now remaining delay
+	now="$(activation_lock_now_ms)"
+	remaining=$((deadline - now))
+	((remaining > 0)) || return 1
+	delay="$ACTIVATION_LOCK_POLL_MS"
+	((delay <= remaining)) || delay="$remaining"
+	((delay > 0)) || delay=1
+	activation_lock_sleep "$delay"
+}
+
 activation_lock_hostname() {
 	local value
 	value="$(hostname 2>/dev/null || uname -n 2>/dev/null || true)"
-	printf '%s' "$value" | tr '[:upper:]' '[:lower:]'
+	printf '%s' "$value" | awk '{$1=$1; print}' | tr '[:upper:]' '[:lower:]'
 }
 
 activation_lock_process_start_id() {
@@ -656,7 +747,7 @@ restore_activation_quarantine() {
 }
 
 reclaim_activation_lock() {
-	local lock_path="$1" observed_raw="$2" allow_corrupt="$3" owner_id="$4" successor_raw="$5"
+	local lock_path="$1" observed_raw="$2" allow_corrupt="$3" owner_id="$4" successor_raw="$5" deadline="$6"
 	local quarantine_path quarantined_raw
 	quarantine_path="${lock_path}.quarantine.${owner_id}.${RANDOM}"
 	while [[ -e "$quarantine_path" ]]; do
@@ -682,6 +773,7 @@ reclaim_activation_lock() {
 	rm -f "$quarantine_path"
 	local attempt=0
 	while ((attempt < 20)); do
+		(( $(activation_lock_now_ms) < deadline )) || return 1
 		if (
 			set -o noclobber
 			umask 077
@@ -696,15 +788,17 @@ reclaim_activation_lock() {
 }
 
 claim_and_reclaim_activation_lock() {
-	local lock_path="$1" observed_raw="$2" allow_corrupt="$3" owner_id="$4" successor_raw="$5"
+	local lock_path="$1" observed_raw="$2" allow_corrupt="$3" owner_id="$4" successor_raw="$5" deadline="$6"
 	local claim_path first_claim current_raw result=1
 	claim_path="$(create_activation_reclaim_claim "$lock_path" "$owner_id" "$successor_raw")" || return 1
 	first_claim="$(first_activation_reclaim_claim "$lock_path")"
 	if [[ "$first_claim" == "$claim_path" ]]; then
 		current_raw="$(cat "$lock_path" 2>/dev/null || true)"
 		if [[ "$current_raw" == "$observed_raw" ]]; then
-			if reclaim_activation_lock "$lock_path" "$current_raw" "$allow_corrupt" "$owner_id" "$successor_raw"; then
+			if reclaim_activation_lock "$lock_path" "$current_raw" "$allow_corrupt" "$owner_id" "$successor_raw" "$deadline"; then
 				result=0
+			else
+				result=$?
 			fi
 		fi
 	fi
@@ -717,8 +811,9 @@ claim_and_reclaim_activation_lock() {
 # every implementation uses the same JSON fields and token-checked release.
 acquire_activation_lock() {
 	local version="$1" lock_path="$2"
-	local elapsed=0 corrupt_elapsed=0 holder="" raw local_hostname process_start process_start_json activation_record
+	local deadline corrupt_since=0 holder="" raw local_hostname process_start process_start_json activation_record reclaim_result attempted=0
 
+	deadline=$(( $(activation_lock_now_ms) + ACTIVATION_LOCK_TIMEOUT_MS ))
 	mkdir -p "$(dirname "$lock_path")"
 	ACTIVATION_LOCK_OWNER_ID="$$-$(date +%s)-$RANDOM"
 	local_hostname="$(activation_lock_hostname)"
@@ -732,13 +827,21 @@ acquire_activation_lock() {
 		"$$" "$(json_escape "$version")" "$(json_escape "$ACTIVATION_LOCK_OWNER_ID")" "$(iso_now)" "$(json_escape "$local_hostname")" "$process_start_json")"
 
 	while :; do
+		if ((attempted == 1 && $(activation_lock_now_ms) >= deadline)); then
+			if [[ -n "$holder" ]]; then
+				err "Activation lock held by pid $holder while activating version $version"
+			else
+				err "Activation lock held while activating version $version"
+			fi
+			return 1
+		fi
+		attempted=1
 		if [[ -n "$(first_activation_reclaim_claim "$lock_path")" ]]; then
-			if ((elapsed >= ACTIVATION_LOCK_TIMEOUT_MS)); then
+			if (( $(activation_lock_now_ms) >= deadline )); then
 				err "Activation reclamation is already in progress for version $version"
 				return 1
 			fi
-			activation_lock_sleep "$ACTIVATION_LOCK_POLL_MS"
-			elapsed=$((elapsed + ACTIVATION_LOCK_POLL_MS))
+			activation_lock_poll_until "$deadline" || continue
 			continue
 		fi
 		if (
@@ -753,35 +856,49 @@ acquire_activation_lock() {
 			continue
 		fi
 		if [[ ! -e "$lock_path" ]]; then
-			if ((elapsed >= ACTIVATION_LOCK_TIMEOUT_MS)); then
+			if (( $(activation_lock_now_ms) >= deadline )); then
 				err "Could not create activation lock at $lock_path"
 				return 1
 			fi
-			activation_lock_sleep "$ACTIVATION_LOCK_POLL_MS"
-			elapsed=$((elapsed + ACTIVATION_LOCK_POLL_MS))
+			activation_lock_poll_until "$deadline" || continue
 			continue
 		fi
 
 		raw="$(cat "$lock_path" 2>/dev/null || true)"
 
 		if read_activation_lock "$raw"; then
-			corrupt_elapsed=0
+			corrupt_since=0
 			holder="$ACTIVATION_READ_PID"
 			if activation_lock_owner_is_stale; then
-				claim_and_reclaim_activation_lock "$lock_path" "$raw" 0 "$ACTIVATION_LOCK_OWNER_ID" "$activation_record" && return 0
-				continue
+				if claim_and_reclaim_activation_lock "$lock_path" "$raw" 0 "$ACTIVATION_LOCK_OWNER_ID" "$activation_record" "$deadline"; then
+					return 0
+				else
+					reclaim_result=$?
+					if ((reclaim_result == 2)); then
+						err "Could not restore activation lock quarantine at $lock_path; refusing activation"
+						return 1
+					fi
+				fi
 			fi
 		else
 			holder=""
-			corrupt_elapsed=$((corrupt_elapsed + ACTIVATION_LOCK_POLL_MS))
-			if ((corrupt_elapsed >= ACTIVATION_LOCK_CORRUPT_GRACE_MS)); then
-				claim_and_reclaim_activation_lock "$lock_path" "$raw" 1 "$ACTIVATION_LOCK_OWNER_ID" "$activation_record" && return 0
-				corrupt_elapsed=0
-				continue
+			if ((corrupt_since == 0)); then
+				corrupt_since="$(activation_lock_now_ms)"
+			elif (( $(activation_lock_now_ms) - corrupt_since >= ACTIVATION_LOCK_CORRUPT_GRACE_MS )); then
+				if claim_and_reclaim_activation_lock "$lock_path" "$raw" 1 "$ACTIVATION_LOCK_OWNER_ID" "$activation_record" "$deadline"; then
+					return 0
+				else
+					reclaim_result=$?
+					if ((reclaim_result == 2)); then
+						err "Could not restore activation lock quarantine at $lock_path; refusing activation"
+						return 1
+					fi
+				fi
+				corrupt_since=0
 			fi
 		fi
 
-		if ((elapsed >= ACTIVATION_LOCK_TIMEOUT_MS)); then
+		if (( $(activation_lock_now_ms) >= deadline )); then
 			if [[ -n "$holder" ]]; then
 				err "Activation lock held by pid $holder while activating version $version"
 			else
@@ -789,8 +906,7 @@ acquire_activation_lock() {
 			fi
 			return 1
 		fi
-		activation_lock_sleep "$ACTIVATION_LOCK_POLL_MS"
-		elapsed=$((elapsed + ACTIVATION_LOCK_POLL_MS))
+		activation_lock_poll_until "$deadline" || true
 	done
 }
 
@@ -809,7 +925,10 @@ release_activation_lock() {
 	if [[ "$current_owner" == "$owner_id" ]]; then
 		rm -f "$quarantine_path"
 	else
-		restore_activation_quarantine "$quarantine_path" "$lock_path" || true
+		if ! restore_activation_quarantine "$quarantine_path" "$lock_path"; then
+			err "Could not restore activation lock quarantine at $lock_path; ownership remains quarantined"
+			return 1
+		fi
 	fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -611,6 +611,35 @@ activation_lock_owner_is_stale() {
 	return 0
 }
 
+first_activation_reclaim_claim() {
+	local lock_path="$1" claim raw
+	for claim in "${lock_path}.reclaim."*; do
+		[[ -f "$claim" ]] || continue
+		raw="$(cat "$claim" 2>/dev/null || true)"
+		if read_activation_lock "$raw" && activation_lock_owner_is_stale; then
+			# Claim names contain a random owner token and are never reused.
+			rm -f "$claim"
+			continue
+		fi
+		printf '%s\n' "$claim"
+	done | sort | head -1
+}
+
+create_activation_reclaim_claim() {
+	local lock_path="$1" owner_id="$2" record="$3" claim_path temp_path
+	claim_path="${lock_path}.reclaim.${owner_id}"
+	temp_path="${claim_path}.tmp.$$.$RANDOM"
+	(
+		umask 077
+		printf '%s\n' "$record" >"$temp_path"
+	) || return 1
+	if ! mv "$temp_path" "$claim_path" 2>/dev/null; then
+		rm -f "$temp_path"
+		return 1
+	fi
+	printf '%s' "$claim_path"
+}
+
 restore_activation_quarantine() {
 	local quarantine_path="$1" lock_path="$2"
 	# A hard link is an exclusive restore: it can never overwrite a canonical
@@ -627,7 +656,7 @@ restore_activation_quarantine() {
 }
 
 reclaim_activation_lock() {
-	local lock_path="$1" observed_raw="$2" allow_corrupt="$3" owner_id="$4"
+	local lock_path="$1" observed_raw="$2" allow_corrupt="$3" owner_id="$4" successor_raw="$5"
 	local quarantine_path quarantined_raw
 	quarantine_path="${lock_path}.quarantine.${owner_id}.${RANDOM}"
 	while [[ -e "$quarantine_path" ]]; do
@@ -651,7 +680,36 @@ reclaim_activation_lock() {
 		return 1
 	fi
 	rm -f "$quarantine_path"
-	return 0
+	local attempt=0
+	while ((attempt < 20)); do
+		if (
+			set -o noclobber
+			umask 077
+			printf '%s\n' "$successor_raw" >"$lock_path"
+		) 2>/dev/null; then
+			return 0
+		fi
+		activation_lock_sleep 1
+		attempt=$((attempt + 1))
+	done
+	return 1
+}
+
+claim_and_reclaim_activation_lock() {
+	local lock_path="$1" observed_raw="$2" allow_corrupt="$3" owner_id="$4" successor_raw="$5"
+	local claim_path first_claim current_raw result=1
+	claim_path="$(create_activation_reclaim_claim "$lock_path" "$owner_id" "$successor_raw")" || return 1
+	first_claim="$(first_activation_reclaim_claim "$lock_path")"
+	if [[ "$first_claim" == "$claim_path" ]]; then
+		current_raw="$(cat "$lock_path" 2>/dev/null || true)"
+		if [[ "$current_raw" == "$observed_raw" ]]; then
+			if reclaim_activation_lock "$lock_path" "$current_raw" "$allow_corrupt" "$owner_id" "$successor_raw"; then
+				result=0
+			fi
+		fi
+	fi
+	rm -f "$claim_path"
+	return "$result"
 }
 
 # Cross-language activation lock shared by install.sh, install.ps1, and the
@@ -659,7 +717,7 @@ reclaim_activation_lock() {
 # every implementation uses the same JSON fields and token-checked release.
 acquire_activation_lock() {
 	local version="$1" lock_path="$2"
-	local elapsed=0 corrupt_elapsed=0 holder="" raw local_hostname process_start process_start_json
+	local elapsed=0 corrupt_elapsed=0 holder="" raw local_hostname process_start process_start_json activation_record
 
 	mkdir -p "$(dirname "$lock_path")"
 	ACTIVATION_LOCK_OWNER_ID="$$-$(date +%s)-$RANDOM"
@@ -670,15 +728,29 @@ acquire_activation_lock() {
 	else
 		process_start_json=null
 	fi
+	activation_record="$(printf '{"schemaVersion":1,"scope":"activation","pid":%s,"version":"%s","execPath":"install.sh","ownerId":"%s","acquiredAt":"%s","hostname":"%s","processStartId":%s}' \
+		"$$" "$(json_escape "$version")" "$(json_escape "$ACTIVATION_LOCK_OWNER_ID")" "$(iso_now)" "$(json_escape "$local_hostname")" "$process_start_json")"
 
 	while :; do
+		if [[ -n "$(first_activation_reclaim_claim "$lock_path")" ]]; then
+			if ((elapsed >= ACTIVATION_LOCK_TIMEOUT_MS)); then
+				err "Activation reclamation is already in progress for version $version"
+				return 1
+			fi
+			activation_lock_sleep "$ACTIVATION_LOCK_POLL_MS"
+			elapsed=$((elapsed + ACTIVATION_LOCK_POLL_MS))
+			continue
+		fi
 		if (
 			set -o noclobber
 			umask 077
-			printf '{"schemaVersion":1,"scope":"activation","pid":%s,"version":"%s","execPath":"install.sh","ownerId":"%s","acquiredAt":"%s","hostname":"%s","processStartId":%s}\n' \
-				"$$" "$(json_escape "$version")" "$(json_escape "$ACTIVATION_LOCK_OWNER_ID")" "$(iso_now)" "$(json_escape "$local_hostname")" "$process_start_json" >"$lock_path"
+			printf '%s\n' "$activation_record" >"$lock_path"
 		) 2>/dev/null; then
-			return 0
+			if [[ -z "$(first_activation_reclaim_claim "$lock_path")" ]]; then
+				return 0
+			fi
+			release_activation_lock "$lock_path" "$ACTIVATION_LOCK_OWNER_ID"
+			continue
 		fi
 		if [[ ! -e "$lock_path" ]]; then
 			if ((elapsed >= ACTIVATION_LOCK_TIMEOUT_MS)); then
@@ -696,24 +768,14 @@ acquire_activation_lock() {
 			corrupt_elapsed=0
 			holder="$ACTIVATION_READ_PID"
 			if activation_lock_owner_is_stale; then
-				if ! reclaim_activation_lock "$lock_path" "$raw" 0 "$ACTIVATION_LOCK_OWNER_ID"; then
-					[[ -e "$lock_path" ]] || {
-						err "Could not safely restore quarantined activation ownership"
-						return 1
-					}
-				fi
+				claim_and_reclaim_activation_lock "$lock_path" "$raw" 0 "$ACTIVATION_LOCK_OWNER_ID" "$activation_record" && return 0
 				continue
 			fi
 		else
 			holder=""
 			corrupt_elapsed=$((corrupt_elapsed + ACTIVATION_LOCK_POLL_MS))
 			if ((corrupt_elapsed >= ACTIVATION_LOCK_CORRUPT_GRACE_MS)); then
-				if ! reclaim_activation_lock "$lock_path" "$raw" 1 "$ACTIVATION_LOCK_OWNER_ID"; then
-					[[ -e "$lock_path" ]] || {
-						err "Could not safely restore quarantined activation ownership"
-						return 1
-					}
-				fi
+				claim_and_reclaim_activation_lock "$lock_path" "$raw" 1 "$ACTIVATION_LOCK_OWNER_ID" "$activation_record" && return 0
 				corrupt_elapsed=0
 				continue
 			fi

--- a/install.sh
+++ b/install.sh
@@ -796,7 +796,7 @@ reclaim_activation_lock() {
 	rm -f "$quarantine_path"
 	local attempt=0
 	while ((attempt < 20)); do
-		(( $(activation_lock_now_ms) < deadline )) || return 1
+		(($(activation_lock_now_ms) < deadline)) || return 1
 		if (
 			set -o noclobber
 			umask 077
@@ -836,7 +836,7 @@ acquire_activation_lock() {
 	local version="$1" lock_path="$2"
 	local deadline corrupt_since=0 holder="" raw local_hostname process_start process_start_json activation_record reclaim_result attempted=0
 
-	deadline=$(( $(activation_lock_now_ms) + ACTIVATION_LOCK_TIMEOUT_MS ))
+	deadline=$(($(activation_lock_now_ms) + ACTIVATION_LOCK_TIMEOUT_MS))
 	mkdir -p "$(dirname "$lock_path")"
 	ACTIVATION_LOCK_OWNER_ID="$$-$(date +%s)-$RANDOM"
 	local_hostname="$(activation_lock_hostname)"
@@ -860,7 +860,7 @@ acquire_activation_lock() {
 		fi
 		attempted=1
 		if [[ -n "$(first_activation_reclaim_claim "$lock_path")" ]]; then
-			if (( $(activation_lock_now_ms) >= deadline )); then
+			if (($(activation_lock_now_ms) >= deadline)); then
 				err "Activation reclamation is already in progress for version $version"
 				return 1
 			fi
@@ -879,7 +879,7 @@ acquire_activation_lock() {
 			continue
 		fi
 		if [[ ! -e "$lock_path" ]]; then
-			if (( $(activation_lock_now_ms) >= deadline )); then
+			if (($(activation_lock_now_ms) >= deadline)); then
 				err "Could not create activation lock at $lock_path"
 				return 1
 			fi
@@ -907,7 +907,7 @@ acquire_activation_lock() {
 			holder=""
 			if ((corrupt_since == 0)); then
 				corrupt_since="$(activation_lock_now_ms)"
-			elif (( $(activation_lock_now_ms) - corrupt_since >= ACTIVATION_LOCK_CORRUPT_GRACE_MS )); then
+			elif (($(activation_lock_now_ms) - corrupt_since >= ACTIVATION_LOCK_CORRUPT_GRACE_MS)); then
 				if claim_and_reclaim_activation_lock "$lock_path" "$raw" 1 "$ACTIVATION_LOCK_OWNER_ID" "$activation_record" "$deadline"; then
 					return 0
 				else
@@ -921,7 +921,7 @@ acquire_activation_lock() {
 			fi
 		fi
 
-		if (( $(activation_lock_now_ms) >= deadline )); then
+		if (($(activation_lock_now_ms) >= deadline)); then
 			if [[ -n "$holder" ]]; then
 				err "Activation lock held by pid $holder while activating version $version"
 			else

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,8 @@
 #   {dataDir}/versions/{semver}/kunai     versioned binary
 #   {dataDir}/versions/{semver}/version.json  per-version metadata
 #   {dataDir}/locks/{semver}.lock         install lock
+#   {dataDir}/locks/activation.lock       shared launcher/manifest lock
+#   {dataDir}.lifecycle.lock              purge-safe uninstall guard
 #   {dataDir}/transactions/{id}.json     install transaction
 #   {cacheDir}/staging/{semver}/txn-…    unique download staging
 #   {binDir}/kunai                       launcher symlink -> versioned binary
@@ -38,6 +40,20 @@ DOWNLOAD_MAX_BYTES="${KUNAI_DOWNLOAD_MAX_BYTES:-268435456}"
 DOWNLOAD_CHECKSUM_MAX_BYTES="${KUNAI_DOWNLOAD_CHECKSUM_MAX_BYTES:-1048576}"
 DOWNLOAD_MAX_ATTEMPTS="${KUNAI_DOWNLOAD_MAX_ATTEMPTS:-3}"
 DOWNLOAD_RETRY_BASE_MS="${KUNAI_DOWNLOAD_RETRY_BASE_MS:-1000}"
+ACTIVATION_LOCK_TIMEOUT_MS="${KUNAI_ACTIVATION_LOCK_TIMEOUT_MS:-10000}"
+ACTIVATION_LOCK_POLL_MS="${KUNAI_ACTIVATION_LOCK_POLL_MS:-50}"
+ACTIVATION_LOCK_CORRUPT_GRACE_MS="${KUNAI_ACTIVATION_LOCK_CORRUPT_GRACE_MS:-250}"
+ACTIVATION_LOCK_OWNER_ID=""
+INSTALL_TXN_PATH=""
+INSTALL_VERSION_LOCK_PATH=""
+INSTALL_STAGING_PATH=""
+INSTALL_ACTIVATION_LOCK_PATH=""
+INSTALL_ACTIVATION_LOCK_HELD=0
+INSTALL_LAUNCHER_ACTIVATED=0
+INSTALL_PRESERVE_LAUNCHER_SNAPSHOT=0
+LAUNCHER_SNAPSHOT_KIND="missing"
+LAUNCHER_SNAPSHOT_TARGET=""
+LAUNCHER_SNAPSHOT_BACKUP=""
 
 case "$(uname -s)" in
 Darwin) HOST_OS="darwin" ;;
@@ -401,7 +417,7 @@ write_manifest() {
 		info "[dry-run] would write schema-1 manifest ($method) to $CONFIG_DIR/install.json"
 		return
 	fi
-	mkdir -p "$CONFIG_DIR"
+	mkdir -p "$CONFIG_DIR" || return 1
 	manifest_path="$CONFIG_DIR/install.json"
 	now="$(iso_now)"
 	installed_at="$now"
@@ -443,8 +459,14 @@ write_manifest() {
 		printf '  "installedAt": "%s",\n' "$(json_escape "$installed_at")"
 		printf '  "updatedAt": "%s"\n' "$(json_escape "$now")"
 		printf '}\n'
-	} >"$tmp"
-	mv -f "$tmp" "$manifest_path"
+	} >"$tmp" || {
+		rm -f "$tmp"
+		return 1
+	}
+	if ! mv -f "$tmp" "$manifest_path"; then
+		rm -f "$tmp"
+		return 1
+	fi
 	info "Recorded install method ($method) in $manifest_path"
 }
 
@@ -470,9 +492,20 @@ JSON
 
 acquire_version_lock() {
 	local version="$1" lock_path="$2"
+	local lifecycle_path lifecycle_guard_path lifecycle_candidate holder
 	mkdir -p "$(dirname "$lock_path")"
+	lifecycle_path="$(dirname "$lock_path")/lifecycle.lock"
+	lifecycle_guard_path="${DATA_DIR}.lifecycle.lock"
+	for lifecycle_candidate in "$lifecycle_guard_path" "$lifecycle_path"; do
+		if [[ -f "$lifecycle_candidate" ]]; then
+			holder="$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' "$lifecycle_candidate" | head -1)"
+			if [[ -n "$holder" ]] && kill -0 "$holder" 2>/dev/null; then
+				err "Install lifecycle lock held by pid $holder; uninstall is in progress"
+				return 1
+			fi
+		fi
+	done
 	if [[ -f "$lock_path" ]]; then
-		local holder
 		holder="$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' "$lock_path" | head -1)"
 		if [[ -n "$holder" ]] && kill -0 "$holder" 2>/dev/null; then
 			err "Install lock held by pid $holder for version $version"
@@ -483,6 +516,18 @@ acquire_version_lock() {
 	cat >"$lock_path" <<JSON
 {"pid":$$,"version":"$(json_escape "$version")","execPath":"install.sh","acquiredAt":"$(iso_now)"}
 JSON
+	# Close the race with lifecycle acquisition. If uninstall won after the
+	# first check, relinquish our version lock before any download or mutation.
+	for lifecycle_candidate in "$lifecycle_guard_path" "$lifecycle_path"; do
+		if [[ -f "$lifecycle_candidate" ]]; then
+			holder="$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' "$lifecycle_candidate" | head -1)"
+			if [[ -n "$holder" ]] && kill -0 "$holder" 2>/dev/null; then
+				release_version_lock "$lock_path"
+				err "Install lifecycle lock held by pid $holder; uninstall is in progress"
+				return 1
+			fi
+		fi
+	done
 }
 
 release_version_lock() {
@@ -492,6 +537,217 @@ release_version_lock() {
 	holder="$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' "$lock_path" | head -1)"
 	if [[ "$holder" == "$$" ]]; then
 		rm -f "$lock_path"
+	fi
+}
+
+activation_lock_sleep() {
+	local milliseconds="$1" seconds
+	seconds="$(awk -v ms="$milliseconds" 'BEGIN { printf "%.3f", ms / 1000 }')"
+	sleep "$seconds"
+}
+
+activation_lock_hostname() {
+	local value
+	value="$(hostname 2>/dev/null || uname -n 2>/dev/null || true)"
+	printf '%s' "$value" | tr '[:upper:]' '[:lower:]'
+}
+
+activation_lock_process_start_id() {
+	local pid="$1" raw rest value
+	if [[ -r "/proc/$pid/stat" ]]; then
+		raw="$(cat "/proc/$pid/stat" 2>/dev/null || true)"
+		if [[ "$raw" == *") "* ]]; then
+			rest="${raw##*) }"
+			# Fields after comm begin with field 3; starttime is field 22.
+			# shellcheck disable=SC2086
+			set -- $rest
+			value="${20:-}"
+			[[ -n "$value" ]] && printf 'linux-proc:%s' "$value"
+		fi
+		return
+	fi
+	if [[ "$HOST_OS" == darwin ]]; then
+		value="$(ps -o lstart= -p "$pid" 2>/dev/null | awk '{$1=$1; print}' || true)"
+		[[ -n "$value" ]] && printf 'darwin-ps:%s' "$value"
+	fi
+}
+
+read_activation_lock() {
+	local raw="$1" process_start_raw
+	ACTIVATION_READ_SCHEMA="$(printf '%s\n' "$raw" | sed -n 's/.*"schemaVersion"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -1)"
+	ACTIVATION_READ_SCOPE="$(printf '%s\n' "$raw" | sed -n 's/.*"scope"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+	ACTIVATION_READ_PID="$(printf '%s\n' "$raw" | sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -1)"
+	ACTIVATION_READ_VERSION="$(printf '%s\n' "$raw" | sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+	ACTIVATION_READ_EXEC_PATH="$(printf '%s\n' "$raw" | sed -n 's/.*"execPath"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+	ACTIVATION_READ_OWNER="$(printf '%s\n' "$raw" | sed -n 's/.*"ownerId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+	ACTIVATION_READ_ACQUIRED_AT="$(printf '%s\n' "$raw" | sed -n 's/.*"acquiredAt"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+	ACTIVATION_READ_HOSTNAME="$(printf '%s\n' "$raw" | sed -n 's/.*"hostname"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1 | tr '[:upper:]' '[:lower:]')"
+	ACTIVATION_READ_PROCESS_START="$(printf '%s\n' "$raw" | sed -n 's/.*"processStartId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+	process_start_raw="$(printf '%s\n' "$raw" | sed -n 's/.*"processStartId"[[:space:]]*:[[:space:]]*\([^,}]*\).*/\1/p' | head -1)"
+
+	[[ "$ACTIVATION_READ_SCHEMA" == 1 ]] || return 1
+	[[ "$ACTIVATION_READ_SCOPE" == activation ]] || return 1
+	[[ "$ACTIVATION_READ_PID" =~ ^[1-9][0-9]*$ ]] || return 1
+	parse_canonical_version "$ACTIVATION_READ_VERSION" >/dev/null 2>&1 || return 1
+	[[ -n "$ACTIVATION_READ_EXEC_PATH" && -n "$ACTIVATION_READ_OWNER" ]] || return 1
+	[[ "$ACTIVATION_READ_ACQUIRED_AT" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z$ ]] || return 1
+	[[ -n "$ACTIVATION_READ_HOSTNAME" ]] || return 1
+	[[ "$process_start_raw" == null || -n "$ACTIVATION_READ_PROCESS_START" ]] || return 1
+}
+
+activation_lock_owner_is_stale() {
+	local local_hostname current_start
+	local_hostname="$(activation_lock_hostname)"
+	# A foreign-host PID has no meaning locally. Preserve it until the bounded
+	# acquisition timeout instead of reclaiming a possibly-live remote owner.
+	[[ "$ACTIVATION_READ_HOSTNAME" == "$local_hostname" ]] || return 1
+	if kill -0 "$ACTIVATION_READ_PID" 2>/dev/null || ps -p "$ACTIVATION_READ_PID" >/dev/null 2>&1; then
+		if [[ -n "$ACTIVATION_READ_PROCESS_START" ]]; then
+			current_start="$(activation_lock_process_start_id "$ACTIVATION_READ_PID")"
+			[[ -n "$current_start" && "$current_start" != "$ACTIVATION_READ_PROCESS_START" ]] && return 0
+		fi
+		return 1
+	fi
+	return 0
+}
+
+restore_activation_quarantine() {
+	local quarantine_path="$1" lock_path="$2"
+	# A hard link is an exclusive restore: it can never overwrite a canonical
+	# path created by a newer owner while reclamation was being validated.
+	if ln "$quarantine_path" "$lock_path" 2>/dev/null; then
+		rm -f "$quarantine_path"
+		return 0
+	fi
+	# EEXIST means a newer canonical owner won and must be preserved. Any
+	# hard-link failure while canonical is absent is fail-closed: the observed
+	# owner remains in quarantine and this contender must not activate.
+	[[ -e "$lock_path" ]] && return 0
+	return 1
+}
+
+reclaim_activation_lock() {
+	local lock_path="$1" observed_raw="$2" allow_corrupt="$3" owner_id="$4"
+	local quarantine_path quarantined_raw
+	quarantine_path="${lock_path}.quarantine.${owner_id}.${RANDOM}"
+	while [[ -e "$quarantine_path" ]]; do
+		quarantine_path="${lock_path}.quarantine.${owner_id}.${RANDOM}"
+	done
+	if ! mv "$lock_path" "$quarantine_path" 2>/dev/null; then
+		return 1
+	fi
+	quarantined_raw="$(cat "$quarantine_path" 2>/dev/null || true)"
+	if [[ "$quarantined_raw" != "$observed_raw" ]]; then
+		restore_activation_quarantine "$quarantine_path" "$lock_path" || return 2
+		return 1
+	fi
+	if read_activation_lock "$quarantined_raw"; then
+		if ! activation_lock_owner_is_stale; then
+			restore_activation_quarantine "$quarantine_path" "$lock_path" || return 2
+			return 1
+		fi
+	elif [[ "$allow_corrupt" != 1 ]]; then
+		restore_activation_quarantine "$quarantine_path" "$lock_path" || return 2
+		return 1
+	fi
+	rm -f "$quarantine_path"
+	return 0
+}
+
+# Cross-language activation lock shared by install.sh, install.ps1, and the
+# in-process native updater. Bash noclobber makes creation atomic (O_EXCL);
+# every implementation uses the same JSON fields and token-checked release.
+acquire_activation_lock() {
+	local version="$1" lock_path="$2"
+	local elapsed=0 corrupt_elapsed=0 holder="" raw local_hostname process_start process_start_json
+
+	mkdir -p "$(dirname "$lock_path")"
+	ACTIVATION_LOCK_OWNER_ID="$$-$(date +%s)-$RANDOM"
+	local_hostname="$(activation_lock_hostname)"
+	process_start="$(activation_lock_process_start_id "$$")"
+	if [[ -n "$process_start" ]]; then
+		process_start_json="\"$(json_escape "$process_start")\""
+	else
+		process_start_json=null
+	fi
+
+	while :; do
+		if (
+			set -o noclobber
+			umask 077
+			printf '{"schemaVersion":1,"scope":"activation","pid":%s,"version":"%s","execPath":"install.sh","ownerId":"%s","acquiredAt":"%s","hostname":"%s","processStartId":%s}\n' \
+				"$$" "$(json_escape "$version")" "$(json_escape "$ACTIVATION_LOCK_OWNER_ID")" "$(iso_now)" "$(json_escape "$local_hostname")" "$process_start_json" >"$lock_path"
+		) 2>/dev/null; then
+			return 0
+		fi
+		if [[ ! -e "$lock_path" ]]; then
+			if ((elapsed >= ACTIVATION_LOCK_TIMEOUT_MS)); then
+				err "Could not create activation lock at $lock_path"
+				return 1
+			fi
+			activation_lock_sleep "$ACTIVATION_LOCK_POLL_MS"
+			elapsed=$((elapsed + ACTIVATION_LOCK_POLL_MS))
+			continue
+		fi
+
+		raw="$(cat "$lock_path" 2>/dev/null || true)"
+
+		if read_activation_lock "$raw"; then
+			corrupt_elapsed=0
+			holder="$ACTIVATION_READ_PID"
+			if activation_lock_owner_is_stale; then
+				if ! reclaim_activation_lock "$lock_path" "$raw" 0 "$ACTIVATION_LOCK_OWNER_ID"; then
+					[[ -e "$lock_path" ]] || {
+						err "Could not safely restore quarantined activation ownership"
+						return 1
+					}
+				fi
+				continue
+			fi
+		else
+			holder=""
+			corrupt_elapsed=$((corrupt_elapsed + ACTIVATION_LOCK_POLL_MS))
+			if ((corrupt_elapsed >= ACTIVATION_LOCK_CORRUPT_GRACE_MS)); then
+				if ! reclaim_activation_lock "$lock_path" "$raw" 1 "$ACTIVATION_LOCK_OWNER_ID"; then
+					[[ -e "$lock_path" ]] || {
+						err "Could not safely restore quarantined activation ownership"
+						return 1
+					}
+				fi
+				corrupt_elapsed=0
+				continue
+			fi
+		fi
+
+		if ((elapsed >= ACTIVATION_LOCK_TIMEOUT_MS)); then
+			if [[ -n "$holder" ]]; then
+				err "Activation lock held by pid $holder while activating version $version"
+			else
+				err "Activation lock held while activating version $version"
+			fi
+			return 1
+		fi
+		activation_lock_sleep "$ACTIVATION_LOCK_POLL_MS"
+		elapsed=$((elapsed + ACTIVATION_LOCK_POLL_MS))
+	done
+}
+
+release_activation_lock() {
+	local lock_path="$1" owner_id="$2" current_owner quarantine_path
+	[[ -f "$lock_path" ]] || return 0
+	[[ -n "$owner_id" ]] || return 0
+	quarantine_path="${lock_path}.quarantine.${owner_id}.release.${RANDOM}"
+	while [[ -e "$quarantine_path" ]]; do
+		quarantine_path="${lock_path}.quarantine.${owner_id}.release.${RANDOM}"
+	done
+	if ! mv "$lock_path" "$quarantine_path" 2>/dev/null; then
+		return 0
+	fi
+	current_owner="$(sed -n 's/.*"ownerId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$quarantine_path" 2>/dev/null | head -1)"
+	if [[ "$current_owner" == "$owner_id" ]]; then
+		rm -f "$quarantine_path"
+	else
+		restore_activation_quarantine "$quarantine_path" "$lock_path" || true
 	fi
 }
 
@@ -547,6 +803,46 @@ activate_launcher() {
 	rm -f "$tmp_link"
 	ln -sfn "$version_path" "$tmp_link"
 	mv -f "$tmp_link" "$launcher"
+}
+
+snapshot_launcher() {
+	local launcher="$1"
+	LAUNCHER_SNAPSHOT_KIND="missing"
+	LAUNCHER_SNAPSHOT_TARGET=""
+	LAUNCHER_SNAPSHOT_BACKUP="${launcher}.activation-backup.$$"
+	rm -f "$LAUNCHER_SNAPSHOT_BACKUP"
+	if [[ -L "$launcher" ]]; then
+		LAUNCHER_SNAPSHOT_KIND="symlink"
+		LAUNCHER_SNAPSHOT_TARGET="$(readlink "$launcher")" || return 1
+	elif [[ -e "$launcher" ]]; then
+		LAUNCHER_SNAPSHOT_KIND="file"
+		cp -p "$launcher" "$LAUNCHER_SNAPSHOT_BACKUP" || return 1
+	fi
+}
+
+restore_launcher_snapshot() {
+	local launcher="$1" tmp_link
+	case "$LAUNCHER_SNAPSHOT_KIND" in
+	symlink)
+		tmp_link="${launcher}.restore.$$"
+		rm -f "$tmp_link"
+		ln -s "$LAUNCHER_SNAPSHOT_TARGET" "$tmp_link" || return 1
+		mv -f "$tmp_link" "$launcher" || return 1
+		;;
+	file)
+		[[ -f "$LAUNCHER_SNAPSHOT_BACKUP" ]] || return 1
+		mv -f "$LAUNCHER_SNAPSHOT_BACKUP" "$launcher" || return 1
+		;;
+	missing) rm -f "$launcher" ;;
+	*) return 1 ;;
+	esac
+}
+
+discard_launcher_snapshot() {
+	[[ -n "$LAUNCHER_SNAPSHOT_BACKUP" ]] && rm -f "$LAUNCHER_SNAPSHOT_BACKUP"
+	LAUNCHER_SNAPSHOT_KIND="missing"
+	LAUNCHER_SNAPSHOT_TARGET=""
+	LAUNCHER_SNAPSHOT_BACKUP=""
 }
 
 detect_musl() {
@@ -688,7 +984,8 @@ read_previous_active_version() {
 install_binary() {
 	local os arch translated asset base url sums resolved_version version_path versions_dir
 	local staging txn_id txn_path lock_path staged_bin staged_sums want got size_bytes
-	local target previous kind metadata_path cleanup_done=0
+	local target previous activation_previous kind metadata_path
+	local activation_lock_path
 
 	os="$(detect_os)"
 	arch="$(detect_arch)"
@@ -755,18 +1052,36 @@ install_binary() {
 	txn_id="$(date +%s)-$$"
 	txn_path="$DATA_DIR/transactions/${txn_id}.json"
 	lock_path="$DATA_DIR/locks/${resolved_version}.lock"
+	activation_lock_path="$DATA_DIR/locks/activation.lock"
 	staged_bin="$staging/$asset"
 	staged_sums="$staging/SHA256SUMS"
 	metadata_path="$versions_dir/$resolved_version/version.json"
+	INSTALL_TXN_PATH="$txn_path"
+	INSTALL_VERSION_LOCK_PATH="$lock_path"
+	INSTALL_STAGING_PATH="$staging"
+	INSTALL_ACTIVATION_LOCK_PATH="$activation_lock_path"
+	INSTALL_ACTIVATION_LOCK_HELD=0
+	INSTALL_LAUNCHER_ACTIVATED=0
+	INSTALL_PRESERVE_LAUNCHER_SNAPSHOT=0
 
 	cleanup_install_state() {
-		[[ "$cleanup_done" == 1 ]] && return
-		cleanup_done=1
-		finish_transaction "$txn_path" 2>/dev/null || true
-		release_version_lock "$lock_path" 2>/dev/null || true
-		rm -rf "$staging" 2>/dev/null || true
+		if [[ "$INSTALL_ACTIVATION_LOCK_HELD" == 1 ]]; then
+			if [[ "$INSTALL_LAUNCHER_ACTIVATED" == 1 ]]; then
+				if ! restore_launcher_snapshot "$BIN_DIR/kunai" 2>/dev/null; then
+					INSTALL_PRESERVE_LAUNCHER_SNAPSHOT=1
+				fi
+			fi
+			release_activation_lock "$INSTALL_ACTIVATION_LOCK_PATH" "$ACTIVATION_LOCK_OWNER_ID" 2>/dev/null || true
+			INSTALL_ACTIVATION_LOCK_HELD=0
+		fi
+		if [[ "$INSTALL_PRESERVE_LAUNCHER_SNAPSHOT" != 1 ]]; then
+			discard_launcher_snapshot 2>/dev/null || true
+		fi
+		finish_transaction "$INSTALL_TXN_PATH" 2>/dev/null || true
+		release_version_lock "$INSTALL_VERSION_LOCK_PATH" 2>/dev/null || true
+		rm -rf "$INSTALL_STAGING_PATH" 2>/dev/null || true
 		# Prune empty version/staging parents left by mkdir -p.
-		rmdir "$(dirname "$staging")" 2>/dev/null || true
+		rmdir "$(dirname "$INSTALL_STAGING_PATH")" 2>/dev/null || true
 		rmdir "$CACHE_DIR/staging" 2>/dev/null || true
 	}
 	trap cleanup_install_state EXIT
@@ -817,7 +1132,6 @@ install_binary() {
 	mv -f "$version_tmp" "$version_path"
 
 	write_version_metadata "$resolved_version" "$target" "$asset" "$got" "$size_bytes" "$url" "$metadata_path"
-	activate_launcher "$version_path" "$BIN_DIR/kunai"
 
 	if [[ "$os" == darwin ]]; then
 		xattr -d com.apple.quarantine "$version_path" 2>/dev/null || true
@@ -843,18 +1157,44 @@ install_binary() {
 		info "Cleared macOS quarantine when present (Gatekeeper may still prompt on first launch)."
 	fi
 
-	local prev_arg=""
-	if [[ -n "$previous" && "$previous" != "$resolved_version" ]]; then
-		prev_arg="$previous"
+	acquire_activation_lock "$resolved_version" "$activation_lock_path" || exit 1
+	INSTALL_ACTIVATION_LOCK_HELD=1
+	# Another version may have activated during this download. Read shared state
+	# under the cross-version lock before publishing the launcher and manifest.
+	activation_previous="$(read_previous_active_version || true)"
+	if ! snapshot_launcher "$BIN_DIR/kunai"; then
+		err "Could not snapshot the current launcher before activation."
+		exit 1
 	fi
-	write_manifest binary "$resolved_version" "$BIN_DIR/kunai" "$version_path" "$target" "$got" "$prev_arg"
+	if ! activate_launcher "$version_path" "$BIN_DIR/kunai"; then
+		err "Could not activate the launcher for version $resolved_version."
+		exit 1
+	fi
+	INSTALL_LAUNCHER_ACTIVATED=1
+
+	local prev_arg=""
+	if [[ -n "$activation_previous" && "$activation_previous" != "$resolved_version" ]]; then
+		prev_arg="$activation_previous"
+	fi
+	if ! write_manifest binary "$resolved_version" "$BIN_DIR/kunai" "$version_path" "$target" "$got" "$prev_arg"; then
+		err "Could not publish install.json; restoring the previous launcher."
+		if ! restore_launcher_snapshot "$BIN_DIR/kunai"; then
+			err "Launcher restoration failed; inspect $LAUNCHER_SNAPSHOT_BACKUP before retrying."
+			INSTALL_PRESERVE_LAUNCHER_SNAPSHOT=1
+		fi
+		INSTALL_LAUNCHER_ACTIVATED=0
+		exit 1
+	fi
+	INSTALL_LAUNCHER_ACTIVATED=0
+	discard_launcher_snapshot
+	release_activation_lock "$activation_lock_path" "$ACTIVATION_LOCK_OWNER_ID"
+	INSTALL_ACTIVATION_LOCK_HELD=0
 
 	finish_transaction "$txn_path"
 	release_version_lock "$lock_path"
 	rm -rf "$staging"
 	rmdir "$(dirname "$staging")" 2>/dev/null || true
 	rmdir "$CACHE_DIR/staging" 2>/dev/null || true
-	cleanup_done=1
 	trap - EXIT
 
 	info "Installed kunai → $BIN_DIR/kunai (v$resolved_version at $version_path)"

--- a/install.sh
+++ b/install.sh
@@ -702,8 +702,31 @@ activation_lock_owner_is_stale() {
 	return 0
 }
 
+activation_reclaim_temp_is_stale() {
+	local temp_path="$1" raw modified now
+	raw="$(cat "$temp_path" 2>/dev/null || true)"
+	if read_activation_lock "$raw"; then
+		activation_lock_owner_is_stale
+		return
+	fi
+	# Invalid partial writes have no usable owner identity. Give an active writer
+	# at least the corrupt grace before treating the uniquely named temp as
+	# abandoned. Preserve it when this platform cannot report modification time.
+	modified="$(stat -c %Y "$temp_path" 2>/dev/null || stat -f %m "$temp_path" 2>/dev/null || true)"
+	[[ "$modified" =~ ^[0-9]+$ ]] || return 1
+	now="$(date +%s)"
+	((now * 1000 - modified * 1000 >= ACTIVATION_LOCK_CORRUPT_GRACE_MS))
+}
+
 first_activation_reclaim_claim() {
-	local lock_path="$1" claim raw
+	local lock_path="$1" claim temp raw
+	# Temp publications are never election claims. Clean both the current
+	# out-of-namespace form and the legacy in-prefix form whose crash residue
+	# otherwise blocked every future activation.
+	for temp in "${lock_path}.reclaim-tmp."* "${lock_path}.reclaim."*.tmp.*; do
+		[[ -f "$temp" ]] || continue
+		activation_reclaim_temp_is_stale "$temp" && rm -f "$temp"
+	done
 	for claim in "${lock_path}.reclaim."*; do
 		[[ -f "$claim" ]] || continue
 		raw="$(cat "$claim" 2>/dev/null || true)"
@@ -719,7 +742,7 @@ first_activation_reclaim_claim() {
 create_activation_reclaim_claim() {
 	local lock_path="$1" owner_id="$2" record="$3" claim_path temp_path
 	claim_path="${lock_path}.reclaim.${owner_id}"
-	temp_path="${claim_path}.tmp.$$.$RANDOM"
+	temp_path="${lock_path}.reclaim-tmp.${owner_id}.$$.$RANDOM"
 	(
 		umask 077
 		printf '%s\n' "$record" >"$temp_path"


### PR DESCRIPTION
## Outcome

Serializes native install, update, rollback, migration, and uninstall activation so concurrent lifecycle commands cannot publish a mixed launcher/manifest state.

## What changed

- adds one compatible TypeScript, Bash, and PowerShell activation-lock protocol
- uses atomic quarantine reclamation with owner metadata, PID-reuse protection, foreign-host safety, bounded deadlines, and race-safe release
- serializes stale lifecycle reclamation and holds lifecycle plus activation ownership through purge
- keeps downloads and per-version preparation outside the activation critical section
- restores the launcher transactionally when manifest publication fails
- ignores and cleans abandoned reclaim temporaries without allowing parent-path text or case aliases to corrupt election
- adds doctor diagnostics and deterministic contention, recovery, timeout-zero, PID-reuse, and cross-language coverage

## Verification

- exact-head full suite: 23/23 tasks; CLI integration 188 pass, 24 expected skips
- exact-head pre-push suite: 23/23 tasks; CLI integration 188 pass, 24 expected skips
- focused final lock/uninstall review suite: 45 pass, 0 fail
- independent final review: no P0/P1/P2 findings
- typecheck 14/14, lint 0 warnings/errors, format, build 10/10, doc paths, and diff checks
- host standalone binary compiled successfully
- Bash parse, ShellCheck, and PowerShell lifecycle coverage

Stacked on #168 because the remaining archive-aware updater and installer work builds on both the deterministic archive producer and this activation boundary.

Closes #114

No release, publish, merge, or deployment is performed by this PR.
