### PR TITLE
fix(diagnostics): redact opaque string values

### DIFF
--- a/.changeset/tidy-lions-redact.md
+++ b/.changeset/tidy-lions-redact.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Redact standalone opaque credential values from diagnostics even when an upstream field uses an unrecognized name.

--- a/apps/cli/src/services/diagnostics/redaction.ts
+++ b/apps/cli/src/services/diagnostics/redaction.ts
@@ -82,6 +82,7 @@ export function redactDiagnosticValue(value: unknown, options: RedactionOptions 
 
 function redactString(value: string, options: RedactionOptions): string {
   const redacted = redactEmbeddedUrls(redactPath(value, options));
+  if (isOpaqueQueryValue(redacted.trim())) return "[redacted]";
   return truncate(redacted, options.maxStringLength ?? DEFAULT_MAX_STRING_LENGTH);
 }
 

--- a/apps/cli/test/unit/services/diagnostics/redaction.test.ts
+++ b/apps/cli/test/unit/services/diagnostics/redaction.test.ts
@@ -134,6 +134,15 @@ describe("opaque query values", () => {
     expect(redactDiagnosticValue(url)).toBe("https://cdn.example/video.m3u8?q=[redacted]");
   });
 
+  test("redacts a standalone opaque token carried under an unrecognized field", () => {
+    const token = "UDdMMzNubjBnVTJYNWRWMkllNy1xdzpfWXp1eHVUSWk3LUhkMGp1";
+
+    expect(redactDiagnosticValue({ providerDetail: token })).toEqual({
+      providerDetail: "[redacted]",
+    });
+    expect(redactDiagnosticValue(token)).toBe("[redacted]");
+  });
+
   test("redacts signed-HLS hash and the viewer's IP", () => {
     const url = "https://cdn.example/hls/master.m3u8?md5=9f8e7d6c5b4a39281706&ip=203.0.113.7";
     expect(redactDiagnosticValue(url)).toBe(


### PR DESCRIPTION
## Outcome

Prevents standalone opaque token-like values from surviving diagnostic redaction when they appear under an unrecognized key or as a top-level string.

## Verification

- TDD regression coverage for nested and top-level opaque values
- focused redaction suite: 12 pass
- full suite: 23/23 tasks; CLI unit 4,694 pass; integration 147 pass with 24 expected skips
- typecheck, zero-warning lint, format, and build passed

This is stacked on #164. No release, merge, publish, or deployment is performed by this PR.