### PR TITLE
ci(release): preserve exact native candidate assets

### DIFF
--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -61,6 +61,13 @@ the Linux smoke after hashes pass; this does not change file bytes. CI isolates
 the 18 native files under the candidate's `native/` directory and runs the exact
 directory verifier immediately before candidate upload, confirmation, draft
 asset upload, and public promotion. No boundary rebuilds or recompresses them.
+The blocking native smoke matrix then serves only the preserved host archive
+and both checksum manifests from a loopback fixture to the checked-out
+production installer on Linux, macOS, and Windows. The raw download is absent,
+so the test cannot pass through compatibility fallback. Each runner verifies
+the recorded archive provenance and executes the sandboxed installed launcher
+with `--version` and `--help`; the separate raw and musl executions remain
+compatibility checks.
 
 The TypeScript native updater and both native installer scripts consume these
 archives. All three verify the archive against `SHA256SUMS.archives`, permit

--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -55,7 +55,12 @@ missing, duplicate, unexpected, empty, oversized, hash-mismatched, or
 non-canonical assets. A canonical archive has one entry whose name is the raw
 asset name and no directory prefix; tar metadata is normalized with executable
 mode `0755`, while zip records that Unix mode but Windows extraction does not
-promise to restore it.
+promise to restore it. GitHub artifact and release downloads do not preserve the
+raw file's Unix executable mode either, so verification restores mode only for
+the Linux smoke after hashes pass; this does not change file bytes. CI isolates
+the 18 native files under the candidate's `native/` directory and runs the exact
+directory verifier immediately before candidate upload, confirmation, draft
+asset upload, and public promotion. No boundary rebuilds or recompresses them.
 
 The TypeScript native updater and both native installer scripts consume these
 archives. All three verify the archive against `SHA256SUMS.archives`, permit

--- a/.docs/repo-infrastructure.md
+++ b/.docs/repo-infrastructure.md
@@ -154,6 +154,12 @@ boundaries use the downloaded files directly without a rebuild, native copy, or
 recompression. GitHub downloads may discard the raw binary's executable mode,
 so the Linux smoke restores that filesystem metadata after byte verification;
 the canonical `0755` mode inside tar archives remains independently verified.
+On every available Linux, macOS, and Windows native runner, the release smoke
+also exposes only that runner's downloaded archive and the two manifests over a
+loopback fixture, installs it through the production shell installer into an
+isolated profile, verifies the archive provenance in `install.json`, and runs
+the installed launcher. Deliberately withholding the raw asset makes an
+accidental archive-to-raw fallback fail this gate.
 
 The TypeScript native updater and the Bash/PowerShell installers consume the
 platform archive, independently verify its transport hash and extracted

--- a/.docs/repo-infrastructure.md
+++ b/.docs/repo-infrastructure.md
@@ -147,8 +147,13 @@ one member named after its raw asset. Tar members have normalized uid/gid/mtime
 and mode `0755`; zip members carry normalized DOS timestamps and Unix mode
 metadata, although Windows zip extraction does not restore POSIX executable
 bits. The build reconstructs and byte-compares each archive after preservation,
-then release confirmation and publication reverify the same bytes without a
-rebuild.
+then the release workflow stages the exact set under the candidate artifact's
+isolated `native/` directory. The verifier runs immediately before candidate
+upload, confirmation, draft asset upload, and draft-to-public promotion; those
+boundaries use the downloaded files directly without a rebuild, native copy, or
+recompression. GitHub downloads may discard the raw binary's executable mode,
+so the Linux smoke restores that filesystem metadata after byte verification;
+the canonical `0755` mode inside tar archives remains independently verified.
 
 The TypeScript native updater and the Bash/PowerShell installers consume the
 platform archive, independently verify its transport hash and extracted

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -51,6 +51,14 @@ jobs:
       - name: Verify release binaries
         run: bash apps/cli/scripts/verify-release-binaries.sh
 
+      - name: Verify exact native artifact set
+        run: |
+          set -euo pipefail
+          VERSION="$(bun -e 'console.log(require("./apps/cli/package.json").version)')"
+          bun run scripts/verify-release-artifact-directory.ts \
+            apps/cli/dist/bin \
+            --expected-version "${VERSION}"
+
       - name: Upload binaries artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -387,6 +387,33 @@ jobs:
           .release-download/native --expected-version
           "${{ needs.candidate.outputs.version }}" --skip-version-smoke
 
+      - name: Exercise exact preserved archive through install.sh
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          KUNAI_RELEASE_CANDIDATE_DIR: ${{ github.workspace }}/.release-download/native
+          KUNAI_RELEASE_CANDIDATE_VERSION: ${{ needs.candidate.outputs.version }}
+          KUNAI_RELEASE_CANDIDATE_ASSET: ${{ matrix.binary }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          bun run --cwd apps/cli test:file -- \
+            test/integration/preserved-native-installer-smoke.test.ts \
+            2>&1 | tee -a "artifacts/native-${{ matrix.id }}.log"
+
+      - name: Exercise exact preserved archive through install.ps1
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          KUNAI_RELEASE_CANDIDATE_DIR: ${{ github.workspace }}/.release-download/native
+          KUNAI_RELEASE_CANDIDATE_VERSION: ${{ needs.candidate.outputs.version }}
+          KUNAI_RELEASE_CANDIDATE_ASSET: ${{ matrix.binary }}
+        run: |
+          New-Item -ItemType Directory -Force artifacts | Out-Null
+          bun run --cwd apps/cli test:file -- test/integration/preserved-native-installer-smoke.test.ts 2>&1 |
+            Tee-Object -FilePath "artifacts/native-${{ matrix.id }}.log" -Append
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Verify checksums and execute Unix candidate
         if: runner.os != 'Windows'
         shell: bash
@@ -407,7 +434,7 @@ jobs:
           export XDG_DATA_HOME="${PROFILE_ROOT}/data"
           export XDG_CACHE_HOME="${PROFILE_ROOT}/cache"
           mkdir -p "${HOME}" "${XDG_CONFIG_HOME}" "${XDG_DATA_HOME}" "${XDG_CACHE_HOME}"
-          ".release-download/native/${KUNAI_NATIVE_BINARY}" --version 2>&1 | tee "artifacts/native-${{ matrix.id }}.log"
+          ".release-download/native/${KUNAI_NATIVE_BINARY}" --version 2>&1 | tee -a "artifacts/native-${{ matrix.id }}.log"
           ".release-download/native/${KUNAI_NATIVE_BINARY}" --help 2>&1 | tee -a "artifacts/native-${{ matrix.id }}.log"
 
       # Alpine on the host's own architecture, so the arm64 runner exercises the
@@ -452,20 +479,12 @@ jobs:
           $version = (& ".release-download/native/$env:KUNAI_NATIVE_BINARY" --version 2>&1 | Out-String).Trim()
           if ($LASTEXITCODE -ne 0) { throw "--version exited $LASTEXITCODE" }
           if ($version -notmatch '^kunai\s+v?\d') { throw "--version did not print a kunai version" }
-          $version | Tee-Object -FilePath "artifacts/native-${{ matrix.id }}.log"
+          $version | Tee-Object -FilePath "artifacts/native-${{ matrix.id }}.log" -Append
 
           $help = (& ".release-download/native/$env:KUNAI_NATIVE_BINARY" --help 2>&1 | Out-String).Trim()
           if ($LASTEXITCODE -ne 0) { throw "--help exited $LASTEXITCODE" }
           if ($help.Length -eq 0) { throw "--help printed nothing" }
           $help | Tee-Object -FilePath "artifacts/native-${{ matrix.id }}.log" -Append
-
-      - name: Exercise PowerShell installer harness
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          bun run --cwd apps/cli test:file -- test/integration/install-scripts-pwsh.test.ts 2>&1 |
-            Tee-Object -FilePath "artifacts/native-${{ matrix.id }}.log" -Append
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Upload native smoke log
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,7 +213,7 @@ jobs:
       - name: Stage candidate upload directory
         run: |
           set -euo pipefail
-          mkdir -p .candidate-upload
+          mkdir -p .candidate-upload/native
           cp ".release-candidate/${NPM_TARBALL_NAME}" .candidate-upload/
           cp -R .release-candidate/npm-platform .candidate-upload/npm-platform
           cp apps/cli/dist/bin/kunai-linux-x64 \
@@ -234,7 +234,7 @@ jobs:
             apps/cli/dist/bin/kunai-windows-arm64.zip \
             apps/cli/dist/bin/SHA256SUMS \
             apps/cli/dist/bin/SHA256SUMS.archives \
-            .candidate-upload/
+            .candidate-upload/native/
 
       - name: Emit candidate gate evidence
         run: |
@@ -265,8 +265,15 @@ jobs:
             --commit "${SHA}" \
             --run-id "${RUN_ID}" \
             --artifact-name "${CANDIDATE_ARTIFACT}-${VERSION}-${SHA}" \
-            --artifact-path apps/cli/dist/bin/SHA256SUMS \
+            --artifact-path .candidate-upload/native/SHA256SUMS \
             --output artifacts/gates/releaseAssets.json
+
+      - name: Reverify exact staged native candidate
+        run: |
+          set -euo pipefail
+          bun run scripts/verify-release-artifact-directory.ts \
+            .candidate-upload/native \
+            --expected-version "${{ steps.ver.outputs.version }}"
 
       - name: Upload candidate artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
@@ -274,7 +281,7 @@ jobs:
           name: ${{ env.CANDIDATE_ARTIFACT }}-${{ steps.ver.outputs.version }}-${{ github.sha }}
           retention-days: 14
           if-no-files-found: error
-          path: .candidate-upload/*
+          path: .candidate-upload/
 
       - name: Upload repository gate evidence
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
@@ -319,7 +326,7 @@ jobs:
           if-no-files-found: error
           path: |
             artifacts/gates/releaseAssets.json
-            apps/cli/dist/bin/SHA256SUMS
+            .candidate-upload/native/SHA256SUMS
 
   # ---------------------------------------------------------------------------
   # Execute the exact preserved native candidate on each blocking host OS.
@@ -374,6 +381,12 @@ jobs:
           name: ${{ env.CANDIDATE_ARTIFACT }}-${{ needs.candidate.outputs.version }}-${{ github.sha }}
           path: .release-download
 
+      - name: Reverify exact preserved native payload
+        run: >-
+          bun run scripts/verify-release-artifact-directory.ts
+          .release-download/native --expected-version
+          "${{ needs.candidate.outputs.version }}" --skip-version-smoke
+
       - name: Verify checksums and execute Unix candidate
         if: runner.os != 'Windows'
         shell: bash
@@ -383,19 +396,19 @@ jobs:
           set -euo pipefail
           mkdir -p artifacts
           if command -v sha256sum >/dev/null 2>&1; then
-            (cd .release-download && sha256sum --check SHA256SUMS)
+            (cd .release-download/native && sha256sum --check SHA256SUMS)
           else
-            (cd .release-download && shasum --algorithm 256 --check SHA256SUMS)
+            (cd .release-download/native && shasum --algorithm 256 --check SHA256SUMS)
           fi
-          chmod +x ".release-download/${KUNAI_NATIVE_BINARY}"
+          chmod +x ".release-download/native/${KUNAI_NATIVE_BINARY}"
           PROFILE_ROOT="$(mktemp -d)"
           export HOME="${PROFILE_ROOT}/home"
           export XDG_CONFIG_HOME="${PROFILE_ROOT}/config"
           export XDG_DATA_HOME="${PROFILE_ROOT}/data"
           export XDG_CACHE_HOME="${PROFILE_ROOT}/cache"
           mkdir -p "${HOME}" "${XDG_CONFIG_HOME}" "${XDG_DATA_HOME}" "${XDG_CACHE_HOME}"
-          ".release-download/${KUNAI_NATIVE_BINARY}" --version 2>&1 | tee "artifacts/native-${{ matrix.id }}.log"
-          ".release-download/${KUNAI_NATIVE_BINARY}" --help 2>&1 | tee -a "artifacts/native-${{ matrix.id }}.log"
+          ".release-download/native/${KUNAI_NATIVE_BINARY}" --version 2>&1 | tee "artifacts/native-${{ matrix.id }}.log"
+          ".release-download/native/${KUNAI_NATIVE_BINARY}" --help 2>&1 | tee -a "artifacts/native-${{ matrix.id }}.log"
 
       # Alpine on the host's own architecture, so the arm64 runner exercises the
       # arm64 musl build rather than emulating x64.
@@ -406,10 +419,10 @@ jobs:
           KUNAI_MUSL_BINARY: ${{ matrix.musl_binary }}
         run: |
           set -euo pipefail
-          chmod +x ".release-download/${KUNAI_MUSL_BINARY}"
+          chmod +x ".release-download/native/${KUNAI_MUSL_BINARY}"
           for command in --version --help; do
             docker run --rm \
-              --volume "$PWD/.release-download:/candidate:ro" \
+              --volume "$PWD/.release-download/native:/candidate:ro" \
               --env HOME=/tmp/kunai-home \
               alpine:3.20 \
               "/candidate/${KUNAI_MUSL_BINARY}" "${command}" \
@@ -424,11 +437,11 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           New-Item -ItemType Directory -Force artifacts | Out-Null
-          foreach ($line in Get-Content .release-download/SHA256SUMS) {
+          foreach ($line in Get-Content .release-download/native/SHA256SUMS) {
             if ($line -notmatch '^([0-9a-f]{64})\s+(.+)$') { throw "Malformed SHA256SUMS row: $line" }
             $expected = $Matches[1]
             $name = $Matches[2]
-            $actual = (Get-FileHash ".release-download/$name" -Algorithm SHA256).Hash.ToLowerInvariant()
+            $actual = (Get-FileHash ".release-download/native/$name" -Algorithm SHA256).Hash.ToLowerInvariant()
             if ($actual -ne $expected) { throw "Checksum mismatch for $name" }
           }
           $profileRoot = Join-Path $env:RUNNER_TEMP "kunai-native-$([guid]::NewGuid())"
@@ -436,12 +449,12 @@ jobs:
           $env:APPDATA = Join-Path $profileRoot "appdata"
           $env:LOCALAPPDATA = Join-Path $profileRoot "localappdata"
           New-Item -ItemType Directory -Force $env:USERPROFILE,$env:APPDATA,$env:LOCALAPPDATA | Out-Null
-          $version = (& ".release-download/$env:KUNAI_NATIVE_BINARY" --version 2>&1 | Out-String).Trim()
+          $version = (& ".release-download/native/$env:KUNAI_NATIVE_BINARY" --version 2>&1 | Out-String).Trim()
           if ($LASTEXITCODE -ne 0) { throw "--version exited $LASTEXITCODE" }
           if ($version -notmatch '^kunai\s+v?\d') { throw "--version did not print a kunai version" }
           $version | Tee-Object -FilePath "artifacts/native-${{ matrix.id }}.log"
 
-          $help = (& ".release-download/$env:KUNAI_NATIVE_BINARY" --help 2>&1 | Out-String).Trim()
+          $help = (& ".release-download/native/$env:KUNAI_NATIVE_BINARY" --help 2>&1 | Out-String).Trim()
           if ($LASTEXITCODE -ne 0) { throw "--help exited $LASTEXITCODE" }
           if ($help.Length -eq 0) { throw "--help printed nothing" }
           $help | Tee-Object -FilePath "artifacts/native-${{ matrix.id }}.log" -Append
@@ -628,11 +641,11 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts
-          chmod +x .release-download/kunai-linux-x64
+          chmod +x .release-download/native/kunai-linux-x64
           bun run verify:readme:commands -- \
             --mode fixture-assets \
             --version "${{ needs.candidate.outputs.version }}" \
-            --binary .release-download/kunai-linux-x64 \
+            --binary .release-download/native/kunai-linux-x64 \
             2>&1 | tee artifacts/readmeCommands.log
           bun run scripts/release-gate-evidence.ts create \
             --gate readmeCommands \
@@ -733,44 +746,21 @@ jobs:
           name: ${{ env.CANDIDATE_ARTIFACT }}-${{ needs.candidate.outputs.version }}-${{ github.sha }}
           path: .release-download
 
-      - name: Stage binaries for confirmation
-        run: |
-          set -euo pipefail
-          mkdir -p apps/cli/dist/bin
-          cp .release-download/kunai-linux-x64 \
-            .release-download/kunai-linux-x64.tar.gz \
-            .release-download/kunai-linux-arm64 \
-            .release-download/kunai-linux-arm64.tar.gz \
-            .release-download/kunai-linux-x64-musl \
-            .release-download/kunai-linux-x64-musl.tar.gz \
-            .release-download/kunai-linux-arm64-musl \
-            .release-download/kunai-linux-arm64-musl.tar.gz \
-            .release-download/kunai-darwin-x64 \
-            .release-download/kunai-darwin-x64.tar.gz \
-            .release-download/kunai-darwin-arm64 \
-            .release-download/kunai-darwin-arm64.tar.gz \
-            .release-download/kunai-windows-x64.exe \
-            .release-download/kunai-windows-x64.zip \
-            .release-download/kunai-windows-arm64.exe \
-            .release-download/kunai-windows-arm64.zip \
-            .release-download/SHA256SUMS \
-            .release-download/SHA256SUMS.archives \
-            apps/cli/dist/bin/
-
-      - name: Reverify preserved release artifacts
-        run: |
-          set -euo pipefail
-          VERSION="${{ needs.candidate.outputs.version }}"
-          bun run scripts/verify-release-artifact-directory.ts \
-            apps/cli/dist/bin \
-            --expected-version "${VERSION}"
-
       - name: Download every gate evidence document and hashed artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
         with:
           pattern: gate-*-${{ needs.candidate.outputs.version }}-${{ github.sha }}
           path: artifacts/gates
           merge-multiple: true
+
+      - name: Reverify exact preserved native candidate
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.candidate.outputs.version }}"
+          bun run scripts/verify-release-artifact-directory.ts \
+            .release-download/native \
+            --expected-version "${VERSION}" \
+            --skip-version-smoke
 
       - name: Run confirmation gate
         id: gate
@@ -805,7 +795,7 @@ jobs:
             --gate-artifact "nativePlatforms-${VERSION}-${SHA}=artifacts/gates/native-platforms.log" \
             --provider-evidence artifacts/gates/release-provider-signoff.json \
             --provider-signoff-run-id "${PROVIDER_SIGNOFF_RUN_ID}" \
-            --binary-dir apps/cli/dist/bin \
+            --binary-dir .release-download/native \
             --binary-artifact-name "${ARTIFACT_NAME}" \
             | tee artifacts/release-confirmation.json
           echo "binary_artifact=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
@@ -875,33 +865,14 @@ jobs:
           name: ${{ env.CANDIDATE_ARTIFACT }}-${{ needs.confirmation.outputs.version }}-${{ github.sha }}
           path: .release-download
 
-      - name: Stage preserved binaries and tarball
+      - name: Stage preserved npm artifacts
         run: |
           set -euo pipefail
-          mkdir -p apps/cli/dist/bin .release-candidate
-          cp .release-download/kunai-linux-x64 \
-            .release-download/kunai-linux-x64.tar.gz \
-            .release-download/kunai-linux-arm64 \
-            .release-download/kunai-linux-arm64.tar.gz \
-            .release-download/kunai-linux-x64-musl \
-            .release-download/kunai-linux-x64-musl.tar.gz \
-            .release-download/kunai-linux-arm64-musl \
-            .release-download/kunai-linux-arm64-musl.tar.gz \
-            .release-download/kunai-darwin-x64 \
-            .release-download/kunai-darwin-x64.tar.gz \
-            .release-download/kunai-darwin-arm64 \
-            .release-download/kunai-darwin-arm64.tar.gz \
-            .release-download/kunai-windows-x64.exe \
-            .release-download/kunai-windows-x64.zip \
-            .release-download/kunai-windows-arm64.exe \
-            .release-download/kunai-windows-arm64.zip \
-            .release-download/SHA256SUMS \
-            .release-download/SHA256SUMS.archives \
-            apps/cli/dist/bin/
+          mkdir -p .release-candidate
           cp .release-download/kunai-npm.tgz .release-candidate/kunai-npm.tgz
           cp -R .release-download/npm-platform .release-candidate/npm-platform
           test -f .release-candidate/kunai-npm.tgz
-          test -f apps/cli/dist/bin/SHA256SUMS
+          test -f .release-download/native/SHA256SUMS
           test -d .release-candidate/npm-platform
 
       - name: Reverify exact preserved npm launcher tarball
@@ -910,11 +881,12 @@ jobs:
           .release-candidate/kunai-npm.tgz --expected-version
           "${{ needs.confirmation.outputs.version }}"
 
-      - name: Reverify preserved binaries
+      - name: Reverify protected native publication input
         run: |
           bun run scripts/verify-release-artifact-directory.ts \
-            apps/cli/dist/bin \
-            --expected-version "${{ needs.confirmation.outputs.version }}"
+            .release-download/native \
+            --expected-version "${{ needs.confirmation.outputs.version }}" \
+            --skip-version-smoke
 
       # Platform packages first, launcher last, refusing on any version skew.
       # Publishing the launcher first leaves anyone installing in that window
@@ -1001,6 +973,13 @@ jobs:
           git tag -a "${TAG}" -m "Release ${TAG}"
           git push origin "refs/tags/${TAG}"
 
+      - name: Reverify exact native payload before draft upload
+        run: |
+          bun run scripts/verify-release-artifact-directory.ts \
+            .release-download/native \
+            --expected-version "${{ needs.confirmation.outputs.version }}" \
+            --skip-version-smoke
+
       - name: Create draft GitHub release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # softprops/action-gh-release@v2
         with:
@@ -1011,24 +990,24 @@ jobs:
           body_path: .release/kunai-${{ needs.confirmation.outputs.tag }}.md
           fail_on_unmatched_files: true
           files: |
-            apps/cli/dist/bin/kunai-linux-x64
-            apps/cli/dist/bin/kunai-linux-x64.tar.gz
-            apps/cli/dist/bin/kunai-linux-arm64
-            apps/cli/dist/bin/kunai-linux-arm64.tar.gz
-            apps/cli/dist/bin/kunai-linux-x64-musl
-            apps/cli/dist/bin/kunai-linux-x64-musl.tar.gz
-            apps/cli/dist/bin/kunai-linux-arm64-musl
-            apps/cli/dist/bin/kunai-linux-arm64-musl.tar.gz
-            apps/cli/dist/bin/kunai-darwin-x64
-            apps/cli/dist/bin/kunai-darwin-x64.tar.gz
-            apps/cli/dist/bin/kunai-darwin-arm64
-            apps/cli/dist/bin/kunai-darwin-arm64.tar.gz
-            apps/cli/dist/bin/kunai-windows-x64.exe
-            apps/cli/dist/bin/kunai-windows-x64.zip
-            apps/cli/dist/bin/kunai-windows-arm64.exe
-            apps/cli/dist/bin/kunai-windows-arm64.zip
-            apps/cli/dist/bin/SHA256SUMS
-            apps/cli/dist/bin/SHA256SUMS.archives
+            .release-download/native/kunai-linux-x64
+            .release-download/native/kunai-linux-x64.tar.gz
+            .release-download/native/kunai-linux-arm64
+            .release-download/native/kunai-linux-arm64.tar.gz
+            .release-download/native/kunai-linux-x64-musl
+            .release-download/native/kunai-linux-x64-musl.tar.gz
+            .release-download/native/kunai-linux-arm64-musl
+            .release-download/native/kunai-linux-arm64-musl.tar.gz
+            .release-download/native/kunai-darwin-x64
+            .release-download/native/kunai-darwin-x64.tar.gz
+            .release-download/native/kunai-darwin-arm64
+            .release-download/native/kunai-darwin-arm64.tar.gz
+            .release-download/native/kunai-windows-x64.exe
+            .release-download/native/kunai-windows-x64.zip
+            .release-download/native/kunai-windows-arm64.exe
+            .release-download/native/kunai-windows-arm64.zip
+            .release-download/native/SHA256SUMS
+            .release-download/native/SHA256SUMS.archives
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -166,6 +166,14 @@ when an older release returns HTTP 404/410 for its archive metadata or asset.
 Do not dispatch a release until the complete archive-consumer stack and these
 protected preservation gates are green.
 
+The blocking native matrix downloads this preserved candidate on Linux, macOS,
+and Windows. Each host serves only its exact archive and both checksum
+manifests from a loopback fixture, runs the checked-out production installer in
+an isolated profile, verifies the published archive provenance, and executes
+the installed launcher with `--version` and `--help`. It also executes the raw
+candidate separately for compatibility; the installer proof cannot silently
+fall back because the fixture never exposes that raw asset.
+
 `release:pack` is:
 
 ```sh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -153,17 +153,18 @@ Job **`candidate`** (no publish):
 3. Builds all 8 release binaries plus their deterministic archives, verifies
    the exact 18 native assets, and runs compiled binary smoke
 4. `bun run release:pack` → `.release-candidate/kunai-npm.tgz`
-5. Uploads artifact `kunai-release-candidate-<version>` (8 archives + 8 raw
-   binaries + `SHA256SUMS` + `SHA256SUMS.archives` + preserved npm artifacts,
-   14-day retention)
+5. Stages the native files under an isolated `native/` directory, reverifies
+   that exact 18-file directory immediately before upload, then uploads artifact
+   `kunai-release-candidate-<version>` with the preserved npm artifacts
+   alongside it (14-day retention)
 
 For the 0.3.0 compatibility bridge, legacy `SHA256SUMS` continues to hash raw
 standalone binaries so already-published installers and updaters remain
-functional. `SHA256SUMS.archives` hashes archives. Archive creation is only the
-first stacked layer: this slice does not close issue #132 or reduce user
-downloads. Installers and the in-app updater still consume raw assets until the
-archive-aware follow-up lands. Do not dispatch a release from the
-archive-creation layer alone.
+functional. `SHA256SUMS.archives` hashes archives. Current installers and the
+in-app updater consume the canonical archive first, then use the raw asset only
+when an older release returns HTTP 404/410 for its archive metadata or asset.
+Do not dispatch a release until the complete archive-consumer stack and these
+protected preservation gates are green.
 
 `release:pack` is:
 
@@ -174,7 +175,10 @@ mkdir -p .release-candidate && ROOT="$PWD" && \
 
 ### 3. Confirmation gate (still no publish)
 
-Job **`confirmation`** needs `candidate`. It downloads the preserved candidate binaries, pulls the provider signoff artifact from `provider_signoff_run_id`, and runs:
+Job **`confirmation`** needs `candidate`. It downloads the preserved candidate,
+pulls the provider signoff artifact from `provider_signoff_run_id`, verifies the
+downloaded `native/` directory immediately before the confirmation boundary,
+and runs:
 
 ```sh
 bun run release:confirmation:check -- \
@@ -182,7 +186,7 @@ bun run release:confirmation:check -- \
   --commit <sha> \
   --provider-evidence artifacts/release-provider-signoff.json \
   --provider-signoff-run-id <run_id> \
-  --binary-dir apps/cli/dist/bin
+  --binary-dir .release-download/native
 ```
 
 Expected machine-readable `ready-for-confirmation` JSON. Nothing has been published yet.
@@ -191,14 +195,17 @@ Expected machine-readable `ready-for-confirmation` JSON. Nothing has been publis
 
 Job **`publish`** needs `confirmation` and declares `environment: release-production`. After approval it:
 
-1. Downloads the preserved candidate artifact (does **not** rebuild or re-pack)
-2. Reverifies binaries against the expected version
+1. Downloads the preserved candidate artifact (does **not** rebuild, re-pack,
+   or recompress native assets)
+2. Reverifies the exact native directory against the expected version
 3. `bun publish .release-candidate/kunai-npm.tgz --access public`
 4. Retries `npm view @kitsunekode/kunai@<version>` until visible
 5. Creates annotated tag `v<version>` and pushes it
-6. Creates a **draft** GitHub release (`make_latest: false`) with the 18 required native assets
+6. Reverifies the same downloaded native directory again, immediately before
+   creating a **draft** GitHub release (`make_latest: false`) with its 18 files
 7. `bun run scripts/verify-github-release-assets.ts <tag> --expect-draft …`
-8. Promotes: `gh release edit <tag> --draft=false --latest`
+8. Promotes immediately after that draft-byte verification:
+   `gh release edit <tag> --draft=false --latest`
 9. Verifies the public release assets again
 
 ### 5. Metadata after public verification

--- a/apps/cli/test/integration/preserved-native-installer-smoke.test.ts
+++ b/apps/cli/test/integration/preserved-native-installer-smoke.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import {
+  RELEASE_BINARY_TARGETS,
+  resolveHostReleaseBinaryTarget,
+} from "@/services/update/platform-assets";
+import { parseCanonicalVersion } from "@/services/update/version";
+
+import { createInstallerSandbox, withReleaseFixture } from "./helpers/installer-script-harness";
+
+const REPO_ROOT = join(import.meta.dirname, "../../../..");
+const CANDIDATE_DIR = process.env.KUNAI_RELEASE_CANDIDATE_DIR?.trim();
+const CANDIDATE_VERSION = process.env.KUNAI_RELEASE_CANDIDATE_VERSION?.trim();
+const CANDIDATE_ASSET = process.env.KUNAI_RELEASE_CANDIDATE_ASSET?.trim();
+const RUN_SMOKE = Boolean(CANDIDATE_DIR || CANDIDATE_VERSION || CANDIDATE_ASSET);
+
+async function runCommand(
+  command: readonly string[],
+  env: NodeJS.ProcessEnv,
+): Promise<{ readonly status: number; readonly stdout: string; readonly stderr: string }> {
+  const proc = Bun.spawn([...command], {
+    cwd: REPO_ROOT,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, status] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { status, stdout, stderr };
+}
+
+const describeCandidate = RUN_SMOKE ? describe : describe.skip;
+
+describeCandidate("preserved native installer smoke", () => {
+  test("installs and executes the exact host archive without raw fallback", async () => {
+    if (!CANDIDATE_DIR || !CANDIDATE_VERSION || !CANDIDATE_ASSET) {
+      throw new Error("All preserved candidate environment variables are required");
+    }
+
+    const version = parseCanonicalVersion(CANDIDATE_VERSION);
+    if (!version) throw new Error(`Invalid candidate version: ${CANDIDATE_VERSION}`);
+    const target = RELEASE_BINARY_TARGETS.find((entry) => entry.out === CANDIDATE_ASSET);
+    if (!target) throw new Error(`Unknown candidate asset: ${CANDIDATE_ASSET}`);
+    const hostTarget = resolveHostReleaseBinaryTarget({ libc: "gnu" });
+    if (target.id !== hostTarget.id) {
+      throw new Error(`Candidate ${target.id} does not match host ${hostTarget.id}`);
+    }
+
+    const candidateDir = resolve(CANDIDATE_DIR);
+    const archivePath = join(candidateDir, target.archiveName);
+    const rawSumsPath = join(candidateDir, "SHA256SUMS");
+    const archiveSumsPath = join(candidateDir, "SHA256SUMS.archives");
+    const archive = new Uint8Array(await Bun.file(archivePath).arrayBuffer());
+    const rawSums = readFileSync(rawSumsPath, "utf8");
+    const archiveSums = readFileSync(archiveSumsPath, "utf8");
+    const archiveSha256 = createHash("sha256").update(archive).digest("hex");
+    const archiveSizeBytes = statSync(archivePath).size;
+    const sandbox = createInstallerSandbox(`preserved-${target.id}`);
+
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v${version}/SHA256SUMS.archives`]: { body: archiveSums },
+          [`/download/v${version}/${target.archiveName}`]: { body: archive },
+          [`/download/v${version}/SHA256SUMS`]: { body: rawSums },
+        },
+        async (baseUrl, evidence) => {
+          const env = {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_SKIP_PATH_UPDATE: "1",
+          };
+          const installCommand =
+            process.platform === "win32"
+              ? [
+                  "pwsh",
+                  "-NoProfile",
+                  "-File",
+                  join(REPO_ROOT, "install.ps1"),
+                  "-Method",
+                  "binary",
+                  "-Version",
+                  version,
+                  "-Yes",
+                  "-SkipDeps",
+                  "-SkipPathUpdate",
+                ]
+              : [
+                  "bash",
+                  join(REPO_ROOT, "install.sh"),
+                  "--method",
+                  "binary",
+                  "--version",
+                  version,
+                  "--yes",
+                  "--skip-deps",
+                  "--skip-path-update",
+                ];
+          const install = await runCommand(installCommand, env);
+          expect(install.status, `${install.stderr}\n${install.stdout}`).toBe(0);
+          expect(evidence.requests).toEqual([
+            `/download/v${version}/SHA256SUMS.archives`,
+            `/download/v${version}/${target.archiveName}`,
+            `/download/v${version}/SHA256SUMS`,
+          ]);
+          expect(evidence.requests).not.toContain(`/download/v${version}/${target.out}`);
+
+          const manifest = JSON.parse(
+            readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
+          ) as Record<string, unknown>;
+          expect(manifest).toMatchObject({
+            activeVersion: version,
+            artifactName: target.out,
+            archiveName: target.archiveName,
+            archiveSha256,
+            archiveSizeBytes,
+            archiveSourceUrl: `${baseUrl}/download/v${version}/${target.archiveName}`,
+          });
+
+          const launcher = join(
+            sandbox.binDir,
+            process.platform === "win32" ? "kunai.exe" : "kunai",
+          );
+          const versionResult = await runCommand([launcher, "--version"], env);
+          expect(versionResult.status, versionResult.stderr).toBe(0);
+          const reportedVersion = /^kunai\s+v?(\d+\.\d+\.\d+)(?:\s|$)/.exec(
+            versionResult.stdout.trim(),
+          )?.[1];
+          expect(reportedVersion).toBe(version);
+          const helpResult = await runCommand([launcher, "--help"], env);
+          expect(helpResult.status, helpResult.stderr).toBe(0);
+          expect(helpResult.stdout.trim().length).toBeGreaterThan(0);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  }, 120_000);
+});

--- a/apps/cli/test/unit/scripts/distribution-contract.test.ts
+++ b/apps/cli/test/unit/scripts/distribution-contract.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -120,6 +120,16 @@ describe("distribution release-asset contract", () => {
     }
   });
 
+  test("build-binaries.yml verifies the exact directory immediately before upload", () => {
+    const workflow = readFileSync(join(REPO_ROOT, ".github/workflows/build-binaries.yml"), "utf8");
+    const upload = workflow.indexOf("- name: Upload binaries artifact");
+    const exactVerify = workflow.lastIndexOf("verify-release-artifact-directory.ts", upload);
+
+    expect(exactVerify).toBeGreaterThanOrEqual(0);
+    expect(upload).toBeGreaterThan(exactVerify);
+    expect(workflow.slice(exactVerify, upload)).not.toContain("- name:");
+  });
+
   test("host and installer-matrix raw-binary checks preserve SHA256SUMS compatibility", () => {
     const verifier = readFileSync(
       join(REPO_ROOT, "apps/cli/scripts/verify-host-binary.sh"),
@@ -214,6 +224,20 @@ describe("release workflow candidate-before-publication contract", () => {
     expect(release.indexOf("upload-artifact")).toBeLessThan(release.indexOf("download-artifact"));
   });
 
+  test("candidate isolates and verifies the exact native payload immediately before upload", () => {
+    const cand = candidate();
+    const stage = cand.indexOf("Stage candidate upload directory");
+    const exactVerify = cand.indexOf("verify-release-artifact-directory.ts", stage);
+    const upload = cand.indexOf("- name: Upload candidate artifacts");
+
+    expect(cand).toContain(".candidate-upload/native");
+    expect(stage).toBeGreaterThanOrEqual(0);
+    expect(exactVerify).toBeGreaterThan(stage);
+    expect(upload).toBeGreaterThan(exactVerify);
+    expect(cand.slice(exactVerify, upload)).not.toContain("- name:");
+    expect(cand).toContain(".candidate-upload/native/SHA256SUMS");
+  });
+
   test("publication downloads the preserved tarball/binaries", () => {
     const pub = publish();
     expect(pub).toContain("download-artifact");
@@ -271,16 +295,40 @@ describe("release workflow candidate-before-publication contract", () => {
     }
   });
 
-  test("confirmation reconstructs and verifies the preserved native archives", () => {
+  test("confirmation directly verifies the preserved native payload immediately before gating", () => {
     const confirm = confirmation();
-    const stage = confirm.indexOf("Stage binaries for confirmation");
     const verify = confirm.indexOf("verify-release-artifact-directory.ts");
-    const gate = confirm.indexOf("Run confirmation gate");
+    const gate = confirm.indexOf("- name: Run confirmation gate");
 
-    expect(stage).toBeGreaterThanOrEqual(0);
-    expect(verify).toBeGreaterThan(stage);
+    expect(confirm).not.toContain("Stage binaries for confirmation");
+    expect(confirm).toContain(".release-download/native");
+    expect(verify).toBeGreaterThanOrEqual(0);
     expect(gate).toBeGreaterThan(verify);
+    expect(confirm.slice(verify, gate)).not.toContain("- name:");
     expect(confirm).toContain('--expected-version "${VERSION}"');
+    expect(confirm).toContain("--binary-dir .release-download/native");
+  });
+
+  test("protected publication reverifies native bytes immediately before draft creation", () => {
+    const pub = publish();
+    const createDraft = pub.indexOf("- name: Create draft GitHub release");
+    const exactVerify = pub.lastIndexOf("verify-release-artifact-directory.ts", createDraft);
+
+    expect(pub).toContain(".release-download/native");
+    expect(exactVerify).toBeGreaterThanOrEqual(0);
+    expect(createDraft).toBeGreaterThan(exactVerify);
+    expect(pub.slice(exactVerify, createDraft)).not.toContain("- name:");
+    for (const name of REQUIRED_RELEASE_ASSET_NAMES) {
+      expect(pub).toContain(`.release-download/native/${name}`);
+    }
+  });
+
+  test("confirmation and publication never rebuild or recompress preserved native assets", () => {
+    for (const job of [confirmation(), publish()]) {
+      expect(job).not.toContain("build:binaries");
+      expect(job).not.toContain("build-release-archives");
+      expect(job).not.toMatch(/^\s+(?:tar|zip|gzip)\s/m);
+    }
   });
 
   test("candidate install gate consumes preserved local tarballs after they are created", () => {
@@ -438,6 +486,36 @@ describe("verifyReleaseArtifactDirectory", () => {
     }
   });
 
+  test("restores downloaded Linux executable mode for the version smoke without changing bytes", async () => {
+    if (process.platform !== "linux" || process.arch !== "x64") return;
+
+    const dir = mkdtempSync(join(tmpdir(), "kunai-release-assets-mode-"));
+    try {
+      for (const name of requiredBinaryNames) {
+        writeFileSync(
+          join(dir, name),
+          name === "kunai-linux-x64"
+            ? '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "kunai 9.9.9"; else echo "Kunai help"; fi\n'
+            : `payload:${name}\n`,
+        );
+      }
+      chmodSync(join(dir, "kunai-linux-x64"), 0o644);
+      buildReleaseArchives(dir);
+      const bytesBefore = readFileSync(join(dir, "kunai-linux-x64"));
+
+      await expect(
+        verifyReleaseArtifactDirectory({
+          directory: dir,
+          expectedVersion: "9.9.9",
+        }),
+      ).resolves.toBeUndefined();
+      expect(readFileSync(join(dir, "kunai-linux-x64"))).toEqual(bytesBefore);
+      expect(statSync(join(dir, "kunai-linux-x64")).mode & 0o111).not.toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("rejects checksum mismatch", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kunai-release-assets-"));
     try {
@@ -454,6 +532,32 @@ describe("verifyReleaseArtifactDirectory", () => {
       ).rejects.toThrow(/checksum|sha256/i);
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects missing, unexpected, and raw-byte-mutated preserved payloads", async () => {
+    for (const failure of ["missing", "unexpected", "mutated"] as const) {
+      const dir = mkdtempSync(join(tmpdir(), `kunai-release-assets-${failure}-`));
+      try {
+        writeCompleteReleaseFixture(dir);
+        if (failure === "missing") {
+          rmSync(join(dir, requiredArchiveNames[0]!));
+        } else if (failure === "unexpected") {
+          writeFileSync(join(dir, "unexpected-release-asset"), "unexpected\n");
+        } else {
+          writeFileSync(join(dir, requiredBinaryNames[0]!), "mutated raw bytes\n");
+        }
+
+        await expect(
+          verifyReleaseArtifactDirectory({
+            directory: dir,
+            expectedVersion: "9.9.9",
+            skipVersionSmoke: true,
+          }),
+        ).rejects.toThrow(failure === "unexpected" ? /unexpected/ : /missing|checksum|sha256/i);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     }
   });
 

--- a/apps/cli/test/unit/scripts/release-confirmation-gate.test.ts
+++ b/apps/cli/test/unit/scripts/release-confirmation-gate.test.ts
@@ -401,7 +401,17 @@ describe("release workflow confirmation dependency graph", () => {
     expect(native).toContain("verify-release-artifact-directory.ts");
     expect(native).toContain(".release-download/native");
     expect(native).toMatch(/Reverify exact preserved native payload[\s\S]*run:\s*>-/);
-    expect(native).toContain("install-scripts-pwsh.test.ts");
+    expect(native).toContain("preserved-native-installer-smoke.test.ts");
+    expect(native).toContain("KUNAI_RELEASE_CANDIDATE_DIR");
+    expect(native).toContain("KUNAI_RELEASE_CANDIDATE_VERSION");
+    expect(native).toContain("KUNAI_RELEASE_CANDIDATE_ASSET");
+    expect(native).toContain("${{ matrix.binary }}");
+    expect(native).toContain("Exercise exact preserved archive through install.sh");
+    expect(native).toContain("Exercise exact preserved archive through install.ps1");
+    expect(native).not.toContain('| tee "artifacts/native-${{ matrix.id }}.log"');
+    expect(native).not.toMatch(
+      /Tee-Object -FilePath "artifacts\/native-\$\{\{ matrix\.id \}\}\.log"\s*$/m,
+    );
     expect(aggregate).toMatch(/needs:[^\n]*native-smoke/);
     expect(aggregate).toContain("nativePlatforms");
     expect(confirmation).toMatch(/needs:[\s\S]*native-platforms-gate/);

--- a/apps/cli/test/unit/scripts/release-confirmation-gate.test.ts
+++ b/apps/cli/test/unit/scripts/release-confirmation-gate.test.ts
@@ -398,6 +398,9 @@ describe("release workflow confirmation dependency graph", () => {
     expect(native).toContain("--version");
     expect(native).toContain("--help");
     expect(native).toContain("download-artifact");
+    expect(native).toContain("verify-release-artifact-directory.ts");
+    expect(native).toContain(".release-download/native");
+    expect(native).toMatch(/Reverify exact preserved native payload[\s\S]*run:\s*>-/);
     expect(native).toContain("install-scripts-pwsh.test.ts");
     expect(aggregate).toMatch(/needs:[^\n]*native-smoke/);
     expect(aggregate).toContain("nativePlatforms");

--- a/scripts/verify-release-artifact-directory.ts
+++ b/scripts/verify-release-artifact-directory.ts
@@ -10,7 +10,7 @@
 
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { chmodSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import { verifyBuiltReleaseArchives } from "../apps/cli/scripts/build-release-archives";
@@ -51,6 +51,11 @@ function smokeLinuxX64(binPath: string, expectedVersion: string): void {
   if (process.platform !== "linux" || process.arch !== "x64") {
     return;
   }
+
+  // GitHub artifact and release downloads intentionally do not preserve Unix
+  // executable mode. Restoring the mode changes filesystem metadata, not the
+  // verified bytes; archive mode is checked independently as canonical 0755.
+  chmodSync(binPath, 0o755);
 
   const version = spawnSync(binPath, ["--version"], {
     encoding: "utf8",


### PR DESCRIPTION
## Summary

- preserve the exact 18 native candidate assets through confirmation, draft release creation, and public promotion
- isolate and verify the candidate native directory immediately before every trust boundary
- prevent release jobs from rebuilding or recompressing native artifacts
- install each host's exact preserved archive through the production Bash/PowerShell installer on Linux, macOS, and Windows
- retain archive-install evidence alongside raw candidate execution, with exact installed-version checks

## Stack

- parent: #204
- #204 depends on #184, which depends on #180
- native attestation PR #183 remains directly downstream

## Verification

- full pre-push gate: 23 tasks green
- 4805 unit tests passed, 1 Windows-only skip
- 235 integration tests passed, 25 opt-in/environment skips
- focused release-contract suite: 65 passed
- exact preserved Linux archive installer smoke passed against the built candidate
- typecheck, zero-warning lint, format, doc paths, YAML parse, and diff check passed
- independent standards/spec review findings resolved: evidence logs are append-only and installed versions require exact equality
- local actionlint is unavailable; remote workflow parsing and native CI remain required

No release workflow was dispatched.

Closes #132