### PR TITLE
ci(release): attest native candidate artifacts

### DIFF
--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -69,6 +69,16 @@ the recorded archive provenance and executes the sandboxed installed launcher
 with `--version` and `--help`; the separate raw and musl executions remain
 compatibility checks.
 
+After the final candidate-directory verification, `actions/attest` signs all 18
+subjects with GitHub OIDC. Confirmation and protected publication run
+`scripts/verify-native-attestations.ts` against the exact workflow identity,
+`refs/heads/main`, and candidate commit before trusting those bytes. Candidate
+permissions are limited to read access plus OIDC, attestation, and artifact
+metadata writes; later jobs receive attestation read access only. Release
+downloads are checked and attested before the Linux smoke executes; protected
+publication verifies provenance before npm receives any package, and draft/public
+downloads repeat the byte and provenance checks.
+
 The TypeScript native updater and both native installer scripts consume these
 archives. All three verify the archive against `SHA256SUMS.archives`, permit
 exactly one expected regular-file member, bound compressed and decompressed

--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -70,14 +70,18 @@ with `--version` and `--help`; the separate raw and musl executions remain
 compatibility checks.
 
 After the final candidate-directory verification, `actions/attest` signs all 18
-subjects with GitHub OIDC. Confirmation and protected publication run
-`scripts/verify-native-attestations.ts` against the exact workflow identity,
-`refs/heads/main`, and candidate commit before trusting those bytes. Candidate
-permissions are limited to read access plus OIDC, attestation, and artifact
-metadata writes; later jobs receive attestation read access only. Release
-downloads are checked and attested before the Linux smoke executes; protected
-publication verifies provenance before npm receives any package, and draft/public
-downloads repeat the byte and provenance checks.
+subjects with GitHub OIDC. The upload's immutable artifact ID is passed through
+the provenance, execution, confirmation, and publication jobs so every boundary
+downloads the same candidate rather than resolving it again by name. A dedicated
+provenance gate runs `scripts/verify-native-attestations.ts` against the exact
+workflow identity, `refs/heads/main`, and candidate commit before any downloaded
+native binary may execute. Confirmation and protected publication repeat that
+check before trusting the bytes. Candidate permissions are limited to read access
+plus OIDC, attestation, and artifact metadata writes; later jobs receive only the
+read permissions they need. Each execution job locally checks the downloaded
+directory before its first smoke. Protected publication verifies provenance
+before npm receives any package, and draft/public downloads repeat the byte and
+provenance checks.
 
 The TypeScript native updater and both native installer scripts consume these
 archives. All three verify the archive against `SHA256SUMS.archives`, permit

--- a/.docs/repo-infrastructure.md
+++ b/.docs/repo-infrastructure.md
@@ -154,6 +154,11 @@ boundaries use the downloaded files directly without a rebuild, native copy, or
 recompression. GitHub downloads may discard the raw binary's executable mode,
 so the Linux smoke restores that filesystem metadata after byte verification;
 the canonical `0755` mode inside tar archives remains independently verified.
+The candidate job then creates GitHub artifact attestations for the exact 18
+verified paths. Confirmation and publication fail closed unless every file
+verifies against `KitsuneKode/kunai/.github/workflows/release.yml`, the main
+branch ref, and the current release commit. The verifier also rejects extra or
+non-regular directory entries before consulting remote provenance.
 On every available Linux, macOS, and Windows native runner, the release smoke
 also exposes only that runner's downloaded archive and the two manifests over a
 loopback fixture, installs it through the production shell installer into an

--- a/.github/scripts/smoke-preserved-musl-installer.sh
+++ b/.github/scripts/smoke-preserved-musl-installer.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Install one attested musl archive through production install.sh inside Alpine.
+# The fixture deliberately withholds the raw binary, so a successful smoke is
+# evidence that the archive path completed without the legacy fallback.
+set -euo pipefail
+
+CANDIDATE_DIR="${1:?usage: smoke-preserved-musl-installer.sh <candidate-dir> <version> <asset>}"
+VERSION="${2:?usage: smoke-preserved-musl-installer.sh <candidate-dir> <version> <asset>}"
+ASSET="${3:?usage: smoke-preserved-musl-installer.sh <candidate-dir> <version> <asset>}"
+
+case "$ASSET" in
+kunai-linux-x64-musl | kunai-linux-arm64-musl) ;;
+*)
+	echo "unsupported musl release asset: $ASSET" >&2
+	exit 1
+	;;
+esac
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+	echo "invalid release version: $VERSION" >&2
+	exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
+CANDIDATE_DIR="$(cd "$CANDIDATE_DIR" && pwd -P)"
+ARCHIVE="${ASSET}.tar.gz"
+for file in "$ARCHIVE" SHA256SUMS SHA256SUMS.archives; do
+	[[ -f "$CANDIDATE_DIR/$file" ]] || {
+		echo "missing preserved release file: $CANDIDATE_DIR/$file" >&2
+		exit 1
+	}
+done
+
+FIXTURE_ROOT="$(mktemp -d)"
+cleanup() {
+	rm -rf "$FIXTURE_ROOT"
+}
+trap cleanup EXIT
+
+FIXTURE_VERSION_DIR="$FIXTURE_ROOT/download/v$VERSION"
+mkdir -p "$FIXTURE_VERSION_DIR"
+cp "$CANDIDATE_DIR/$ARCHIVE" "$FIXTURE_VERSION_DIR/$ARCHIVE"
+cp "$CANDIDATE_DIR/SHA256SUMS" "$FIXTURE_VERSION_DIR/SHA256SUMS"
+cp "$CANDIDATE_DIR/SHA256SUMS.archives" "$FIXTURE_VERSION_DIR/SHA256SUMS.archives"
+test ! -e "$FIXTURE_VERSION_DIR/$ASSET"
+
+EXPECTED_ARCHIVE_SHA="$(sha256sum "$CANDIDATE_DIR/$ARCHIVE" | awk '{print $1}')"
+IMAGE="kunai-release-musl-installer:${VERSION}"
+docker build \
+	--target musl \
+	--tag "$IMAGE" \
+	--file "$REPO_ROOT/apps/cli/test/docker/native-installer/Dockerfile" \
+	"$REPO_ROOT/apps/cli/test/docker/native-installer"
+
+docker run --rm --network none \
+	--volume "$FIXTURE_ROOT:/release:ro" \
+	--volume "$REPO_ROOT/install.sh:/work/install.sh:ro" \
+	--env "KUNAI_EXPECTED_ARCHIVE_SHA=$EXPECTED_ARCHIVE_SHA" \
+	--env "KUNAI_RELEASE_ASSET=$ASSET" \
+	--env "KUNAI_RELEASE_VERSION=$VERSION" \
+	"$IMAGE" \
+	bash -ceu '
+		profile=/tmp/kunai-release-smoke
+		export HOME="$profile/home"
+		export KUNAI_BIN_DIR="$profile/bin"
+		export KUNAI_CONFIG_DIR="$profile/config"
+		export KUNAI_DATA_DIR="$profile/data"
+		export KUNAI_CACHE_DIR="$profile/cache"
+		export KUNAI_DL_BASE=file:///release
+		export KUNAI_SKIP_PATH_UPDATE=1
+		mkdir -p "$HOME"
+
+		bash /work/install.sh \
+			--method binary \
+			--version "$KUNAI_RELEASE_VERSION" \
+			--yes \
+			--skip-deps \
+			--skip-path-update
+
+		manifest="$KUNAI_CONFIG_DIR/install.json"
+		test -f "$manifest"
+		grep -F "\"activeVersion\": \"$KUNAI_RELEASE_VERSION\"" "$manifest"
+		grep -F "\"artifactName\": \"$KUNAI_RELEASE_ASSET\"" "$manifest"
+		grep -F "\"archiveName\": \"$KUNAI_RELEASE_ASSET.tar.gz\"" "$manifest"
+		grep -F "\"archiveSha256\": \"$KUNAI_EXPECTED_ARCHIVE_SHA\"" "$manifest"
+		grep -F "\"archiveSourceUrl\": \"file:///release/download/v$KUNAI_RELEASE_VERSION/$KUNAI_RELEASE_ASSET.tar.gz\"" "$manifest"
+
+		version_output="$("$KUNAI_BIN_DIR/kunai" --version)"
+		printf "%s\n" "$version_output"
+		printf "%s\n" "$version_output" | grep -E "^kunai[[:space:]]+v?$KUNAI_RELEASE_VERSION([[:space:]]|$)"
+		help_output="$("$KUNAI_BIN_DIR/kunai" --help)"
+		test -n "$help_output"
+		printf "%s\n" "$help_output"
+	'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ on:
       - "scripts/release-binary-checksums.ts"
       - "scripts/release-asset-contract.ts"
       - "scripts/verify-release-artifact-directory.ts"
+      - "scripts/verify-native-attestations.ts"
       - "scripts/verify-github-release-assets.ts"
       - "scripts/release-guard.ts"
       - "scripts/release-confirmation-gate.ts"
@@ -100,6 +101,11 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     outputs:
       version: ${{ steps.ver.outputs.version }}
       tag: ${{ steps.ver.outputs.tag }}
@@ -274,6 +280,11 @@ jobs:
           bun run scripts/verify-release-artifact-directory.ts \
             .candidate-upload/native \
             --expected-version "${{ steps.ver.outputs.version }}"
+
+      - name: Attest exact native candidate
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # actions/attest@v4
+        with:
+          subject-path: .candidate-upload/native/*
 
       - name: Upload candidate artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
@@ -744,6 +755,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      attestations: read
     outputs:
       version: ${{ needs.candidate.outputs.version }}
       tag: ${{ needs.candidate.outputs.tag }}
@@ -780,6 +794,15 @@ jobs:
             .release-download/native \
             --expected-version "${VERSION}" \
             --skip-version-smoke
+
+      - name: Verify preserved native provenance
+        run: |
+          bun run scripts/verify-native-attestations.ts \
+            .release-download/native \
+            --repo "${GITHUB_REPOSITORY}" \
+            --source-digest "${GITHUB_SHA}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run confirmation gate
         id: gate
@@ -841,6 +864,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      attestations: read
     outputs:
       version: ${{ needs.confirmation.outputs.version }}
       tag: ${{ needs.confirmation.outputs.tag }}
@@ -906,6 +930,15 @@ jobs:
             .release-download/native \
             --expected-version "${{ needs.confirmation.outputs.version }}" \
             --skip-version-smoke
+
+      - name: Verify native provenance before npm publication
+        run: |
+          bun run scripts/verify-native-attestations.ts \
+            .release-download/native \
+            --repo "${GITHUB_REPOSITORY}" \
+            --source-digest "${GITHUB_SHA}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Platform packages first, launcher last, refusing on any version skew.
       # Publishing the launcher first leaves anyone installing in that window
@@ -999,6 +1032,15 @@ jobs:
             --expected-version "${{ needs.confirmation.outputs.version }}" \
             --skip-version-smoke
 
+      - name: Verify native provenance before draft upload
+        run: |
+          bun run scripts/verify-native-attestations.ts \
+            .release-download/native \
+            --repo "${GITHUB_REPOSITORY}" \
+            --source-digest "${GITHUB_SHA}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create draft GitHub release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # softprops/action-gh-release@v2
         with:
@@ -1035,7 +1077,9 @@ jobs:
           bun run scripts/verify-github-release-assets.ts \
             "${{ needs.confirmation.outputs.tag }}" \
             --expect-draft \
-            --expected-version "${{ needs.confirmation.outputs.version }}"
+            --expected-version "${{ needs.confirmation.outputs.version }}" \
+            --attestation-repo "${GITHUB_REPOSITORY}" \
+            --attestation-source-digest "${GITHUB_SHA}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -1049,7 +1093,10 @@ jobs:
         run: |
           bun run scripts/verify-github-release-assets.ts \
             "${{ needs.confirmation.outputs.tag }}" \
-            --expected-version "${{ needs.confirmation.outputs.version }}"
+            --expect-public \
+            --expected-version "${{ needs.confirmation.outputs.version }}" \
+            --attestation-repo "${GITHUB_REPOSITORY}" \
+            --attestation-source-digest "${GITHUB_SHA}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ on:
       - "scripts/verify-release-artifact-directory.ts"
       - "scripts/verify-native-attestations.ts"
       - "scripts/verify-github-release-assets.ts"
+      - ".github/scripts/smoke-preserved-musl-installer.sh"
       - "scripts/release-guard.ts"
       - "scripts/release-confirmation-gate.ts"
       - "scripts/set-release-status.ts"
@@ -51,9 +52,7 @@ concurrency:
   group: release-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 env:
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -73,6 +72,9 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # actions/checkout@v5
@@ -508,24 +510,23 @@ jobs:
           ".release-download/native/${KUNAI_NATIVE_BINARY}" --version 2>&1 | tee -a "artifacts/native-${{ matrix.id }}.log"
           ".release-download/native/${KUNAI_NATIVE_BINARY}" --help 2>&1 | tee -a "artifacts/native-${{ matrix.id }}.log"
 
-      # Alpine on the host's own architecture, so the arm64 runner exercises the
-      # arm64 musl build rather than emulating x64.
-      - name: Execute preserved musl candidate in Alpine
+      # Alpine on the host's own architecture, so the arm64 runner installs the
+      # arm64 musl archive rather than emulating x64. The shared smoke fixture
+      # withholds the raw asset, verifies install.json provenance, and executes
+      # the installed launcher with both public non-interactive commands.
+      - name: Install preserved musl archive in Alpine
         if: matrix.musl_binary != ''
         shell: bash
         env:
           KUNAI_MUSL_BINARY: ${{ matrix.musl_binary }}
+          KUNAI_RELEASE_CANDIDATE_VERSION: ${{ needs.candidate.outputs.version }}
         run: |
           set -euo pipefail
-          chmod +x ".release-download/native/${KUNAI_MUSL_BINARY}"
-          for command in --version --help; do
-            docker run --rm \
-              --volume "$PWD/.release-download/native:/candidate:ro" \
-              --env HOME=/tmp/kunai-home \
-              alpine:3.20 \
-              "/candidate/${KUNAI_MUSL_BINARY}" "${command}" \
-              2>&1 | tee -a "artifacts/native-${{ matrix.id }}.log"
-          done
+          .github/scripts/smoke-preserved-musl-installer.sh \
+            .release-download/native \
+            "${KUNAI_RELEASE_CANDIDATE_VERSION}" \
+            "${KUNAI_MUSL_BINARY}" \
+            2>&1 | tee -a "artifacts/native-${{ matrix.id }}.log"
 
       - name: Verify checksums and execute Windows candidate
         if: runner.os == 'Windows'
@@ -571,6 +572,8 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # actions/checkout@v5
@@ -622,6 +625,8 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 25
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -669,6 +674,8 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # actions/checkout@v5
@@ -770,6 +777,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
 
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,7 @@ jobs:
     outputs:
       version: ${{ steps.ver.outputs.version }}
       tag: ${{ steps.ver.outputs.tag }}
+      candidate_artifact_id: ${{ steps.upload-candidate.outputs.artifact-id }}
 
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # actions/checkout@v5
@@ -287,6 +288,7 @@ jobs:
           subject-path: .candidate-upload/native/*
 
       - name: Upload candidate artifacts
+        id: upload-candidate
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
         with:
           name: ${{ env.CANDIDATE_ARTIFACT }}-${{ steps.ver.outputs.version }}-${{ github.sha }}
@@ -340,14 +342,71 @@ jobs:
             .candidate-upload/native/SHA256SUMS
 
   # ---------------------------------------------------------------------------
+  # Verify the preserved candidate's bytes and provenance before any downstream
+  # job is allowed to execute a downloaded native binary.
+  # ---------------------------------------------------------------------------
+  native-provenance-gate:
+    name: Verify native candidate provenance
+    needs: candidate
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      attestations: read
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # actions/checkout@v5
+      - uses: ./.github/actions/setup-bun-monorepo
+        with:
+          turbo-cache-prefix: release-native-provenance
+          skip-turbo-cache: "true"
+
+      - name: Download preserved native candidate
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ needs.candidate.outputs.candidate_artifact_id }}
+          path: .release-download
+          merge-multiple: "true"
+
+      - name: Verify exact bytes without executing them
+        run: |
+          set -euo pipefail
+          bun run scripts/verify-release-artifact-directory.ts \
+            .release-download/native \
+            --expected-version "${{ needs.candidate.outputs.version }}" \
+            --skip-version-smoke
+
+      - name: Verify candidate provenance before native execution
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if bun run scripts/verify-native-attestations.ts \
+              .release-download/native \
+              --repo "${GITHUB_REPOSITORY}" \
+              --source-digest "${GITHUB_SHA}"; then
+              exit 0
+            fi
+            if [[ "${attempt}" -eq 3 ]]; then
+              echo "::error::native candidate provenance did not verify after ${attempt} attempts"
+              exit 1
+            fi
+            sleep "$((attempt * 5))"
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ---------------------------------------------------------------------------
   # Execute the exact preserved native candidate on each blocking host OS.
   # ---------------------------------------------------------------------------
   native-smoke:
     name: Native candidate smoke (${{ matrix.id }})
-    needs: candidate
+    needs: [candidate, native-provenance-gate]
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 25
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -389,8 +448,9 @@ jobs:
       - name: Download exact preserved candidate
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
         with:
-          name: ${{ env.CANDIDATE_ARTIFACT }}-${{ needs.candidate.outputs.version }}-${{ github.sha }}
+          artifact-ids: ${{ needs.candidate.outputs.candidate_artifact_id }}
           path: .release-download
+          merge-multiple: "true"
 
       - name: Reverify exact preserved native payload
         run: >-
@@ -651,10 +711,12 @@ jobs:
 
   readme-commands-gate:
     name: Verify README commands
-    needs: candidate
+    needs: [candidate, native-provenance-gate]
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # actions/checkout@v5
@@ -664,8 +726,15 @@ jobs:
           skip-turbo-cache: "true"
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
         with:
-          name: ${{ env.CANDIDATE_ARTIFACT }}-${{ needs.candidate.outputs.version }}-${{ github.sha }}
+          artifact-ids: ${{ needs.candidate.outputs.candidate_artifact_id }}
           path: .release-download
+          merge-multiple: "true"
+
+      - name: Reverify exact preserved native payload without executing it
+        run: >-
+          bun run scripts/verify-release-artifact-directory.ts
+          .release-download/native --expected-version
+          "${{ needs.candidate.outputs.version }}" --skip-version-smoke
 
       - name: Execute README quick-start commands
         run: |
@@ -751,7 +820,7 @@ jobs:
   confirmation:
     name: Release confirmation gate
     needs:
-      [candidate, installer-gate, readme-commands-gate, live-providers-gate, native-platforms-gate]
+      [candidate, installer-gate, readme-commands-gate, live-providers-gate, native-platforms-gate, native-provenance-gate]
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -761,6 +830,7 @@ jobs:
     outputs:
       version: ${{ needs.candidate.outputs.version }}
       tag: ${{ needs.candidate.outputs.tag }}
+      candidate_artifact_id: ${{ needs.candidate.outputs.candidate_artifact_id }}
       binary_artifact: ${{ steps.gate.outputs.binary_artifact }}
 
     steps:
@@ -776,8 +846,9 @@ jobs:
       - name: Download candidate artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
         with:
-          name: ${{ env.CANDIDATE_ARTIFACT }}-${{ needs.candidate.outputs.version }}-${{ github.sha }}
+          artifact-ids: ${{ needs.candidate.outputs.candidate_artifact_id }}
           path: .release-download
+          merge-multiple: "true"
 
       - name: Download every gate evidence document and hashed artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
@@ -905,8 +976,9 @@ jobs:
       - name: Download candidate artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
         with:
-          name: ${{ env.CANDIDATE_ARTIFACT }}-${{ needs.confirmation.outputs.version }}-${{ github.sha }}
+          artifact-ids: ${{ needs.confirmation.outputs.candidate_artifact_id }}
           path: .release-download
+          merge-multiple: "true"
 
       - name: Stage preserved npm artifacts
         run: |

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -13,10 +13,22 @@ Use this before cutting a public release via the staged promotion workflow ([REL
 
 ## Candidate artifacts (before approval)
 
-Built only by **Release** `workflow_dispatch` with the exact version; publish must not rebuild.
+Built only by **Release** `workflow_dispatch` with the exact version; publish
+must not rebuild, repack, or recompress it.
 
 - [ ] Dispatch version matches `apps/cli/package.json`
-- [ ] Candidate job produced preserved upload: 8 binaries + `SHA256SUMS` + `kunai-npm.tgz`
+- [ ] Candidate upload is immutable
+      `kunai-release-candidate-<version>-<commit-sha>` and downstream jobs use
+      its numeric artifact id, not a mutable name lookup
+- [ ] Native payload is exactly 18 regular files: eight raw binaries, their
+      eight canonical archives (`.tar.gz` on Linux/macOS, `.zip` on Windows),
+      `SHA256SUMS`, and `SHA256SUMS.archives`; no extras or zero-byte files
+- [ ] Candidate contains the preserved launcher `kunai-npm.tgz` plus all eight
+      preserved npm platform-package tarballs
+- [ ] GitHub OIDC attestations cover every one of the 18 native files and bind
+      them to `KitsuneKode/kunai/.github/workflows/release.yml`, the release
+      commit, and the main-branch workflow identity before any downloaded native
+      byte is executed
 - [ ] Local/CI packing path is `bun run release:pack` → `.release-candidate/kunai-npm.tgz` via:
 
 ```sh
@@ -35,13 +47,21 @@ ROOT="$PWD" && (cd apps/cli && bun pm pack --ignore-scripts --quiet --filename "
 - [ ] **Installer troubleshooting present** — `type -a` / `which -a` (bash), `whence -a` (zsh), `Get-Command kunai -All` (PowerShell), doctor text/JSON, ownership, checksum/404 (`kunai install --force` / pin version), rollback, uninstall-by-owner, unsigned binaries, PATH shadowing ([docs/users/troubleshooting.mdx](docs/users/troubleshooting.mdx#installer-and-path-issues))
 - [ ] **YouTube cookie safety documented** — `cookiesFromBrowser` / absolute `cookiesFile`; never paste contents; review redacted bundles; no DRM bypass claim
 - [ ] **Download path docs are platform-accurate** — default download directory matches storage path resolution on Linux/macOS/Windows
-- [ ] **GitHub Release assets** — all 8 binaries + `SHA256SUMS` present (`bun run scripts/verify-github-release-assets.ts`); upload uses `fail_on_unmatched_files: true`
+- [ ] **GitHub Release assets** — exact 18-file native set is present (`bun run scripts/verify-github-release-assets.ts` with full attestation repository/source arguments for byte verification); upload uses `fail_on_unmatched_files: true`
+- [ ] **musl archive evidence** — x64 and arm64 Alpine cells install the exact
+      preserved `.tar.gz` through production `install.sh`, record archive
+      provenance in `install.json`, and pass exact `--version` plus non-empty
+      `--help` with the raw fallback withheld
 
 ## Publication (protected)
 
 - [ ] Confirmation gate green (`bun run release:confirmation:check`) with fresh provider signoff evidence
 - [ ] Approve GitHub environment `release-production` only after confirmation evidence looks correct
-- [ ] Publish job downloads preserved artifacts and runs `bun publish .release-candidate/kunai-npm.tgz --access public`
+- [ ] Publish job downloads the immutable preserved candidate, reverifies all 18
+      native attestations, publishes/reconciles all eight platform packages,
+      then publishes the exact-version launcher last through `bun run release`
+- [ ] Public-registry smoke proves the launcher resolves its physical host
+      platform package and executes `--version` / `--help` without Bun
 - [ ] Draft GitHub release verified (`--expect-draft`) before `gh release edit … --draft=false --latest`
 - [ ] Metadata job (or recovery) marks `.release/kunai-vX.Y.Z.json` `published` via `set-release-status.ts`
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -154,7 +154,8 @@ Job **`candidate`** (no publish):
    the exact 18 native assets, and runs compiled binary smoke
 4. `bun run release:pack` → `.release-candidate/kunai-npm.tgz`
 5. Stages the native files under an isolated `native/` directory, reverifies
-   that exact 18-file directory immediately before upload, then uploads artifact
+   that exact 18-file directory, creates GitHub OIDC attestations for all 18
+   subjects, then uploads artifact
    `kunai-release-candidate-<version>` with the preserved npm artifacts
    alongside it (14-day retention)
 
@@ -186,6 +187,8 @@ mkdir -p .release-candidate && ROOT="$PWD" && \
 Job **`confirmation`** needs `candidate`. It downloads the preserved candidate,
 pulls the provider signoff artifact from `provider_signoff_run_id`, verifies the
 downloaded `native/` directory immediately before the confirmation boundary,
+verifies every native attestation against the release workflow and candidate
+commit,
 and runs:
 
 ```sh
@@ -205,16 +208,21 @@ Job **`publish`** needs `confirmation` and declares `environment: release-produc
 
 1. Downloads the preserved candidate artifact (does **not** rebuild, re-pack,
    or recompress native assets)
-2. Reverifies the exact native directory against the expected version
+2. Reverifies the exact native directory and all 18 attestations, before npm
+   publication, against the
+   expected version, release workflow, main-branch ref, and candidate commit
 3. `bun publish .release-candidate/kunai-npm.tgz --access public`
 4. Retries `npm view @kitsunekode/kunai@<version>` until visible
 5. Creates annotated tag `v<version>` and pushes it
-6. Reverifies the same downloaded native directory again, immediately before
-   creating a **draft** GitHub release (`make_latest: false`) with its 18 files
+6. Reverifies the same downloaded native directory and provenance again,
+   immediately before creating a **draft** GitHub release (`make_latest: false`)
+   with its 18 files
 7. `bun run scripts/verify-github-release-assets.ts <tag> --expect-draft …`
+   downloads the draft assets and verifies their bytes and attestations
 8. Promotes immediately after that draft-byte verification:
    `gh release edit <tag> --draft=false --latest`
-9. Verifies the public release assets again
+9. Proves the release is public, then downloads and verifies its bytes and
+   attestations again
 
 ### 5. Metadata after public verification
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -150,14 +150,41 @@ Job **`candidate`** (no publish):
 
 1. Asserts `inputs.version` equals `apps/cli/package.json` `version`
 2. `bun run ci` → `build` → `pkg:check` → real npm global install → `guard` → `release:notes:check`
-3. Builds all 8 release binaries plus their deterministic archives, verifies
-   the exact 18 native assets, and runs compiled binary smoke
-4. `bun run release:pack` → `.release-candidate/kunai-npm.tgz`
+3. Builds all eight release binaries plus their deterministic archives,
+   verifies the exact 18 native files listed below, and runs compiled binary
+   smoke
+4. Builds the eight exact-version npm platform packages and preserves their
+   tarballs, then runs `bun run release:pack` to preserve the launcher as
+   `.release-candidate/kunai-npm.tgz`
 5. Stages the native files under an isolated `native/` directory, reverifies
    that exact 18-file directory, creates GitHub OIDC attestations for all 18
    subjects, then uploads artifact
-   `kunai-release-candidate-<version>` with the preserved npm artifacts
-   alongside it (14-day retention)
+   `kunai-release-candidate-<version>-<commit-sha>` with the preserved launcher
+   and platform-package tarballs alongside it (14-day retention). Downstream
+   jobs download this immutable artifact by its numeric artifact id.
+
+The exact native directory is:
+
+```text
+kunai-linux-x64
+kunai-linux-x64.tar.gz
+kunai-linux-arm64
+kunai-linux-arm64.tar.gz
+kunai-linux-x64-musl
+kunai-linux-x64-musl.tar.gz
+kunai-linux-arm64-musl
+kunai-linux-arm64-musl.tar.gz
+kunai-darwin-x64
+kunai-darwin-x64.tar.gz
+kunai-darwin-arm64
+kunai-darwin-arm64.tar.gz
+kunai-windows-x64.exe
+kunai-windows-x64.zip
+kunai-windows-arm64.exe
+kunai-windows-arm64.zip
+SHA256SUMS
+SHA256SUMS.archives
+```
 
 For the 0.3.0 compatibility bridge, legacy `SHA256SUMS` continues to hash raw
 standalone binaries so already-published installers and updaters remain
@@ -173,7 +200,9 @@ manifests from a loopback fixture, runs the checked-out production installer in
 an isolated profile, verifies the published archive provenance, and executes
 the installed launcher with `--version` and `--help`. It also executes the raw
 candidate separately for compatibility; the installer proof cannot silently
-fall back because the fixture never exposes that raw asset.
+fall back because the fixture never exposes that raw asset. The x64 and arm64
+Linux runners repeat the production `install.sh` archive path inside native
+Alpine containers for both musl builds, also with the raw fallback withheld.
 
 `release:pack` is:
 
@@ -184,12 +213,12 @@ mkdir -p .release-candidate && ROOT="$PWD" && \
 
 ### 3. Confirmation gate (still no publish)
 
-Job **`confirmation`** needs `candidate`. It downloads the preserved candidate,
-pulls the provider signoff artifact from `provider_signoff_run_id`, verifies the
-downloaded `native/` directory immediately before the confirmation boundary,
-verifies every native attestation against the release workflow and candidate
-commit,
-and runs:
+Job **`confirmation`** waits for the candidate, installer, README-command,
+live-provider, native-platform, and native-provenance gates. It downloads the
+preserved candidate by artifact id, pulls the provider signoff artifact from
+`provider_signoff_run_id`, verifies the downloaded `native/` directory
+immediately before the confirmation boundary, verifies every native attestation
+against the release workflow and candidate commit, and runs:
 
 ```sh
 bun run release:confirmation:check -- \
@@ -211,8 +240,12 @@ Job **`publish`** needs `confirmation` and declares `environment: release-produc
 2. Reverifies the exact native directory and all 18 attestations, before npm
    publication, against the
    expected version, release workflow, main-branch ref, and candidate commit
-3. `bun publish .release-candidate/kunai-npm.tgz --access public`
-4. Retries `npm view @kitsunekode/kunai@<version>` until visible
+3. Runs `bun run release`, whose npm publisher reconciles all eight preserved
+   platform-package tarballs first and the exact-version launcher tarball last,
+   refusing integrity or version skew and publishing with npm provenance
+4. Retries `npm view` for the launcher and all eight platform packages until
+   every exact version is visible, then performs a clean registry install and
+   launcher smoke
 5. Creates annotated tag `v<version>` and pushes it
 6. Reverifies the same downloaded native directory and provenance again,
    immediately before creating a **draft** GitHub release (`make_latest: false`)
@@ -289,7 +322,9 @@ comes from `.release/kunai-vX.Y.Z.md`. Avoid duplicate
 - `bun run changeset` → create release intent files
 - `bun run version:packages` → apply pending versions + update both changelogs + staged `.release` notes
 - `bun run release:pack` → write `.release-candidate/kunai-npm.tgz` (same packing path CI uses)
-- `bun run release` → `bun publish` of the preserved tarball (CI publish job in practice)
+- `bun run release` → reconcile/publish the eight preserved platform tarballs,
+  then the preserved launcher tarball last, using npm trusted publishing and
+  provenance (CI publish job in practice)
 - `bun run guard` → verify version ↔ changelog sync locally (also runs on pre-commit when release files change)
 - `bun run scripts/set-release-status.ts` → flip staged / published / withdrawn on one artifact
 

--- a/apps/cli/test/unit/scripts/distribution-contract.test.ts
+++ b/apps/cli/test/unit/scripts/distribution-contract.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -13,6 +22,7 @@ import {
   assertRequiredReleaseAssets,
 } from "../../../../../scripts/release-asset-contract";
 import { shouldWriteReleaseChecksums } from "../../../../../scripts/release-binary-checksums";
+import { assertExpectedReleaseState } from "../../../../../scripts/verify-github-release-assets";
 import { verifyReleaseArtifactDirectory } from "../../../../../scripts/verify-release-artifact-directory";
 import { buildReleaseArchives } from "../../../scripts/build-release-archives";
 import { buildNpmPublishManifest } from "../../../scripts/write-npm-publish-manifest";
@@ -228,14 +238,30 @@ describe("release workflow candidate-before-publication contract", () => {
     const cand = candidate();
     const stage = cand.indexOf("Stage candidate upload directory");
     const exactVerify = cand.indexOf("verify-release-artifact-directory.ts", stage);
+    const attestStep = cand.indexOf("- name: Attest exact native candidate", exactVerify);
+    const attest = cand.indexOf("actions/attest@", attestStep);
     const upload = cand.indexOf("- name: Upload candidate artifacts");
 
     expect(cand).toContain(".candidate-upload/native");
     expect(stage).toBeGreaterThanOrEqual(0);
     expect(exactVerify).toBeGreaterThan(stage);
-    expect(upload).toBeGreaterThan(exactVerify);
-    expect(cand.slice(exactVerify, upload)).not.toContain("- name:");
+    expect(attestStep).toBeGreaterThan(exactVerify);
+    expect(attest).toBeGreaterThan(attestStep);
+    expect(upload).toBeGreaterThan(attest);
+    expect(cand.slice(exactVerify, attestStep)).not.toContain("- name:");
     expect(cand).toContain(".candidate-upload/native/SHA256SUMS");
+  });
+
+  test("candidate attests the exact native payload with narrowly scoped OIDC permissions", () => {
+    const cand = candidate();
+    expect(release).toContain('- "scripts/verify-native-attestations.ts"');
+    expect(cand).toMatch(
+      /permissions:[\s\S]*contents:\s*read[\s\S]*id-token:\s*write[\s\S]*attestations:\s*write[\s\S]*artifact-metadata:\s*write/,
+    );
+    expect(cand).toContain(
+      "actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # actions/attest@v4",
+    );
+    expect(cand).toContain("subject-path: .candidate-upload/native/*");
   });
 
   test("publication downloads the preserved tarball/binaries", () => {
@@ -260,6 +286,19 @@ describe("release workflow candidate-before-publication contract", () => {
     expect(draftVerify).toBeGreaterThanOrEqual(0);
     expect(promote).toBeGreaterThan(draftVerify);
     expect(pub.indexOf("verify-github-release-assets.ts")).toBeGreaterThanOrEqual(0);
+    expect(pub.match(/--attestation-repo/g)).toHaveLength(2);
+    expect(pub.match(/--attestation-source-digest/g)).toHaveLength(2);
+    expect(pub).toContain("--expect-public");
+  });
+
+  test("release-state verification fails closed for draft and public boundaries", () => {
+    expect(() => assertExpectedReleaseState(true, "draft", "v0.3.0")).not.toThrow();
+    expect(() => assertExpectedReleaseState(false, "public", "v0.3.0")).not.toThrow();
+    expect(() => assertExpectedReleaseState(false, "draft", "v0.3.0")).toThrow(/expected draft/i);
+    expect(() => assertExpectedReleaseState(true, "public", "v0.3.0")).toThrow(/expected public/i);
+    expect(() => assertExpectedReleaseState(undefined, "public", "v0.3.0")).toThrow(
+      /expected public/i,
+    );
   });
 
   test("metadata publication follows public verification", () => {
@@ -298,26 +337,48 @@ describe("release workflow candidate-before-publication contract", () => {
   test("confirmation directly verifies the preserved native payload immediately before gating", () => {
     const confirm = confirmation();
     const verify = confirm.indexOf("verify-release-artifact-directory.ts");
+    const attest = confirm.indexOf("verify-native-attestations.ts", verify);
     const gate = confirm.indexOf("- name: Run confirmation gate");
 
     expect(confirm).not.toContain("Stage binaries for confirmation");
     expect(confirm).toContain(".release-download/native");
     expect(verify).toBeGreaterThanOrEqual(0);
-    expect(gate).toBeGreaterThan(verify);
-    expect(confirm.slice(verify, gate)).not.toContain("- name:");
+    expect(attest).toBeGreaterThan(verify);
+    expect(gate).toBeGreaterThan(attest);
     expect(confirm).toContain('--expected-version "${VERSION}"');
     expect(confirm).toContain("--binary-dir .release-download/native");
+  });
+
+  test("confirmation and publication verify native provenance against the exact source commit", () => {
+    for (const job of [confirmation(), publish()]) {
+      expect(job).toMatch(/permissions:[\s\S]*attestations:\s*read/);
+      expect(job).toContain("verify-native-attestations.ts");
+      expect(job).toContain('--repo "${GITHUB_REPOSITORY}"');
+      expect(job).toContain('--source-digest "${GITHUB_SHA}"');
+    }
+  });
+
+  test("publication verifies provenance before its first irreversible publish", () => {
+    const pub = publish();
+    const exactVerify = pub.indexOf("Reverify protected native publication input");
+    const provenance = pub.indexOf("Verify native provenance before npm publication", exactVerify);
+    const npmPublish = pub.search(PUBLISH_STEP);
+
+    expect(exactVerify).toBeGreaterThanOrEqual(0);
+    expect(provenance).toBeGreaterThan(exactVerify);
+    expect(npmPublish).toBeGreaterThan(provenance);
   });
 
   test("protected publication reverifies native bytes immediately before draft creation", () => {
     const pub = publish();
     const createDraft = pub.indexOf("- name: Create draft GitHub release");
     const exactVerify = pub.lastIndexOf("verify-release-artifact-directory.ts", createDraft);
+    const attest = pub.lastIndexOf("verify-native-attestations.ts", createDraft);
 
     expect(pub).toContain(".release-download/native");
     expect(exactVerify).toBeGreaterThanOrEqual(0);
-    expect(createDraft).toBeGreaterThan(exactVerify);
-    expect(pub.slice(exactVerify, createDraft)).not.toContain("- name:");
+    expect(attest).toBeGreaterThan(exactVerify);
+    expect(createDraft).toBeGreaterThan(attest);
     for (const name of REQUIRED_RELEASE_ASSET_NAMES) {
       expect(pub).toContain(`.release-download/native/${name}`);
     }
@@ -560,6 +621,45 @@ describe("verifyReleaseArtifactDirectory", () => {
       }
     }
   });
+
+  test("rejects unexpected directories instead of filtering them out", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kunai-release-assets-directory-"));
+    try {
+      writeCompleteReleaseFixture(dir);
+      mkdirSync(join(dir, "unexpected-directory"));
+
+      await expect(
+        verifyReleaseArtifactDirectory({
+          directory: dir,
+          expectedVersion: "9.9.9",
+          skipVersionSmoke: true,
+        }),
+      ).rejects.toThrow(/unexpected non-regular/i);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test.skipIf(process.platform === "win32")(
+    "rejects unexpected symlinks instead of following them",
+    async () => {
+      const dir = mkdtempSync(join(tmpdir(), "kunai-release-assets-symlink-"));
+      try {
+        writeCompleteReleaseFixture(dir);
+        symlinkSync("kunai-linux-x64", join(dir, "unexpected-symlink"));
+
+        await expect(
+          verifyReleaseArtifactDirectory({
+            directory: dir,
+            expectedVersion: "9.9.9",
+            skipVersionSmoke: true,
+          }),
+        ).rejects.toThrow(/unexpected non-regular/i);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
 
   test("rejects SHA256SUMS with the wrong row count", async () => {
     const dir = mkdtempSync(join(tmpdir(), "kunai-release-assets-"));

--- a/apps/cli/test/unit/scripts/distribution-contract.test.ts
+++ b/apps/cli/test/unit/scripts/distribution-contract.test.ts
@@ -22,7 +22,10 @@ import {
   assertRequiredReleaseAssets,
 } from "../../../../../scripts/release-asset-contract";
 import { shouldWriteReleaseChecksums } from "../../../../../scripts/release-binary-checksums";
-import { assertExpectedReleaseState } from "../../../../../scripts/verify-github-release-assets";
+import {
+  assertExpectedReleaseState,
+  verifyDownloadedReleaseAssets,
+} from "../../../../../scripts/verify-github-release-assets";
 import { verifyReleaseArtifactDirectory } from "../../../../../scripts/verify-release-artifact-directory";
 import { buildReleaseArchives } from "../../../scripts/build-release-archives";
 import { buildNpmPublishManifest } from "../../../scripts/write-npm-publish-manifest";
@@ -76,7 +79,7 @@ describe("distribution release-asset contract", () => {
       assertCompleteReleaseAssetSet(
         completeSizedAssets().map((asset) =>
           asset.name === archive.archiveName
-            ? { ...asset, size: archive.maxArchiveBytes + 1 }
+            ? { name: asset.name, size: archive.maxArchiveBytes + 1 }
             : asset,
         ),
       ),
@@ -84,7 +87,9 @@ describe("distribution release-asset contract", () => {
     expect(() =>
       assertCompleteReleaseAssetSet(
         completeSizedAssets().map((asset) =>
-          asset.name === archive.out ? { ...asset, size: archive.maxBinaryBytes + 1 } : asset,
+          asset.name === archive.out
+            ? { name: asset.name, size: archive.maxBinaryBytes + 1 }
+            : asset,
         ),
       ),
     ).toThrow(/size budget.*kunai-linux-x64/i);
@@ -176,7 +181,11 @@ describe("release workflow candidate-before-publication contract", () => {
   const candidate = () => extractWorkflowJob(release, "candidate");
   const nativeProvenanceGate = () => extractWorkflowJob(release, "native-provenance-gate");
   const nativeSmoke = () => extractWorkflowJob(release, "native-smoke");
+  const nativePlatformsGate = () => extractWorkflowJob(release, "native-platforms-gate");
+  const installerSmoke = () => extractWorkflowJob(release, "installer-smoke");
+  const installerGate = () => extractWorkflowJob(release, "installer-gate");
   const readmeCommandsGate = () => extractWorkflowJob(release, "readme-commands-gate");
+  const liveProvidersGate = () => extractWorkflowJob(release, "live-providers-gate");
   const confirmation = () => extractWorkflowJob(release, "confirmation");
   const publish = () => extractWorkflowJob(release, "publish");
   const metadata = () => extractWorkflowJob(release, "metadata");
@@ -191,6 +200,43 @@ describe("release workflow candidate-before-publication contract", () => {
     expect(pushJob).not.toContain("bun publish");
     expect(pushJob).not.toContain("changeset publish");
     expect(pushJob).not.toContain("bun run release");
+  });
+
+  test("workflow permissions deny by default and grant only each job's required scope", () => {
+    expect(release).toMatch(/^permissions:\s*\{\}\s*$/m);
+    expect(versionPr()).toMatch(
+      /permissions:\s*\n\s+contents:\s*write\s*\n\s+pull-requests:\s*write/,
+    );
+    for (const job of [nativePlatformsGate(), installerSmoke(), installerGate()]) {
+      expect(job).toMatch(/permissions:\s*\n\s+contents:\s*read/);
+      expect(job).not.toMatch(/(?:contents|pull-requests):\s*write/);
+    }
+    expect(liveProvidersGate()).toMatch(
+      /permissions:\s*\n\s+contents:\s*read\s*\n\s+actions:\s*read/,
+    );
+
+    const jobsWithContentsWrite = [
+      versionPr(),
+      candidate(),
+      nativeProvenanceGate(),
+      nativeSmoke(),
+      nativePlatformsGate(),
+      installerSmoke(),
+      installerGate(),
+      readmeCommandsGate(),
+      liveProvidersGate(),
+      confirmation(),
+      publish(),
+      metadata(),
+    ].filter((job) => /contents:\s*write/.test(job));
+    expect(jobsWithContentsWrite).toEqual([versionPr(), publish(), metadata()]);
+  });
+
+  test("cross-run provider evidence download has actions read without inherited write access", () => {
+    const live = liveProvidersGate();
+    expect(live).toContain('gh run download "${PROVIDER_SIGNOFF_RUN_ID}"');
+    expect(live).toMatch(/permissions:[\s\S]*actions:\s*read/);
+    expect(live).not.toMatch(/(?:contents|pull-requests|actions):\s*write/);
   });
 
   // The publish step is `bun run release` (scripts/publish-npm-release.ts),
@@ -318,6 +364,104 @@ describe("release workflow candidate-before-publication contract", () => {
     expect(release.indexOf("  native-provenance-gate:")).toBeLessThan(
       release.indexOf("  readme-commands-gate:"),
     );
+  });
+
+  test("both musl candidates install their preserved archive through production install.sh", () => {
+    const smoke = nativeSmoke();
+    expect(smoke).toContain("smoke-preserved-musl-installer.sh");
+    expect(smoke).toContain("KUNAI_MUSL_BINARY");
+    expect(smoke).toContain("KUNAI_RELEASE_CANDIDATE_VERSION");
+    expect(smoke).toContain("kunai-linux-x64-musl");
+    expect(smoke).toContain("kunai-linux-arm64-musl");
+
+    const installerSmokeSource = readFileSync(
+      join(REPO_ROOT, ".github/scripts/smoke-preserved-musl-installer.sh"),
+      "utf8",
+    );
+    expect(installerSmokeSource).toContain("install.sh");
+    expect(installerSmokeSource).toContain("apps/cli/test/docker/native-installer/Dockerfile");
+    expect(installerSmokeSource).toContain("SHA256SUMS.archives");
+    expect(installerSmokeSource).toContain("archiveSha256");
+    expect(installerSmokeSource).toContain("archiveSourceUrl");
+    expect(installerSmokeSource).toContain("--version");
+    expect(installerSmokeSource).toContain("--help");
+    expect(installerSmokeSource).toContain('test ! -e "$FIXTURE_VERSION_DIR/$ASSET"');
+    expect(installerSmokeSource).toContain("--network none");
+  });
+
+  test("release-asset byte smoke is ordered after provenance and refuses incomplete provenance", async () => {
+    const calls: string[] = [];
+    await verifyDownloadedReleaseAssets(
+      {
+        directory: "/tmp/release-assets",
+        expectedVersion: "0.3.0",
+        attestationRepository: "KitsuneKode/kunai",
+        attestationSourceDigest: "a".repeat(40),
+      },
+      {
+        verifyDirectory: async (options) => {
+          calls.push(`bytes:${String(options.skipVersionSmoke)}`);
+        },
+        verifyAttestations: () => {
+          calls.push("provenance");
+        },
+        smokeLinuxX64: () => {
+          calls.push("execute");
+        },
+      },
+    );
+    expect(calls).toEqual(["bytes:true", "provenance", "execute"]);
+
+    const unsafeCalls: string[] = [];
+    await expect(
+      verifyDownloadedReleaseAssets(
+        {
+          directory: "/tmp/release-assets",
+          expectedVersion: "0.3.0",
+          attestationRepository: undefined,
+          attestationSourceDigest: undefined,
+        },
+        {
+          verifyDirectory: async () => {
+            unsafeCalls.push("bytes");
+          },
+          verifyAttestations: () => {
+            unsafeCalls.push("provenance");
+          },
+          smokeLinuxX64: () => {
+            unsafeCalls.push("execute");
+          },
+        },
+      ),
+    ).rejects.toThrow(/expected-version.*attestation/i);
+    expect(unsafeCalls).toEqual([]);
+  });
+
+  test("failed release provenance verification prevents downloaded byte execution", async () => {
+    const calls: string[] = [];
+    await expect(
+      verifyDownloadedReleaseAssets(
+        {
+          directory: "/tmp/release-assets",
+          expectedVersion: "0.3.0",
+          attestationRepository: "KitsuneKode/kunai",
+          attestationSourceDigest: "a".repeat(40),
+        },
+        {
+          verifyDirectory: async () => {
+            calls.push("bytes");
+          },
+          verifyAttestations: () => {
+            calls.push("provenance");
+            throw new Error("attestation rejected");
+          },
+          smokeLinuxX64: () => {
+            calls.push("execute");
+          },
+        },
+      ),
+    ).rejects.toThrow(/attestation rejected/);
+    expect(calls).toEqual(["bytes", "provenance"]);
   });
 
   test("publication downloads the preserved tarball/binaries", () => {

--- a/apps/cli/test/unit/scripts/distribution-contract.test.ts
+++ b/apps/cli/test/unit/scripts/distribution-contract.test.ts
@@ -174,6 +174,9 @@ describe("release workflow candidate-before-publication contract", () => {
   const publisher = readFileSync(join(REPO_ROOT, "scripts/publish-npm-release.ts"), "utf8");
   const versionPr = () => extractWorkflowJob(release, "version-pr");
   const candidate = () => extractWorkflowJob(release, "candidate");
+  const nativeProvenanceGate = () => extractWorkflowJob(release, "native-provenance-gate");
+  const nativeSmoke = () => extractWorkflowJob(release, "native-smoke");
+  const readmeCommandsGate = () => extractWorkflowJob(release, "readme-commands-gate");
   const confirmation = () => extractWorkflowJob(release, "confirmation");
   const publish = () => extractWorkflowJob(release, "publish");
   const metadata = () => extractWorkflowJob(release, "metadata");
@@ -262,6 +265,59 @@ describe("release workflow candidate-before-publication contract", () => {
       "actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # actions/attest@v4",
     );
     expect(cand).toContain("subject-path: .candidate-upload/native/*");
+  });
+
+  test("downloaded native candidates are provenance-gated before any execution job", () => {
+    const cand = candidate();
+    const provenance = nativeProvenanceGate();
+    expect(cand).toContain("id: upload-candidate");
+    expect(cand).toContain(
+      "candidate_artifact_id: ${{ steps.upload-candidate.outputs.artifact-id }}",
+    );
+    expect(provenance).toMatch(/needs:\s*candidate/);
+    expect(provenance).toMatch(/permissions:[\s\S]*contents:\s*read[\s\S]*attestations:\s*read/);
+    expect(provenance).toContain(
+      "artifact-ids: ${{ needs.candidate.outputs.candidate_artifact_id }}",
+    );
+    expect(provenance).toContain('merge-multiple: "true"');
+    expect(provenance).toContain("verify-release-artifact-directory.ts");
+    expect(provenance).toContain("verify-native-attestations.ts");
+    expect(provenance).toContain('--source-digest "${GITHUB_SHA}"');
+
+    for (const executionJob of [nativeSmoke(), readmeCommandsGate()]) {
+      expect(executionJob).toMatch(/needs:\s*\[candidate, native-provenance-gate\]/);
+      expect(executionJob).toMatch(/permissions:\s*\n\s+contents:\s*read/);
+      expect(executionJob.indexOf("download-artifact")).toBeGreaterThanOrEqual(0);
+      expect(executionJob).toContain(
+        "artifact-ids: ${{ needs.candidate.outputs.candidate_artifact_id }}",
+      );
+      expect(executionJob).toContain('merge-multiple: "true"');
+    }
+
+    const smoke = nativeSmoke();
+    expect(smoke.indexOf("verify-release-artifact-directory.ts")).toBeLessThan(
+      smoke.indexOf("Exercise exact preserved archive"),
+    );
+    const readme = readmeCommandsGate();
+    expect(readme.indexOf("verify-release-artifact-directory.ts")).toBeLessThan(
+      readme.indexOf("Execute README quick-start commands"),
+    );
+
+    const confirm = confirmation();
+    expect(confirm).toMatch(/needs:[\s\S]*native-provenance-gate/);
+    expect(confirm).toContain(
+      "candidate_artifact_id: ${{ needs.candidate.outputs.candidate_artifact_id }}",
+    );
+    expect(publish()).toContain(
+      "artifact-ids: ${{ needs.confirmation.outputs.candidate_artifact_id }}",
+    );
+
+    expect(release.indexOf("  native-provenance-gate:")).toBeLessThan(
+      release.indexOf("  native-smoke:"),
+    );
+    expect(release.indexOf("  native-provenance-gate:")).toBeLessThan(
+      release.indexOf("  readme-commands-gate:"),
+    );
   });
 
   test("publication downloads the preserved tarball/binaries", () => {

--- a/apps/cli/test/unit/scripts/native-attestation.test.ts
+++ b/apps/cli/test/unit/scripts/native-attestation.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { REQUIRED_RELEASE_ASSET_NAMES } from "../../../../../scripts/release-asset-contract";
+import {
+  verifyNativeAttestations,
+  type AttestationCommandRunner,
+} from "../../../../../scripts/verify-native-attestations";
+
+function fixture(): string {
+  const directory = mkdtempSync(join(tmpdir(), "kunai-native-attestations-"));
+  for (const name of REQUIRED_RELEASE_ASSET_NAMES) {
+    writeFileSync(join(directory, name), `payload:${name}\n`);
+  }
+  return directory;
+}
+
+describe("native release attestations", () => {
+  test("verifies every exact release asset against the release workflow and source commit", () => {
+    const directory = fixture();
+    const calls: string[][] = [];
+    const run: AttestationCommandRunner = (args) => {
+      calls.push([...args]);
+      return { status: 0, stdout: "verified", stderr: "" };
+    };
+
+    try {
+      verifyNativeAttestations({
+        directory,
+        repository: "KitsuneKode/kunai",
+        sourceDigest: "a".repeat(40),
+        run,
+      });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+
+    expect(calls).toHaveLength(REQUIRED_RELEASE_ASSET_NAMES.length);
+    expect(calls.map((args) => args[2]?.split(/[\\/]/).at(-1))).toEqual(
+      [...REQUIRED_RELEASE_ASSET_NAMES].sort(),
+    );
+    for (const args of calls) {
+      expect(args.slice(0, 2)).toEqual(["attestation", "verify"]);
+      expect(args).toContain("--repo");
+      expect(args).toContain("KitsuneKode/kunai");
+      expect(args).toContain("--signer-workflow");
+      expect(args).toContain("KitsuneKode/kunai/.github/workflows/release.yml");
+      expect(args).toContain("--source-digest");
+      expect(args).toContain("a".repeat(40));
+      expect(args).toContain("--source-ref");
+      expect(args).toContain("refs/heads/main");
+      expect(args).toContain("--deny-self-hosted-runners");
+    }
+  });
+
+  test("fails closed when one asset has no valid attestation", () => {
+    const directory = fixture();
+    const run: AttestationCommandRunner = (args) => ({
+      status: args[2]?.endsWith("kunai-linux-x64") ? 1 : 0,
+      stdout: "",
+      stderr: "no attestation found",
+    });
+
+    try {
+      expect(() =>
+        verifyNativeAttestations({
+          directory,
+          repository: "KitsuneKode/kunai",
+          sourceDigest: "b".repeat(40),
+          run,
+        }),
+      ).toThrow(/kunai-linux-x64.*no attestation found/i);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects unexpected files before trusting any attestation", () => {
+    const directory = fixture();
+    writeFileSync(join(directory, "surprise.bin"), "unexpected");
+    let calls = 0;
+
+    try {
+      expect(() =>
+        verifyNativeAttestations({
+          directory,
+          repository: "KitsuneKode/kunai",
+          sourceDigest: "c".repeat(40),
+          run: () => {
+            calls += 1;
+            return { status: 0, stdout: "", stderr: "" };
+          },
+        }),
+      ).toThrow(/unexpected/i);
+      expect(calls).toBe(0);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects malformed repository and source identities", () => {
+    const directory = fixture();
+    const run: AttestationCommandRunner = () => ({ status: 0, stdout: "", stderr: "" });
+
+    try {
+      expect(() =>
+        verifyNativeAttestations({
+          directory,
+          repository: "not-a-repository",
+          sourceDigest: "d".repeat(40),
+          run,
+        }),
+      ).toThrow(/repository/i);
+      expect(() =>
+        verifyNativeAttestations({
+          directory,
+          repository: "KitsuneKode/kunai",
+          sourceDigest: "main",
+          run,
+        }),
+      ).toThrow(/source digest/i);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/verify-github-release-assets.ts
+++ b/scripts/verify-github-release-assets.ts
@@ -6,7 +6,9 @@
 //   bun run scripts/verify-github-release-assets.ts              # latest (names + sizes)
 //   bun run scripts/verify-github-release-assets.ts v0.3.0
 //   bun run scripts/verify-github-release-assets.ts v0.3.0 \
-//     --expect-draft --expected-version 0.3.0
+//     --expect-draft --expected-version 0.3.0 \
+//     --attestation-repo KitsuneKode/kunai \
+//     --attestation-source-digest <40-character-commit-sha>
 // =============================================================================
 
 import { spawnSync } from "node:child_process";
@@ -31,14 +33,16 @@ type GhReleaseView = {
   readonly assets?: readonly { readonly name?: string; readonly size?: number }[];
 };
 
-function parseArgs(argv: readonly string[]): {
-  tag: string | undefined;
-  expectDraft: boolean;
-  expectPublic: boolean;
-  expectedVersion: string | undefined;
-  attestationRepository: string | undefined;
-  attestationSourceDigest: string | undefined;
-} {
+type GitHubReleaseAssetArguments = {
+  readonly tag: string | undefined;
+  readonly expectDraft: boolean;
+  readonly expectPublic: boolean;
+  readonly expectedVersion: string | undefined;
+  readonly attestationRepository: string | undefined;
+  readonly attestationSourceDigest: string | undefined;
+};
+
+function parseArgs(argv: readonly string[]): GitHubReleaseAssetArguments {
   let tag: string | undefined;
   let expectDraft = false;
   let expectPublic = false;
@@ -95,6 +99,11 @@ function parseArgs(argv: readonly string[]): {
   if (attestationRepository && !expectedVersion) {
     throw new Error("[release-assets] attestation verification requires --expected-version");
   }
+  if (expectedVersion && (!attestationRepository || !attestationSourceDigest)) {
+    throw new Error(
+      "[release-assets] --expected-version requires --attestation-repo and --attestation-source-digest before version smoke",
+    );
+  }
   if (expectDraft && expectPublic) {
     throw new Error("[release-assets] --expect-draft and --expect-public are mutually exclusive");
   }
@@ -136,6 +145,9 @@ function viewRelease(tag: string | undefined): GhReleaseView {
     const detail = (result.stderr || result.stdout || "gh release view failed").trim();
     throw new Error(`[release-assets] ${detail}`);
   }
+  // SAFETY: `gh release view --json isDraft,tagName,assets` owns this local
+  // machine-readable shape; all asset names/counts/sizes are checked by the
+  // exact release contract before downloaded bytes are trusted.
   return JSON.parse(result.stdout) as GhReleaseView;
 }
 
@@ -143,7 +155,7 @@ function descriptorsFromRelease(release: GhReleaseView): ReleaseAssetDescriptor[
   const assets = release.assets ?? [];
   return assets.map((asset) => ({
     name: String(asset.name ?? ""),
-    size: typeof asset.size === "number" ? asset.size : 0,
+    size: Number.isFinite(asset.size) ? (asset.size ?? 0) : 0,
   }));
 }
 
@@ -155,6 +167,52 @@ function downloadReleaseAssets(tag: string, directory: string): void {
     const detail = (result.stderr || result.stdout || "gh release download failed").trim();
     throw new Error(`[release-assets] ${detail}`);
   }
+}
+
+type DownloadedReleaseVerification = {
+  readonly directory: string;
+  readonly expectedVersion: string;
+  readonly attestationRepository: string | undefined;
+  readonly attestationSourceDigest: string | undefined;
+};
+
+type DownloadedReleaseVerificationDependencies = {
+  readonly verifyDirectory: typeof verifyReleaseArtifactDirectory;
+  readonly verifyAttestations: typeof verifyNativeAttestations;
+  readonly smokeLinuxX64: typeof smokeReleaseLinuxX64;
+};
+
+const downloadedReleaseVerificationDependencies: DownloadedReleaseVerificationDependencies = {
+  verifyDirectory: verifyReleaseArtifactDirectory,
+  verifyAttestations: verifyNativeAttestations,
+  smokeLinuxX64: smokeReleaseLinuxX64,
+};
+
+/**
+ * Verify untrusted release downloads without ever executing them before their
+ * workflow and source-commit identity is authenticated.
+ */
+export async function verifyDownloadedReleaseAssets(
+  input: DownloadedReleaseVerification,
+  dependencies: DownloadedReleaseVerificationDependencies = downloadedReleaseVerificationDependencies,
+): Promise<void> {
+  if (!input.attestationRepository || !input.attestationSourceDigest) {
+    throw new Error(
+      "[release-assets] --expected-version requires complete attestation arguments before version smoke",
+    );
+  }
+
+  await dependencies.verifyDirectory({
+    directory: input.directory,
+    expectedVersion: input.expectedVersion,
+    skipVersionSmoke: true,
+  });
+  dependencies.verifyAttestations({
+    directory: input.directory,
+    repository: input.attestationRepository,
+    sourceDigest: input.attestationSourceDigest,
+  });
+  dependencies.smokeLinuxX64(input.directory, input.expectedVersion);
 }
 
 async function main(): Promise<void> {
@@ -187,21 +245,12 @@ async function main(): Promise<void> {
     const tempDir = mkdtempSync(join(tmpdir(), "kunai-gh-release-assets-"));
     try {
       downloadReleaseAssets(downloadTag, tempDir);
-      await verifyReleaseArtifactDirectory({
+      await verifyDownloadedReleaseAssets({
         directory: tempDir,
         expectedVersion,
-        // Never execute bytes downloaded from a release until their signed
-        // workflow/source identity has been verified.
-        skipVersionSmoke: Boolean(attestationRepository),
+        attestationRepository,
+        attestationSourceDigest,
       });
-      if (attestationRepository && attestationSourceDigest) {
-        verifyNativeAttestations({
-          directory: tempDir,
-          repository: attestationRepository,
-          sourceDigest: attestationSourceDigest,
-        });
-        smokeReleaseLinuxX64(tempDir, expectedVersion);
-      }
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/scripts/verify-github-release-assets.ts
+++ b/scripts/verify-github-release-assets.ts
@@ -19,7 +19,11 @@ import {
   assertCompleteReleaseAssetSet,
   type ReleaseAssetDescriptor,
 } from "./release-asset-contract";
-import { verifyReleaseArtifactDirectory } from "./verify-release-artifact-directory";
+import { verifyNativeAttestations } from "./verify-native-attestations";
+import {
+  smokeReleaseLinuxX64,
+  verifyReleaseArtifactDirectory,
+} from "./verify-release-artifact-directory";
 
 type GhReleaseView = {
   readonly isDraft?: boolean;
@@ -30,22 +34,47 @@ type GhReleaseView = {
 function parseArgs(argv: readonly string[]): {
   tag: string | undefined;
   expectDraft: boolean;
+  expectPublic: boolean;
   expectedVersion: string | undefined;
+  attestationRepository: string | undefined;
+  attestationSourceDigest: string | undefined;
 } {
   let tag: string | undefined;
   let expectDraft = false;
+  let expectPublic = false;
   let expectedVersion: string | undefined;
+  let attestationRepository: string | undefined;
+  let attestationSourceDigest: string | undefined;
 
   for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i]!;
+    const arg = argv[i];
+    if (arg === undefined) break;
     if (arg === "--expect-draft") {
       expectDraft = true;
+      continue;
+    }
+    if (arg === "--expect-public") {
+      expectPublic = true;
       continue;
     }
     if (arg === "--expected-version") {
       expectedVersion = argv[++i];
       if (!expectedVersion) {
         throw new Error("[release-assets] --expected-version requires a semver value");
+      }
+      continue;
+    }
+    if (arg === "--attestation-repo") {
+      attestationRepository = argv[++i];
+      if (!attestationRepository) {
+        throw new Error("[release-assets] --attestation-repo requires owner/name");
+      }
+      continue;
+    }
+    if (arg === "--attestation-source-digest") {
+      attestationSourceDigest = argv[++i];
+      if (!attestationSourceDigest) {
+        throw new Error("[release-assets] --attestation-source-digest requires a Git commit SHA");
       }
       continue;
     }
@@ -58,7 +87,43 @@ function parseArgs(argv: readonly string[]): {
     tag = arg;
   }
 
-  return { tag, expectDraft, expectedVersion };
+  if (Boolean(attestationRepository) !== Boolean(attestationSourceDigest)) {
+    throw new Error(
+      "[release-assets] --attestation-repo and --attestation-source-digest are required together",
+    );
+  }
+  if (attestationRepository && !expectedVersion) {
+    throw new Error("[release-assets] attestation verification requires --expected-version");
+  }
+  if (expectDraft && expectPublic) {
+    throw new Error("[release-assets] --expect-draft and --expect-public are mutually exclusive");
+  }
+
+  return {
+    tag,
+    expectDraft,
+    expectPublic,
+    expectedVersion,
+    attestationRepository,
+    attestationSourceDigest,
+  };
+}
+
+export function assertExpectedReleaseState(
+  isDraft: boolean | undefined,
+  expected: "draft" | "public" | undefined,
+  tag?: string,
+): void {
+  if (expected === "draft" && isDraft !== true) {
+    throw new Error(
+      `[release-assets] expected draft release${tag ? ` for ${tag}` : ""}, got isDraft=${String(isDraft)}`,
+    );
+  }
+  if (expected === "public" && isDraft !== false) {
+    throw new Error(
+      `[release-assets] expected public release${tag ? ` for ${tag}` : ""}, got isDraft=${String(isDraft)}`,
+    );
+  }
 }
 
 function viewRelease(tag: string | undefined): GhReleaseView {
@@ -93,16 +158,21 @@ function downloadReleaseAssets(tag: string, directory: string): void {
 }
 
 async function main(): Promise<void> {
-  const { tag, expectDraft, expectedVersion } = parseArgs(process.argv.slice(2));
+  const {
+    tag,
+    expectDraft,
+    expectPublic,
+    expectedVersion,
+    attestationRepository,
+    attestationSourceDigest,
+  } = parseArgs(process.argv.slice(2));
   const release = viewRelease(tag);
 
-  if (expectDraft && release.isDraft !== true) {
-    throw new Error(
-      `[release-assets] expected draft release` +
-        (tag ? ` for ${tag}` : "") +
-        `, got isDraft=${String(release.isDraft)}`,
-    );
-  }
+  assertExpectedReleaseState(
+    release.isDraft,
+    expectDraft ? "draft" : expectPublic ? "public" : undefined,
+    tag,
+  );
 
   const descriptors = descriptorsFromRelease(release);
   assertCompleteReleaseAssetSet(descriptors);
@@ -120,7 +190,18 @@ async function main(): Promise<void> {
       await verifyReleaseArtifactDirectory({
         directory: tempDir,
         expectedVersion,
+        // Never execute bytes downloaded from a release until their signed
+        // workflow/source identity has been verified.
+        skipVersionSmoke: Boolean(attestationRepository),
       });
+      if (attestationRepository && attestationSourceDigest) {
+        verifyNativeAttestations({
+          directory: tempDir,
+          repository: attestationRepository,
+          sourceDigest: attestationSourceDigest,
+        });
+        smokeReleaseLinuxX64(tempDir, expectedVersion);
+      }
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -130,7 +211,9 @@ async function main(): Promise<void> {
     `[release-assets] OK — ${REQUIRED_RELEASE_ASSET_NAMES.length} required assets present` +
       (tag ? ` on ${tag}` : " on latest") +
       (expectDraft ? " (draft)" : "") +
+      (expectPublic ? " (public)" : "") +
       (expectedVersion ? ` / verified v${expectedVersion}` : "") +
+      (attestationRepository ? " / provenance verified" : "") +
       ".",
   );
 }

--- a/scripts/verify-native-attestations.ts
+++ b/scripts/verify-native-attestations.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env bun
+/** Verify provenance for the exact native release payload before publication. */
+
+import { spawnSync } from "node:child_process";
+import { lstatSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  REQUIRED_RELEASE_ASSET_NAMES,
+  assertCompleteReleaseAssetSet,
+} from "./release-asset-contract";
+
+export type AttestationCommandResult = {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+};
+
+export type AttestationCommandRunner = (args: readonly string[]) => AttestationCommandResult;
+
+export type VerifyNativeAttestationsInput = {
+  readonly directory: string;
+  readonly repository: string;
+  readonly sourceDigest: string;
+  readonly run?: AttestationCommandRunner;
+};
+
+const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const SOURCE_DIGEST_PATTERN = /^[0-9a-f]{40}$/i;
+
+function defaultRunner(args: readonly string[]): AttestationCommandResult {
+  const result = spawnSync("gh", [...args], { encoding: "utf8" });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function exactReleaseFiles(directory: string): readonly string[] {
+  const entries = readdirSync(directory).sort();
+  const descriptors = entries.map((name) => {
+    const stat = lstatSync(join(directory, name));
+    if (!stat.isFile()) {
+      throw new Error(`[attestation] native payload entry is not a regular file: ${name}`);
+    }
+    return { name, size: stat.size };
+  });
+  assertCompleteReleaseAssetSet(descriptors);
+  return entries;
+}
+
+export function verifyNativeAttestations(input: VerifyNativeAttestationsInput): void {
+  if (!REPOSITORY_PATTERN.test(input.repository)) {
+    throw new Error(`[attestation] repository must be owner/name, got: ${input.repository}`);
+  }
+  if (!SOURCE_DIGEST_PATTERN.test(input.sourceDigest)) {
+    throw new Error("[attestation] source digest must be a 40-character Git commit SHA");
+  }
+
+  const files = exactReleaseFiles(input.directory);
+  const expected = [...REQUIRED_RELEASE_ASSET_NAMES].sort();
+  if (files.length !== expected.length || files.some((name, index) => name !== expected[index])) {
+    throw new Error("[attestation] native payload does not match the exact release asset set");
+  }
+
+  const run = input.run ?? defaultRunner;
+  const signerWorkflow = `${input.repository}/.github/workflows/release.yml`;
+  for (const name of files) {
+    const result = run([
+      "attestation",
+      "verify",
+      join(input.directory, name),
+      "--repo",
+      input.repository,
+      "--signer-workflow",
+      signerWorkflow,
+      "--source-digest",
+      input.sourceDigest,
+      "--source-ref",
+      "refs/heads/main",
+      "--deny-self-hosted-runners",
+    ]);
+    if (result.status !== 0) {
+      const detail = (
+        result.stderr ||
+        result.stdout ||
+        `gh exited ${String(result.status)}`
+      ).trim();
+      throw new Error(`[attestation] ${name}: ${detail}`);
+    }
+  }
+}
+
+function parseArgs(argv: readonly string[]): Omit<VerifyNativeAttestationsInput, "run"> {
+  let directory: string | undefined;
+  let repository: string | undefined;
+  let sourceDigest: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === undefined) break;
+    if (arg === "--repo") {
+      repository = argv[++index];
+      continue;
+    }
+    if (arg === "--source-digest") {
+      sourceDigest = argv[++index];
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(`[attestation] unknown option: ${arg}`);
+    }
+    if (directory) {
+      throw new Error(`[attestation] unexpected argument: ${arg}`);
+    }
+    directory = arg;
+  }
+
+  if (!directory || !repository || !sourceDigest) {
+    throw new Error(
+      "[attestation] usage: verify-native-attestations.ts <dir> --repo <owner/name> --source-digest <sha>",
+    );
+  }
+  return { directory, repository, sourceDigest };
+}
+
+if (import.meta.main) {
+  try {
+    const input = parseArgs(process.argv.slice(2));
+    verifyNativeAttestations(input);
+    console.log(
+      `[attestation] OK — verified ${REQUIRED_RELEASE_ASSET_NAMES.length} native assets from ${input.repository}@${input.sourceDigest}`,
+    );
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/verify-native-attestations.ts
+++ b/scripts/verify-native-attestations.ts
@@ -2,13 +2,13 @@
 /** Verify provenance for the exact native release payload before publication. */
 
 import { spawnSync } from "node:child_process";
-import { lstatSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import {
   REQUIRED_RELEASE_ASSET_NAMES,
   assertCompleteReleaseAssetSet,
 } from "./release-asset-contract";
+import { listRegularReleaseFiles } from "./verify-release-artifact-directory";
 
 export type AttestationCommandResult = {
   readonly status: number | null;
@@ -37,19 +37,6 @@ function defaultRunner(args: readonly string[]): AttestationCommandResult {
   };
 }
 
-function exactReleaseFiles(directory: string): readonly string[] {
-  const entries = readdirSync(directory).sort();
-  const descriptors = entries.map((name) => {
-    const stat = lstatSync(join(directory, name));
-    if (!stat.isFile()) {
-      throw new Error(`[attestation] native payload entry is not a regular file: ${name}`);
-    }
-    return { name, size: stat.size };
-  });
-  assertCompleteReleaseAssetSet(descriptors);
-  return entries;
-}
-
 export function verifyNativeAttestations(input: VerifyNativeAttestationsInput): void {
   if (!REPOSITORY_PATTERN.test(input.repository)) {
     throw new Error(`[attestation] repository must be owner/name, got: ${input.repository}`);
@@ -58,15 +45,12 @@ export function verifyNativeAttestations(input: VerifyNativeAttestationsInput): 
     throw new Error("[attestation] source digest must be a 40-character Git commit SHA");
   }
 
-  const files = exactReleaseFiles(input.directory);
-  const expected = [...REQUIRED_RELEASE_ASSET_NAMES].sort();
-  if (files.length !== expected.length || files.some((name, index) => name !== expected[index])) {
-    throw new Error("[attestation] native payload does not match the exact release asset set");
-  }
+  const files = listRegularReleaseFiles(input.directory);
+  assertCompleteReleaseAssetSet(files);
 
   const run = input.run ?? defaultRunner;
   const signerWorkflow = `${input.repository}/.github/workflows/release.yml`;
-  for (const name of files) {
+  for (const { name } of files) {
     const result = run([
       "attestation",
       "verify",

--- a/scripts/verify-release-artifact-directory.ts
+++ b/scripts/verify-release-artifact-directory.ts
@@ -10,7 +10,7 @@
 
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmodSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { chmodSync, lstatSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { verifyBuiltReleaseArchives } from "../apps/cli/scripts/build-release-archives";
@@ -33,24 +33,21 @@ function fileSha256(path: string): string {
 }
 
 function listReleaseFiles(directory: string): readonly { name: string; size: number }[] {
-  return readdirSync(directory)
-    .filter((name) => {
-      try {
-        return statSync(join(directory, name)).isFile();
-      } catch {
-        return false;
-      }
-    })
-    .map((name) => ({
-      name,
-      size: statSync(join(directory, name)).size,
-    }));
+  return readdirSync(directory).map((name) => {
+    const stat = lstatSync(join(directory, name));
+    if (!stat.isFile()) {
+      throw new Error(`[release-assets] unexpected non-regular entry: ${name}`);
+    }
+    return { name, size: stat.size };
+  });
 }
 
-function smokeLinuxX64(binPath: string, expectedVersion: string): void {
+export function smokeReleaseLinuxX64(directory: string, expectedVersion: string): void {
   if (process.platform !== "linux" || process.arch !== "x64") {
     return;
   }
+
+  const binPath = join(directory, "kunai-linux-x64");
 
   // GitHub artifact and release downloads intentionally do not preserve Unix
   // executable mode. Restoring the mode changes filesystem metadata, not the
@@ -111,7 +108,7 @@ export async function verifyReleaseArtifactDirectory(
   verifyBuiltReleaseArchives(input.directory);
 
   if (!input.skipVersionSmoke) {
-    smokeLinuxX64(join(input.directory, "kunai-linux-x64"), input.expectedVersion);
+    smokeReleaseLinuxX64(input.directory, input.expectedVersion);
   }
 }
 

--- a/scripts/verify-release-artifact-directory.ts
+++ b/scripts/verify-release-artifact-directory.ts
@@ -32,14 +32,18 @@ function fileSha256(path: string): string {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
 
-function listReleaseFiles(directory: string): readonly { name: string; size: number }[] {
-  return readdirSync(directory).map((name) => {
-    const stat = lstatSync(join(directory, name));
-    if (!stat.isFile()) {
-      throw new Error(`[release-assets] unexpected non-regular entry: ${name}`);
-    }
-    return { name, size: stat.size };
-  });
+export function listRegularReleaseFiles(
+  directory: string,
+): readonly { name: string; size: number }[] {
+  return readdirSync(directory)
+    .sort()
+    .map((name) => {
+      const stat = lstatSync(join(directory, name));
+      if (!stat.isFile()) {
+        throw new Error(`[release-assets] unexpected non-regular entry: ${name}`);
+      }
+      return { name, size: stat.size };
+    });
 }
 
 export function smokeReleaseLinuxX64(directory: string, expectedVersion: string): void {
@@ -100,7 +104,7 @@ export function smokeReleaseLinuxX64(directory: string, expectedVersion: string)
 export async function verifyReleaseArtifactDirectory(
   input: VerifyReleaseArtifactDirectoryInput,
 ): Promise<void> {
-  const files = listReleaseFiles(input.directory);
+  const files = listRegularReleaseFiles(input.directory);
   assertCompleteReleaseAssetSet(files);
 
   verifyChecksumManifest(input.directory, "SHA256SUMS", REQUIRED_BINARY_ASSET_NAMES);


### PR DESCRIPTION
## Summary

- generate GitHub artifact attestations for all 18 exact native candidate assets using a commit-pinned actions/attest v4 action
- verify repository, signer workflow, source SHA/ref, and runner policy before any downloaded native binary executes and before publication
- gate confirmation and protected publication on the immutable candidate artifact ID
- reject non-regular release-directory entries and assert draft/public release state at the appropriate boundaries

## Stack

- parent: #182
- #182 depends on #204, #184, and #180
- merge only after the parent stack and all provenance CI gates are green

## Verification

- independent security review: all provenance/order findings resolved; no release-logic blocker remains
- full pre-push gate: 23 tasks green
- 4816 unit tests passed, 1 Windows-only skip
- 235 integration tests passed, 25 opt-in/environment skips
- focused provenance/release-contract suite: 56 passed
- build, typecheck, zero-warning lint, format, doc paths, YAML parse, and diff check passed

The protected release workflow was not dispatched. Actual GitHub OIDC signing remains a remote candidate-workflow gate.