### PR TITLE
feat(updater): consume verified release archives

### DIFF
--- a/.changeset/safe-apes-unpack.md
+++ b/.changeset/safe-apes-unpack.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Download verified platform archives for native self-updates, safely extract one bounded executable in-process, and preserve rollback-compatible provenance while migrating schema-1 install manifests.

--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -65,10 +65,16 @@ legacy raw `SHA256SUMS` before version-store or launcher activation. Missing
 archive manifests on an older release fall back to its raw compatibility asset;
 a present but malformed or mismatched archive fails closed. Native
 `install.json` is schema 2 and records both archive transport and extracted
-binary provenance; schema-1 manifests migrate atomically while preserving
-active/previous version fields used by doctor and rollback. The shell and
-PowerShell installer archive-consumption slices remain release blockers for
-issue #132.
+binary provenance. Per-version `version.json` records the raw artifact as
+`artifactName`, `artifactSha256`, `sizeBytes`, and `sourceUrl`; archive installs
+add the all-or-none `archiveName`, `archiveSha256`, `archiveSizeBytes`, and
+`archiveSourceUrl` quartet. Rollback republishes both groups into `install.json`
+(`artifactSizeBytes` and `artifactSourceUrl` are the manifest spellings).
+Schema-1 manifest migration is an explicit startup transition: it acquires the
+version and activation locks, which exclude uninstall through the lifecycle
+guard, then re-reads before publishing so a newer activation is not overwritten
+and a removed manifest is not recreated. The shell and PowerShell installer
+archive-consumption slices remain release blockers for issue #132.
 
 ## Native Installer Activation Gate
 

--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -55,10 +55,20 @@ missing, duplicate, unexpected, empty, oversized, hash-mismatched, or
 non-canonical assets. A canonical archive has one entry whose name is the raw
 asset name and no directory prefix; tar metadata is normalized with executable
 mode `0755`, while zip records that Unix mode but Windows extraction does not
-promise to restore it. Archive consumers are intentionally outside the first
-creation/verification slice. This builder slice does not close issue #132 and
-does not yet reduce user downloads: 0.3.0 release dispatch remains blocked until
-the installer/updater archive-consumption stack lands and is verified.
+promise to restore it.
+
+The TypeScript native updater consumes these archives. It verifies the archive
+against `SHA256SUMS.archives`, parses tar/gzip or zip in-process without invoking
+an OS extractor, permits exactly one expected regular-file member, bounds both
+compressed and decompressed bytes, and then verifies that member against the
+legacy raw `SHA256SUMS` before version-store or launcher activation. Missing
+archive manifests on an older release fall back to its raw compatibility asset;
+a present but malformed or mismatched archive fails closed. Native
+`install.json` is schema 2 and records both archive transport and extracted
+binary provenance; schema-1 manifests migrate atomically while preserving
+active/previous version fields used by doctor and rollback. The shell and
+PowerShell installer archive-consumption slices remain release blockers for
+issue #132.
 
 ## Native Installer Activation Gate
 
@@ -131,6 +141,8 @@ bun run --cwd apps/cli test:file -- \
   test/unit/services/update/native-installer/activation-lock.test.ts \
   test/unit/services/update/native-installer/version-lock.test.ts \
   test/unit/services/update/native-installer/install-latest.test.ts \
+  test/unit/services/update/native-installer/release-archive.test.ts \
+  test/unit/install-manifest.test.ts \
   test/unit/services/update/native-installer/migrate-flat-install.test.ts \
   test/unit/services/update/native-installer/rollback.test.ts \
   test/unit/services/update/native-installer/native-uninstall.test.ts \

--- a/.docs/repo-infrastructure.md
+++ b/.docs/repo-infrastructure.md
@@ -150,10 +150,13 @@ bits. The build reconstructs and byte-compares each archive after preservation,
 then release confirmation and publication reverify the same bytes without a
 rebuild.
 
-Installer/updater archive consumption is a separate stacked change. Until that
-lands, they still follow the functional legacy raw-asset path. This builder
-slice does not close issue #132 or reduce end-user downloads; do not dispatch
-0.3.0 from the archive-creation slice alone.
+The TypeScript native updater now consumes the platform archive, independently
+verifies its transport hash and its extracted raw-binary hash, and keeps a
+404/410-only raw fallback for releases published before archives existed. It
+uses an in-process, bounded one-member parser rather than an external tar/zip
+command. The Bash and PowerShell installers still follow the functional legacy
+raw-asset path until their later stacked consumption slice lands. Issue #132
+and 0.3.0 release dispatch remain blocked on that cross-language parity.
 
 ### Windows parity
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -718,7 +718,9 @@ export async function runCli(argv = process.argv.slice(2)): Promise<void> {
   lifetimeLockReady = (async () => {
     const { lockCurrentVersion, cleanupOldVersions } =
       await import("./services/update/native-installer");
-    const { readInstallManifest } = await import("./services/update/install-manifest");
+    const { migrateInstallManifest, readInstallManifest } =
+      await import("./services/update/install-manifest");
+    await migrateInstallManifest().catch(() => {});
     const manifest = await readInstallManifest();
     if (manifest?.method === "binary" || manifest?.versionedPath) {
       await lockCurrentVersion().catch(() => {});

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -718,9 +718,9 @@ export async function runCli(argv = process.argv.slice(2)): Promise<void> {
   lifetimeLockReady = (async () => {
     const { lockCurrentVersion, cleanupOldVersions } =
       await import("./services/update/native-installer");
-    const { migrateInstallManifest, readInstallManifest } =
+    const { migrateInstallManifestAtStartup, readInstallManifest } =
       await import("./services/update/install-manifest");
-    await migrateInstallManifest().catch(() => {});
+    await migrateInstallManifestAtStartup();
     const manifest = await readInstallManifest();
     if (manifest?.method === "binary" || manifest?.versionedPath) {
       await lockCurrentVersion().catch(() => {});

--- a/apps/cli/src/services/update/install-manifest.ts
+++ b/apps/cli/src/services/update/install-manifest.ts
@@ -115,6 +115,19 @@ export function sameInstallManifestPublication(
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
+function sameInstallManifestMigrationSource(
+  left: InstallManifest,
+  right: InstallManifest,
+): boolean {
+  // Legacy manifests have no updatedAt, so each read synthesizes a fresh one.
+  // Ignore only that derived field while still detecting a replacement of any
+  // ownership, path, version, or provenance field during migration planning.
+  return sameInstallManifestPublication(
+    { ...left, updatedAt: "migration-source" },
+    { ...right, updatedAt: "migration-source" },
+  );
+}
+
 /** Derive ownership roots Kunai may manage for a native binary install. */
 export function deriveManagedPaths(
   method: InstallManifestMethod,
@@ -188,11 +201,24 @@ export async function migrateInstallManifest(
       const current = await inspectInstallManifest(layout.configDir);
       if (current.status === "missing") return { status: "missing" } as const;
       if (current.status === "invalid") return current;
+      if (!sameInstallManifestMigrationSource(current.manifest, observed.manifest)) {
+        if (!current.needsMigration) {
+          return { status: "unchanged", manifest: current.manifest } as const;
+        }
+        return { status: "deferred", manifest: current.manifest } as const;
+      }
       if (!current.needsMigration) {
         return { status: "unchanged", manifest: current.manifest } as const;
       }
 
-      await migrateArchiveVersionMetadata(layout, current.manifest);
+      if (
+        current.manifest.archiveName &&
+        !(await migrateArchiveVersionMetadata(layout, current.manifest))
+      ) {
+        throw new Error(
+          `Archive version metadata unavailable for install manifest migration (${current.manifest.activeVersion})`,
+        );
+      }
       await persistManifest(current.manifest, layout.configDir);
       return { status: "migrated", manifest: current.manifest } as const;
     });

--- a/apps/cli/src/services/update/install-manifest.ts
+++ b/apps/cli/src/services/update/install-manifest.ts
@@ -12,12 +12,12 @@ import { parseCanonicalVersion } from "./version";
  * route to the correct mechanism and never fight another installer.
  * Authoritative when present; otherwise callers fall back to `detectInstallMethod`.
  */
-export const INSTALL_MANIFEST_SCHEMA_VERSION = 1 as const;
+export const INSTALL_MANIFEST_SCHEMA_VERSION = 2 as const;
 
 export type InstallManifestMethod = "binary" | "npm-global" | "bun-global" | "source";
 
 export interface InstallManifest {
-  readonly schemaVersion: 1;
+  readonly schemaVersion: 2;
   readonly method: InstallManifestMethod;
   readonly observedProvenance?: string;
   readonly activeVersion: string;
@@ -27,7 +27,13 @@ export interface InstallManifest {
   readonly versionedPath?: string;
   readonly managedPaths: readonly string[];
   readonly target?: string;
+  readonly artifactName?: string;
   readonly artifactSha256?: string;
+  readonly artifactSizeBytes?: number;
+  readonly archiveName?: string;
+  readonly archiveSha256?: string;
+  readonly archiveSizeBytes?: number;
+  readonly archiveSourceUrl?: string;
   readonly downloadBaseUrl: string;
   readonly installedAt: string;
   readonly updatedAt: string;
@@ -60,7 +66,13 @@ export type WriteInstallManifestInput = {
   readonly previousVersion?: string;
   readonly observedProvenance?: string;
   readonly target?: string;
+  readonly artifactName?: string;
   readonly artifactSha256?: string;
+  readonly artifactSizeBytes?: number;
+  readonly archiveName?: string;
+  readonly archiveSha256?: string;
+  readonly archiveSizeBytes?: number;
+  readonly archiveSourceUrl?: string;
   readonly managedPaths?: readonly string[];
 };
 
@@ -142,6 +154,23 @@ export async function writeInstallManifest(
   partial: WriteInstallManifestInput,
   configDir = getKunaiPaths().configDir,
 ): Promise<void> {
+  if (!archiveProvenanceComplete(partial)) {
+    throw new Error("Archive provenance must include name, checksum, size, and source URL");
+  }
+  if (!archiveHasArtifactProvenance(partial)) {
+    throw new Error("Archive installs must include extracted binary provenance");
+  }
+  if (
+    !optionalString(partial.artifactName) ||
+    !optionalSha256(partial.artifactSha256) ||
+    !optionalSize(partial.artifactSizeBytes) ||
+    !optionalString(partial.archiveName) ||
+    !optionalSha256(partial.archiveSha256) ||
+    !optionalSize(partial.archiveSizeBytes) ||
+    !optionalString(partial.archiveSourceUrl)
+  ) {
+    throw new Error("Invalid install manifest artifact provenance");
+  }
   const activeVersion = parseCanonicalVersion(partial.activeVersion);
   if (!activeVersion) {
     throw new Error(`Invalid install manifest version: ${partial.activeVersion}`);
@@ -182,7 +211,17 @@ export async function writeInstallManifest(
     ...(previousVersion ? { previousVersion } : {}),
     ...(partial.observedProvenance ? { observedProvenance: partial.observedProvenance } : {}),
     ...(partial.target ? { target: partial.target } : {}),
+    ...(partial.artifactName ? { artifactName: partial.artifactName } : {}),
     ...(partial.artifactSha256 ? { artifactSha256: partial.artifactSha256 } : {}),
+    ...(partial.artifactSizeBytes !== undefined
+      ? { artifactSizeBytes: partial.artifactSizeBytes }
+      : {}),
+    ...(partial.archiveName ? { archiveName: partial.archiveName } : {}),
+    ...(partial.archiveSha256 ? { archiveSha256: partial.archiveSha256 } : {}),
+    ...(partial.archiveSizeBytes !== undefined
+      ? { archiveSizeBytes: partial.archiveSizeBytes }
+      : {}),
+    ...(partial.archiveSourceUrl ? { archiveSourceUrl: partial.archiveSourceUrl } : {}),
   };
 
   await persistManifest(full, configDir);
@@ -209,7 +248,7 @@ function inspectCurrentSchema(
   if (typeof schemaVersion !== "number" || !Number.isInteger(schemaVersion)) {
     return { status: "invalid", reason: "invalid-shape" };
   }
-  if (schemaVersion !== INSTALL_MANIFEST_SCHEMA_VERSION) {
+  if (schemaVersion !== 1 && schemaVersion !== INSTALL_MANIFEST_SCHEMA_VERSION) {
     return { status: "invalid", reason: "unsupported-schema" };
   }
 
@@ -254,6 +293,26 @@ function inspectCurrentSchema(
   ) {
     return { status: "invalid", reason: "invalid-shape" };
   }
+  if (!archiveProvenanceComplete(record)) {
+    return { status: "invalid", reason: "invalid-shape" };
+  }
+  if (!archiveHasArtifactProvenance(record)) {
+    return { status: "invalid", reason: "invalid-shape" };
+  }
+  if (!optionalString(record.artifactName) || !optionalSha256(record.artifactSha256)) {
+    return { status: "invalid", reason: "invalid-shape" };
+  }
+  if (!optionalSize(record.artifactSizeBytes)) {
+    return { status: "invalid", reason: "invalid-shape" };
+  }
+  if (
+    !optionalString(record.archiveName) ||
+    !optionalSha256(record.archiveSha256) ||
+    !optionalSize(record.archiveSizeBytes) ||
+    !optionalString(record.archiveSourceUrl)
+  ) {
+    return { status: "invalid", reason: "invalid-shape" };
+  }
 
   const layout = getInstallLayoutPaths({
     configDir,
@@ -264,7 +323,7 @@ function inspectCurrentSchema(
   }
 
   const manifest: InstallManifest = {
-    schemaVersion: 1,
+    schemaVersion: INSTALL_MANIFEST_SCHEMA_VERSION,
     method: typedMethod,
     activeVersion: record.activeVersion,
     preferredChannel: "stable",
@@ -281,10 +340,22 @@ function inspectCurrentSchema(
       ? { observedProvenance: record.observedProvenance }
       : {}),
     ...(typeof record.target === "string" ? { target: record.target } : {}),
+    ...(typeof record.artifactName === "string" ? { artifactName: record.artifactName } : {}),
     ...(typeof record.artifactSha256 === "string" ? { artifactSha256: record.artifactSha256 } : {}),
+    ...(typeof record.artifactSizeBytes === "number"
+      ? { artifactSizeBytes: record.artifactSizeBytes }
+      : {}),
+    ...(typeof record.archiveName === "string" ? { archiveName: record.archiveName } : {}),
+    ...(typeof record.archiveSha256 === "string" ? { archiveSha256: record.archiveSha256 } : {}),
+    ...(typeof record.archiveSizeBytes === "number"
+      ? { archiveSizeBytes: record.archiveSizeBytes }
+      : {}),
+    ...(typeof record.archiveSourceUrl === "string"
+      ? { archiveSourceUrl: record.archiveSourceUrl }
+      : {}),
   };
 
-  return { status: "loaded", needsMigration: false, manifest };
+  return { status: "loaded", needsMigration: schemaVersion === 1, manifest };
 }
 
 function inspectLegacySchema(
@@ -354,4 +425,52 @@ function managedPathsAreSafe(
     if (!ok) return false;
   }
   return true;
+}
+
+function optionalString(value: unknown): boolean {
+  return value === undefined || (typeof value === "string" && value.length > 0);
+}
+
+function optionalSha256(value: unknown): boolean {
+  return value === undefined || (typeof value === "string" && /^[a-fA-F0-9]{64}$/.test(value));
+}
+
+function optionalSize(value: unknown): boolean {
+  return (
+    value === undefined || (typeof value === "number" && Number.isSafeInteger(value) && value > 0)
+  );
+}
+
+function archiveProvenanceComplete(value: {
+  readonly archiveName?: unknown;
+  readonly archiveSha256?: unknown;
+  readonly archiveSizeBytes?: unknown;
+  readonly archiveSourceUrl?: unknown;
+}): boolean {
+  const fields = [
+    value.archiveName,
+    value.archiveSha256,
+    value.archiveSizeBytes,
+    value.archiveSourceUrl,
+  ];
+  const present = fields.filter((field) => field !== undefined).length;
+  return present === 0 || present === fields.length;
+}
+
+function archiveHasArtifactProvenance(value: {
+  readonly archiveName?: unknown;
+  readonly artifactName?: unknown;
+  readonly artifactSha256?: unknown;
+  readonly artifactSizeBytes?: unknown;
+}): boolean {
+  if (value.archiveName === undefined) return true;
+  return (
+    typeof value.artifactName === "string" &&
+    value.artifactName.length > 0 &&
+    typeof value.artifactSha256 === "string" &&
+    /^[a-fA-F0-9]{64}$/.test(value.artifactSha256) &&
+    typeof value.artifactSizeBytes === "number" &&
+    Number.isSafeInteger(value.artifactSizeBytes) &&
+    value.artifactSizeBytes > 0
+  );
 }

--- a/apps/cli/src/services/update/install-manifest.ts
+++ b/apps/cli/src/services/update/install-manifest.ts
@@ -4,9 +4,10 @@ import { isAbsolute, join, normalize, resolve, sep } from "node:path";
 
 import { getKunaiPaths } from "@kunai/storage";
 
-import { withActivationLock } from "./native-installer/activation-lock";
+import { withActivationLock, type ActivationLockOptions } from "./native-installer/activation-lock";
 import { getInstallLayoutPaths, type InstallLayoutPaths } from "./native-installer/install-layout";
 import { withVersionLock } from "./native-installer/version-lock";
+import { migrateArchiveVersionMetadata } from "./native-installer/version-metadata";
 import { parseCanonicalVersion } from "./version";
 
 /**
@@ -191,6 +192,7 @@ export async function migrateInstallManifest(
         return { status: "unchanged", manifest: current.manifest } as const;
       }
 
+      await migrateArchiveVersionMetadata(layout, current.manifest);
       await persistManifest(current.manifest, layout.configDir);
       return { status: "migrated", manifest: current.manifest } as const;
     });
@@ -202,6 +204,7 @@ export async function migrateInstallManifest(
 export async function writeInstallManifest(
   partial: WriteInstallManifestInput,
   layout: InstallLayoutPaths = getInstallLayoutPaths({ launcherPath: partial.launcherPath }),
+  activationOptions: ActivationLockOptions = {},
 ): Promise<void> {
   validateWriteProvenance(partial);
   const activeVersion = parseCanonicalVersion(partial.activeVersion);
@@ -211,8 +214,11 @@ export async function writeInstallManifest(
   if (partial.previousVersion !== undefined && !parseCanonicalVersion(partial.previousVersion)) {
     throw new Error(`Invalid install manifest previousVersion: ${partial.previousVersion}`);
   }
-  const published = await withActivationLock(layout, activeVersion, () =>
-    writeInstallManifestUnderActivation(partial, layout),
+  const published = await withActivationLock(
+    layout,
+    activeVersion,
+    () => writeInstallManifestUnderActivation(partial, layout),
+    activationOptions,
   );
   if (published === null) {
     throw new Error(`Install manifest publication lock held while publishing ${activeVersion}`);

--- a/apps/cli/src/services/update/install-manifest.ts
+++ b/apps/cli/src/services/update/install-manifest.ts
@@ -4,7 +4,9 @@ import { isAbsolute, join, normalize, resolve, sep } from "node:path";
 
 import { getKunaiPaths } from "@kunai/storage";
 
+import { withActivationLock } from "./native-installer/activation-lock";
 import { getInstallLayoutPaths, type InstallLayoutPaths } from "./native-installer/install-layout";
+import { withVersionLock } from "./native-installer/version-lock";
 import { parseCanonicalVersion } from "./version";
 
 /**
@@ -30,6 +32,7 @@ export interface InstallManifest {
   readonly artifactName?: string;
   readonly artifactSha256?: string;
   readonly artifactSizeBytes?: number;
+  readonly artifactSourceUrl?: string;
   readonly archiveName?: string;
   readonly archiveSha256?: string;
   readonly archiveSizeBytes?: number;
@@ -57,6 +60,13 @@ export type InstallManifestInspection =
       readonly manifest: InstallManifest;
     };
 
+export type InstallManifestMigrationResult =
+  | { readonly status: "migrated" | "unchanged"; readonly manifest: InstallManifest }
+  | { readonly status: "deferred"; readonly manifest: InstallManifest }
+  | { readonly status: "missing" }
+  | { readonly status: "invalid"; readonly reason: InstallManifestInvalidReason }
+  | { readonly status: "lock-contention" };
+
 export type WriteInstallManifestInput = {
   readonly method: InstallManifestMethod;
   readonly activeVersion: string;
@@ -69,6 +79,7 @@ export type WriteInstallManifestInput = {
   readonly artifactName?: string;
   readonly artifactSha256?: string;
   readonly artifactSizeBytes?: number;
+  readonly artifactSourceUrl?: string;
   readonly archiveName?: string;
   readonly archiveSha256?: string;
   readonly archiveSizeBytes?: number;
@@ -135,19 +146,49 @@ export async function inspectInstallManifest(
   return inspectLegacySchema(record as LegacyInstallManifest, configDir);
 }
 
-/**
- * Read the install ownership record. Atomically migrates valid legacy schema.
- * Never writes for invalid / unsupported / missing manifests.
- */
+/** Read the install ownership record without mutating it. */
 export async function readInstallManifest(
   configDir = getKunaiPaths().configDir,
 ): Promise<InstallManifest | null> {
   const inspection = await inspectInstallManifest(configDir);
   if (inspection.status !== "loaded") return null;
-  if (inspection.needsMigration) {
-    await persistManifest(inspection.manifest, configDir);
-  }
   return inspection.manifest;
+}
+
+/**
+ * Publish a schema migration only while lifecycle, version, and activation
+ * ownership exclude uninstall and competing native activation. The manifest is
+ * re-read inside the locks so a replacement is preserved and a removal is not
+ * recreated from a stale snapshot.
+ */
+export async function migrateInstallManifest(
+  layout: InstallLayoutPaths = getInstallLayoutPaths(),
+): Promise<InstallManifestMigrationResult> {
+  const observed = await inspectInstallManifest(layout.configDir);
+  if (observed.status === "missing") return { status: "missing" };
+  if (observed.status === "invalid") return observed;
+  if (!observed.needsMigration) {
+    return { status: "unchanged", manifest: observed.manifest };
+  }
+  if (observed.manifest.method !== "binary") {
+    return { status: "deferred", manifest: observed.manifest };
+  }
+
+  const migrated = await withVersionLock(layout, observed.manifest.activeVersion, async () => {
+    return withActivationLock(layout, observed.manifest.activeVersion, async () => {
+      const current = await inspectInstallManifest(layout.configDir);
+      if (current.status === "missing") return { status: "missing" } as const;
+      if (current.status === "invalid") return current;
+      if (!current.needsMigration) {
+        return { status: "unchanged", manifest: current.manifest } as const;
+      }
+
+      await persistManifest(current.manifest, layout.configDir);
+      return { status: "migrated", manifest: current.manifest } as const;
+    });
+  });
+
+  return migrated ?? { status: "lock-contention" };
 }
 
 export async function writeInstallManifest(
@@ -164,6 +205,7 @@ export async function writeInstallManifest(
     !optionalString(partial.artifactName) ||
     !optionalSha256(partial.artifactSha256) ||
     !optionalSize(partial.artifactSizeBytes) ||
+    !optionalString(partial.artifactSourceUrl) ||
     !optionalString(partial.archiveName) ||
     !optionalSha256(partial.archiveSha256) ||
     !optionalSize(partial.archiveSizeBytes) ||
@@ -216,6 +258,7 @@ export async function writeInstallManifest(
     ...(partial.artifactSizeBytes !== undefined
       ? { artifactSizeBytes: partial.artifactSizeBytes }
       : {}),
+    ...(partial.artifactSourceUrl ? { artifactSourceUrl: partial.artifactSourceUrl } : {}),
     ...(partial.archiveName ? { archiveName: partial.archiveName } : {}),
     ...(partial.archiveSha256 ? { archiveSha256: partial.archiveSha256 } : {}),
     ...(partial.archiveSizeBytes !== undefined
@@ -305,6 +348,9 @@ function inspectCurrentSchema(
   if (!optionalSize(record.artifactSizeBytes)) {
     return { status: "invalid", reason: "invalid-shape" };
   }
+  if (!optionalString(record.artifactSourceUrl)) {
+    return { status: "invalid", reason: "invalid-shape" };
+  }
   if (
     !optionalString(record.archiveName) ||
     !optionalSha256(record.archiveSha256) ||
@@ -344,6 +390,9 @@ function inspectCurrentSchema(
     ...(typeof record.artifactSha256 === "string" ? { artifactSha256: record.artifactSha256 } : {}),
     ...(typeof record.artifactSizeBytes === "number"
       ? { artifactSizeBytes: record.artifactSizeBytes }
+      : {}),
+    ...(typeof record.artifactSourceUrl === "string"
+      ? { artifactSourceUrl: record.artifactSourceUrl }
       : {}),
     ...(typeof record.archiveName === "string" ? { archiveName: record.archiveName } : {}),
     ...(typeof record.archiveSha256 === "string" ? { archiveSha256: record.archiveSha256 } : {}),
@@ -462,6 +511,7 @@ function archiveHasArtifactProvenance(value: {
   readonly artifactName?: unknown;
   readonly artifactSha256?: unknown;
   readonly artifactSizeBytes?: unknown;
+  readonly artifactSourceUrl?: unknown;
 }): boolean {
   if (value.archiveName === undefined) return true;
   return (
@@ -471,6 +521,8 @@ function archiveHasArtifactProvenance(value: {
     /^[a-fA-F0-9]{64}$/.test(value.artifactSha256) &&
     typeof value.artifactSizeBytes === "number" &&
     Number.isSafeInteger(value.artifactSizeBytes) &&
-    value.artifactSizeBytes > 0
+    value.artifactSizeBytes > 0 &&
+    typeof value.artifactSourceUrl === "string" &&
+    value.artifactSourceUrl.length > 0
   );
 }

--- a/apps/cli/src/services/update/install-manifest.ts
+++ b/apps/cli/src/services/update/install-manifest.ts
@@ -106,6 +106,14 @@ export function isVersionedBinaryManifest(manifest: InstallManifest): boolean {
   return manifest.method === "binary" && Boolean(manifest.versionedPath);
 }
 
+/** Identity used by removers to avoid deleting a replacement publication. */
+export function sameInstallManifestPublication(
+  left: InstallManifest,
+  right: InstallManifest,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
 /** Derive ownership roots Kunai may manage for a native binary install. */
 export function deriveManagedPaths(
   method: InstallManifestMethod,
@@ -193,37 +201,60 @@ export async function migrateInstallManifest(
 
 export async function writeInstallManifest(
   partial: WriteInstallManifestInput,
-  configDir = getKunaiPaths().configDir,
+  layout: InstallLayoutPaths = getInstallLayoutPaths({ launcherPath: partial.launcherPath }),
 ): Promise<void> {
-  if (!archiveProvenanceComplete(partial)) {
-    throw new Error("Archive provenance must include name, checksum, size, and source URL");
+  validateWriteProvenance(partial);
+  const activeVersion = parseCanonicalVersion(partial.activeVersion);
+  if (!activeVersion) {
+    throw new Error(`Invalid install manifest version: ${partial.activeVersion}`);
   }
-  if (!archiveHasArtifactProvenance(partial)) {
-    throw new Error("Archive installs must include extracted binary provenance");
+  if (partial.previousVersion !== undefined && !parseCanonicalVersion(partial.previousVersion)) {
+    throw new Error(`Invalid install manifest previousVersion: ${partial.previousVersion}`);
   }
-  if (
-    !optionalString(partial.artifactName) ||
-    !optionalSha256(partial.artifactSha256) ||
-    !optionalSize(partial.artifactSizeBytes) ||
-    !optionalString(partial.artifactSourceUrl) ||
-    !optionalString(partial.archiveName) ||
-    !optionalSha256(partial.archiveSha256) ||
-    !optionalSize(partial.archiveSizeBytes) ||
-    !optionalString(partial.archiveSourceUrl)
-  ) {
-    throw new Error("Invalid install manifest artifact provenance");
+  const published = await withActivationLock(layout, activeVersion, () =>
+    writeInstallManifestUnderActivation(partial, layout),
+  );
+  if (published === null) {
+    throw new Error(`Install manifest publication lock held while publishing ${activeVersion}`);
   }
+}
+
+/** Hold the shared launcher/manifest publication boundary across a compound operation. */
+export async function withInstallManifestPublication<T>(
+  version: string,
+  fn: () => Promise<T>,
+  layout: InstallLayoutPaths = getInstallLayoutPaths(),
+): Promise<T | null> {
+  return withActivationLock(layout, version, fn);
+}
+
+/**
+ * Publish while the caller already owns the activation lock.
+ *
+ * Native lifecycle paths use this primitive after acquiring locks in the only
+ * supported order: lifecycle/version -> activation -> manifest I/O. Package
+ * publishers use `writeInstallManifest`, which acquires activation directly.
+ */
+export async function writeInstallManifestUnderActivation(
+  partial: WriteInstallManifestInput,
+  layout: InstallLayoutPaths = getInstallLayoutPaths({ launcherPath: partial.launcherPath }),
+): Promise<void> {
+  validateWriteProvenance(partial);
   const activeVersion = parseCanonicalVersion(partial.activeVersion);
   if (!activeVersion) {
     throw new Error(`Invalid install manifest version: ${partial.activeVersion}`);
   }
 
-  const layout = getInstallLayoutPaths({
-    configDir,
+  // Ownership validation remains based on the persisted config/launcher pair;
+  // the supplied full layout selects the publication lock root. In production
+  // those roots agree, while isolated tests can use a writable lock root
+  // without teaching a config-only reader an unverifiable dataDir override.
+  const ownershipLayout = getInstallLayoutPaths({
+    configDir: layout.configDir,
     launcherPath: partial.launcherPath,
   });
-  const managedPaths = partial.managedPaths ?? deriveManagedPaths(partial.method, layout);
-  if (!managedPathsAreSafe(managedPaths, layout, partial.method)) {
+  const managedPaths = partial.managedPaths ?? deriveManagedPaths(partial.method, ownershipLayout);
+  if (!managedPathsAreSafe(managedPaths, ownershipLayout, partial.method)) {
     throw new Error("Refusing to write install manifest with unsafe managedPaths");
   }
 
@@ -235,7 +266,7 @@ export async function writeInstallManifest(
     }
   }
 
-  const existing = await inspectInstallManifest(configDir);
+  const existing = await inspectInstallManifest(layout.configDir);
   const now = new Date().toISOString();
   const installedAt = existing.status === "loaded" ? existing.manifest.installedAt : now;
 
@@ -267,7 +298,49 @@ export async function writeInstallManifest(
     ...(partial.archiveSourceUrl ? { archiveSourceUrl: partial.archiveSourceUrl } : {}),
   };
 
-  await persistManifest(full, configDir);
+  await persistManifest(full, layout.configDir);
+}
+
+function validateWriteProvenance(partial: WriteInstallManifestInput): void {
+  if (!archiveProvenanceComplete(partial)) {
+    throw new Error("Archive provenance must include name, checksum, size, and source URL");
+  }
+  if (!archiveHasArtifactProvenance(partial)) {
+    throw new Error("Archive installs must include extracted binary provenance");
+  }
+  if (
+    !optionalString(partial.artifactName) ||
+    !optionalSha256(partial.artifactSha256) ||
+    !optionalSize(partial.artifactSizeBytes) ||
+    !optionalString(partial.artifactSourceUrl) ||
+    !optionalString(partial.archiveName) ||
+    !optionalSha256(partial.archiveSha256) ||
+    !optionalSize(partial.archiveSizeBytes) ||
+    !optionalString(partial.archiveSourceUrl)
+  ) {
+    throw new Error("Invalid install manifest artifact provenance");
+  }
+}
+
+/** Startup-only wrapper: expected contention is quiet; corrupt state and I/O fail nonfatally. */
+export async function migrateInstallManifestAtStartup(
+  options: {
+    readonly migrate?: () => Promise<InstallManifestMigrationResult>;
+    readonly warn?: (message: string) => void;
+  } = {},
+): Promise<void> {
+  const migrate = options.migrate ?? (() => migrateInstallManifest());
+  const warn = options.warn ?? ((message: string) => console.warn(message));
+  try {
+    const result = await migrate();
+    if (result.status === "invalid") {
+      warn(`Kunai install manifest migration skipped invalid install.json (${result.reason}).`);
+    }
+  } catch (error) {
+    warn(
+      `Kunai install manifest migration failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }
 
 function joinManifestPath(configDir: string): string {
@@ -339,7 +412,14 @@ function inspectCurrentSchema(
   if (!archiveProvenanceComplete(record)) {
     return { status: "invalid", reason: "invalid-shape" };
   }
-  if (!archiveHasArtifactProvenance(record)) {
+  const predecessorArtifactSourceUrl =
+    schemaVersion === INSTALL_MANIFEST_SCHEMA_VERSION &&
+    record.archiveName !== undefined &&
+    record.artifactSourceUrl === undefined &&
+    typeof record.artifactName === "string"
+      ? `${record.downloadBaseUrl.replace(/\/+$/, "")}/download/v${record.activeVersion}/${record.artifactName}`
+      : undefined;
+  if (!archiveHasArtifactProvenance(record, predecessorArtifactSourceUrl !== undefined)) {
     return { status: "invalid", reason: "invalid-shape" };
   }
   if (!optionalString(record.artifactName) || !optionalSha256(record.artifactSha256)) {
@@ -393,7 +473,9 @@ function inspectCurrentSchema(
       : {}),
     ...(typeof record.artifactSourceUrl === "string"
       ? { artifactSourceUrl: record.artifactSourceUrl }
-      : {}),
+      : predecessorArtifactSourceUrl
+        ? { artifactSourceUrl: predecessorArtifactSourceUrl }
+        : {}),
     ...(typeof record.archiveName === "string" ? { archiveName: record.archiveName } : {}),
     ...(typeof record.archiveSha256 === "string" ? { archiveSha256: record.archiveSha256 } : {}),
     ...(typeof record.archiveSizeBytes === "number"
@@ -404,7 +486,11 @@ function inspectCurrentSchema(
       : {}),
   };
 
-  return { status: "loaded", needsMigration: schemaVersion === 1, manifest };
+  return {
+    status: "loaded",
+    needsMigration: schemaVersion === 1 || predecessorArtifactSourceUrl !== undefined,
+    manifest,
+  };
 }
 
 function inspectLegacySchema(
@@ -506,13 +592,16 @@ function archiveProvenanceComplete(value: {
   return present === 0 || present === fields.length;
 }
 
-function archiveHasArtifactProvenance(value: {
-  readonly archiveName?: unknown;
-  readonly artifactName?: unknown;
-  readonly artifactSha256?: unknown;
-  readonly artifactSizeBytes?: unknown;
-  readonly artifactSourceUrl?: unknown;
-}): boolean {
+function archiveHasArtifactProvenance(
+  value: {
+    readonly archiveName?: unknown;
+    readonly artifactName?: unknown;
+    readonly artifactSha256?: unknown;
+    readonly artifactSizeBytes?: unknown;
+    readonly artifactSourceUrl?: unknown;
+  },
+  allowMissingSourceUrl = false,
+): boolean {
   if (value.archiveName === undefined) return true;
   return (
     typeof value.artifactName === "string" &&
@@ -522,7 +611,7 @@ function archiveHasArtifactProvenance(value: {
     typeof value.artifactSizeBytes === "number" &&
     Number.isSafeInteger(value.artifactSizeBytes) &&
     value.artifactSizeBytes > 0 &&
-    typeof value.artifactSourceUrl === "string" &&
-    value.artifactSourceUrl.length > 0
+    (allowMissingSourceUrl ||
+      (typeof value.artifactSourceUrl === "string" && value.artifactSourceUrl.length > 0))
   );
 }

--- a/apps/cli/src/services/update/native-installer/activation-lock.ts
+++ b/apps/cli/src/services/update/native-installer/activation-lock.ts
@@ -40,6 +40,8 @@ export type ActivationLockOptions = {
   readonly corruptGraceMs?: number;
   /** Test seam for deterministic PID-reuse coverage. */
   readonly processStartIdLookup?: ProcessStartIdLookup;
+  /** Test/embedding seam fired once this acquisition request has started. */
+  readonly onAcquireAttempt?: () => void;
 };
 
 export type ActivationLockInspection =
@@ -351,6 +353,7 @@ export async function tryAcquireActivationLock(
   const canonical = parseCanonicalVersion(version);
   if (!canonical) throw new Error(`Invalid activation lock version: ${version}`);
 
+  options.onAcquireAttempt?.();
   const path = activationLockPath(layout);
   const timeoutMs = Math.max(0, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
   const deadlineAt = Date.now() + timeoutMs;

--- a/apps/cli/src/services/update/native-installer/activation-lock.ts
+++ b/apps/cli/src/services/update/native-installer/activation-lock.ts
@@ -465,6 +465,10 @@ async function tryAcquireActivationLockFromFilesystem(
       await quarantineForRelease(path, ownerId);
       continue;
     } catch (error) {
+      if (errorCode(error) === "ENOENT") {
+        await mkdir(dirname(path), { recursive: true });
+        continue;
+      }
       if (errorCode(error) !== "EEXIST") {
         throw new Error(`Could not create activation lock at ${path}`, { cause: error });
       }

--- a/apps/cli/src/services/update/native-installer/install-latest.ts
+++ b/apps/cli/src/services/update/native-installer/install-latest.ts
@@ -180,6 +180,8 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
           }
         }
 
+        let expectedArchive: string | null | undefined;
+        let archiveDownload: Awaited<ReturnType<typeof downloadToFile>> | undefined;
         if (
           archiveManifestAvailable &&
           releaseTarget &&
@@ -188,17 +190,36 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
           stagedArchive
         ) {
           const archiveSums = await readFile(stagedArchiveChecksums, "utf8");
-          const expectedArchive = pickChecksum(archiveSums, archiveName);
+          expectedArchive = pickChecksum(archiveSums, archiveName);
           if (!expectedArchive) throw new Error(`No checksum entry for ${archiveName}`);
-          const archiveDownload = await downloadToFile({
-            url: archiveUrl,
-            destinationPath: stagedArchive,
-            fetchImpl,
-            policy: {
-              ...DEFAULT_BINARY_DOWNLOAD_POLICY,
-              maxBytes: releaseTarget.maxArchiveBytes,
-            },
-          });
+          try {
+            archiveDownload = await downloadToFile({
+              url: archiveUrl,
+              destinationPath: stagedArchive,
+              fetchImpl,
+              policy: {
+                ...DEFAULT_BINARY_DOWNLOAD_POLICY,
+                maxBytes: releaseTarget.maxArchiveBytes,
+              },
+            });
+          } catch (error) {
+            if (error instanceof DownloadError && (error.status === 404 || error.status === 410)) {
+              archiveManifestAvailable = false;
+            } else {
+              throw error;
+            }
+          }
+        }
+
+        if (
+          archiveManifestAvailable &&
+          archiveDownload &&
+          expectedArchive &&
+          releaseTarget &&
+          archiveName &&
+          archiveUrl &&
+          stagedArchive
+        ) {
           if (!verifyChecksum(archiveDownload.sha256, expectedArchive)) {
             throw new Error(`Checksum mismatch for ${archiveName}`);
           }

--- a/apps/cli/src/services/update/native-installer/install-latest.ts
+++ b/apps/cli/src/services/update/native-installer/install-latest.ts
@@ -251,6 +251,16 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
           // Another version may have activated while this version downloaded.
           // Re-read shared state only after winning the cross-version lock.
           const activeManifest = await readInstallManifest(layout.configDir);
+          const ownershipChanged =
+            activeManifest?.method !== undefined && activeManifest.method !== "binary";
+          const nativeInstallWasRemoved = manifest !== null && activeManifest === null;
+          const nativeInstallWasNeverOwner =
+            manifest?.method !== undefined && manifest.method !== "binary";
+          if (ownershipChanged || nativeInstallWasRemoved || nativeInstallWasNeverOwner) {
+            throw new Error(
+              "Install ownership changed while downloading; refusing to replace a non-native publication",
+            );
+          }
           const launcherPath = activeManifest?.launcherPath ?? layout.launcherPath;
           const launcherSnapshot = await captureLauncherSnapshot(launcherPath);
           let preserveSnapshot = false;

--- a/apps/cli/src/services/update/native-installer/install-latest.ts
+++ b/apps/cli/src/services/update/native-installer/install-latest.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
@@ -17,6 +18,7 @@ import { cleanupOldVersions } from "./cleanup-versions";
 import {
   DEFAULT_BINARY_DOWNLOAD_POLICY,
   DEFAULT_CHECKSUM_DOWNLOAD_POLICY,
+  DownloadError,
   downloadToFile,
   type FetchLike,
 } from "./download";
@@ -36,6 +38,7 @@ import {
   updateLauncher,
 } from "./launcher";
 import { isMuslEnvironmentSync } from "./musl";
+import { extractReleaseArchive } from "./release-archive";
 import {
   beginInstallTransaction,
   cleanupAbandonedTransactions,
@@ -99,6 +102,9 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
   const tag = `v${resolved}`;
   const downloadUrl = `${dlBase}/download/${tag}/${assetName}`;
   const checksumUrl = `${dlBase}/download/${tag}/SHA256SUMS`;
+  const archiveName = releaseTarget?.archiveName;
+  const archiveUrl = archiveName ? `${dlBase}/download/${tag}/${archiveName}` : undefined;
+  const archiveChecksumUrl = `${dlBase}/download/${tag}/SHA256SUMS.archives`;
   const versionPath = versionBinaryPath(layout, resolved);
 
   if (!options.force && existsSync(versionPath) && manifest?.activeVersion === resolved) {
@@ -127,6 +133,8 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
 
       const stagedBinary = join(staging, assetName);
       const stagedChecksums = join(staging, "SHA256SUMS");
+      const stagedArchiveChecksums = join(staging, "SHA256SUMS.archives");
+      const stagedArchive = archiveName ? join(staging, archiveName) : undefined;
 
       try {
         await downloadToFile({
@@ -141,15 +149,89 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
           throw new Error(`No checksum entry for ${assetName}`);
         }
 
-        const downloaded = await downloadToFile({
-          url: downloadUrl,
-          destinationPath: stagedBinary,
-          fetchImpl,
-          policy: DEFAULT_BINARY_DOWNLOAD_POLICY,
-        });
+        let artifactSha256: string;
+        let artifactSizeBytes: number;
+        let artifactSourceUrl: string;
+        let archiveProvenance:
+          | {
+              readonly archiveName: string;
+              readonly archiveSha256: string;
+              readonly archiveSizeBytes: number;
+              readonly archiveSourceUrl: string;
+            }
+          | undefined;
 
-        if (!verifyChecksum(downloaded.sha256, expected)) {
-          throw new Error(`Checksum mismatch for ${assetName}`);
+        let archiveManifestAvailable = Boolean(
+          releaseTarget && archiveName && archiveUrl && stagedArchive,
+        );
+        if (archiveManifestAvailable) {
+          try {
+            await downloadToFile({
+              url: archiveChecksumUrl,
+              destinationPath: stagedArchiveChecksums,
+              fetchImpl,
+              policy: DEFAULT_CHECKSUM_DOWNLOAD_POLICY,
+            });
+          } catch (error) {
+            if (error instanceof DownloadError && (error.status === 404 || error.status === 410)) {
+              archiveManifestAvailable = false;
+            } else {
+              throw error;
+            }
+          }
+        }
+
+        if (
+          archiveManifestAvailable &&
+          releaseTarget &&
+          archiveName &&
+          archiveUrl &&
+          stagedArchive
+        ) {
+          const archiveSums = await readFile(stagedArchiveChecksums, "utf8");
+          const expectedArchive = pickChecksum(archiveSums, archiveName);
+          if (!expectedArchive) throw new Error(`No checksum entry for ${archiveName}`);
+          const archiveDownload = await downloadToFile({
+            url: archiveUrl,
+            destinationPath: stagedArchive,
+            fetchImpl,
+            policy: {
+              ...DEFAULT_BINARY_DOWNLOAD_POLICY,
+              maxBytes: releaseTarget.maxArchiveBytes,
+            },
+          });
+          if (!verifyChecksum(archiveDownload.sha256, expectedArchive)) {
+            throw new Error(`Checksum mismatch for ${archiveName}`);
+          }
+
+          const archiveBytes = new Uint8Array(await Bun.file(stagedArchive).arrayBuffer());
+          const binaryBytes = extractReleaseArchive(archiveBytes, releaseTarget);
+          artifactSha256 = createHash("sha256").update(binaryBytes).digest("hex");
+          artifactSizeBytes = binaryBytes.length;
+          artifactSourceUrl = archiveUrl;
+          if (!verifyChecksum(artifactSha256, expected)) {
+            throw new Error(`Checksum mismatch for extracted ${assetName}`);
+          }
+          await Bun.write(stagedBinary, binaryBytes);
+          archiveProvenance = {
+            archiveName,
+            archiveSha256: archiveDownload.sha256,
+            archiveSizeBytes: archiveDownload.sizeBytes,
+            archiveSourceUrl: archiveUrl,
+          };
+        } else {
+          const downloaded = await downloadToFile({
+            url: downloadUrl,
+            destinationPath: stagedBinary,
+            fetchImpl,
+            policy: DEFAULT_BINARY_DOWNLOAD_POLICY,
+          });
+          if (!verifyChecksum(downloaded.sha256, expected)) {
+            throw new Error(`Checksum mismatch for ${assetName}`);
+          }
+          artifactSha256 = downloaded.sha256;
+          artifactSizeBytes = downloaded.sizeBytes;
+          artifactSourceUrl = downloadUrl;
         }
 
         await mkdir(dirname(versionPath), { recursive: true });
@@ -160,9 +242,9 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
           version: resolved,
           target: releaseTarget?.id ?? `${os}-${arch}`,
           artifactName: assetName,
-          artifactSha256: downloaded.sha256,
-          sizeBytes: downloaded.sizeBytes,
-          sourceUrl: downloadUrl,
+          artifactSha256,
+          sizeBytes: artifactSizeBytes,
+          sourceUrl: artifactSourceUrl,
           verification: "release-checksum",
           installedAt: new Date().toISOString(),
         });
@@ -188,7 +270,10 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
                 versionedPath: versionPath,
                 downloadBaseUrl: dlBase,
                 target: releaseTarget?.id ?? `${os}-${arch}`,
-                artifactSha256: downloaded.sha256,
+                artifactName: assetName,
+                artifactSha256,
+                artifactSizeBytes,
+                ...archiveProvenance,
                 ...(activeManifest?.activeVersion && activeManifest.activeVersion !== resolved
                   ? { previousVersion: activeManifest.activeVersion }
                   : {}),

--- a/apps/cli/src/services/update/native-installer/install-latest.ts
+++ b/apps/cli/src/services/update/native-installer/install-latest.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
-import { readInstallManifest, writeInstallManifest } from "../install-manifest";
+import { readInstallManifest, writeInstallManifestUnderActivation } from "../install-manifest";
 import { fetchLatestVersion } from "../latest-version";
 import {
   detectPlatform,
@@ -260,7 +260,7 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
               launcherPath,
               versionPath,
             });
-            await writeInstallManifest(
+            await writeInstallManifestUnderActivation(
               {
                 method: "binary",
                 activeVersion: resolved,
@@ -277,7 +277,7 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
                   ? { previousVersion: activeManifest.activeVersion }
                   : {}),
               },
-              layout.configDir,
+              layout,
             );
           } catch (manifestError) {
             try {

--- a/apps/cli/src/services/update/native-installer/install-latest.ts
+++ b/apps/cli/src/services/update/native-installer/install-latest.ts
@@ -151,7 +151,6 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
 
         let artifactSha256: string;
         let artifactSizeBytes: number;
-        let artifactSourceUrl: string;
         let archiveProvenance:
           | {
               readonly archiveName: string;
@@ -208,7 +207,6 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
           const binaryBytes = extractReleaseArchive(archiveBytes, releaseTarget);
           artifactSha256 = createHash("sha256").update(binaryBytes).digest("hex");
           artifactSizeBytes = binaryBytes.length;
-          artifactSourceUrl = archiveUrl;
           if (!verifyChecksum(artifactSha256, expected)) {
             throw new Error(`Checksum mismatch for extracted ${assetName}`);
           }
@@ -231,7 +229,6 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
           }
           artifactSha256 = downloaded.sha256;
           artifactSizeBytes = downloaded.sizeBytes;
-          artifactSourceUrl = downloadUrl;
         }
 
         await mkdir(dirname(versionPath), { recursive: true });
@@ -244,7 +241,8 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
           artifactName: assetName,
           artifactSha256,
           sizeBytes: artifactSizeBytes,
-          sourceUrl: artifactSourceUrl,
+          sourceUrl: downloadUrl,
+          ...archiveProvenance,
           verification: "release-checksum",
           installedAt: new Date().toISOString(),
         });
@@ -273,6 +271,7 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
                 artifactName: assetName,
                 artifactSha256,
                 artifactSizeBytes,
+                artifactSourceUrl: downloadUrl,
                 ...archiveProvenance,
                 ...(activeManifest?.activeVersion && activeManifest.activeVersion !== resolved
                   ? { previousVersion: activeManifest.activeVersion }

--- a/apps/cli/src/services/update/native-installer/migrate-flat-install.ts
+++ b/apps/cli/src/services/update/native-installer/migrate-flat-install.ts
@@ -3,7 +3,7 @@ import { copyFile, mkdir, rename } from "node:fs/promises";
 
 import {
   readInstallManifest,
-  writeInstallManifest,
+  writeInstallManifestUnderActivation,
   type InstallManifest,
 } from "../install-manifest";
 import { parseCanonicalVersion } from "../version";
@@ -89,7 +89,7 @@ export async function migrateFlatInstall(input: {
 
       const downloadBaseUrl =
         activeManifest?.downloadBaseUrl ?? "https://github.com/KitsuneKode/kunai/releases";
-      await writeInstallManifest(
+      await writeInstallManifestUnderActivation(
         {
           method: "binary",
           activeVersion: version,
@@ -97,7 +97,7 @@ export async function migrateFlatInstall(input: {
           versionedPath: targetPath,
           downloadBaseUrl,
         },
-        layout.configDir,
+        layout,
       );
 
       return { migrated: true, versionPath: targetPath } as const;

--- a/apps/cli/src/services/update/native-installer/native-uninstall.ts
+++ b/apps/cli/src/services/update/native-installer/native-uninstall.ts
@@ -3,8 +3,10 @@ import { readdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 
 import {
+  inspectInstallManifest,
   isVersionedBinaryManifest,
   readInstallManifest,
+  sameInstallManifestPublication,
   type InstallManifest,
 } from "../install-manifest";
 import { getInstallLayoutPaths, type InstallLayoutPaths } from "./install-layout";
@@ -161,6 +163,20 @@ export async function nativeUninstall(
     ]);
   }
 
+  const currentManifest = await inspectInstallManifest(layout.configDir);
+  if (
+    currentManifest.status !== "loaded" ||
+    !sameInstallManifestPublication(currentManifest.manifest, manifest)
+  ) {
+    await lifecycle.release();
+    return blocked([
+      layout.launcherPath,
+      layout.versionsDir,
+      layout.configDir,
+      layout.dataDir,
+      layout.cacheDir,
+    ]);
+  }
   const transaction = await beginInstallTransaction(layout, {
     kind: "uninstall",
     version: manifest.activeVersion,

--- a/apps/cli/src/services/update/native-installer/release-archive.ts
+++ b/apps/cli/src/services/update/native-installer/release-archive.ts
@@ -1,0 +1,255 @@
+import { gunzipSync, inflateRawSync } from "node:zlib";
+
+import type { ReleaseBinaryTarget } from "../platform-assets";
+
+const TAR_BLOCK_BYTES = 512;
+const TAR_TRAILER_BYTES = TAR_BLOCK_BYTES * 2;
+const ZIP_LOCAL_SIGNATURE = 0x04034b50;
+const ZIP_CENTRAL_SIGNATURE = 0x02014b50;
+const ZIP_END_SIGNATURE = 0x06054b50;
+const ZIP_END_MIN_BYTES = 22;
+const ZIP_MAX_COMMENT_BYTES = 0xffff;
+const ZIP_FLAG_ENCRYPTED = 0x0001;
+const ZIP_FLAG_DATA_DESCRIPTOR = 0x0008;
+const ZIP_FLAG_UTF8 = 0x0800;
+
+const CRC32_TABLE = Uint32Array.from({ length: 256 }, (_, value) => {
+  let crc = value;
+  for (let bit = 0; bit < 8; bit++) {
+    crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return crc >>> 0;
+});
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc = (crc >>> 8) ^ (CRC32_TABLE[(crc ^ byte) & 0xff] ?? 0);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function decodeNullTerminated(bytes: Uint8Array): string {
+  const end = bytes.indexOf(0);
+  return new TextDecoder("utf-8", { fatal: true }).decode(
+    end === -1 ? bytes : bytes.subarray(0, end),
+  );
+}
+
+function assertExpectedEntryName(name: string, target: ReleaseBinaryTarget): void {
+  if (!name || name === "." || name === ".." || name.includes("/") || name.includes("\\")) {
+    throw new Error(`Archive contains unsafe traversal entry: ${JSON.stringify(name)}`);
+  }
+  if (name !== target.archiveEntryName) {
+    throw new Error(
+      `Archive contains unexpected entry ${JSON.stringify(name)}; expected ${target.archiveEntryName}`,
+    );
+  }
+}
+
+function parseTarOctal(field: Uint8Array, label: string): number {
+  const text = decodeNullTerminated(field).trim();
+  if (!/^[0-7]+$/.test(text)) throw new Error(`Invalid tar ${label}`);
+  const value = Number.parseInt(text, 8);
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error(`Invalid tar ${label}`);
+  return value;
+}
+
+function isZeroBlock(bytes: Uint8Array): boolean {
+  return bytes.every((byte) => byte === 0);
+}
+
+function extractTarGz(archive: Uint8Array, target: ReleaseBinaryTarget): Uint8Array {
+  const paddedBudget = Math.ceil(target.maxBinaryBytes / TAR_BLOCK_BYTES) * TAR_BLOCK_BYTES;
+  const outputBudget = TAR_BLOCK_BYTES + paddedBudget + TAR_TRAILER_BYTES;
+  let tar: Uint8Array;
+  try {
+    tar = new Uint8Array(gunzipSync(archive, { maxOutputLength: outputBudget }));
+  } catch (error) {
+    throw new Error(`Archive decompression exceeded the binary output budget or is invalid`, {
+      cause: error,
+    });
+  }
+  if (tar.length < TAR_BLOCK_BYTES + TAR_TRAILER_BYTES || tar.length % TAR_BLOCK_BYTES !== 0) {
+    throw new Error("Invalid tar container size");
+  }
+
+  let offset = 0;
+  let extracted: Uint8Array | undefined;
+  let sawTrailer = false;
+  while (offset + TAR_BLOCK_BYTES <= tar.length) {
+    const header = tar.subarray(offset, offset + TAR_BLOCK_BYTES);
+    if (isZeroBlock(header)) {
+      const second = tar.subarray(offset + TAR_BLOCK_BYTES, offset + TAR_TRAILER_BYTES);
+      if (second.length !== TAR_BLOCK_BYTES || !isZeroBlock(second)) {
+        throw new Error("Tar archive is missing its two-block trailer");
+      }
+      if (!isZeroBlock(tar.subarray(offset + TAR_TRAILER_BYTES))) {
+        throw new Error("Tar archive contains data after its trailer");
+      }
+      sawTrailer = true;
+      break;
+    }
+    if (extracted) throw new Error("Release archive must contain exactly one regular file");
+
+    const storedChecksum = parseTarOctal(header.subarray(148, 156), "header checksum");
+    const checksumHeader = new Uint8Array(header);
+    checksumHeader.fill(0x20, 148, 156);
+    const actualChecksum = checksumHeader.reduce((sum, byte) => sum + byte, 0);
+    if (storedChecksum !== actualChecksum) throw new Error("Invalid tar header checksum");
+
+    const name = decodeNullTerminated(header.subarray(0, 100));
+    if (!isZeroBlock(header.subarray(345, 500))) {
+      throw new Error("Tar path prefixes are forbidden");
+    }
+    assertExpectedEntryName(name, target);
+    const type = header[156];
+    if (type !== 0 && type !== 0x30) {
+      throw new Error("Release archive entry must be a regular file; links are forbidden");
+    }
+    const size = parseTarOctal(header.subarray(124, 136), "entry size");
+    if (size <= 0 || size > target.maxBinaryBytes) {
+      throw new Error(
+        `Extracted binary size ${size} exceeds the ${target.maxBinaryBytes} byte budget`,
+      );
+    }
+    const bodyStart = offset + TAR_BLOCK_BYTES;
+    const bodyEnd = bodyStart + size;
+    if (bodyEnd > tar.length) throw new Error("Tar entry is truncated");
+    extracted = tar.slice(bodyStart, bodyEnd);
+    offset = bodyStart + Math.ceil(size / TAR_BLOCK_BYTES) * TAR_BLOCK_BYTES;
+  }
+
+  if (!sawTrailer) throw new Error("Tar archive is missing its two-block trailer");
+  if (!extracted) throw new Error("Release archive must contain exactly one regular file");
+  return extracted;
+}
+
+function findZipEnd(archive: Uint8Array): number {
+  const view = new DataView(archive.buffer, archive.byteOffset, archive.byteLength);
+  const minimum = Math.max(0, archive.length - ZIP_END_MIN_BYTES - ZIP_MAX_COMMENT_BYTES);
+  for (let offset = archive.length - ZIP_END_MIN_BYTES; offset >= minimum; offset--) {
+    if (view.getUint32(offset, true) === ZIP_END_SIGNATURE) return offset;
+  }
+  throw new Error("Zip archive is missing its end record");
+}
+
+function extractZip(archive: Uint8Array, target: ReleaseBinaryTarget): Uint8Array {
+  if (archive.length < ZIP_END_MIN_BYTES) throw new Error("Zip archive is truncated");
+  const view = new DataView(archive.buffer, archive.byteOffset, archive.byteLength);
+  const end = findZipEnd(archive);
+  const commentLength = view.getUint16(end + 20, true);
+  if (end + ZIP_END_MIN_BYTES + commentLength !== archive.length) {
+    throw new Error("Zip archive contains trailing data");
+  }
+  if (view.getUint16(end + 4, true) !== 0 || view.getUint16(end + 6, true) !== 0) {
+    throw new Error("Multi-disk zip archives are not supported");
+  }
+  const diskEntries = view.getUint16(end + 8, true);
+  const totalEntries = view.getUint16(end + 10, true);
+  if (diskEntries !== 1 || totalEntries !== 1) {
+    throw new Error("Release archive must contain exactly one regular file");
+  }
+  const centralSize = view.getUint32(end + 12, true);
+  const centralOffset = view.getUint32(end + 16, true);
+  if (centralOffset + centralSize !== end || centralOffset < 30) {
+    throw new Error("Invalid zip central directory bounds");
+  }
+  if (view.getUint32(centralOffset, true) !== ZIP_CENTRAL_SIGNATURE) {
+    throw new Error("Invalid zip central directory");
+  }
+
+  const flags = view.getUint16(centralOffset + 8, true);
+  if ((flags & (ZIP_FLAG_ENCRYPTED | ZIP_FLAG_DATA_DESCRIPTOR)) !== 0) {
+    throw new Error("Encrypted or data-descriptor zip entries are forbidden");
+  }
+  if ((flags & ~ZIP_FLAG_UTF8) !== 0) throw new Error("Unsupported zip entry flags");
+  const method = view.getUint16(centralOffset + 10, true);
+  if (method !== 0 && method !== 8) throw new Error(`Unsupported zip compression method ${method}`);
+  const expectedCrc = view.getUint32(centralOffset + 16, true);
+  const compressedSize = view.getUint32(centralOffset + 20, true);
+  const binarySize = view.getUint32(centralOffset + 24, true);
+  if (binarySize <= 0 || binarySize > target.maxBinaryBytes) {
+    throw new Error(
+      `Extracted binary size ${binarySize} exceeds the ${target.maxBinaryBytes} byte budget`,
+    );
+  }
+  const centralNameLength = view.getUint16(centralOffset + 28, true);
+  const centralExtraLength = view.getUint16(centralOffset + 30, true);
+  const centralCommentLength = view.getUint16(centralOffset + 32, true);
+  if (centralOffset + 46 + centralNameLength + centralExtraLength + centralCommentLength !== end) {
+    throw new Error("Zip central directory contains unexpected records");
+  }
+  const centralName = new TextDecoder("utf-8", { fatal: true }).decode(
+    archive.subarray(centralOffset + 46, centralOffset + 46 + centralNameLength),
+  );
+  assertExpectedEntryName(centralName, target);
+  const externalAttributes = view.getUint32(centralOffset + 38, true);
+  const unixType = (externalAttributes >>> 16) & 0o170000;
+  if (unixType !== 0 && unixType !== 0o100000) {
+    throw new Error("Release archive entry must be a regular file; symlinks are forbidden");
+  }
+  if ((externalAttributes & 0x10) !== 0) throw new Error("Zip directory entries are forbidden");
+
+  const localOffset = view.getUint32(centralOffset + 42, true);
+  if (localOffset !== 0 || view.getUint32(localOffset, true) !== ZIP_LOCAL_SIGNATURE) {
+    throw new Error("Zip archive contains an unsafe prefix or invalid local entry");
+  }
+  const localFlags = view.getUint16(localOffset + 6, true);
+  const localMethod = view.getUint16(localOffset + 8, true);
+  const localCrc = view.getUint32(localOffset + 14, true);
+  const localCompressedSize = view.getUint32(localOffset + 18, true);
+  const localBinarySize = view.getUint32(localOffset + 22, true);
+  const localNameLength = view.getUint16(localOffset + 26, true);
+  const localExtraLength = view.getUint16(localOffset + 28, true);
+  if (
+    localFlags !== flags ||
+    localMethod !== method ||
+    localCrc !== expectedCrc ||
+    localCompressedSize !== compressedSize ||
+    localBinarySize !== binarySize
+  ) {
+    throw new Error("Zip local entry does not match its central record");
+  }
+  const localName = new TextDecoder("utf-8", { fatal: true }).decode(
+    archive.subarray(localOffset + 30, localOffset + 30 + localNameLength),
+  );
+  if (localName !== centralName) throw new Error("Zip entry names do not match");
+  const bodyStart = localOffset + 30 + localNameLength + localExtraLength;
+  const bodyEnd = bodyStart + compressedSize;
+  if (bodyEnd !== centralOffset) throw new Error("Zip archive contains unexpected local records");
+
+  const compressed = archive.subarray(bodyStart, bodyEnd);
+  let binary: Uint8Array;
+  try {
+    binary =
+      method === 0
+        ? new Uint8Array(compressed)
+        : new Uint8Array(inflateRawSync(compressed, { maxOutputLength: target.maxBinaryBytes }));
+  } catch (error) {
+    throw new Error("Zip decompression exceeded the binary output budget or is invalid", {
+      cause: error,
+    });
+  }
+  if (binary.length !== binarySize) throw new Error("Zip entry decompressed size mismatch");
+  if (crc32(binary) !== expectedCrc) throw new Error("Zip entry CRC mismatch");
+  return binary;
+}
+
+/**
+ * Parse a release archive in-process and return its only verified regular-file
+ * member. No platform extractor is invoked, so archive names never become argv.
+ */
+export function extractReleaseArchive(
+  archive: Uint8Array,
+  target: ReleaseBinaryTarget,
+): Uint8Array {
+  if (archive.length <= 0 || archive.length > target.maxArchiveBytes) {
+    throw new Error(
+      `Release archive size ${archive.length} exceeds the ${target.maxArchiveBytes} byte budget`,
+    );
+  }
+  return target.archiveFormat === "zip"
+    ? extractZip(archive, target)
+    : extractTarGz(archive, target);
+}

--- a/apps/cli/src/services/update/native-installer/rollback.ts
+++ b/apps/cli/src/services/update/native-installer/rollback.ts
@@ -2,11 +2,7 @@ import { existsSync } from "node:fs";
 import { readdir, readlink } from "node:fs/promises";
 import { join } from "node:path";
 
-import {
-  readInstallManifest,
-  writeInstallManifestUnderActivation,
-  type InstallManifest,
-} from "../install-manifest";
+import { readInstallManifest, writeInstallManifestUnderActivation } from "../install-manifest";
 import { parseCanonicalVersion } from "../version";
 import { withActivationLock } from "./activation-lock";
 import {
@@ -46,6 +42,7 @@ export type RollbackRefuseCode =
   | "missing"
   | "corrupt"
   | "locked"
+  | "ownership-changed"
   | "not-candidate";
 
 export type RollbackPlanResult =
@@ -76,6 +73,8 @@ export type RollbackOptions = {
   readonly layout?: InstallLayoutPaths;
   /** Test/embedding seam; production uses the shared lock default. */
   readonly activationLockTimeoutMs?: number;
+  /** Test/embedding seam fired when rollback starts activation acquisition. */
+  readonly onActivationAcquireAttempt?: () => void;
 };
 
 async function listInstalledVersions(
@@ -333,7 +332,18 @@ export async function executeRollback(
             layout,
             candidate.version,
             async () => {
-              const manifest = (await readInstallManifest(layout.configDir)) as InstallManifest;
+              const manifest = await readInstallManifest(layout.configDir);
+              if (
+                !manifest ||
+                manifest.method !== "binary" ||
+                manifest.activeVersion !== plan.fromVersion
+              ) {
+                return {
+                  status: "refused" as const,
+                  code: "ownership-changed" as const,
+                  reason: "Install ownership changed after rollback planning; refusing activation",
+                };
+              }
               if (manifest.activeVersion === candidate.version) {
                 return {
                   status: "refused" as const,
@@ -348,30 +358,34 @@ export async function executeRollback(
 
               await updateLauncher({
                 launcherPath: manifest.launcherPath,
-                versionPath: candidate.versionPath,
+                versionPath: versionBinaryPath(layout, reverify.metadata.version),
               });
 
               try {
                 await writeInstallManifestUnderActivation(
                   {
                     method: "binary",
-                    activeVersion: candidate.version,
+                    activeVersion: reverify.metadata.version,
                     previousVersion: manifest.activeVersion,
                     launcherPath: manifest.launcherPath,
-                    versionedPath: candidate.versionPath,
+                    versionedPath: versionBinaryPath(layout, reverify.metadata.version),
                     downloadBaseUrl: manifest.downloadBaseUrl,
-                    target: candidate.target,
-                    artifactName: candidate.artifactName,
-                    artifactSha256: candidate.artifactSha256,
-                    artifactSizeBytes: candidate.sizeBytes,
-                    artifactSourceUrl: candidate.sourceUrl,
-                    ...(candidate.archiveName ? { archiveName: candidate.archiveName } : {}),
-                    ...(candidate.archiveSha256 ? { archiveSha256: candidate.archiveSha256 } : {}),
-                    ...(candidate.archiveSizeBytes !== undefined
-                      ? { archiveSizeBytes: candidate.archiveSizeBytes }
+                    target: reverify.metadata.target,
+                    artifactName: reverify.metadata.artifactName,
+                    artifactSha256: reverify.metadata.artifactSha256,
+                    artifactSizeBytes: reverify.metadata.sizeBytes,
+                    artifactSourceUrl: reverify.metadata.sourceUrl,
+                    ...(reverify.metadata.archiveName
+                      ? { archiveName: reverify.metadata.archiveName }
                       : {}),
-                    ...(candidate.archiveSourceUrl
-                      ? { archiveSourceUrl: candidate.archiveSourceUrl }
+                    ...(reverify.metadata.archiveSha256
+                      ? { archiveSha256: reverify.metadata.archiveSha256 }
+                      : {}),
+                    ...(reverify.metadata.archiveSizeBytes !== undefined
+                      ? { archiveSizeBytes: reverify.metadata.archiveSizeBytes }
+                      : {}),
+                    ...(reverify.metadata.archiveSourceUrl
+                      ? { archiveSourceUrl: reverify.metadata.archiveSourceUrl }
                       : {}),
                     managedPaths: manifest.managedPaths,
                     ...(manifest.observedProvenance
@@ -395,7 +409,10 @@ export async function executeRollback(
                 toVersion: candidate.version,
               };
             },
-            { timeoutMs: options.activationLockTimeoutMs },
+            {
+              timeoutMs: options.activationLockTimeoutMs,
+              onAcquireAttempt: options.onActivationAcquireAttempt,
+            },
           );
 
           if (activated === null) {

--- a/apps/cli/src/services/update/native-installer/rollback.ts
+++ b/apps/cli/src/services/update/native-installer/rollback.ts
@@ -23,8 +23,14 @@ export interface RollbackCandidate {
   readonly version: string;
   readonly versionPath: string;
   readonly target: string;
+  readonly artifactName: string;
   readonly artifactSha256: string;
   readonly sizeBytes: number;
+  readonly sourceUrl: string;
+  readonly archiveName?: string;
+  readonly archiveSha256?: string;
+  readonly archiveSizeBytes?: number;
+  readonly archiveSourceUrl?: string;
   readonly installedAt: string;
   readonly active: boolean;
   readonly previous: boolean;
@@ -108,8 +114,22 @@ export async function listRollbackCandidates(
       version,
       versionPath: versionBinaryPath(layout, version),
       target: verification.metadata.target,
+      artifactName: verification.metadata.artifactName,
       artifactSha256: verification.metadata.artifactSha256,
       sizeBytes: verification.metadata.sizeBytes,
+      sourceUrl: verification.metadata.sourceUrl,
+      ...(verification.metadata.archiveName
+        ? { archiveName: verification.metadata.archiveName }
+        : {}),
+      ...(verification.metadata.archiveSha256
+        ? { archiveSha256: verification.metadata.archiveSha256 }
+        : {}),
+      ...(verification.metadata.archiveSizeBytes !== undefined
+        ? { archiveSizeBytes: verification.metadata.archiveSizeBytes }
+        : {}),
+      ...(verification.metadata.archiveSourceUrl
+        ? { archiveSourceUrl: verification.metadata.archiveSourceUrl }
+        : {}),
       installedAt: verification.metadata.installedAt,
       active: manifest?.activeVersion === version,
       previous: manifest?.previousVersion === version,
@@ -341,7 +361,18 @@ export async function executeRollback(
                     versionedPath: candidate.versionPath,
                     downloadBaseUrl: manifest.downloadBaseUrl,
                     target: candidate.target,
+                    artifactName: candidate.artifactName,
                     artifactSha256: candidate.artifactSha256,
+                    artifactSizeBytes: candidate.sizeBytes,
+                    artifactSourceUrl: candidate.sourceUrl,
+                    ...(candidate.archiveName ? { archiveName: candidate.archiveName } : {}),
+                    ...(candidate.archiveSha256 ? { archiveSha256: candidate.archiveSha256 } : {}),
+                    ...(candidate.archiveSizeBytes !== undefined
+                      ? { archiveSizeBytes: candidate.archiveSizeBytes }
+                      : {}),
+                    ...(candidate.archiveSourceUrl
+                      ? { archiveSourceUrl: candidate.archiveSourceUrl }
+                      : {}),
                     managedPaths: manifest.managedPaths,
                     ...(manifest.observedProvenance
                       ? { observedProvenance: manifest.observedProvenance }

--- a/apps/cli/src/services/update/native-installer/rollback.ts
+++ b/apps/cli/src/services/update/native-installer/rollback.ts
@@ -2,7 +2,12 @@ import { existsSync } from "node:fs";
 import { readdir, readlink } from "node:fs/promises";
 import { join } from "node:path";
 
-import { readInstallManifest, writeInstallManifestUnderActivation } from "../install-manifest";
+import {
+  readInstallManifest,
+  sameInstallManifestPublication,
+  writeInstallManifestUnderActivation,
+  type InstallManifest,
+} from "../install-manifest";
 import { parseCanonicalVersion } from "../version";
 import { withActivationLock } from "./activation-lock";
 import {
@@ -49,6 +54,7 @@ export type RollbackPlanResult =
   | {
       readonly status: "ready";
       readonly fromVersion: string;
+      readonly fromManifest: InstallManifest;
       readonly candidate: RollbackCandidate;
     }
   | {
@@ -256,6 +262,7 @@ export async function planRollback(
   return {
     status: "ready",
     fromVersion: manifest.activeVersion,
+    fromManifest: manifest,
     candidate,
   };
 }
@@ -333,11 +340,7 @@ export async function executeRollback(
             candidate.version,
             async () => {
               const manifest = await readInstallManifest(layout.configDir);
-              if (
-                !manifest ||
-                manifest.method !== "binary" ||
-                manifest.activeVersion !== plan.fromVersion
-              ) {
+              if (!manifest || !sameInstallManifestPublication(manifest, plan.fromManifest)) {
                 return {
                   status: "refused" as const,
                   code: "ownership-changed" as const,

--- a/apps/cli/src/services/update/native-installer/rollback.ts
+++ b/apps/cli/src/services/update/native-installer/rollback.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import {
   readInstallManifest,
-  writeInstallManifest,
+  writeInstallManifestUnderActivation,
   type InstallManifest,
 } from "../install-manifest";
 import { parseCanonicalVersion } from "../version";
@@ -352,7 +352,7 @@ export async function executeRollback(
               });
 
               try {
-                await writeInstallManifest(
+                await writeInstallManifestUnderActivation(
                   {
                     method: "binary",
                     activeVersion: candidate.version,
@@ -378,7 +378,7 @@ export async function executeRollback(
                       ? { observedProvenance: manifest.observedProvenance }
                       : {}),
                   },
-                  layout.configDir,
+                  layout,
                 );
               } catch (manifestError) {
                 await restoreLauncher(

--- a/apps/cli/src/services/update/native-installer/version-metadata.ts
+++ b/apps/cli/src/services/update/native-installer/version-metadata.ts
@@ -16,6 +16,10 @@ export interface InstalledVersionMetadata {
   readonly artifactSha256: string;
   readonly sizeBytes: number;
   readonly sourceUrl: string;
+  readonly archiveName?: string;
+  readonly archiveSha256?: string;
+  readonly archiveSizeBytes?: number;
+  readonly archiveSourceUrl?: string;
   readonly verification: "release-checksum" | "legacy-unverified";
   readonly installedAt: string;
 }
@@ -39,6 +43,27 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.length > 0;
 }
 
+function archiveProvenanceIsValid(value: Record<string, unknown>): boolean {
+  const fields = [
+    value.archiveName,
+    value.archiveSha256,
+    value.archiveSizeBytes,
+    value.archiveSourceUrl,
+  ];
+  const present = fields.filter((field) => field !== undefined).length;
+  if (present === 0) return true;
+  return (
+    present === fields.length &&
+    isNonEmptyString(value.archiveName) &&
+    isNonEmptyString(value.archiveSha256) &&
+    /^[a-fA-F0-9]{64}$/.test(value.archiveSha256) &&
+    typeof value.archiveSizeBytes === "number" &&
+    Number.isSafeInteger(value.archiveSizeBytes) &&
+    value.archiveSizeBytes > 0 &&
+    isNonEmptyString(value.archiveSourceUrl)
+  );
+}
+
 function parseMetadata(raw: unknown): InstalledVersionMetadata | null {
   if (!raw || typeof raw !== "object") return null;
   const value = raw as Record<string, unknown>;
@@ -57,6 +82,7 @@ function parseMetadata(raw: unknown): InstalledVersionMetadata | null {
     return null;
   }
   if (!isNonEmptyString(value.sourceUrl)) return null;
+  if (!archiveProvenanceIsValid(value)) return null;
   if (typeof value.verification !== "string" || !VERIFICATIONS.has(value.verification)) {
     return null;
   }
@@ -72,6 +98,16 @@ function parseMetadata(raw: unknown): InstalledVersionMetadata | null {
     artifactSha256: value.artifactSha256.toLowerCase(),
     sizeBytes: value.sizeBytes,
     sourceUrl: value.sourceUrl,
+    ...(typeof value.archiveName === "string" ? { archiveName: value.archiveName } : {}),
+    ...(typeof value.archiveSha256 === "string"
+      ? { archiveSha256: value.archiveSha256.toLowerCase() }
+      : {}),
+    ...(typeof value.archiveSizeBytes === "number"
+      ? { archiveSizeBytes: value.archiveSizeBytes }
+      : {}),
+    ...(typeof value.archiveSourceUrl === "string"
+      ? { archiveSourceUrl: value.archiveSourceUrl }
+      : {}),
     verification: value.verification as InstalledVersionMetadata["verification"],
     installedAt: value.installedAt,
   };
@@ -88,13 +124,13 @@ export async function writeInstalledVersionMetadata(
   if (metadata.schemaVersion !== 1) {
     throw new Error(`Unsupported version metadata schema: ${metadata.schemaVersion}`);
   }
+  const normalized = parseMetadata({ ...metadata, version: canonical });
+  if (!normalized) {
+    throw new Error("Installed version metadata failed schema validation");
+  }
   const path = versionMetadataPath(layout, canonical);
   await mkdir(dirname(path), { recursive: true });
-  await writeAtomicJson(path, {
-    ...metadata,
-    version: canonical,
-    artifactSha256: metadata.artifactSha256.toLowerCase(),
-  });
+  await writeAtomicJson(path, normalized);
 }
 
 export async function verifyStoredVersion(

--- a/apps/cli/src/services/update/native-installer/version-metadata.ts
+++ b/apps/cli/src/services/update/native-installer/version-metadata.ts
@@ -5,6 +5,7 @@ import { dirname } from "node:path";
 
 import { writeAtomicJson } from "@/infra/fs/atomic-write";
 
+import type { InstallManifest } from "../install-manifest";
 import { parseCanonicalVersion } from "../version";
 import { versionBinaryPath, versionMetadataPath, type InstallLayoutPaths } from "./install-layout";
 
@@ -131,6 +132,72 @@ export async function writeInstalledVersionMetadata(
   const path = versionMetadataPath(layout, canonical);
   await mkdir(dirname(path), { recursive: true });
   await writeAtomicJson(path, normalized);
+}
+
+/**
+ * Repair the exact archive metadata shape emitted before version.json carried
+ * transport provenance. The manifest migration owns both version and
+ * activation locks, so this cannot race a replacement publication.
+ */
+export async function migrateArchiveVersionMetadata(
+  layout: Pick<InstallLayoutPaths, "versionsDir" | "binaryFileName">,
+  manifest: Pick<
+    InstallManifest,
+    | "activeVersion"
+    | "artifactName"
+    | "artifactSha256"
+    | "artifactSizeBytes"
+    | "artifactSourceUrl"
+    | "archiveName"
+    | "archiveSha256"
+    | "archiveSizeBytes"
+    | "archiveSourceUrl"
+  >,
+): Promise<boolean> {
+  if (
+    !manifest.artifactName ||
+    !manifest.artifactSha256 ||
+    manifest.artifactSizeBytes === undefined ||
+    !manifest.artifactSourceUrl ||
+    !manifest.archiveName ||
+    !manifest.archiveSha256 ||
+    manifest.archiveSizeBytes === undefined ||
+    !manifest.archiveSourceUrl
+  ) {
+    return false;
+  }
+
+  const path = versionMetadataPath(layout, manifest.activeVersion);
+  if (!existsSync(path)) return false;
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(await readFile(path, "utf8"));
+  } catch {
+    return false;
+  }
+  const metadata = parseMetadata(raw);
+  if (
+    !metadata ||
+    metadata.version !== manifest.activeVersion ||
+    metadata.archiveName !== undefined ||
+    metadata.artifactName !== manifest.artifactName ||
+    metadata.artifactSha256 !== manifest.artifactSha256.toLowerCase() ||
+    metadata.sizeBytes !== manifest.artifactSizeBytes ||
+    metadata.sourceUrl !== manifest.archiveSourceUrl
+  ) {
+    return false;
+  }
+
+  await writeInstalledVersionMetadata(layout, {
+    ...metadata,
+    sourceUrl: manifest.artifactSourceUrl,
+    archiveName: manifest.archiveName,
+    archiveSha256: manifest.archiveSha256,
+    archiveSizeBytes: manifest.archiveSizeBytes,
+    archiveSourceUrl: manifest.archiveSourceUrl,
+  });
+  return true;
 }
 
 export async function verifyStoredVersion(

--- a/apps/cli/src/services/update/run-install.ts
+++ b/apps/cli/src/services/update/run-install.ts
@@ -3,7 +3,11 @@ import { join } from "node:path";
 
 import { joinerForNodePlatform } from "@kunai/storage";
 
-import { writeInstallManifest, type WriteInstallManifestInput } from "./install-manifest";
+import {
+  withInstallManifestPublication,
+  writeInstallManifestUnderActivation,
+  type WriteInstallManifestInput,
+} from "./install-manifest";
 import { checkInstall, getInstallDiagnostics, installLatest } from "./native-installer";
 import { DEFAULT_DL_BASE } from "./native-installer/install-layout";
 import { normalizeRequestedVersion, type CanonicalVersion } from "./version";
@@ -21,6 +25,7 @@ export interface RunInstallPorts {
     method: PackageInstallMethod,
   ) => Promise<PackageInstallEvidence | null>;
   readonly writeInstallManifest: (manifest: WriteInstallManifestInput) => Promise<void>;
+  readonly withManifestPublication: <T>(version: string, fn: () => Promise<T>) => Promise<T | null>;
 }
 
 export interface PackageInstallEvidence {
@@ -47,7 +52,8 @@ const defaultPorts: RunInstallPorts = {
     return proc.exited;
   },
   inspectPackageInstall,
-  writeInstallManifest,
+  writeInstallManifest: (manifest) => writeInstallManifestUnderActivation(manifest),
+  withManifestPublication: (version, fn) => withInstallManifestPublication(version, fn),
 };
 
 function parsePackageInstallVersion(value: string | undefined): PackageInstallVersion | null {
@@ -145,7 +151,8 @@ function isRunInstallPorts(value: unknown): value is RunInstallPorts {
   return (
     typeof candidate.runCommand === "function" &&
     typeof candidate.inspectPackageInstall === "function" &&
-    typeof candidate.writeInstallManifest === "function"
+    typeof candidate.writeInstallManifest === "function" &&
+    typeof candidate.withManifestPublication === "function"
   );
 }
 
@@ -214,30 +221,42 @@ export async function runInstall(
       return 1;
     }
 
-    const command = buildPackageInstallCommand(method, requestedVersion);
-    const code = await ports.runCommand(command);
-    if (code !== 0) return code;
+    const result = await ports.withManifestPublication(
+      requestedVersion === "latest" ? "0.0.0" : requestedVersion,
+      async () => {
+        const command = buildPackageInstallCommand(method, requestedVersion);
+        const code = await ports.runCommand(command);
+        if (code !== 0) return code;
 
-    const evidence = await ports.inspectPackageInstall(method);
-    const normalizedObserved = evidence ? normalizeRequestedVersion(evidence.version) : null;
-    if (!evidence || !normalizedObserved) {
-      console.error("Could not verify the installed Kunai version; install manifest not written.");
+        const evidence = await ports.inspectPackageInstall(method);
+        const normalizedObserved = evidence ? normalizeRequestedVersion(evidence.version) : null;
+        if (!evidence || !normalizedObserved) {
+          console.error(
+            "Could not verify the installed Kunai version; install manifest not written.",
+          );
+          return 1;
+        }
+        if (requestedVersion !== "latest" && normalizedObserved !== requestedVersion) {
+          console.error(
+            `Installed Kunai version ${normalizedObserved} does not match requested ${requestedVersion}; install manifest not written.`,
+          );
+          return 1;
+        }
+
+        await ports.writeInstallManifest({
+          method: method === "npm" ? "npm-global" : "bun-global",
+          activeVersion: normalizedObserved,
+          launcherPath: evidence.launcherPath,
+          downloadBaseUrl: DEFAULT_DL_BASE,
+        });
+        return 0;
+      },
+    );
+    if (result === null) {
+      console.error("Package install blocked: another launcher/manifest publication is active.");
       return 1;
     }
-    if (requestedVersion !== "latest" && normalizedObserved !== requestedVersion) {
-      console.error(
-        `Installed Kunai version ${normalizedObserved} does not match requested ${requestedVersion}; install manifest not written.`,
-      );
-      return 1;
-    }
-
-    await ports.writeInstallManifest({
-      method: method === "npm" ? "npm-global" : "bun-global",
-      activeVersion: normalizedObserved,
-      launcherPath: evidence.launcherPath,
-      downloadBaseUrl: DEFAULT_DL_BASE,
-    });
-    return 0;
+    return result;
   }
 
   if (method === "source") {

--- a/apps/cli/src/services/update/run-uninstall.ts
+++ b/apps/cli/src/services/update/run-uninstall.ts
@@ -12,7 +12,6 @@ import {
   type DetectInstallMethodInput,
   type InstallMethodKind,
 } from "./install-method";
-import { tryAcquireActivationLock } from "./native-installer/activation-lock";
 import { getInstallLayoutPaths, type InstallLayoutPaths } from "./native-installer/install-layout";
 import { nativeUninstall } from "./native-installer/native-uninstall";
 import { tryAcquireLifecycleLock } from "./native-installer/version-lock";
@@ -99,24 +98,19 @@ export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
       console.log("Left your config/history/cache in place. Re-run with --purge to remove them.");
       return 0;
     }
-    const purged = await withPurgeSafeUninstallOwnership(
-      layout,
-      manifest?.activeVersion ?? "0.0.0",
-      opts.force,
-      async () => {
-        const current = await inspectInstallManifest(layout.configDir);
-        if (
-          current.status === "invalid" ||
-          (current.status === "loaded" &&
-            (!manifest || !sameInstallManifestPublication(current.manifest, manifest)))
-        ) {
-          return false;
-        }
-        console.log(plan.message);
-        await purgeUserRoots(layout, opts.preservePaths, rmImpl);
-        return true;
-      },
-    );
+    const purged = await withPurgeSafeUninstallOwnership(layout, opts.force, async () => {
+      const current = await inspectInstallManifest(layout.configDir);
+      if (
+        current.status === "invalid" ||
+        (current.status === "loaded" &&
+          (!manifest || !sameInstallManifestPublication(current.manifest, manifest)))
+      ) {
+        return false;
+      }
+      console.log(plan.message);
+      await purgeUserRoots(layout, opts.preservePaths, rmImpl);
+      return true;
+    });
     if (!purged) {
       console.error("Uninstall blocked: install manifest changed or publication lock is active.");
       return 1;
@@ -127,28 +121,23 @@ export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
       opts.execImpl ??
       ((command: readonly string[]) =>
         Bun.spawn([...command], { stdout: "inherit", stderr: "inherit" }).exited);
-    const removed = await withPurgeSafeUninstallOwnership(
-      layout,
-      manifest?.activeVersion ?? "0.0.0",
-      opts.force,
-      async () => {
-        const current = await inspectInstallManifest(layout.configDir);
-        if (
-          current.status === "invalid" ||
-          (current.status === "loaded" &&
-            (!manifest || !sameInstallManifestPublication(current.manifest, manifest)))
-        ) {
-          return { status: "changed" as const };
-        }
-        const code = await execImpl(plan.command);
-        if (code !== 0) return { status: "failed" as const, code };
-        await rmImpl(join(layout.configDir, "install.json"), { force: true });
-        if (opts.purge) {
-          await purgeUserRoots(layout, opts.preservePaths, rmImpl);
-        }
-        return { status: "removed" as const };
-      },
-    );
+    const removed = await withPurgeSafeUninstallOwnership(layout, opts.force, async () => {
+      const current = await inspectInstallManifest(layout.configDir);
+      if (
+        current.status === "invalid" ||
+        (current.status === "loaded" &&
+          (!manifest || !sameInstallManifestPublication(current.manifest, manifest)))
+      ) {
+        return { status: "changed" as const };
+      }
+      const code = await execImpl(plan.command);
+      if (code !== 0) return { status: "failed" as const, code };
+      await rmImpl(join(layout.configDir, "install.json"), { force: true });
+      if (opts.purge) {
+        await purgeUserRoots(layout, opts.preservePaths, rmImpl);
+      }
+      return { status: "removed" as const };
+    });
     if (removed === null || removed.status === "changed") {
       console.error("Uninstall blocked: install manifest changed or publication lock is active.");
       return 1;
@@ -198,28 +187,23 @@ export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
     }
     return 0;
   } else {
-    const removed = await withPurgeSafeUninstallOwnership(
-      layout,
-      manifest?.activeVersion ?? "0.0.0",
-      opts.force,
-      async () => {
-        const current = await inspectInstallManifest(layout.configDir);
-        if (
-          current.status === "invalid" ||
-          (current.status === "loaded" &&
-            (!manifest || !sameInstallManifestPublication(current.manifest, manifest)))
-        ) {
-          return false;
-        }
-        await rmImpl(plan.path, { force: true });
-        console.log(`Removed ${plan.path}`);
-        await rmImpl(join(layout.configDir, "install.json"), { force: true }).catch(() => {});
-        if (opts.purge) {
-          await purgeUserRoots(layout, opts.preservePaths, rmImpl);
-        }
-        return true;
-      },
-    );
+    const removed = await withPurgeSafeUninstallOwnership(layout, opts.force, async () => {
+      const current = await inspectInstallManifest(layout.configDir);
+      if (
+        current.status === "invalid" ||
+        (current.status === "loaded" &&
+          (!manifest || !sameInstallManifestPublication(current.manifest, manifest)))
+      ) {
+        return false;
+      }
+      await rmImpl(plan.path, { force: true });
+      console.log(`Removed ${plan.path}`);
+      await rmImpl(join(layout.configDir, "install.json"), { force: true }).catch(() => {});
+      if (opts.purge) {
+        await purgeUserRoots(layout, opts.preservePaths, rmImpl);
+      }
+      return true;
+    });
     if (!removed) {
       console.error("Uninstall blocked: install manifest changed or publication lock is active.");
       return 1;
@@ -233,13 +217,12 @@ export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
 }
 
 /**
- * Current-base adapter for the purge-safe lifecycle -> activation composite.
- * Keeping the acquisition boundary here lets the base lifecycle implementation
- * own this contract after the updater branch is rebased.
+ * Hold the shared lifecycle -> activation composite across command execution,
+ * manifest removal, and every purge root. The lifecycle primitive owns both
+ * locks; acquiring activation again here would self-contend until timeout.
  */
 async function withPurgeSafeUninstallOwnership<T>(
   layout: InstallLayoutPaths,
-  version: string,
   force: boolean | undefined,
   fn: () => Promise<T>,
 ): Promise<T | null> {
@@ -249,13 +232,7 @@ async function withPurgeSafeUninstallOwnership<T>(
   });
   if (!lifecycle.acquired) return null;
   try {
-    const activation = await tryAcquireActivationLock(layout, version);
-    if (!activation.acquired) return null;
-    try {
-      return await fn();
-    } finally {
-      await activation.release();
-    }
+    return await fn();
   } finally {
     await lifecycle.release();
   }

--- a/apps/cli/src/services/update/run-uninstall.ts
+++ b/apps/cli/src/services/update/run-uninstall.ts
@@ -108,11 +108,13 @@ export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
         return false;
       }
       console.log(plan.message);
-      await purgeUserRoots(layout, opts.preservePaths, rmImpl);
+      if (!(await purgeUserRoots(layout, opts.preservePaths, rmImpl))) return false;
       return true;
     });
     if (!purged) {
-      console.error("Uninstall blocked: install manifest changed or publication lock is active.");
+      console.error(
+        "Uninstall did not complete: ownership changed, a publication lock is active, or purge failed.",
+      );
       return 1;
     }
     return 0;
@@ -134,7 +136,9 @@ export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
       if (code !== 0) return { status: "failed" as const, code };
       await rmImpl(join(layout.configDir, "install.json"), { force: true });
       if (opts.purge) {
-        await purgeUserRoots(layout, opts.preservePaths, rmImpl);
+        if (!(await purgeUserRoots(layout, opts.preservePaths, rmImpl))) {
+          return { status: "purge-failed" as const };
+        }
       }
       return { status: "removed" as const };
     });
@@ -146,6 +150,7 @@ export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
       console.error(`Package manager uninstall exited with code ${removed.code}.`);
       return removed.code;
     }
+    if (removed.status === "purge-failed") return 1;
     if (!opts.purge) {
       console.log("Left your config/history/cache in place. Re-run with --purge to remove them.");
     }
@@ -200,12 +205,14 @@ export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
       console.log(`Removed ${plan.path}`);
       await rmImpl(join(layout.configDir, "install.json"), { force: true }).catch(() => {});
       if (opts.purge) {
-        await purgeUserRoots(layout, opts.preservePaths, rmImpl);
+        if (!(await purgeUserRoots(layout, opts.preservePaths, rmImpl))) return false;
       }
       return true;
     });
     if (!removed) {
-      console.error("Uninstall blocked: install manifest changed or publication lock is active.");
+      console.error(
+        "Uninstall did not complete: ownership changed, a publication lock is active, or purge failed.",
+      );
       return 1;
     }
   }
@@ -242,14 +249,23 @@ async function purgeUserRoots(
   layout: Pick<InstallLayoutPaths, "configDir" | "dataDir" | "cacheDir">,
   preservePaths: readonly string[] | undefined,
   rmImpl: typeof rm = rm,
-): Promise<void> {
+): Promise<boolean> {
   const preserve = new Set(preservePaths ?? []);
+  let success = true;
   for (const target of [layout.configDir, layout.cacheDir, layout.dataDir]) {
     if (preserve.has(target)) {
       console.log(`Preserved ${target}`);
       continue;
     }
-    await rmImpl(target, { recursive: true, force: true }).catch(() => {});
-    console.log(`Removed ${target}`);
+    try {
+      await rmImpl(target, { recursive: true, force: true });
+      console.log(`Removed ${target}`);
+    } catch (error) {
+      success = false;
+      console.error(
+        `Failed to remove ${target}: ${error instanceof Error ? error.message : error}`,
+      );
+    }
   }
+  return success;
 }

--- a/apps/cli/src/services/update/run-uninstall.ts
+++ b/apps/cli/src/services/update/run-uninstall.ts
@@ -2,12 +2,17 @@ import { existsSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { join } from "node:path";
 
-import { readInstallManifest } from "./install-manifest";
+import {
+  inspectInstallManifest,
+  readInstallManifest,
+  sameInstallManifestPublication,
+} from "./install-manifest";
 import {
   detectInstallMethod,
   type DetectInstallMethodInput,
   type InstallMethodKind,
 } from "./install-method";
+import { withActivationLock } from "./native-installer/activation-lock";
 import { getInstallLayoutPaths, type InstallLayoutPaths } from "./native-installer/install-layout";
 import { nativeUninstall } from "./native-installer/native-uninstall";
 
@@ -91,12 +96,32 @@ export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
       opts.execImpl ??
       ((command: readonly string[]) =>
         Bun.spawn([...command], { stdout: "inherit", stderr: "inherit" }).exited);
-    const code = await execImpl(plan.command);
-    if (code !== 0) {
-      console.error(`Package manager uninstall exited with code ${code}.`);
-      return code;
+    const removed = await withActivationLock(
+      layout,
+      manifest?.activeVersion ?? "0.0.0",
+      async () => {
+        const current = await inspectInstallManifest(layout.configDir);
+        if (
+          current.status === "invalid" ||
+          (current.status === "loaded" &&
+            (!manifest || !sameInstallManifestPublication(current.manifest, manifest)))
+        ) {
+          return { status: "changed" as const };
+        }
+        const code = await execImpl(plan.command);
+        if (code !== 0) return { status: "failed" as const, code };
+        await rm(join(layout.configDir, "install.json"), { force: true });
+        return { status: "removed" as const };
+      },
+    );
+    if (removed === null || removed.status === "changed") {
+      console.error("Uninstall blocked: install manifest changed or publication lock is active.");
+      return 1;
     }
-    await rm(join(layout.configDir, "install.json"), { force: true });
+    if (removed.status === "failed") {
+      console.error(`Package manager uninstall exited with code ${removed.code}.`);
+      return removed.code;
+    }
     if (opts.purge) {
       await purgeUserRoots(layout, opts.preservePaths);
     } else {
@@ -140,9 +165,28 @@ export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
     }
     return 0;
   } else {
-    await rm(plan.path, { force: true });
-    console.log(`Removed ${plan.path}`);
-    await rm(join(layout.configDir, "install.json"), { force: true }).catch(() => {});
+    const removed = await withActivationLock(
+      layout,
+      manifest?.activeVersion ?? "0.0.0",
+      async () => {
+        const current = await inspectInstallManifest(layout.configDir);
+        if (
+          current.status === "invalid" ||
+          (current.status === "loaded" &&
+            (!manifest || !sameInstallManifestPublication(current.manifest, manifest)))
+        ) {
+          return false;
+        }
+        await rm(plan.path, { force: true });
+        console.log(`Removed ${plan.path}`);
+        await rm(join(layout.configDir, "install.json"), { force: true }).catch(() => {});
+        return true;
+      },
+    );
+    if (!removed) {
+      console.error("Uninstall blocked: install manifest changed or publication lock is active.");
+      return 1;
+    }
   }
 
   if (opts.purge) {

--- a/apps/cli/src/services/update/run-uninstall.ts
+++ b/apps/cli/src/services/update/run-uninstall.ts
@@ -12,9 +12,10 @@ import {
   type DetectInstallMethodInput,
   type InstallMethodKind,
 } from "./install-method";
-import { withActivationLock } from "./native-installer/activation-lock";
+import { tryAcquireActivationLock } from "./native-installer/activation-lock";
 import { getInstallLayoutPaths, type InstallLayoutPaths } from "./native-installer/install-layout";
 import { nativeUninstall } from "./native-installer/native-uninstall";
+import { tryAcquireLifecycleLock } from "./native-installer/version-lock";
 
 const PKG = "@kitsunekode/kunai";
 
@@ -64,6 +65,8 @@ export type RunUninstallOptions = {
   readonly preservePaths?: readonly string[];
   /** Test seam for package-manager delegation. */
   readonly execImpl?: (command: readonly string[]) => Promise<number>;
+  /** Test seam for deterministic purge interleavings. */
+  readonly rmImpl?: typeof rm;
   /** Test seam for compiled children carrying launcher ownership context. */
   readonly detectInstallMethodInput?: DetectInstallMethodInput;
 };
@@ -76,6 +79,7 @@ export type RunUninstallOptions = {
  */
 export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
   const layout = opts.layout ?? getInstallLayoutPaths();
+  const rmImpl = opts.rmImpl ?? rm;
   const manifest = await readInstallManifest(layout.configDir);
   const channel: InstallMethodKind =
     manifest?.method ??
@@ -90,15 +94,43 @@ export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
   });
 
   if (plan.kind === "manual") {
-    console.log(plan.message);
+    if (!opts.purge) {
+      console.log(plan.message);
+      console.log("Left your config/history/cache in place. Re-run with --purge to remove them.");
+      return 0;
+    }
+    const purged = await withPurgeSafeUninstallOwnership(
+      layout,
+      manifest?.activeVersion ?? "0.0.0",
+      opts.force,
+      async () => {
+        const current = await inspectInstallManifest(layout.configDir);
+        if (
+          current.status === "invalid" ||
+          (current.status === "loaded" &&
+            (!manifest || !sameInstallManifestPublication(current.manifest, manifest)))
+        ) {
+          return false;
+        }
+        console.log(plan.message);
+        await purgeUserRoots(layout, opts.preservePaths, rmImpl);
+        return true;
+      },
+    );
+    if (!purged) {
+      console.error("Uninstall blocked: install manifest changed or publication lock is active.");
+      return 1;
+    }
+    return 0;
   } else if (plan.kind === "exec") {
     const execImpl =
       opts.execImpl ??
       ((command: readonly string[]) =>
         Bun.spawn([...command], { stdout: "inherit", stderr: "inherit" }).exited);
-    const removed = await withActivationLock(
+    const removed = await withPurgeSafeUninstallOwnership(
       layout,
       manifest?.activeVersion ?? "0.0.0",
+      opts.force,
       async () => {
         const current = await inspectInstallManifest(layout.configDir);
         if (
@@ -110,7 +142,10 @@ export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
         }
         const code = await execImpl(plan.command);
         if (code !== 0) return { status: "failed" as const, code };
-        await rm(join(layout.configDir, "install.json"), { force: true });
+        await rmImpl(join(layout.configDir, "install.json"), { force: true });
+        if (opts.purge) {
+          await purgeUserRoots(layout, opts.preservePaths, rmImpl);
+        }
         return { status: "removed" as const };
       },
     );
@@ -122,9 +157,7 @@ export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
       console.error(`Package manager uninstall exited with code ${removed.code}.`);
       return removed.code;
     }
-    if (opts.purge) {
-      await purgeUserRoots(layout, opts.preservePaths);
-    } else {
+    if (!opts.purge) {
       console.log("Left your config/history/cache in place. Re-run with --purge to remove them.");
     }
     return 0;
@@ -165,9 +198,10 @@ export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
     }
     return 0;
   } else {
-    const removed = await withActivationLock(
+    const removed = await withPurgeSafeUninstallOwnership(
       layout,
       manifest?.activeVersion ?? "0.0.0",
+      opts.force,
       async () => {
         const current = await inspectInstallManifest(layout.configDir);
         if (
@@ -177,9 +211,12 @@ export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
         ) {
           return false;
         }
-        await rm(plan.path, { force: true });
+        await rmImpl(plan.path, { force: true });
         console.log(`Removed ${plan.path}`);
-        await rm(join(layout.configDir, "install.json"), { force: true }).catch(() => {});
+        await rmImpl(join(layout.configDir, "install.json"), { force: true }).catch(() => {});
+        if (opts.purge) {
+          await purgeUserRoots(layout, opts.preservePaths, rmImpl);
+        }
         return true;
       },
     );
@@ -189,25 +226,53 @@ export async function runUninstall(opts: RunUninstallOptions): Promise<number> {
     }
   }
 
-  if (opts.purge) {
-    await purgeUserRoots(layout, opts.preservePaths);
-  } else {
+  if (!opts.purge) {
     console.log("Left your config/history/cache in place. Re-run with --purge to remove them.");
   }
   return 0;
 }
 
+/**
+ * Current-base adapter for the purge-safe lifecycle -> activation composite.
+ * Keeping the acquisition boundary here lets the base lifecycle implementation
+ * own this contract after the updater branch is rebased.
+ */
+async function withPurgeSafeUninstallOwnership<T>(
+  layout: InstallLayoutPaths,
+  version: string,
+  force: boolean | undefined,
+  fn: () => Promise<T>,
+): Promise<T | null> {
+  const lifecycle = await tryAcquireLifecycleLock(layout, {
+    force,
+    execPath: process.execPath,
+  });
+  if (!lifecycle.acquired) return null;
+  try {
+    const activation = await tryAcquireActivationLock(layout, version);
+    if (!activation.acquired) return null;
+    try {
+      return await fn();
+    } finally {
+      await activation.release();
+    }
+  } finally {
+    await lifecycle.release();
+  }
+}
+
 async function purgeUserRoots(
   layout: Pick<InstallLayoutPaths, "configDir" | "dataDir" | "cacheDir">,
   preservePaths: readonly string[] | undefined,
+  rmImpl: typeof rm = rm,
 ): Promise<void> {
   const preserve = new Set(preservePaths ?? []);
-  for (const target of [layout.configDir, layout.dataDir, layout.cacheDir]) {
+  for (const target of [layout.configDir, layout.cacheDir, layout.dataDir]) {
     if (preserve.has(target)) {
       console.log(`Preserved ${target}`);
       continue;
     }
-    await rm(target, { recursive: true, force: true }).catch(() => {});
+    await rmImpl(target, { recursive: true, force: true }).catch(() => {});
     console.log(`Removed ${target}`);
   }
 }

--- a/apps/cli/src/services/update/run-upgrade.ts
+++ b/apps/cli/src/services/update/run-upgrade.ts
@@ -2,7 +2,8 @@ import { existsSync } from "node:fs";
 
 import {
   readInstallManifest,
-  writeInstallManifest,
+  withInstallManifestPublication,
+  writeInstallManifestUnderActivation,
   type InstallManifest,
   type WriteInstallManifestInput,
 } from "./install-manifest";
@@ -36,6 +37,7 @@ export interface RunUpgradePorts {
    */
   readonly inspectPackageInstall: (method: "npm" | "bun") => Promise<PackageInstallEvidence | null>;
   readonly writeInstallManifest: (manifest: WriteInstallManifestInput) => Promise<void>;
+  readonly withManifestPublication: <T>(version: string, fn: () => Promise<T>) => Promise<T | null>;
 }
 
 const defaultPorts: RunUpgradePorts = {
@@ -43,7 +45,8 @@ const defaultPorts: RunUpgradePorts = {
   resolveLatestVersion,
   runCommand: (command) => Bun.spawn([...command], { stdout: "inherit", stderr: "inherit" }).exited,
   inspectPackageInstall,
-  writeInstallManifest,
+  writeInstallManifest: (manifest) => writeInstallManifestUnderActivation(manifest),
+  withManifestPublication: (version, fn) => withInstallManifestPublication(version, fn),
 };
 
 /**
@@ -100,36 +103,43 @@ export async function runUpgrade(opts: RunUpgradeOptions): Promise<number> {
   }
 
   if (plan.kind === "exec") {
-    const code = await ports.runCommand(plan.command);
-    if (code !== 0) return code;
+    const result = await ports.withManifestPublication(opts.currentVersion, async () => {
+      const code = await ports.runCommand(plan.command);
+      if (code !== 0) return code;
 
-    // `planUpgrade` only emits exec for the two package-manager channels.
-    if (channel !== "npm-global" && channel !== "bun-global") {
-      console.error(`Unexpected package-manager upgrade plan for channel ${channel}.`);
-      return 1;
-    }
+      // `planUpgrade` only emits exec for the two package-manager channels.
+      if (channel !== "npm-global" && channel !== "bun-global") {
+        console.error(`Unexpected package-manager upgrade plan for channel ${channel}.`);
+        return 1;
+      }
 
-    // Record what the package manager actually installed, never what we asked
-    // for: a manifest that claims an unverified version silently corrupts every
-    // later upgrade comparison and version display.
-    const method = channel === "npm-global" ? "npm" : "bun";
-    const evidence = await ports.inspectPackageInstall(method);
-    const observed = evidence ? normalizeRequestedVersion(evidence.version) : null;
-    if (!observed) {
-      console.error("Could not verify the upgraded Kunai version; install manifest not updated.");
-      return 1;
-    }
+      // Record what the package manager actually installed, never what we asked
+      // for: a manifest that claims an unverified version silently corrupts every
+      // later upgrade comparison and version display.
+      const method = channel === "npm-global" ? "npm" : "bun";
+      const evidence = await ports.inspectPackageInstall(method);
+      const observed = evidence ? normalizeRequestedVersion(evidence.version) : null;
+      if (!observed) {
+        console.error("Could not verify the upgraded Kunai version; install manifest not updated.");
+        return 1;
+      }
 
-    await ports.writeInstallManifest({
-      method: channel,
-      activeVersion: observed,
-      launcherPath: evidence?.launcherPath ?? binPath,
-      downloadBaseUrl: dlBase,
+      await ports.writeInstallManifest({
+        method: channel,
+        activeVersion: observed,
+        launcherPath: evidence?.launcherPath ?? binPath,
+        downloadBaseUrl: dlBase,
+      });
+      if (observed !== latest) {
+        console.log(`Installed ${observed} (resolved latest was ${latest}).`);
+      }
+      return 0;
     });
-    if (observed !== latest) {
-      console.log(`Installed ${observed} (resolved latest was ${latest}).`);
+    if (result === null) {
+      console.error("Package upgrade blocked: another launcher/manifest publication is active.");
+      return 1;
     }
-    return 0;
+    return result;
   }
 
   // Binary channel: migrate flat installs, then use versioned native installer.

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -1224,6 +1224,7 @@ describePwsh("install.ps1 package activeVersion", () => {
       expect(`${result.stderr}${result.stdout}`).toContain("exit code 17");
       expect(result.stdout).not.toMatch(/^Done\.$/m);
       expect(existsSync(join(sandbox.configDir, "install.json"))).toBe(false);
+      expect(existsSync(join(sandbox.dataDir, "locks", "activation.lock"))).toBe(false);
     } finally {
       sandbox.cleanup();
     }

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -1427,6 +1427,7 @@ describe("install.sh package activeVersion", () => {
 
       expect(result.status).not.toBe(0);
       expect(existsSync(join(sandbox.configDir, "install.json"))).toBe(false);
+      expect(existsSync(join(sandbox.dataDir, "locks", "activation.lock"))).toBe(false);
     } finally {
       sandbox.cleanup();
     }

--- a/apps/cli/test/unit/install-manifest.test.ts
+++ b/apps/cli/test/unit/install-manifest.test.ts
@@ -194,6 +194,41 @@ test("reads and safely backfills the exact predecessor schema-2 archive shape", 
   });
 });
 
+for (const metadataState of ["missing", "corrupt", "mismatched"] as const) {
+  test(`archive predecessor migration stays retryable when version metadata is ${metadataState}`, async () => {
+    const dir = tempDir();
+    const layout = migrationLayout(dir);
+    const path = join(dir, "install.json");
+    const predecessor = { ...PREDECESSOR_SCHEMA_2_ARCHIVE };
+    await Bun.write(path, `${JSON.stringify(predecessor, null, 2)}\n`);
+
+    if (metadataState !== "missing") {
+      await writeInstalledVersionMetadata(layout, {
+        schemaVersion: 1,
+        version: predecessor.activeVersion,
+        target: predecessor.target,
+        artifactName:
+          metadataState === "mismatched" ? "kunai-linux-arm64" : predecessor.artifactName,
+        artifactSha256: predecessor.artifactSha256,
+        sizeBytes: predecessor.artifactSizeBytes,
+        sourceUrl: predecessor.archiveSourceUrl,
+        verification: "release-checksum",
+        installedAt: predecessor.installedAt,
+      });
+      if (metadataState === "corrupt") {
+        await Bun.write(versionMetadataPath(layout, predecessor.activeVersion), "{broken-json");
+      }
+    }
+
+    await expect(migrateInstallManifest(layout)).rejects.toThrow(/archive.*metadata/i);
+    expect(JSON.parse(await Bun.file(path).text())).toEqual(predecessor);
+    expect(await inspectInstallManifest(dir)).toMatchObject({
+      status: "loaded",
+      needsMigration: true,
+    });
+  });
+}
+
 test("explicit migration upgrades schema v1 without losing rollback fields", async () => {
   const dir = tempDir();
   const path = join(dir, "install.json");
@@ -428,8 +463,6 @@ test("migration does not overwrite a newer activation published while it waits",
   const activation = await tryAcquireActivationLock(layout, "9.9.9");
   expect(activation.acquired).toBe(true);
   const migration = migrateInstallManifest(layout);
-  await waitForPath(lockFilePath(layout, "1.2.3"));
-
   const replacement = {
     schemaVersion: 2,
     method: "binary",
@@ -442,14 +475,63 @@ test("migration does not overwrite a newer activation published while it waits",
     installedAt: "2026-03-01T00:00:00.000Z",
     updatedAt: "2026-03-02T00:00:00.000Z",
   };
-  await Bun.write(path, `${JSON.stringify(replacement)}\n`);
-  if (activation.acquired) await activation.release();
+  try {
+    await waitForPath(lockFilePath(layout, "1.2.3"));
+    await Bun.write(path, `${JSON.stringify(replacement)}\n`);
+  } finally {
+    if (activation.acquired) await activation.release();
+  }
 
   expect(await migration).toMatchObject({
     status: "unchanged",
     manifest: { activeVersion: "9.9.9" },
   });
   expect(JSON.parse(await Bun.file(path).text())).toEqual(replacement);
+});
+
+test("migration defers a replacement predecessor until its own version lock is held", async () => {
+  const dir = tempDir();
+  const layout = migrationLayout(dir);
+  const path = join(dir, "install.json");
+  await Bun.write(path, JSON.stringify(PREDECESSOR_SCHEMA_2_ARCHIVE));
+
+  const activation = await tryAcquireActivationLock(layout, "9.9.9");
+  expect(activation.acquired).toBe(true);
+  const migration = migrateInstallManifest(layout);
+  const replacement = {
+    ...PREDECESSOR_SCHEMA_2_ARCHIVE,
+    activeVersion: "2.0.0",
+    versionedPath: join(layout.versionsDir, "2.0.0", "kunai"),
+    archiveSourceUrl:
+      "https://github.com/KitsuneKode/kunai/releases/download/v2.0.0/kunai-linux-x64.tar.gz",
+  };
+  await writeInstalledVersionMetadata(layout, {
+    schemaVersion: 1,
+    version: replacement.activeVersion,
+    target: replacement.target,
+    artifactName: replacement.artifactName,
+    artifactSha256: replacement.artifactSha256,
+    sizeBytes: replacement.artifactSizeBytes,
+    sourceUrl: replacement.archiveSourceUrl,
+    verification: "release-checksum",
+    installedAt: replacement.installedAt,
+  });
+
+  try {
+    await waitForPath(lockFilePath(layout, PREDECESSOR_SCHEMA_2_ARCHIVE.activeVersion));
+    await Bun.write(path, `${JSON.stringify(replacement)}\n`);
+  } finally {
+    if (activation.acquired) await activation.release();
+  }
+
+  expect(await migration).toMatchObject({
+    status: "deferred",
+    manifest: { activeVersion: "2.0.0" },
+  });
+  expect(JSON.parse(await Bun.file(path).text())).toEqual(replacement);
+  expect(
+    JSON.parse(await Bun.file(versionMetadataPath(layout, replacement.activeVersion)).text()),
+  ).not.toHaveProperty("archiveName");
 });
 
 test("migration does not recreate a manifest removed while it waits", async () => {
@@ -461,9 +543,12 @@ test("migration does not recreate a manifest removed while it waits", async () =
   const activation = await tryAcquireActivationLock(layout, "9.9.9");
   expect(activation.acquired).toBe(true);
   const migration = migrateInstallManifest(layout);
-  await waitForPath(lockFilePath(layout, "1.2.3"));
-  await Bun.file(path).delete();
-  if (activation.acquired) await activation.release();
+  try {
+    await waitForPath(lockFilePath(layout, "1.2.3"));
+    await Bun.file(path).delete();
+  } finally {
+    if (activation.acquired) await activation.release();
+  }
 
   expect(await migration).toEqual({ status: "missing" });
   expect(existsSync(path)).toBe(false);
@@ -479,6 +564,10 @@ test("package publication serializes with migration and wins without stale overw
   expect(activation.acquired).toBe(true);
 
   let packagePublished = false;
+  let announcePackageAttempt!: () => void;
+  const packageAttempted = new Promise<void>((resolve) => {
+    announcePackageAttempt = resolve;
+  });
   const migration = migrateInstallManifest(layout);
   const packageWrite = writeInstallManifest(
     {
@@ -488,15 +577,17 @@ test("package publication serializes with migration and wins without stale overw
       downloadBaseUrl: "https://new.example.test/releases",
     },
     layout,
+    { onAcquireAttempt: announcePackageAttempt },
   ).then(() => {
     packagePublished = true;
     return true;
   });
-  await waitForPath(lockFilePath(layout, "1.2.3"));
-  await Bun.sleep(25);
-  expect(packagePublished).toBe(false);
-
-  if (activation.acquired) await activation.release();
+  try {
+    await Promise.all([waitForPath(lockFilePath(layout, "1.2.3")), packageAttempted]);
+    expect(packagePublished).toBe(false);
+  } finally {
+    if (activation.acquired) await activation.release();
+  }
   await Promise.all([migration, packageWrite]);
 
   expect(await readInstallManifest(dir)).toMatchObject({

--- a/apps/cli/test/unit/install-manifest.test.ts
+++ b/apps/cli/test/unit/install-manifest.test.ts
@@ -50,6 +50,13 @@ test("write then read round-trips the versioned manifest", async () => {
       launcherPath: "/x/kunai",
       versionedPath: "/data/versions/1.2.3/kunai",
       downloadBaseUrl: "https://dl",
+      artifactName: "kunai-linux-x64",
+      artifactSha256: "a".repeat(64),
+      artifactSizeBytes: 42,
+      archiveName: "kunai-linux-x64.tar.gz",
+      archiveSha256: "b".repeat(64),
+      archiveSizeBytes: 21,
+      archiveSourceUrl: "https://dl/download/v1.2.3/kunai-linux-x64.tar.gz",
     },
     dir,
   );
@@ -60,10 +67,135 @@ test("write then read round-trips the versioned manifest", async () => {
   expect(m?.launcherPath).toBe("/x/kunai");
   expect(m?.versionedPath).toBe("/data/versions/1.2.3/kunai");
   expect(m?.downloadBaseUrl).toBe("https://dl");
+  expect(m?.artifactName).toBe("kunai-linux-x64");
+  expect(m?.artifactSha256).toBe("a".repeat(64));
+  expect(m?.artifactSizeBytes).toBe(42);
+  expect(m?.archiveName).toBe("kunai-linux-x64.tar.gz");
+  expect(m?.archiveSha256).toBe("b".repeat(64));
+  expect(m?.archiveSizeBytes).toBe(21);
+  expect(m?.archiveSourceUrl).toBe("https://dl/download/v1.2.3/kunai-linux-x64.tar.gz");
   expect(m?.preferredChannel).toBe("stable");
   expect(m?.managedPaths.length).toBeGreaterThan(0);
   expect(typeof m?.installedAt).toBe("string");
   expect(typeof m?.updatedAt).toBe("string");
+});
+
+test("read migrates a schema-v1 manifest to schema v2 without losing rollback fields", async () => {
+  const dir = tempDir();
+  const path = join(dir, "install.json");
+  await Bun.write(
+    path,
+    JSON.stringify({
+      schemaVersion: 1,
+      method: "binary",
+      activeVersion: "1.2.3",
+      previousVersion: "1.2.2",
+      preferredChannel: "stable",
+      launcherPath: "/x/kunai",
+      versionedPath: "/data/versions/1.2.3/kunai",
+      managedPaths: [],
+      target: "linux-x64",
+      artifactSha256: "c".repeat(64),
+      downloadBaseUrl: "https://dl",
+      installedAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    }),
+  );
+
+  expect(await inspectInstallManifest(dir)).toMatchObject({
+    status: "loaded",
+    needsMigration: true,
+    manifest: {
+      schemaVersion: 2,
+      activeVersion: "1.2.3",
+      previousVersion: "1.2.2",
+      artifactSha256: "c".repeat(64),
+    },
+  });
+  expect(await readInstallManifest(dir)).toMatchObject({
+    schemaVersion: 2,
+    activeVersion: "1.2.3",
+    previousVersion: "1.2.2",
+  });
+  expect(JSON.parse(await Bun.file(path).text())).toMatchObject({ schemaVersion: 2 });
+});
+
+test("schema v2 rejects partial archive provenance", async () => {
+  const dir = tempDir();
+  await Bun.write(
+    join(dir, "install.json"),
+    JSON.stringify({
+      schemaVersion: 2,
+      method: "binary",
+      activeVersion: "1.2.3",
+      preferredChannel: "stable",
+      launcherPath: "/x/kunai",
+      managedPaths: [],
+      downloadBaseUrl: "https://dl",
+      installedAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+      archiveName: "kunai-linux-x64.tar.gz",
+    }),
+  );
+
+  expect(await inspectInstallManifest(dir)).toMatchObject({
+    status: "invalid",
+    reason: "invalid-shape",
+  });
+});
+
+test("write rejects partial archive provenance", async () => {
+  const dir = tempDir();
+  await expect(
+    writeInstallManifest(
+      {
+        method: "binary",
+        activeVersion: "1.2.3",
+        launcherPath: "/x/kunai",
+        downloadBaseUrl: "https://dl",
+        archiveName: "kunai-linux-x64.tar.gz",
+      },
+      dir,
+    ),
+  ).rejects.toThrow(/archive provenance/i);
+});
+
+test("write rejects empty archive provenance strings", async () => {
+  const dir = tempDir();
+  await expect(
+    writeInstallManifest(
+      {
+        method: "binary",
+        activeVersion: "1.2.3",
+        launcherPath: "/x/kunai",
+        downloadBaseUrl: "https://dl",
+        archiveName: "",
+        archiveSha256: "d".repeat(64),
+        archiveSizeBytes: 10,
+        archiveSourceUrl: "https://dl/archive",
+      },
+      dir,
+    ),
+  ).rejects.toThrow(/provenance/i);
+});
+
+test("write requires extracted-binary provenance when archive provenance is present", async () => {
+  const dir = tempDir();
+  await expect(
+    writeInstallManifest(
+      {
+        method: "binary",
+        activeVersion: "1.2.3",
+        launcherPath: "/x/kunai",
+        downloadBaseUrl: "https://dl",
+        archiveName: "kunai-linux-x64.tar.gz",
+        archiveSha256: "d".repeat(64),
+        archiveSizeBytes: 10,
+        archiveSourceUrl: "https://dl/archive",
+      },
+      dir,
+    ),
+  ).rejects.toThrow(/extracted binary provenance/i);
 });
 
 test("read returns null when manifest is absent", async () => {
@@ -90,7 +222,7 @@ test("read migrates legacy versioned binary atomically", async () => {
   await Bun.write(path, `${JSON.stringify(LEGACY_VERSIONED, null, 2)}\n`);
   const m = await readInstallManifest(dir);
   expect(m).toMatchObject({
-    schemaVersion: 1,
+    schemaVersion: 2,
     method: "binary",
     activeVersion: "1.2.3",
     launcherPath: "/home/u/.local/bin/kunai",
@@ -104,7 +236,7 @@ test("read migrates legacy versioned binary atomically", async () => {
 
   const onDisk = JSON.parse(await Bun.file(path).text()) as typeof m;
   expect(onDisk).toMatchObject({
-    schemaVersion: 1,
+    schemaVersion: 2,
     method: "binary",
     activeVersion: "1.2.3",
     installedAt: "2026-01-01T00:00:00.000Z",
@@ -119,7 +251,7 @@ test("read migrates legacy flat binary without versionedPath", async () => {
   await Bun.write(join(dir, "install.json"), JSON.stringify(LEGACY_FLAT));
   const m = await readInstallManifest(dir);
   expect(m).toMatchObject({
-    schemaVersion: 1,
+    schemaVersion: 2,
     method: "binary",
     activeVersion: "1.0.0",
     launcherPath: "/home/u/.local/bin/kunai",
@@ -147,7 +279,7 @@ test.each([
   );
   const m = await readInstallManifest(dir);
   expect(m).toMatchObject({
-    schemaVersion: 1,
+    schemaVersion: 2,
     method: channel,
     activeVersion: version,
     launcherPath: "/usr/bin/kunai",

--- a/apps/cli/test/unit/install-manifest.test.ts
+++ b/apps/cli/test/unit/install-manifest.test.ts
@@ -7,6 +7,7 @@ import {
   INSTALL_MANIFEST_SCHEMA_VERSION,
   inspectInstallManifest,
   migrateInstallManifest,
+  migrateInstallManifestAtStartup,
   readInstallManifest,
   writeInstallManifest,
 } from "@/services/update/install-manifest";
@@ -65,6 +66,31 @@ const LEGACY_FLAT = {
   layout: "flat",
 } as const;
 
+// Exact archive-bearing schema-2 shape emitted by 69b81763. That release did
+// not yet persist artifactSourceUrl, so this fixture is a compatibility
+// boundary rather than a hand-written approximation of the current schema.
+const PREDECESSOR_SCHEMA_2_ARCHIVE = {
+  schemaVersion: 2,
+  method: "binary",
+  activeVersion: "1.2.3",
+  preferredChannel: "stable",
+  launcherPath: "/x/kunai",
+  versionedPath: "/data/versions/1.2.3/kunai",
+  managedPaths: [],
+  target: "linux-x64",
+  artifactName: "kunai-linux-x64",
+  artifactSha256: "a".repeat(64),
+  artifactSizeBytes: 42,
+  archiveName: "kunai-linux-x64.tar.gz",
+  archiveSha256: "b".repeat(64),
+  archiveSizeBytes: 21,
+  archiveSourceUrl:
+    "https://github.com/KitsuneKode/kunai/releases/download/v1.2.3/kunai-linux-x64.tar.gz",
+  downloadBaseUrl: "https://github.com/KitsuneKode/kunai/releases",
+  installedAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-02T00:00:00.000Z",
+} as const;
+
 test("write then read round-trips the versioned manifest", async () => {
   const dir = tempDir();
   await writeInstallManifest(
@@ -83,7 +109,7 @@ test("write then read round-trips the versioned manifest", async () => {
       archiveSizeBytes: 21,
       archiveSourceUrl: "https://dl/download/v1.2.3/kunai-linux-x64.tar.gz",
     },
-    dir,
+    migrationLayout(dir),
   );
   const m = await readInstallManifest(dir);
   expect(m?.schemaVersion).toBe(INSTALL_MANIFEST_SCHEMA_VERSION);
@@ -104,6 +130,36 @@ test("write then read round-trips the versioned manifest", async () => {
   expect(m?.managedPaths.length).toBeGreaterThan(0);
   expect(typeof m?.installedAt).toBe("string");
   expect(typeof m?.updatedAt).toBe("string");
+});
+
+test("reads and safely backfills the exact predecessor schema-2 archive shape", async () => {
+  const dir = tempDir();
+  const path = join(dir, "install.json");
+  await Bun.write(path, `${JSON.stringify(PREDECESSOR_SCHEMA_2_ARCHIVE, null, 2)}\n`);
+
+  expect(await inspectInstallManifest(dir)).toMatchObject({
+    status: "loaded",
+    needsMigration: true,
+    manifest: {
+      schemaVersion: 2,
+      artifactSourceUrl:
+        "https://github.com/KitsuneKode/kunai/releases/download/v1.2.3/kunai-linux-x64",
+    },
+  });
+  expect(JSON.parse(await Bun.file(path).text())).toEqual(PREDECESSOR_SCHEMA_2_ARCHIVE);
+
+  expect(await migrateInstallManifest(migrationLayout(dir))).toMatchObject({
+    status: "migrated",
+    manifest: {
+      artifactSourceUrl:
+        "https://github.com/KitsuneKode/kunai/releases/download/v1.2.3/kunai-linux-x64",
+    },
+  });
+  expect(JSON.parse(await Bun.file(path).text())).toMatchObject({
+    schemaVersion: 2,
+    artifactSourceUrl:
+      "https://github.com/KitsuneKode/kunai/releases/download/v1.2.3/kunai-linux-x64",
+  });
 });
 
 test("explicit migration upgrades schema v1 without losing rollback fields", async () => {
@@ -191,7 +247,7 @@ test("write rejects partial archive provenance", async () => {
         downloadBaseUrl: "https://dl",
         archiveName: "kunai-linux-x64.tar.gz",
       },
-      dir,
+      migrationLayout(dir),
     ),
   ).rejects.toThrow(/archive provenance/i);
 });
@@ -210,7 +266,7 @@ test("write rejects empty archive provenance strings", async () => {
         archiveSizeBytes: 10,
         archiveSourceUrl: "https://dl/archive",
       },
-      dir,
+      migrationLayout(dir),
     ),
   ).rejects.toThrow(/provenance/i);
 });
@@ -229,7 +285,7 @@ test("write requires extracted-binary provenance when archive provenance is pres
         archiveSizeBytes: 10,
         archiveSourceUrl: "https://dl/archive",
       },
-      dir,
+      migrationLayout(dir),
     ),
   ).rejects.toThrow(/extracted binary provenance/i);
 });
@@ -381,6 +437,69 @@ test("migration does not recreate a manifest removed while it waits", async () =
   expect(existsSync(path)).toBe(false);
 });
 
+test("package publication serializes with migration and wins without stale overwrite", async () => {
+  const dir = tempDir();
+  const layout = migrationLayout(dir);
+  const path = join(dir, "install.json");
+  await Bun.write(path, JSON.stringify(LEGACY_VERSIONED));
+
+  const activation = await tryAcquireActivationLock(layout, "9.9.9");
+  expect(activation.acquired).toBe(true);
+
+  let packagePublished = false;
+  const migration = migrateInstallManifest(layout);
+  const packageWrite = writeInstallManifest(
+    {
+      method: "npm-global",
+      activeVersion: "9.9.9",
+      launcherPath: "/npm/bin/kunai",
+      downloadBaseUrl: "https://new.example.test/releases",
+    },
+    layout,
+  ).then(() => {
+    packagePublished = true;
+    return true;
+  });
+  await waitForPath(lockFilePath(layout, "1.2.3"));
+  await Bun.sleep(25);
+  expect(packagePublished).toBe(false);
+
+  if (activation.acquired) await activation.release();
+  await Promise.all([migration, packageWrite]);
+
+  expect(await readInstallManifest(dir)).toMatchObject({
+    schemaVersion: 2,
+    method: "npm-global",
+    activeVersion: "9.9.9",
+    launcherPath: "/npm/bin/kunai",
+  });
+});
+
+test("startup migration diagnoses invalid state and errors but keeps contention quiet", async () => {
+  const warnings: string[] = [];
+  const warn = (message: string) => warnings.push(message);
+
+  await migrateInstallManifestAtStartup({
+    migrate: async () => ({ status: "invalid", reason: "invalid-shape" }),
+    warn,
+  });
+  await migrateInstallManifestAtStartup({
+    migrate: async () => ({ status: "lock-contention" }),
+    warn,
+  });
+  await migrateInstallManifestAtStartup({
+    migrate: async () => {
+      throw new Error("disk unavailable");
+    },
+    warn,
+  });
+
+  expect(warnings).toEqual([
+    "Kunai install manifest migration skipped invalid install.json (invalid-shape).",
+    "Kunai install manifest migration failed: disk unavailable",
+  ]);
+});
+
 test("inspect reports invalid JSON without writing", async () => {
   const dir = tempDir();
   const path = join(dir, "install.json");
@@ -516,7 +635,7 @@ test("write rejects non-canonical previousVersion", async () => {
         launcherPath: "/x/kunai",
         downloadBaseUrl: "https://dl",
       },
-      dir,
+      migrationLayout(dir),
     ),
   ).rejects.toThrow(/previousVersion/);
 });
@@ -532,7 +651,7 @@ test("write accepts canonical previousVersion", async () => {
       versionedPath: "/data/versions/1.0.1/kunai",
       downloadBaseUrl: "https://dl",
     },
-    dir,
+    migrationLayout(dir),
   );
   const m = await readInstallManifest(dir);
   expect(m?.previousVersion).toBe("1.0.0");
@@ -547,7 +666,7 @@ test("write preserves installedAt and refreshes updatedAt", async () => {
       launcherPath: "/usr/bin/kunai",
       downloadBaseUrl: "https://dl",
     },
-    dir,
+    migrationLayout(dir),
   );
   const first = await readInstallManifest(dir);
   expect(first?.managedPaths).toEqual([]);
@@ -559,7 +678,7 @@ test("write preserves installedAt and refreshes updatedAt", async () => {
       launcherPath: "/usr/bin/kunai",
       downloadBaseUrl: "https://dl",
     },
-    dir,
+    migrationLayout(dir),
   );
   const second = await readInstallManifest(dir);
   expect(second?.installedAt).toBe(first?.installedAt);

--- a/apps/cli/test/unit/install-manifest.test.ts
+++ b/apps/cli/test/unit/install-manifest.test.ts
@@ -1,15 +1,20 @@
 import { afterEach, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
   INSTALL_MANIFEST_SCHEMA_VERSION,
   inspectInstallManifest,
+  migrateInstallManifest,
   readInstallManifest,
   writeInstallManifest,
 } from "@/services/update/install-manifest";
-import { getInstallLayoutPaths } from "@/services/update/native-installer/install-layout";
+import { tryAcquireActivationLock } from "@/services/update/native-installer/activation-lock";
+import {
+  getInstallLayoutPaths,
+  lockFilePath,
+} from "@/services/update/native-installer/install-layout";
 
 const made: string[] = [];
 afterEach(() => {
@@ -20,6 +25,25 @@ function tempDir(): string {
   const dir = mkdtempSync(join(tmpdir(), "kunai-manifest-"));
   made.push(dir);
   return dir;
+}
+
+function migrationLayout(configDir: string) {
+  const root = join(configDir, "native");
+  return getInstallLayoutPaths({
+    configDir,
+    dataDir: join(root, "data"),
+    cacheDir: join(root, "cache"),
+    launcherPath: join(root, "bin", "kunai"),
+    platform: "linux",
+  });
+}
+
+async function waitForPath(path: string): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!existsSync(path)) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${path}`);
+    await Bun.sleep(5);
+  }
 }
 
 const LEGACY_VERSIONED = {
@@ -53,6 +77,7 @@ test("write then read round-trips the versioned manifest", async () => {
       artifactName: "kunai-linux-x64",
       artifactSha256: "a".repeat(64),
       artifactSizeBytes: 42,
+      artifactSourceUrl: "https://dl/download/v1.2.3/kunai-linux-x64",
       archiveName: "kunai-linux-x64.tar.gz",
       archiveSha256: "b".repeat(64),
       archiveSizeBytes: 21,
@@ -70,6 +95,7 @@ test("write then read round-trips the versioned manifest", async () => {
   expect(m?.artifactName).toBe("kunai-linux-x64");
   expect(m?.artifactSha256).toBe("a".repeat(64));
   expect(m?.artifactSizeBytes).toBe(42);
+  expect(m?.artifactSourceUrl).toBe("https://dl/download/v1.2.3/kunai-linux-x64");
   expect(m?.archiveName).toBe("kunai-linux-x64.tar.gz");
   expect(m?.archiveSha256).toBe("b".repeat(64));
   expect(m?.archiveSizeBytes).toBe(21);
@@ -80,7 +106,7 @@ test("write then read round-trips the versioned manifest", async () => {
   expect(typeof m?.updatedAt).toBe("string");
 });
 
-test("read migrates a schema-v1 manifest to schema v2 without losing rollback fields", async () => {
+test("explicit migration upgrades schema v1 without losing rollback fields", async () => {
   const dir = tempDir();
   const path = join(dir, "install.json");
   await Bun.write(
@@ -116,6 +142,16 @@ test("read migrates a schema-v1 manifest to schema v2 without losing rollback fi
     schemaVersion: 2,
     activeVersion: "1.2.3",
     previousVersion: "1.2.2",
+  });
+  expect(JSON.parse(await Bun.file(path).text())).toMatchObject({ schemaVersion: 1 });
+
+  expect(await migrateInstallManifest(migrationLayout(dir))).toMatchObject({
+    status: "migrated",
+    manifest: {
+      schemaVersion: 2,
+      activeVersion: "1.2.3",
+      previousVersion: "1.2.2",
+    },
   });
   expect(JSON.parse(await Bun.file(path).text())).toMatchObject({ schemaVersion: 2 });
 });
@@ -216,10 +252,12 @@ test("inspection reports migration without writing", async () => {
   expect(await Bun.file(path).text()).toBe(before);
 });
 
-test("read migrates legacy versioned binary atomically", async () => {
+test("explicit migration upgrades legacy versioned binary atomically", async () => {
   const dir = tempDir();
   const path = join(dir, "install.json");
   await Bun.write(path, `${JSON.stringify(LEGACY_VERSIONED, null, 2)}\n`);
+  const migrated = await migrateInstallManifest(migrationLayout(dir));
+  expect(migrated.status).toBe("migrated");
   const m = await readInstallManifest(dir);
   expect(m).toMatchObject({
     schemaVersion: 2,
@@ -246,9 +284,10 @@ test("read migrates legacy versioned binary atomically", async () => {
   expect(again).toMatchObject({ status: "loaded", needsMigration: false });
 });
 
-test("read migrates legacy flat binary without versionedPath", async () => {
+test("explicit migration upgrades legacy flat binary without versionedPath", async () => {
   const dir = tempDir();
   await Bun.write(join(dir, "install.json"), JSON.stringify(LEGACY_FLAT));
+  expect((await migrateInstallManifest(migrationLayout(dir))).status).toBe("migrated");
   const m = await readInstallManifest(dir);
   expect(m).toMatchObject({
     schemaVersion: 2,
@@ -265,27 +304,81 @@ test.each([
   ["npm-global", "2.0.0"],
   ["bun-global", "2.1.0"],
   ["source", "0.3.0"],
-] as const)("read migrates legacy %s with empty managedPaths", async (channel, version) => {
-  const dir = tempDir();
-  await Bun.write(
-    join(dir, "install.json"),
-    JSON.stringify({
+] as const)(
+  "legacy %s is converted in memory without unsafe native-lock publication",
+  async (channel, version) => {
+    const dir = tempDir();
+    const path = join(dir, "install.json");
+    const legacy = JSON.stringify({
       channel,
       version,
       binPath: "/usr/bin/kunai",
       dlBase: "https://dl.example/releases",
       installedAt: "2026-03-01T00:00:00.000Z",
-    }),
-  );
-  const m = await readInstallManifest(dir);
-  expect(m).toMatchObject({
+    });
+    await Bun.write(path, legacy);
+    expect((await migrateInstallManifest(migrationLayout(dir))).status).toBe("deferred");
+    const m = await readInstallManifest(dir);
+    expect(m).toMatchObject({
+      schemaVersion: 2,
+      method: channel,
+      activeVersion: version,
+      launcherPath: "/usr/bin/kunai",
+      managedPaths: [],
+      installedAt: "2026-03-01T00:00:00.000Z",
+    });
+    expect(await Bun.file(path).text()).toBe(legacy);
+  },
+);
+
+test("migration does not overwrite a newer activation published while it waits", async () => {
+  const dir = tempDir();
+  const layout = migrationLayout(dir);
+  const path = join(dir, "install.json");
+  await Bun.write(path, JSON.stringify(LEGACY_VERSIONED));
+
+  const activation = await tryAcquireActivationLock(layout, "9.9.9");
+  expect(activation.acquired).toBe(true);
+  const migration = migrateInstallManifest(layout);
+  await waitForPath(lockFilePath(layout, "1.2.3"));
+
+  const replacement = {
     schemaVersion: 2,
-    method: channel,
-    activeVersion: version,
-    launcherPath: "/usr/bin/kunai",
+    method: "binary",
+    activeVersion: "9.9.9",
+    preferredChannel: "stable",
+    launcherPath: layout.launcherPath,
+    versionedPath: join(layout.versionsDir, "9.9.9", "kunai"),
     managedPaths: [],
+    downloadBaseUrl: "https://new.example.test/releases",
     installedAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-02T00:00:00.000Z",
+  };
+  await Bun.write(path, `${JSON.stringify(replacement)}\n`);
+  if (activation.acquired) await activation.release();
+
+  expect(await migration).toMatchObject({
+    status: "unchanged",
+    manifest: { activeVersion: "9.9.9" },
   });
+  expect(JSON.parse(await Bun.file(path).text())).toEqual(replacement);
+});
+
+test("migration does not recreate a manifest removed while it waits", async () => {
+  const dir = tempDir();
+  const layout = migrationLayout(dir);
+  const path = join(dir, "install.json");
+  await Bun.write(path, JSON.stringify(LEGACY_VERSIONED));
+
+  const activation = await tryAcquireActivationLock(layout, "9.9.9");
+  expect(activation.acquired).toBe(true);
+  const migration = migrateInstallManifest(layout);
+  await waitForPath(lockFilePath(layout, "1.2.3"));
+  await Bun.file(path).delete();
+  if (activation.acquired) await activation.release();
+
+  expect(await migration).toEqual({ status: "missing" });
+  expect(existsSync(path)).toBe(false);
 });
 
 test("inspect reports invalid JSON without writing", async () => {

--- a/apps/cli/test/unit/install-manifest.test.ts
+++ b/apps/cli/test/unit/install-manifest.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -15,7 +16,10 @@ import { tryAcquireActivationLock } from "@/services/update/native-installer/act
 import {
   getInstallLayoutPaths,
   lockFilePath,
+  versionBinaryPath,
+  versionMetadataPath,
 } from "@/services/update/native-installer/install-layout";
+import { writeInstalledVersionMetadata } from "@/services/update/native-installer/version-metadata";
 
 const made: string[] = [];
 afterEach(() => {
@@ -134,8 +138,29 @@ test("write then read round-trips the versioned manifest", async () => {
 
 test("reads and safely backfills the exact predecessor schema-2 archive shape", async () => {
   const dir = tempDir();
+  const layout = migrationLayout(dir);
   const path = join(dir, "install.json");
-  await Bun.write(path, `${JSON.stringify(PREDECESSOR_SCHEMA_2_ARCHIVE, null, 2)}\n`);
+  const bytes = new TextEncoder().encode("predecessor-archive-member");
+  const artifactSha256 = createHash("sha256").update(bytes).digest("hex");
+  const predecessor = {
+    ...PREDECESSOR_SCHEMA_2_ARCHIVE,
+    artifactSha256,
+    artifactSizeBytes: bytes.length,
+  };
+  await Bun.write(path, `${JSON.stringify(predecessor, null, 2)}\n`);
+  const binaryPath = versionBinaryPath(layout, predecessor.activeVersion);
+  await Bun.write(binaryPath, bytes);
+  await writeInstalledVersionMetadata(layout, {
+    schemaVersion: 1,
+    version: predecessor.activeVersion,
+    target: predecessor.target,
+    artifactName: predecessor.artifactName,
+    artifactSha256,
+    sizeBytes: bytes.length,
+    sourceUrl: predecessor.archiveSourceUrl,
+    verification: "release-checksum",
+    installedAt: predecessor.installedAt,
+  });
 
   expect(await inspectInstallManifest(dir)).toMatchObject({
     status: "loaded",
@@ -146,9 +171,9 @@ test("reads and safely backfills the exact predecessor schema-2 archive shape", 
         "https://github.com/KitsuneKode/kunai/releases/download/v1.2.3/kunai-linux-x64",
     },
   });
-  expect(JSON.parse(await Bun.file(path).text())).toEqual(PREDECESSOR_SCHEMA_2_ARCHIVE);
+  expect(JSON.parse(await Bun.file(path).text())).toEqual(predecessor);
 
-  expect(await migrateInstallManifest(migrationLayout(dir))).toMatchObject({
+  expect(await migrateInstallManifest(layout)).toMatchObject({
     status: "migrated",
     manifest: {
       artifactSourceUrl:
@@ -159,6 +184,13 @@ test("reads and safely backfills the exact predecessor schema-2 archive shape", 
     schemaVersion: 2,
     artifactSourceUrl:
       "https://github.com/KitsuneKode/kunai/releases/download/v1.2.3/kunai-linux-x64",
+  });
+  expect(JSON.parse(await Bun.file(versionMetadataPath(layout, "1.2.3")).text())).toMatchObject({
+    sourceUrl: "https://github.com/KitsuneKode/kunai/releases/download/v1.2.3/kunai-linux-x64",
+    archiveName: predecessor.archiveName,
+    archiveSha256: predecessor.archiveSha256,
+    archiveSizeBytes: predecessor.archiveSizeBytes,
+    archiveSourceUrl: predecessor.archiveSourceUrl,
   });
 });
 

--- a/apps/cli/test/unit/run-rollback.test.ts
+++ b/apps/cli/test/unit/run-rollback.test.ts
@@ -76,7 +76,7 @@ describe("runRollback", () => {
         versionedPath: versionBinaryPath(layout, "2.0.0"),
         downloadBaseUrl: "https://example.test/releases",
       },
-      layout.configDir,
+      layout,
     );
 
     const lines: string[] = [];
@@ -109,7 +109,7 @@ describe("runRollback", () => {
         versionedPath: versionBinaryPath(layout, "2.0.0"),
         downloadBaseUrl: "https://example.test/releases",
       },
-      layout.configDir,
+      layout,
     );
 
     const lines: string[] = [];
@@ -137,7 +137,7 @@ describe("runRollback", () => {
         launcherPath: layout.launcherPath,
         downloadBaseUrl: "https://example.test/releases",
       },
-      layout.configDir,
+      layout,
     );
 
     const errors: string[] = [];

--- a/apps/cli/test/unit/run-uninstall.test.ts
+++ b/apps/cli/test/unit/run-uninstall.test.ts
@@ -5,7 +5,7 @@ import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
-import { writeInstallManifest } from "@/services/update/install-manifest";
+import { readInstallManifest, writeInstallManifest } from "@/services/update/install-manifest";
 import {
   getInstallLayoutPaths,
   versionBinaryPath,
@@ -132,6 +132,83 @@ test("runUninstall retains the manifest when package-manager uninstall fails", a
 
   expect(code).toBe(7);
   expect(existsSync(join(layout.configDir, "install.json"))).toBe(true);
+});
+
+test("runUninstall keeps a concurrent package publication behind every purge root", async () => {
+  const root = await mkdtemp(join(tmpdir(), "kunai-run-uninstall-package-purge-race-"));
+  made.push(root);
+  const layout = getInstallLayoutPaths({
+    dataDir: join(root, "data"),
+    cacheDir: join(root, "cache"),
+    configDir: join(root, "config"),
+    launcherPath: join(root, "bin", "kunai"),
+    platform: "linux",
+  });
+  await writeInstallManifest(
+    {
+      method: "npm-global",
+      activeVersion: "1.0.0",
+      launcherPath: layout.launcherPath,
+      downloadBaseUrl: "https://registry.npmjs.org",
+    },
+    layout,
+  );
+  await mkdir(layout.cacheDir, { recursive: true });
+  await writeFile(join(layout.cacheDir, "cache"), "old");
+
+  let announcePurge!: () => void;
+  const purgeStarted = new Promise<void>((resolve) => {
+    announcePurge = resolve;
+  });
+  let resumePurge!: () => void;
+  const purgeMayContinue = new Promise<void>((resolve) => {
+    resumePurge = resolve;
+  });
+  const lifecycleGuard = `${layout.dataDir}.lifecycle.lock`;
+  const guardedRoots: string[] = [];
+  const originalRm = rm;
+  const rmImpl: typeof rm = async (path, options) => {
+    if (path === layout.configDir) {
+      announcePurge();
+      await purgeMayContinue;
+    }
+    const isPurgeRoot =
+      path === layout.configDir || path === layout.cacheDir || path === layout.dataDir;
+    if (isPurgeRoot && existsSync(lifecycleGuard)) guardedRoots.push(String(path));
+    const result = await originalRm(path, options);
+    if (isPurgeRoot) expect(existsSync(lifecycleGuard)).toBe(true);
+    return result;
+  };
+
+  const uninstalling = runUninstall({
+    purge: true,
+    layout,
+    execImpl: async () => 0,
+    rmImpl,
+  });
+  await purgeStarted;
+
+  let publicationFinished = false;
+  const publishing = (async () => {
+    await writeInstallManifest(
+      {
+        method: "npm-global",
+        activeVersion: "2.0.0",
+        launcherPath: layout.launcherPath,
+        downloadBaseUrl: "https://registry.npmjs.org",
+      },
+      layout,
+    );
+    publicationFinished = true;
+  })();
+  await Bun.sleep(25);
+
+  expect(publicationFinished).toBe(false);
+  resumePurge();
+  expect(await uninstalling).toBe(0);
+  await publishing;
+  expect(guardedRoots).toEqual([layout.configDir, layout.cacheDir, layout.dataDir]);
+  expect((await readInstallManifest(layout.configDir))?.activeVersion).toBe("2.0.0");
 });
 
 for (const [manager, expectedCommand] of [

--- a/apps/cli/test/unit/run-uninstall.test.ts
+++ b/apps/cli/test/unit/run-uninstall.test.ts
@@ -83,7 +83,7 @@ test("runUninstall removes the manifest after package-manager uninstall succeeds
       launcherPath: layout.launcherPath,
       downloadBaseUrl: "https://registry.npmjs.org",
     },
-    layout.configDir,
+    layout,
   );
   const configJson = join(layout.configDir, "config.json");
   await writeFile(configJson, "{}\n");
@@ -121,7 +121,7 @@ test("runUninstall retains the manifest when package-manager uninstall fails", a
       launcherPath: layout.launcherPath,
       downloadBaseUrl: "https://registry.npmjs.org",
     },
-    layout.configDir,
+    layout,
   );
 
   const code = await runUninstall({
@@ -211,7 +211,7 @@ test("runUninstall native path preserves config/history/cache/downloads by defau
       downloadBaseUrl: "https://example.test/releases",
       artifactSha256: sha,
     },
-    layout.configDir,
+    layout,
   );
 
   const configJson = join(layout.configDir, "config.json");

--- a/apps/cli/test/unit/run-uninstall.test.ts
+++ b/apps/cli/test/unit/run-uninstall.test.ts
@@ -189,6 +189,10 @@ test("runUninstall keeps a concurrent package publication behind every purge roo
   await purgeStarted;
 
   let publicationFinished = false;
+  let announcePublicationAttempt!: () => void;
+  const publicationAttempted = new Promise<void>((resolve) => {
+    announcePublicationAttempt = resolve;
+  });
   const publishing = (async () => {
     await writeInstallManifest(
       {
@@ -198,10 +202,11 @@ test("runUninstall keeps a concurrent package publication behind every purge roo
         downloadBaseUrl: "https://registry.npmjs.org",
       },
       layout,
+      { onAcquireAttempt: announcePublicationAttempt },
     );
     publicationFinished = true;
   })();
-  await Bun.sleep(25);
+  await publicationAttempted;
 
   expect(publicationFinished).toBe(false);
   resumePurge();
@@ -209,6 +214,46 @@ test("runUninstall keeps a concurrent package publication behind every purge roo
   await publishing;
   expect(guardedRoots).toEqual([layout.configDir, layout.cacheDir, layout.dataDir]);
   expect((await readInstallManifest(layout.configDir))?.activeVersion).toBe("2.0.0");
+});
+
+test("runUninstall reports purge failures instead of claiming the root was removed", async () => {
+  const root = await mkdtemp(join(tmpdir(), "kunai-run-uninstall-purge-failure-"));
+  made.push(root);
+  const layout = getInstallLayoutPaths({
+    dataDir: join(root, "data"),
+    cacheDir: join(root, "cache"),
+    configDir: join(root, "config"),
+    launcherPath: join(root, "bin", "kunai"),
+    platform: "linux",
+  });
+  await writeInstallManifest(
+    {
+      method: "npm-global",
+      activeVersion: "1.0.0",
+      launcherPath: layout.launcherPath,
+      downloadBaseUrl: "https://registry.npmjs.org",
+    },
+    layout,
+  );
+
+  const originalError = console.error;
+  const errors: string[] = [];
+  console.error = (...args) => errors.push(args.map(String).join(" "));
+  try {
+    const code = await runUninstall({
+      purge: true,
+      layout,
+      execImpl: async () => 0,
+      rmImpl: async (path, options) => {
+        if (path === layout.cacheDir) throw new Error("cache busy");
+        return rm(path, options);
+      },
+    });
+    expect(code).toBe(1);
+  } finally {
+    console.error = originalError;
+  }
+  expect(errors).toContain(`Failed to remove ${layout.cacheDir}: cache busy`);
 });
 
 for (const [manager, expectedCommand] of [

--- a/apps/cli/test/unit/services/update/BinaryAutoUpdater.test.ts
+++ b/apps/cli/test/unit/services/update/BinaryAutoUpdater.test.ts
@@ -201,7 +201,7 @@ describe("resolveAutoUpdateGate", () => {
 
 function binaryManifest(): InstallManifest {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     method: "binary",
     activeVersion: "0.3.0",
     preferredChannel: "stable",

--- a/apps/cli/test/unit/services/update/native-installer/doctor.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/doctor.test.ts
@@ -250,7 +250,7 @@ describe("buildDoctorReport", () => {
         status: "loaded",
         needsMigration: false,
         manifest: {
-          schemaVersion: 1,
+          schemaVersion: 2,
           method: "binary",
           activeVersion: "9.9.9",
           preferredChannel: "stable",

--- a/apps/cli/test/unit/services/update/native-installer/install-diagnostic.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/install-diagnostic.test.ts
@@ -11,7 +11,7 @@ import {
 } from "@/services/update/native-installer/install-layout";
 
 const binaryManifest: InstallManifest = {
-  schemaVersion: 1,
+  schemaVersion: 2,
   method: "binary",
   activeVersion: "0.3.0",
   preferredChannel: "stable",

--- a/apps/cli/test/unit/services/update/native-installer/install-latest.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/install-latest.test.ts
@@ -25,7 +25,13 @@ import {
 } from "@/services/update/native-installer/install-layout";
 import { isMuslEnvironmentSync } from "@/services/update/native-installer/musl";
 import { verifyStoredVersion } from "@/services/update/native-installer/version-metadata";
-import { releaseAssetName } from "@/services/update/platform-assets";
+import {
+  releaseAssetName,
+  resolveReleaseBinaryTarget,
+  type ReleaseBinaryTarget,
+} from "@/services/update/platform-assets";
+
+import { createReleaseArchive } from "../../../../../scripts/build-release-archives";
 
 const made: string[] = [];
 
@@ -63,6 +69,16 @@ function hostAssetName(): string {
   return releaseAssetName(os, arch, libc);
 }
 
+function hostTarget(): ReleaseBinaryTarget {
+  const os =
+    process.platform === "darwin" ? "darwin" : process.platform === "win32" ? "windows" : "linux";
+  const arch = process.arch === "arm64" ? "arm64" : "x64";
+  const libc = os === "linux" && isMuslEnvironmentSync() ? "musl" : "gnu";
+  const target = resolveReleaseBinaryTarget(os, arch, libc);
+  if (!target) throw new Error(`Missing host release target ${os}-${arch}-${libc}`);
+  return target;
+}
+
 function sumsFor(assetName: string, digest: string): string {
   return `${digest}  ${assetName}\n`;
 }
@@ -92,6 +108,98 @@ async function expectLauncherPointsTo(launcherPath: string, versionPath: string)
 }
 
 describe("installLatest", () => {
+  test("installs the verified archive member and records transport plus binary provenance", async () => {
+    const { layout } = await makeLayout();
+    const releaseTarget = hostTarget();
+    const bytes = new TextEncoder().encode("ARCHIVED-VERIFIED-BINARY");
+    const archive = createReleaseArchive(releaseTarget, bytes);
+    const binaryDigest = sha256Hex(bytes);
+    const archiveDigest = sha256Hex(archive);
+    const requested: string[] = [];
+
+    const result = await installLatest({
+      version: "3.2.0",
+      force: true,
+      layout,
+      dlBase: "https://example.test/releases",
+      fetchImpl: async (input) => {
+        const url = String(input);
+        requested.push(url);
+        if (url.endsWith("/SHA256SUMS.archives")) {
+          return new Response(sumsFor(releaseTarget.archiveName, archiveDigest));
+        }
+        if (url.endsWith("/SHA256SUMS")) {
+          return new Response(sumsFor(releaseTarget.out, binaryDigest));
+        }
+        if (url.endsWith(`/${releaseTarget.archiveName}`)) return new Response(archive);
+        return new Response("missing", { status: 404 });
+      },
+    });
+
+    expect(result).toMatchObject({ status: "installed", version: "3.2.0" });
+    expect(await Bun.file(versionBinaryPath(layout, "3.2.0")).text()).toBe(
+      "ARCHIVED-VERIFIED-BINARY",
+    );
+    expect(requested.some((url) => url.endsWith(`/${releaseTarget.out}`))).toBe(false);
+    expect(await readInstallManifest(layout.configDir)).toMatchObject({
+      schemaVersion: 2,
+      artifactName: releaseTarget.out,
+      artifactSha256: binaryDigest,
+      artifactSizeBytes: bytes.length,
+      archiveName: releaseTarget.archiveName,
+      archiveSha256: archiveDigest,
+      archiveSizeBytes: archive.length,
+      archiveSourceUrl: `https://example.test/releases/download/v3.2.0/${releaseTarget.archiveName}`,
+    });
+  });
+
+  test("archive checksum failure preserves the active launcher and manifest", async () => {
+    const { layout } = await makeLayout();
+    const previousPath = versionBinaryPath(layout, "1.0.0");
+    await mkdir(dirname(previousPath), { recursive: true });
+    await writeFile(previousPath, "OLD-BINARY");
+    await seedLauncher(layout.launcherPath, previousPath);
+    await writeInstallManifest(
+      {
+        method: "binary",
+        activeVersion: "1.0.0",
+        launcherPath: layout.launcherPath,
+        versionedPath: previousPath,
+        downloadBaseUrl: "https://example.test/releases",
+        artifactSha256: sha256Hex("OLD-BINARY"),
+      },
+      layout.configDir,
+    );
+    const releaseTarget = hostTarget();
+    const bytes = new TextEncoder().encode("NEW-BINARY");
+    const archive = createReleaseArchive(releaseTarget, bytes);
+
+    const result = await installLatest({
+      version: "2.0.0",
+      force: true,
+      layout,
+      dlBase: "https://example.test/releases",
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.endsWith("/SHA256SUMS.archives")) {
+          return new Response(sumsFor(releaseTarget.archiveName, "0".repeat(64)));
+        }
+        if (url.endsWith("/SHA256SUMS")) {
+          return new Response(sumsFor(releaseTarget.out, sha256Hex(bytes)));
+        }
+        if (url.endsWith(`/${releaseTarget.archiveName}`)) return new Response(archive);
+        return new Response("missing", { status: 404 });
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "failed",
+      error: `Checksum mismatch for ${releaseTarget.archiveName}`,
+    });
+    await expectLauncherPointsTo(layout.launcherPath, previousPath);
+    expect((await readInstallManifest(layout.configDir))?.activeVersion).toBe("1.0.0");
+  });
+
   test("checksum failure preserves launcher and manifest", async () => {
     const { layout } = await makeLayout();
     const previousPath = versionBinaryPath(layout, "1.0.0");
@@ -121,6 +229,7 @@ describe("installLatest", () => {
       dlBase: "https://example.test/releases",
       fetchImpl: async (input) => {
         const url = String(input);
+        if (url.endsWith("/SHA256SUMS.archives")) return new Response("missing", { status: 404 });
         if (url.includes("SHA256SUMS")) {
           return new Response(badSums, { status: 200 });
         }
@@ -149,6 +258,7 @@ describe("installLatest", () => {
       dlBase: "https://example.test/releases",
       fetchImpl: async (input) => {
         const url = String(input);
+        if (url.endsWith("/SHA256SUMS.archives")) return new Response("missing", { status: 404 });
         if (url.includes("SHA256SUMS")) {
           return new Response(sumsFor(assetName, digest), { status: 200 });
         }
@@ -187,6 +297,7 @@ describe("installLatest", () => {
       dlBase: "https://example.test/releases",
       fetchImpl: async (input) => {
         const url = String(input);
+        if (url.endsWith("/SHA256SUMS.archives")) return new Response("missing", { status: 404 });
         if (url.includes("SHA256SUMS")) {
           return new Response(sumsFor(assetName, digest), { status: 200 });
         }
@@ -238,6 +349,7 @@ describe("installLatest", () => {
       dlBase: "https://example.test/releases",
       fetchImpl: async (input) => {
         const url = String(input);
+        if (url.endsWith("/SHA256SUMS.archives")) return new Response("missing", { status: 404 });
         if (url.includes("SHA256SUMS")) {
           return new Response(sumsFor(assetName, digest), { status: 200 });
         }
@@ -285,6 +397,9 @@ describe("installLatest", () => {
           dlBase: "https://example.test/releases",
           fetchImpl: async (input) => {
             const url = String(input);
+            if (url.endsWith("/SHA256SUMS.archives")) {
+              return new Response("missing", { status: 404 });
+            }
             if (url.includes("SHA256SUMS")) {
               return new Response(sumsFor(assetName, digest), { status: 200 });
             }
@@ -332,6 +447,9 @@ describe("installLatest", () => {
           dlBase: "https://example.test/releases",
           fetchImpl: async (input) => {
             const url = String(input);
+            if (url.endsWith("/SHA256SUMS.archives")) {
+              return new Response("missing", { status: 404 });
+            }
             if (url.includes("SHA256SUMS")) {
               return new Response(sumsFor(assetName, digest), { status: 200 });
             }

--- a/apps/cli/test/unit/services/update/native-installer/install-latest.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/install-latest.test.ts
@@ -24,6 +24,7 @@ import { installLatest } from "@/services/update/native-installer/install-latest
 import {
   activationLockPath,
   getInstallLayoutPaths,
+  stagingDirForVersion,
   versionBinaryPath,
   versionMetadataPath,
 } from "@/services/update/native-installer/install-layout";
@@ -203,6 +204,95 @@ describe("installLatest", () => {
       artifactSourceUrl: `https://example.test/releases/download/v2.9.0/${releaseTarget.out}`,
     });
     expect((await readInstallManifest(layout.configDir))?.archiveName).toBeUndefined();
+  });
+
+  test.each([404, 410] as const)(
+    "%i archive response falls back to the verified raw asset",
+    async (status) => {
+      const { layout } = await makeLayout();
+      const releaseTarget = hostTarget();
+      const bytes = new TextEncoder().encode(`LEGACY-RAW-BINARY-${status}`);
+      const digest = sha256Hex(bytes);
+      const requested: string[] = [];
+
+      const result = await installLatest({
+        version: "2.9.1",
+        force: true,
+        layout,
+        dlBase: "https://example.test/releases",
+        fetchImpl: async (input) => {
+          const url = String(input);
+          requested.push(url);
+          if (url.endsWith("/SHA256SUMS.archives")) {
+            return new Response(sumsFor(releaseTarget.archiveName, "a".repeat(64)));
+          }
+          if (url.endsWith("/SHA256SUMS")) {
+            return new Response(sumsFor(releaseTarget.out, digest));
+          }
+          if (url.endsWith(`/${releaseTarget.archiveName}`)) {
+            return new Response("missing", { status });
+          }
+          if (url.endsWith(`/${releaseTarget.out}`)) return new Response(bytes);
+          return new Response("missing", { status: 404 });
+        },
+      });
+
+      expect(result).toMatchObject({ status: "installed", version: "2.9.1" });
+      expect(requested.some((url) => url.endsWith(`/${releaseTarget.archiveName}`))).toBe(true);
+      expect(requested.some((url) => url.endsWith(`/${releaseTarget.out}`))).toBe(true);
+      expect(await Bun.file(versionBinaryPath(layout, "2.9.1")).text()).toBe(
+        `LEGACY-RAW-BINARY-${status}`,
+      );
+      expect((await readInstallManifest(layout.configDir))?.archiveName).toBeUndefined();
+    },
+  );
+
+  test("archive server failure never falls back or disturbs the active install", async () => {
+    const { layout } = await makeLayout();
+    const previousPath = versionBinaryPath(layout, "1.0.0");
+    await mkdir(dirname(previousPath), { recursive: true });
+    await writeFile(previousPath, "OLD-BINARY");
+    await seedLauncher(layout.launcherPath, previousPath);
+    await writeInstallManifest(
+      {
+        method: "binary",
+        activeVersion: "1.0.0",
+        launcherPath: layout.launcherPath,
+        versionedPath: previousPath,
+        downloadBaseUrl: "https://example.test/releases",
+        artifactSha256: sha256Hex("OLD-BINARY"),
+      },
+      layout,
+    );
+    const releaseTarget = hostTarget();
+    const rawRequested: string[] = [];
+
+    const result = await installLatest({
+      version: "2.9.2",
+      force: true,
+      layout,
+      dlBase: "https://example.test/releases",
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.endsWith("/SHA256SUMS.archives")) {
+          return new Response(sumsFor(releaseTarget.archiveName, "a".repeat(64)));
+        }
+        if (url.endsWith("/SHA256SUMS")) {
+          return new Response(sumsFor(releaseTarget.out, "b".repeat(64)));
+        }
+        if (url.endsWith(`/${releaseTarget.archiveName}`)) {
+          return new Response("unavailable", { status: 500 });
+        }
+        if (url.endsWith(`/${releaseTarget.out}`)) rawRequested.push(url);
+        return new Response("missing", { status: 404 });
+      },
+    });
+
+    expect(result).toMatchObject({ status: "failed", error: "Download failed with HTTP 500" });
+    expect(rawRequested).toEqual([]);
+    await expectLauncherPointsTo(layout.launcherPath, previousPath);
+    expect((await readInstallManifest(layout.configDir))?.activeVersion).toBe("1.0.0");
+    expect(existsSync(stagingDirForVersion(layout, "2.9.2"))).toBe(false);
   });
 
   test("present malformed archive manifest fails closed without raw fallback", async () => {

--- a/apps/cli/test/unit/services/update/native-installer/install-latest.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/install-latest.test.ts
@@ -14,7 +14,11 @@ import {
 import { hostname, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
-import { readInstallManifest, writeInstallManifest } from "@/services/update/install-manifest";
+import {
+  readInstallManifest,
+  writeInstallManifest,
+  writeInstallManifestUnderActivation,
+} from "@/services/update/install-manifest";
 import { tryAcquireActivationLock } from "@/services/update/native-installer/activation-lock";
 import { installLatest } from "@/services/update/native-installer/install-latest";
 import {
@@ -425,6 +429,51 @@ describe("installLatest", () => {
     expect(await install).toMatchObject({ status: "installed", version: "2.0.0" });
     await expectLauncherPointsTo(layout.launcherPath, versionPath);
     expect((await readInstallManifest(layout.configDir))?.activeVersion).toBe("2.0.0");
+  });
+
+  test("does not replace package ownership published while the native binary downloads", async () => {
+    const { layout } = await makeLayout();
+    const held = await tryAcquireActivationLock(layout, "1.0.0");
+    expect(held.acquired).toBe(true);
+
+    const assetName = hostAssetName();
+    const bytes = new TextEncoder().encode("DOWNLOADED-BUT-NOT-ACTIVATED");
+    const digest = sha256Hex(bytes);
+    const install = installLatest({
+      version: "2.0.0",
+      force: true,
+      layout,
+      dlBase: "https://example.test/releases",
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.endsWith("/SHA256SUMS.archives")) return new Response("missing", { status: 404 });
+        if (url.includes("SHA256SUMS")) return new Response(sumsFor(assetName, digest));
+        if (url.includes(assetName)) return new Response(bytes);
+        return new Response("missing", { status: 404 });
+      },
+    });
+
+    await waitForPath(versionMetadataPath(layout, "2.0.0"));
+    await writeInstallManifestUnderActivation(
+      {
+        method: "npm-global",
+        activeVersion: "9.9.9",
+        launcherPath: layout.launcherPath,
+        downloadBaseUrl: "https://registry.npmjs.org",
+      },
+      layout,
+    );
+    if (held.acquired) await held.release();
+
+    expect(await install).toMatchObject({
+      status: "failed",
+      error: expect.stringContaining("Install ownership changed"),
+    });
+    expect(await readInstallManifest(layout.configDir)).toMatchObject({
+      method: "npm-global",
+      activeVersion: "9.9.9",
+    });
+    expect(existsSync(layout.launcherPath)).toBe(false);
   });
 
   test("releases a reclaimed activation lock when manifest publication fails", async () => {

--- a/apps/cli/test/unit/services/update/native-installer/install-latest.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/install-latest.test.ts
@@ -277,7 +277,7 @@ describe("installLatest", () => {
         downloadBaseUrl: "https://example.test/releases",
         artifactSha256: sha256Hex("OLD-BINARY"),
       },
-      layout.configDir,
+      layout,
     );
     const releaseTarget = hostTarget();
     const bytes = new TextEncoder().encode("NEW-BINARY");
@@ -324,7 +324,7 @@ describe("installLatest", () => {
         downloadBaseUrl: "https://example.test/releases",
         artifactSha256: sha256Hex("OLD-BINARY"),
       },
-      layout.configDir,
+      layout,
     );
 
     const assetName = hostAssetName();
@@ -489,7 +489,7 @@ describe("installLatest", () => {
           downloadBaseUrl: "https://example.test/releases",
           artifactSha256: sha256Hex("OLD-BINARY"),
         },
-        layout.configDir,
+        layout,
       );
       const beforeManifest = await readFile(join(layout.configDir, "install.json"), "utf8");
       await chmod(layout.configDir, 0o555);
@@ -539,7 +539,7 @@ describe("installLatest", () => {
           launcherPath: layout.launcherPath,
           downloadBaseUrl: "https://example.test/releases",
         },
-        layout.configDir,
+        layout,
       );
       const beforeManifest = await readFile(join(layout.configDir, "install.json"), "utf8");
       await chmod(layout.configDir, 0o555);

--- a/apps/cli/test/unit/services/update/native-installer/install-latest.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/install-latest.test.ts
@@ -146,11 +146,120 @@ describe("installLatest", () => {
       artifactName: releaseTarget.out,
       artifactSha256: binaryDigest,
       artifactSizeBytes: bytes.length,
+      artifactSourceUrl: `https://example.test/releases/download/v3.2.0/${releaseTarget.out}`,
       archiveName: releaseTarget.archiveName,
       archiveSha256: archiveDigest,
       archiveSizeBytes: archive.length,
       archiveSourceUrl: `https://example.test/releases/download/v3.2.0/${releaseTarget.archiveName}`,
     });
+    expect(JSON.parse(await Bun.file(versionMetadataPath(layout, "3.2.0")).text())).toMatchObject({
+      artifactName: releaseTarget.out,
+      artifactSha256: binaryDigest,
+      sizeBytes: bytes.length,
+      sourceUrl: `https://example.test/releases/download/v3.2.0/${releaseTarget.out}`,
+      archiveName: releaseTarget.archiveName,
+      archiveSha256: archiveDigest,
+      archiveSizeBytes: archive.length,
+      archiveSourceUrl: `https://example.test/releases/download/v3.2.0/${releaseTarget.archiveName}`,
+    });
+  });
+
+  test("410 archive manifest response falls back to the verified raw asset", async () => {
+    const { layout } = await makeLayout();
+    const releaseTarget = hostTarget();
+    const bytes = new TextEncoder().encode("LEGACY-RAW-BINARY");
+    const digest = sha256Hex(bytes);
+    const requested: string[] = [];
+
+    const result = await installLatest({
+      version: "2.9.0",
+      force: true,
+      layout,
+      dlBase: "https://example.test/releases",
+      fetchImpl: async (input) => {
+        const url = String(input);
+        requested.push(url);
+        if (url.endsWith("/SHA256SUMS.archives")) {
+          return new Response("gone", { status: 410 });
+        }
+        if (url.endsWith("/SHA256SUMS")) {
+          return new Response(sumsFor(releaseTarget.out, digest));
+        }
+        if (url.endsWith(`/${releaseTarget.out}`)) return new Response(bytes);
+        return new Response("missing", { status: 404 });
+      },
+    });
+
+    expect(result).toMatchObject({ status: "installed", version: "2.9.0" });
+    expect(requested.some((url) => url.endsWith(`/${releaseTarget.archiveName}`))).toBe(false);
+    expect(await readInstallManifest(layout.configDir)).toMatchObject({
+      artifactName: releaseTarget.out,
+      artifactSha256: digest,
+      artifactSizeBytes: bytes.length,
+      artifactSourceUrl: `https://example.test/releases/download/v2.9.0/${releaseTarget.out}`,
+    });
+    expect((await readInstallManifest(layout.configDir))?.archiveName).toBeUndefined();
+  });
+
+  test("present malformed archive manifest fails closed without raw fallback", async () => {
+    const { layout } = await makeLayout();
+    const releaseTarget = hostTarget();
+    const rawRequested: string[] = [];
+
+    const result = await installLatest({
+      version: "3.0.0",
+      force: true,
+      layout,
+      dlBase: "https://example.test/releases",
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.endsWith("/SHA256SUMS.archives")) return new Response("malformed\n");
+        if (url.endsWith("/SHA256SUMS")) {
+          return new Response(sumsFor(releaseTarget.out, "a".repeat(64)));
+        }
+        if (url.endsWith(`/${releaseTarget.out}`)) rawRequested.push(url);
+        return new Response("missing", { status: 404 });
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "failed",
+      error: `No checksum entry for ${releaseTarget.archiveName}`,
+    });
+    expect(rawRequested).toEqual([]);
+    expect(await readInstallManifest(layout.configDir)).toBeNull();
+  });
+
+  test("archive extraction fails closed when the raw artifact checksum mismatches", async () => {
+    const { layout } = await makeLayout();
+    const releaseTarget = hostTarget();
+    const bytes = new TextEncoder().encode("WRONG-EXTRACTED-BINARY");
+    const archive = createReleaseArchive(releaseTarget, bytes);
+
+    const result = await installLatest({
+      version: "3.0.1",
+      force: true,
+      layout,
+      dlBase: "https://example.test/releases",
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.endsWith("/SHA256SUMS.archives")) {
+          return new Response(sumsFor(releaseTarget.archiveName, sha256Hex(archive)));
+        }
+        if (url.endsWith("/SHA256SUMS")) {
+          return new Response(sumsFor(releaseTarget.out, "0".repeat(64)));
+        }
+        if (url.endsWith(`/${releaseTarget.archiveName}`)) return new Response(archive);
+        return new Response("missing", { status: 404 });
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "failed",
+      error: `Checksum mismatch for extracted ${releaseTarget.out}`,
+    });
+    expect(existsSync(versionBinaryPath(layout, "3.0.1"))).toBe(false);
+    expect(await readInstallManifest(layout.configDir)).toBeNull();
   });
 
   test("archive checksum failure preserves the active launcher and manifest", async () => {

--- a/apps/cli/test/unit/services/update/native-installer/migrate-flat-install.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/migrate-flat-install.test.ts
@@ -41,7 +41,7 @@ async function seedFlatInstall() {
       launcherPath: layout.launcherPath,
       downloadBaseUrl: "https://example.test/releases",
     },
-    layout.configDir,
+    layout,
   );
   const manifest = await readInstallManifest(layout.configDir);
   if (!manifest) throw new Error("Expected seeded flat install manifest");

--- a/apps/cli/test/unit/services/update/native-installer/native-uninstall.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/native-uninstall.test.ts
@@ -98,7 +98,7 @@ async function seedManagedUnixInstall(
       downloadBaseUrl: "https://example.test/releases",
       artifactSha256: sha256,
     },
-    layout.configDir,
+    layout,
   );
   return { path, sha256 };
 }
@@ -327,7 +327,7 @@ describe("nativeUninstall refusal", () => {
         downloadBaseUrl: "https://example.test/releases",
         artifactSha256: sha256,
       },
-      layout.configDir,
+      layout,
     );
 
     const result = await nativeUninstall({ layout, platform: "linux" });
@@ -350,7 +350,7 @@ describe("nativeUninstall refusal", () => {
         downloadBaseUrl: "https://example.test/releases",
         artifactSha256: sha256,
       },
-      layout.configDir,
+      layout,
     );
 
     const ok = await nativeUninstall({ layout, platform: "win32" });
@@ -369,7 +369,7 @@ describe("nativeUninstall refusal", () => {
         downloadBaseUrl: "https://example.test/releases",
         artifactSha256: seeded.sha256,
       },
-      layout2.configDir,
+      layout2,
     );
 
     const blocked = await nativeUninstall({ layout: layout2, platform: "win32" });

--- a/apps/cli/test/unit/services/update/native-installer/release-archive.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/release-archive.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { gunzipSync, gzipSync } from "node:zlib";
+
+import { extractReleaseArchive } from "@/services/update/native-installer/release-archive";
+import {
+  RELEASE_BINARY_TARGETS,
+  type ReleaseBinaryTarget,
+} from "@/services/update/platform-assets";
+
+import { createReleaseArchive } from "../../../../../scripts/build-release-archives";
+
+const encoder = new TextEncoder();
+
+function target(id: string): ReleaseBinaryTarget {
+  const found = RELEASE_BINARY_TARGETS.find((candidate) => candidate.id === id);
+  if (!found) throw new Error(`Missing fixture target ${id}`);
+  return found;
+}
+
+function rewriteTarHeader(archive: Uint8Array, mutate: (header: Uint8Array) => void): Uint8Array {
+  const tar = new Uint8Array(gunzipSync(archive));
+  const header = tar.subarray(0, 512);
+  mutate(header);
+  header.fill(0x20, 148, 156);
+  const sum = header.reduce((total, byte) => total + byte, 0);
+  header.set(encoder.encode(`${sum.toString(8).padStart(6, "0")}\0 `), 148);
+  return new Uint8Array(gzipSync(tar));
+}
+
+function duplicateTarMember(archive: Uint8Array, bodyLength: number): Uint8Array {
+  const tar = new Uint8Array(gunzipSync(archive));
+  const memberLength = 512 + Math.ceil(bodyLength / 512) * 512;
+  const output = new Uint8Array(memberLength * 2 + 1_024);
+  output.set(tar.subarray(0, memberLength), 0);
+  output.set(tar.subarray(0, memberLength), memberLength);
+  return new Uint8Array(gzipSync(output));
+}
+
+function rewriteZipNames(archive: Uint8Array, replacement: string): Uint8Array {
+  const output = new Uint8Array(archive);
+  const view = new DataView(output.buffer, output.byteOffset, output.byteLength);
+  const localLength = view.getUint16(26, true);
+  const bytes = encoder.encode(replacement.padEnd(localLength, "x").slice(0, localLength));
+  output.set(bytes, 30);
+  const compressedSize = view.getUint32(18, true);
+  const centralOffset = 30 + localLength + compressedSize;
+  output.set(bytes, centralOffset + 46);
+  return output;
+}
+
+describe("extractReleaseArchive", () => {
+  for (const id of ["linux-x64", "darwin-arm64"] as const) {
+    test(`extracts the canonical one-member ${id} tar.gz`, () => {
+      const releaseTarget = target(id);
+      const binary = encoder.encode(`binary-${id}`);
+      const archive = createReleaseArchive(releaseTarget, binary);
+
+      expect(extractReleaseArchive(archive, releaseTarget)).toEqual(binary);
+    });
+  }
+
+  test("extracts the canonical one-member Windows zip", () => {
+    const releaseTarget = target("windows-x64");
+    const binary = encoder.encode("MZ-windows-binary");
+
+    expect(
+      extractReleaseArchive(createReleaseArchive(releaseTarget, binary), releaseTarget),
+    ).toEqual(binary);
+  });
+
+  test("rejects traversal, unexpected, symlink, and multiple tar members", () => {
+    const releaseTarget = target("linux-x64");
+    const binary = encoder.encode("linux-binary");
+    const archive = createReleaseArchive(releaseTarget, binary);
+
+    const traversal = rewriteTarHeader(archive, (header) => {
+      header.fill(0, 0, 100);
+      header.set(encoder.encode("../kunai"), 0);
+    });
+    const unexpected = rewriteTarHeader(archive, (header) => {
+      header.fill(0, 0, 100);
+      header.set(encoder.encode("other-binary"), 0);
+    });
+    const symlink = rewriteTarHeader(archive, (header) => {
+      header[156] = "2".charCodeAt(0);
+    });
+    const prefixedTraversal = rewriteTarHeader(archive, (header) => {
+      header.set(encoder.encode("../escape"), 345);
+    });
+
+    expect(() => extractReleaseArchive(traversal, releaseTarget)).toThrow(/unsafe|traversal/i);
+    expect(() => extractReleaseArchive(unexpected, releaseTarget)).toThrow(/unexpected/i);
+    expect(() => extractReleaseArchive(symlink, releaseTarget)).toThrow(/regular file|symlink/i);
+    expect(() => extractReleaseArchive(prefixedTraversal, releaseTarget)).toThrow(
+      /prefix|unsafe|traversal/i,
+    );
+    expect(() =>
+      extractReleaseArchive(duplicateTarMember(archive, binary.length), releaseTarget),
+    ).toThrow(/exactly one|multiple/i);
+  });
+
+  test("rejects a tar member without the required two-block trailer", () => {
+    const releaseTarget = target("linux-x64");
+    const binary = new Uint8Array(1_024).fill(7);
+    const tar = new Uint8Array(gunzipSync(createReleaseArchive(releaseTarget, binary)));
+    const withoutTrailer = new Uint8Array(gzipSync(tar.subarray(0, 1_536)));
+
+    expect(() => extractReleaseArchive(withoutTrailer, releaseTarget)).toThrow(/trailer/i);
+  });
+
+  test("rejects traversal, symlink, and multiple Windows zip members", () => {
+    const releaseTarget = target("windows-x64");
+    const binary = encoder.encode("MZ-windows-binary");
+    const archive = createReleaseArchive(releaseTarget, binary);
+    const symlink = new Uint8Array(archive);
+    const symlinkView = new DataView(symlink.buffer, symlink.byteOffset, symlink.byteLength);
+    const centralOffset = 30 + symlinkView.getUint16(26, true) + symlinkView.getUint32(18, true);
+    symlinkView.setUint32(centralOffset + 38, (0o120777 << 16) >>> 0, true);
+    const multiple = new Uint8Array(archive);
+    const multipleView = new DataView(multiple.buffer, multiple.byteOffset, multiple.byteLength);
+    multipleView.setUint16(multiple.length - 14, 2, true);
+    multipleView.setUint16(multiple.length - 12, 2, true);
+
+    expect(() => extractReleaseArchive(rewriteZipNames(archive, "../evil"), releaseTarget)).toThrow(
+      /unsafe|traversal/i,
+    );
+    expect(() => extractReleaseArchive(symlink, releaseTarget)).toThrow(/regular file|symlink/i);
+    expect(() => extractReleaseArchive(multiple, releaseTarget)).toThrow(/exactly one|multiple/i);
+  });
+
+  test("bounds archive bytes and decompressed output before allocation", () => {
+    const releaseTarget = target("linux-x64");
+    const tinyArchiveBudget = { ...releaseTarget, maxArchiveBytes: 8 };
+    const tinyBinaryBudget = { ...releaseTarget, maxBinaryBytes: 4 };
+    const archive = createReleaseArchive(releaseTarget, encoder.encode("larger-than-four"));
+
+    expect(() => extractReleaseArchive(archive, tinyArchiveBudget)).toThrow(/archive.*size/i);
+    expect(() => extractReleaseArchive(archive, tinyBinaryBudget)).toThrow(
+      /decompression|binary.*size|output/i,
+    );
+  });
+});

--- a/apps/cli/test/unit/services/update/native-installer/release-archive.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/release-archive.test.ts
@@ -48,6 +48,11 @@ function rewriteZipNames(archive: Uint8Array, replacement: string): Uint8Array {
   return output;
 }
 
+function zipCentralOffset(archive: Uint8Array): number {
+  const view = new DataView(archive.buffer, archive.byteOffset, archive.byteLength);
+  return 30 + view.getUint16(26, true) + view.getUint16(28, true) + view.getUint32(18, true);
+}
+
 describe("extractReleaseArchive", () => {
   for (const id of ["linux-x64", "darwin-arm64"] as const) {
     test(`extracts the canonical one-member ${id} tar.gz`, () => {
@@ -126,6 +131,59 @@ describe("extractReleaseArchive", () => {
     );
     expect(() => extractReleaseArchive(symlink, releaseTarget)).toThrow(/regular file|symlink/i);
     expect(() => extractReleaseArchive(multiple, releaseTarget)).toThrow(/exactly one|multiple/i);
+  });
+
+  test("rejects a Windows zip whose payload CRC is corrupted", () => {
+    const releaseTarget = target("windows-x64");
+    const archive = createReleaseArchive(releaseTarget, encoder.encode("MZ-crc-binary"));
+    const corrupted = new Uint8Array(archive);
+    const view = new DataView(corrupted.buffer, corrupted.byteOffset, corrupted.byteLength);
+    const centralOffset = zipCentralOffset(corrupted);
+    const corruptedCrc = (view.getUint32(14, true) ^ 0xffff_ffff) >>> 0;
+    view.setUint32(14, corruptedCrc, true);
+    view.setUint32(centralOffset + 16, corruptedCrc, true);
+
+    expect(() => extractReleaseArchive(corrupted, releaseTarget)).toThrow(/CRC/i);
+  });
+
+  test("rejects local and central Windows zip size disagreement", () => {
+    const releaseTarget = target("windows-x64");
+    const archive = createReleaseArchive(releaseTarget, encoder.encode("MZ-size-binary"));
+    const mismatched = new Uint8Array(archive);
+    const view = new DataView(mismatched.buffer, mismatched.byteOffset, mismatched.byteLength);
+    view.setUint32(22, view.getUint32(22, true) + 1, true);
+
+    expect(() => extractReleaseArchive(mismatched, releaseTarget)).toThrow(
+      /local entry.*central record/i,
+    );
+  });
+
+  test("rejects records trailing the Windows zip end record", () => {
+    const releaseTarget = target("windows-x64");
+    const archive = createReleaseArchive(releaseTarget, encoder.encode("MZ-trailing-binary"));
+    const trailing = new Uint8Array(archive.length + 4);
+    trailing.set(archive);
+    trailing.set([0x50, 0x4b, 0x05, 0x06], archive.length);
+
+    expect(() => extractReleaseArchive(trailing, releaseTarget)).toThrow(/trailing data/i);
+  });
+
+  test("enforces the Windows zip decompression output budget", () => {
+    const releaseTarget = target("windows-x64");
+    const archive = createReleaseArchive(releaseTarget, new Uint8Array(4_096).fill(7));
+    const budgetMismatch = new Uint8Array(archive);
+    const view = new DataView(
+      budgetMismatch.buffer,
+      budgetMismatch.byteOffset,
+      budgetMismatch.byteLength,
+    );
+    const centralOffset = zipCentralOffset(budgetMismatch);
+    view.setUint32(22, 4, true);
+    view.setUint32(centralOffset + 24, 4, true);
+
+    expect(() =>
+      extractReleaseArchive(budgetMismatch, { ...releaseTarget, maxBinaryBytes: 4 }),
+    ).toThrow(/decompression.*budget|output budget/i);
   });
 
   test("bounds archive bytes and decompressed output before allocation", () => {

--- a/apps/cli/test/unit/services/update/native-installer/rollback.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/rollback.test.ts
@@ -133,7 +133,7 @@ async function seedBinaryManifest(
       target: "linux-x64-gnu",
       ...(previousVersion ? { previousVersion } : {}),
     },
-    layout.configDir,
+    layout,
   );
 }
 
@@ -317,7 +317,7 @@ describePosixOnly("executeRollback activation and refusal", () => {
         archiveSizeBytes: 456,
         archiveSourceUrl: archiveBUrl,
       },
-      layout.configDir,
+      layout,
     );
 
     expect(await executeRollback(layout)).toMatchObject({
@@ -402,7 +402,7 @@ describePosixOnly("executeRollback activation and refusal", () => {
         launcherPath: layout.launcherPath,
         downloadBaseUrl: "https://example.test/releases",
       },
-      layout.configDir,
+      layout,
     );
     before = await snapshotTree(root);
     expect(await executeRollback(layout)).toMatchObject({ status: "refused", code: "non-native" });

--- a/apps/cli/test/unit/services/update/native-installer/rollback.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/rollback.test.ts
@@ -15,7 +15,11 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
 
-import { readInstallManifest, writeInstallManifest } from "@/services/update/install-manifest";
+import {
+  readInstallManifest,
+  writeInstallManifest,
+  writeInstallManifestUnderActivation,
+} from "@/services/update/install-manifest";
 import { tryAcquireActivationLock } from "@/services/update/native-installer/activation-lock";
 import {
   getInstallLayoutPaths,
@@ -465,5 +469,47 @@ describePosixOnly("executeRollback activation and refusal", () => {
     } finally {
       if (activation.acquired) await activation.release();
     }
+  });
+
+  test("refuses when package ownership replaces the native manifest after planning", async () => {
+    const { layout } = await makeRoot();
+    await seedVerifiedVersion(layout, "1.0.0", "old");
+    const activePath = await seedVerifiedVersion(layout, "2.0.0", "new");
+    await symlink(activePath, layout.launcherPath);
+    await seedBinaryManifest(layout, "2.0.0", "1.0.0");
+
+    const activation = await tryAcquireActivationLock(layout, "9.9.9");
+    expect(activation.acquired).toBe(true);
+    let announceActivationAttempt!: () => void;
+    const activationAttempted = new Promise<void>((resolve) => {
+      announceActivationAttempt = resolve;
+    });
+    const rollingBack = executeRollback(layout, {
+      onActivationAcquireAttempt: announceActivationAttempt,
+    });
+    try {
+      await activationAttempted;
+      await writeInstallManifestUnderActivation(
+        {
+          method: "bun-global",
+          activeVersion: "9.9.9",
+          launcherPath: layout.launcherPath,
+          downloadBaseUrl: "https://registry.npmjs.org",
+        },
+        layout,
+      );
+    } finally {
+      if (activation.acquired) await activation.release();
+    }
+
+    expect(await rollingBack).toMatchObject({
+      status: "refused",
+      code: "ownership-changed",
+    });
+    expect(await readlink(layout.launcherPath)).toBe(activePath);
+    expect(await readInstallManifest(layout.configDir)).toMatchObject({
+      method: "bun-global",
+      activeVersion: "9.9.9",
+    });
   });
 });

--- a/apps/cli/test/unit/services/update/native-installer/rollback.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/rollback.test.ts
@@ -271,6 +271,77 @@ describePosixOnly("executeRollback activation and refusal", () => {
     expect(manifest?.preferredChannel).toBe("stable");
   });
 
+  test("archive A to B to rollback A restores A transport and raw artifact provenance", async () => {
+    const { layout } = await makeRoot();
+    const rawAUrl = "https://example.test/download/v1.0.0/kunai-linux-x64-gnu";
+    const archiveAUrl = `${rawAUrl}.tar.gz`;
+    const archiveASha = "a".repeat(64);
+    const archiveAPath = await seedVerifiedVersion(layout, "1.0.0", "archive-a", {
+      sourceUrl: rawAUrl,
+      archiveName: "kunai-linux-x64-gnu.tar.gz",
+      archiveSha256: archiveASha,
+      archiveSizeBytes: 123,
+      archiveSourceUrl: archiveAUrl,
+    });
+    const rawBUrl = "https://example.test/download/v2.0.0/kunai-linux-x64-gnu";
+    const archiveBUrl = `${rawBUrl}.tar.gz`;
+    const archiveBSha = "b".repeat(64);
+    const archiveBPath = await seedVerifiedVersion(layout, "2.0.0", "archive-b", {
+      sourceUrl: rawBUrl,
+      archiveName: "kunai-linux-x64-gnu.tar.gz",
+      archiveSha256: archiveBSha,
+      archiveSizeBytes: 456,
+      archiveSourceUrl: archiveBUrl,
+    });
+    const metadataA = await readFile(
+      join(layout.versionsDir, "1.0.0", "version.json"),
+      "utf8",
+    ).then((raw) => JSON.parse(raw) as InstalledVersionMetadata);
+
+    await symlink(archiveBPath, layout.launcherPath);
+    await writeInstallManifest(
+      {
+        method: "binary",
+        activeVersion: "2.0.0",
+        previousVersion: "1.0.0",
+        launcherPath: layout.launcherPath,
+        versionedPath: archiveBPath,
+        downloadBaseUrl: "https://example.test/releases",
+        target: "linux-x64-gnu",
+        artifactName: "kunai-linux-x64-gnu",
+        artifactSha256: createHash("sha256").update("archive-b").digest("hex"),
+        artifactSizeBytes: 9,
+        artifactSourceUrl: rawBUrl,
+        archiveName: "kunai-linux-x64-gnu.tar.gz",
+        archiveSha256: archiveBSha,
+        archiveSizeBytes: 456,
+        archiveSourceUrl: archiveBUrl,
+      },
+      layout.configDir,
+    );
+
+    expect(await executeRollback(layout)).toMatchObject({
+      status: "rolled-back",
+      fromVersion: "2.0.0",
+      toVersion: "1.0.0",
+    });
+    expect(await readlink(layout.launcherPath)).toBe(archiveAPath);
+    expect(await readInstallManifest(layout.configDir)).toMatchObject({
+      activeVersion: "1.0.0",
+      previousVersion: "2.0.0",
+      versionedPath: archiveAPath,
+      target: metadataA.target,
+      artifactName: metadataA.artifactName,
+      artifactSha256: metadataA.artifactSha256,
+      artifactSizeBytes: metadataA.sizeBytes,
+      artifactSourceUrl: rawAUrl,
+      archiveName: "kunai-linux-x64-gnu.tar.gz",
+      archiveSha256: archiveASha,
+      archiveSizeBytes: 123,
+      archiveSourceUrl: archiveAUrl,
+    });
+  });
+
   test("explicit --to validates strictly and activates that version", async () => {
     const { layout } = await makeRoot();
     await seedVerifiedVersion(layout, "1.0.0", "v1");

--- a/apps/cli/test/unit/services/update/native-installer/rollback.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/rollback.test.ts
@@ -512,4 +512,51 @@ describePosixOnly("executeRollback activation and refusal", () => {
       activeVersion: "9.9.9",
     });
   });
+
+  test("refuses when a different native publication replaces the same active version", async () => {
+    const { layout } = await makeRoot();
+    await seedVerifiedVersion(layout, "1.0.0", "old");
+    const activePath = await seedVerifiedVersion(layout, "2.0.0", "new");
+    await symlink(activePath, layout.launcherPath);
+    await seedBinaryManifest(layout, "2.0.0", "1.0.0");
+
+    const activation = await tryAcquireActivationLock(layout, "9.9.9");
+    expect(activation.acquired).toBe(true);
+    let announceActivationAttempt!: () => void;
+    const activationAttempted = new Promise<void>((resolve) => {
+      announceActivationAttempt = resolve;
+    });
+    const rollingBack = executeRollback(layout, {
+      onActivationAcquireAttempt: announceActivationAttempt,
+    });
+    try {
+      await activationAttempted;
+      await writeInstallManifestUnderActivation(
+        {
+          method: "binary",
+          activeVersion: "2.0.0",
+          previousVersion: "1.0.0",
+          launcherPath: layout.launcherPath,
+          versionedPath: activePath,
+          downloadBaseUrl: "https://replacement.example.test/releases",
+          observedProvenance: "replacement-native-publication",
+        },
+        layout,
+      );
+    } finally {
+      if (activation.acquired) await activation.release();
+    }
+
+    expect(await rollingBack).toMatchObject({
+      status: "refused",
+      code: "ownership-changed",
+    });
+    expect(await readlink(layout.launcherPath)).toBe(activePath);
+    expect(await readInstallManifest(layout.configDir)).toMatchObject({
+      method: "binary",
+      activeVersion: "2.0.0",
+      downloadBaseUrl: "https://replacement.example.test/releases",
+      observedProvenance: "replacement-native-publication",
+    });
+  });
 });

--- a/apps/cli/test/unit/services/update/native-installer/version-metadata.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/version-metadata.test.ts
@@ -99,6 +99,38 @@ describe("version metadata", () => {
     await rm(root, { recursive: true, force: true });
   });
 
+  test("archive transport provenance round-trips with raw artifact provenance", async () => {
+    const { root, layout } = await makeLayout();
+    const bytes = new Uint8Array([4, 3, 2, 1]);
+    const metadata = baseMetadata({
+      artifactSha256: createHash("sha256").update(bytes).digest("hex"),
+      sourceUrl: "https://example.test/v1.2.3/kunai-linux-x64-gnu",
+      archiveName: "kunai-linux-x64-gnu.tar.gz",
+      archiveSha256: "b".repeat(64),
+      archiveSizeBytes: 321,
+      archiveSourceUrl: "https://example.test/v1.2.3/kunai-linux-x64-gnu.tar.gz",
+    });
+    await seedBinary(layout, "1.2.3", bytes);
+    await writeInstalledVersionMetadata(layout, metadata);
+
+    expect(await verifyStoredVersion(layout, "1.2.3")).toEqual({
+      status: "verified",
+      metadata,
+    });
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("refuses incomplete archive transport provenance", async () => {
+    const { root, layout } = await makeLayout();
+    await expect(
+      writeInstalledVersionMetadata(
+        layout,
+        baseMetadata({ archiveName: "kunai-linux-x64-gnu.tar.gz" }),
+      ),
+    ).rejects.toThrow(/metadata.*schema|archive provenance/i);
+    await rm(root, { recursive: true, force: true });
+  });
+
   test("reports missing binary and metadata distinctly", async () => {
     const { root, layout } = await makeLayout();
 

--- a/apps/cli/test/unit/services/update/run-install-ownership.test.ts
+++ b/apps/cli/test/unit/services/update/run-install-ownership.test.ts
@@ -1,13 +1,28 @@
-import { afterAll, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import {
+  readInstallManifest,
+  withInstallManifestPublication,
+  writeInstallManifestUnderActivation,
+} from "@/services/update/install-manifest";
 import type { InstallDiagnostic } from "@/services/update/native-installer/install-diagnostic";
+import { getInstallLayoutPaths } from "@/services/update/native-installer/install-layout";
 import type { PackageInspectionPorts, RunInstallPorts } from "@/services/update/run-install";
 
 const UPDATE_ROOT = join(import.meta.dir, "../../../../src/services/update");
 const installLatest = mock(async () => ({ status: "installed" as const, version: "0.3.0" }));
 const checkInstall = mock(async () => []);
 const getInstallDiagnostics = mock(async (): Promise<InstallDiagnostic[]> => []);
+const made: string[] = [];
+const withTestPublication = async <T>(_version: string, fn: () => Promise<T>): Promise<T> => fn();
+
+afterEach(() => {
+  for (const path of made.splice(0)) rmSync(path, { recursive: true, force: true });
+});
 
 // Capture the real module before mocking so we can put it back afterwards.
 // The native-installer index re-exports install-diagnostic; a leaked module
@@ -94,6 +109,7 @@ test("records the observed installed version only after a successful package ins
   const manifests: Array<{ activeVersion: string }> = [];
 
   const code = await runInstall(["--method", "npm"], {
+    withManifestPublication: withTestPublication,
     runCommand: async (command) => {
       events.push(`command:${command.join(" ")}`);
       return 0;
@@ -117,6 +133,74 @@ test("records the observed installed version only after a successful package ins
   expect(manifests).toEqual([expect.objectContaining({ activeVersion: "4.5.6" })]);
 });
 
+test("holds launcher and manifest publication ownership across package command and verification", async () => {
+  const root = mkdtempSync(join(tmpdir(), "kunai-package-publication-"));
+  made.push(root);
+  const layout = getInstallLayoutPaths({
+    configDir: join(root, "config"),
+    dataDir: join(root, "data"),
+    cacheDir: join(root, "cache"),
+    launcherPath: join(root, "bin", "kunai"),
+    platform: "linux",
+  });
+  await mkdir(join(root, "bin"), { recursive: true });
+  let releasePackage!: () => void;
+  const packageGate = new Promise<void>((resolve) => {
+    releasePackage = resolve;
+  });
+  let commandStarted!: () => void;
+  const commandEntered = new Promise<void>((resolve) => {
+    commandStarted = resolve;
+  });
+  let nativeActivated = false;
+
+  const install = runInstall(["--method", "npm", "4.5.6"], {
+    withManifestPublication: (version, fn) => withInstallManifestPublication(version, fn, layout),
+    runCommand: async () => {
+      commandStarted();
+      await packageGate;
+      await Bun.write(layout.launcherPath, "package-launcher");
+      return 0;
+    },
+    inspectPackageInstall: async () => ({
+      version: "4.5.6",
+      launcherPath: layout.launcherPath,
+    }),
+    writeInstallManifest: (manifest) => writeInstallManifestUnderActivation(manifest, layout),
+  });
+  await commandEntered;
+
+  const native = withInstallManifestPublication(
+    "9.9.9",
+    async () => {
+      nativeActivated = true;
+      await Bun.write(layout.launcherPath, "native-launcher");
+      await writeInstallManifestUnderActivation(
+        {
+          method: "binary",
+          activeVersion: "9.9.9",
+          launcherPath: layout.launcherPath,
+          versionedPath: join(layout.versionsDir, "9.9.9", "kunai"),
+          downloadBaseUrl: "https://example.test/releases",
+        },
+        layout,
+      );
+    },
+    layout,
+  );
+  await Bun.sleep(25);
+  expect(nativeActivated).toBe(false);
+
+  releasePackage();
+  expect(await install).toBe(0);
+  await native;
+  expect(await Bun.file(layout.launcherPath).text()).toBe("native-launcher");
+  expect(await readInstallManifest(layout.configDir)).toMatchObject({
+    method: "binary",
+    activeVersion: "9.9.9",
+  });
+});
+
 test("rejects an incomplete injected port object before invoking any command", async () => {
   const events: string[] = [];
   const incompletePorts = {
@@ -133,6 +217,7 @@ test("rejects an incomplete injected port object before invoking any command", a
 test("rejects invalid package versions before commands or manifest writes", async () => {
   const events: string[] = [];
   const code = await runInstall(["--method", "bun", "../4.5.6"], {
+    withManifestPublication: withTestPublication,
     runCommand: async () => {
       events.push("command");
       return 0;
@@ -153,6 +238,7 @@ test("rejects invalid package versions before commands or manifest writes", asyn
 test("does not observe or write a manifest after a package-manager failure", async () => {
   const events: string[] = [];
   const code = await runInstall(["--method", "npm", "4.5.6"], {
+    withManifestPublication: withTestPublication,
     runCommand: async (command) => {
       events.push(`command:${command.join(" ")}`);
       return 17;
@@ -176,6 +262,7 @@ test.each([
 ] as const)("does not write a manifest for %s", async (_label, observedVersion) => {
   const events: string[] = [];
   const code = await runInstall(["--method", "bun", "4.5.6"], {
+    withManifestPublication: withTestPublication,
     runCommand: async () => {
       events.push("command");
       return 0;

--- a/apps/cli/test/unit/services/update/run-upgrade-verification.test.ts
+++ b/apps/cli/test/unit/services/update/run-upgrade-verification.test.ts
@@ -43,6 +43,7 @@ function createPorts(overrides: Partial<RunUpgradePorts> = {}): {
       written.push(manifest);
       return Promise.resolve();
     },
+    withManifestPublication: async (_version, fn) => fn(),
     ...overrides,
   };
   return { ports, written, commands };

--- a/install.ps1
+++ b/install.ps1
@@ -857,6 +857,7 @@ function Acquire-ActivationLock([string]$Ver, [string]$LockPath) {
         if ($timer.ElapsedMilliseconds -ge $ActivationLockTimeoutMs) {
           throw "Could not create activation lock at $LockPath"
         }
+        New-Item -ItemType Directory -Force -Path (Split-Path $LockPath) | Out-Null
         Wait-ActivationLockPoll $timer
         continue
       }

--- a/install.ps1
+++ b/install.ps1
@@ -384,6 +384,19 @@ function Write-Manifest(
   Write-Info "Recorded install method ($MethodName)."
 }
 
+function Invoke-WithManifestPublication([string]$Ver, [scriptblock]$Action) {
+  if ($DryRun) { & $Action; return }
+  $lockPath = Join-Path $LocksDir 'activation.lock'
+  New-Item -ItemType Directory -Force -Path $LocksDir | Out-Null
+  $ownerId = Acquire-ActivationLock $Ver $lockPath
+  try {
+    & $Action
+  }
+  finally {
+    Release-ActivationLock $lockPath $ownerId
+  }
+}
+
 function Write-VersionMetadata {
   param(
     [string]$Ver,
@@ -1432,59 +1445,68 @@ Write-Host 'Kunai installer' -ForegroundColor Cyan
 switch ($Method) {
   'binary' { Install-Binary }
   'npm' {
-    Require-Cmd 'node' 'Install Node.js before using -Method npm.'
-    Require-Cmd 'npm' 'Install npm before using -Method npm.'
-    $resolved = if ($Version -eq 'latest') { 'latest' } else { Get-NormalizedVersion $Version }
-    if ($resolved -eq 'latest') {
-      Invoke-Step "npm install -g $Package" { & npm install -g $Package }
+    $publicationVersion = if ($Version -eq 'latest') { '0.0.0' } else { Get-NormalizedVersion $Version }
+    Invoke-WithManifestPublication $publicationVersion {
+      Require-Cmd 'node' 'Install Node.js before using -Method npm.'
+      Require-Cmd 'npm' 'Install npm before using -Method npm.'
+      $resolved = if ($Version -eq 'latest') { 'latest' } else { Get-NormalizedVersion $Version }
+      if ($resolved -eq 'latest') {
+        Invoke-Step "npm install -g $Package" { & npm install -g $Package }
+      }
+      else {
+        Invoke-Step "npm install -g $Package@$resolved" { & npm install -g "$Package@$resolved" }
+      }
+      $resolved = Complete-PackageActiveVersion 'npm' $resolved
+      Write-Manifest 'npm-global' $resolved (Resolve-OwnedPackageLauncher 'npm')
     }
-    else {
-      Invoke-Step "npm install -g $Package@$resolved" { & npm install -g "$Package@$resolved" }
-    }
-    $resolved = Complete-PackageActiveVersion 'npm' $resolved
-    Write-Manifest 'npm-global' $resolved (Resolve-OwnedPackageLauncher 'npm')
   }
   'bun' {
-    Require-Cmd 'bun' 'Install Bun before using -Method bun.'
-    $resolved = if ($Version -eq 'latest') { 'latest' } else { Get-NormalizedVersion $Version }
-    if ($resolved -eq 'latest') {
-      Invoke-Step "bun install -g $Package" { & bun install -g $Package }
+    $publicationVersion = if ($Version -eq 'latest') { '0.0.0' } else { Get-NormalizedVersion $Version }
+    Invoke-WithManifestPublication $publicationVersion {
+      Require-Cmd 'bun' 'Install Bun before using -Method bun.'
+      $resolved = if ($Version -eq 'latest') { 'latest' } else { Get-NormalizedVersion $Version }
+      if ($resolved -eq 'latest') {
+        Invoke-Step "bun install -g $Package" { & bun install -g $Package }
+      }
+      else {
+        Invoke-Step "bun install -g $Package@$resolved" { & bun install -g "$Package@$resolved" }
+      }
+      $resolved = Complete-PackageActiveVersion 'bun' $resolved
+      Write-Manifest 'bun-global' $resolved (Resolve-OwnedPackageLauncher 'bun')
     }
-    else {
-      Invoke-Step "bun install -g $Package@$resolved" { & bun install -g "$Package@$resolved" }
-    }
-    $resolved = Complete-PackageActiveVersion 'bun' $resolved
-    Write-Manifest 'bun-global' $resolved (Resolve-OwnedPackageLauncher 'bun')
   }
   'source' {
-    Require-Cmd 'git' 'Install Git before using -Method source.'
-    Require-Cmd 'bun' 'Install Bun before using -Method source.'
-    $resolved = if ($Version -eq 'latest') { 'latest' } else { Get-NormalizedVersion $Version }
-    $src = if ($env:KUNAI_SOURCE_DIR) { $env:KUNAI_SOURCE_DIR } else { Join-Path $env:LOCALAPPDATA 'kunai\src' }
-    if (Test-Path (Join-Path $src '.git')) {
-      Invoke-Step "git pull Kunai in $src" { & git -C $src pull --ff-only }
-    }
-    else {
-      Invoke-Step "git clone Kunai into $src" { & git clone --depth 1 'https://github.com/KitsuneKode/kunai.git' $src }
-    }
-    if (-not $DryRun) {
-      Push-Location $src
-      try {
-        Invoke-Step 'bun install' { & bun install }
-        Invoke-Step 'bun run build' { & bun run build }
-        Invoke-Step 'bun run link:global' { & bun run link:global }
+    $publicationVersion = if ($Version -eq 'latest') { '0.0.0' } else { Get-NormalizedVersion $Version }
+    Invoke-WithManifestPublication $publicationVersion {
+      Require-Cmd 'git' 'Install Git before using -Method source.'
+      Require-Cmd 'bun' 'Install Bun before using -Method source.'
+      $resolved = if ($Version -eq 'latest') { 'latest' } else { Get-NormalizedVersion $Version }
+      $src = if ($env:KUNAI_SOURCE_DIR) { $env:KUNAI_SOURCE_DIR } else { Join-Path $env:LOCALAPPDATA 'kunai\src' }
+      if (Test-Path (Join-Path $src '.git')) {
+        Invoke-Step "git pull Kunai in $src" { & git -C $src pull --ff-only }
       }
-      finally {
-        Pop-Location
+      else {
+        Invoke-Step "git clone Kunai into $src" { & git clone --depth 1 'https://github.com/KitsuneKode/kunai.git' $src }
       }
+      if (-not $DryRun) {
+        Push-Location $src
+        try {
+          Invoke-Step 'bun install' { & bun install }
+          Invoke-Step 'bun run build' { & bun run build }
+          Invoke-Step 'bun run link:global' { & bun run link:global }
+        }
+        finally {
+          Pop-Location
+        }
+      }
+      else {
+        Invoke-Step 'bun install' { }
+        Invoke-Step 'bun run build' { }
+        Invoke-Step 'bun run link:global' { }
+      }
+      $resolved = Complete-PackageActiveVersion 'source' $resolved
+      Write-Manifest 'source' $resolved 'kunai'
     }
-    else {
-      Invoke-Step 'bun install' { }
-      Invoke-Step 'bun run build' { }
-      Invoke-Step 'bun run link:global' { }
-    }
-    $resolved = Complete-PackageActiveVersion 'source' $resolved
-    Write-Manifest 'source' $resolved 'kunai'
   }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -883,6 +883,7 @@ acquire_activation_lock() {
 				err "Could not create activation lock at $lock_path"
 				return 1
 			fi
+			mkdir -p "$(dirname "$lock_path")" || return 1
 			activation_lock_poll_until "$deadline" || continue
 			continue
 		fi

--- a/install.sh
+++ b/install.sh
@@ -1479,7 +1479,7 @@ ensure_bun() {
 }
 
 install_npm() {
-	local resolved launcher
+	local resolved launcher publication_lock="$DATA_DIR/locks/activation.lock" publication_owner publication_version
 	require node
 	require npm
 	if [[ "$VERSION" != latest ]]; then
@@ -1490,6 +1490,14 @@ install_npm() {
 	else
 		resolved="latest"
 	fi
+	if [[ "$DRY" == 0 ]]; then
+		publication_version="$resolved"
+		[[ "$publication_version" == latest ]] && publication_version="0.0.0"
+		mkdir -p "$DATA_DIR/locks" || exit 1
+		acquire_activation_lock "$publication_version" "$publication_lock" || exit 1
+		publication_owner="$ACTIVATION_LOCK_OWNER_ID"
+		trap 'release_activation_lock "$publication_lock" "$publication_owner" 2>/dev/null || true' EXIT
+	fi
 	info "Installing $KUNAI_PACKAGE with npm..."
 	if [[ "$resolved" == latest ]]; then
 		run npm install -g "$KUNAI_PACKAGE"
@@ -1499,11 +1507,13 @@ install_npm() {
 	resolved="$(finalize_package_active_version npm "$resolved")" || exit 1
 	if [[ "$DRY" == 1 ]]; then launcher="kunai"; else launcher="$(resolve_owned_package_launcher npm)" || exit 1; fi
 	write_manifest npm-global "${resolved}" "$launcher"
+	[[ "$DRY" == 1 ]] || release_activation_lock "$publication_lock" "$publication_owner"
+	[[ "$DRY" == 1 ]] || trap - EXIT
 	[[ "$DRY" == 1 ]] || path_hint "$(dirname "$launcher")"
 }
 
 install_bun() {
-	local resolved launcher
+	local resolved launcher publication_lock="$DATA_DIR/locks/activation.lock" publication_owner publication_version
 	ensure_bun
 	if [[ "$VERSION" != latest ]]; then
 		resolved="$(normalize_requested_version "$VERSION")" || {
@@ -1512,6 +1522,14 @@ install_bun() {
 		}
 	else
 		resolved="latest"
+	fi
+	if [[ "$DRY" == 0 ]]; then
+		publication_version="$resolved"
+		[[ "$publication_version" == latest ]] && publication_version="0.0.0"
+		mkdir -p "$DATA_DIR/locks" || exit 1
+		acquire_activation_lock "$publication_version" "$publication_lock" || exit 1
+		publication_owner="$ACTIVATION_LOCK_OWNER_ID"
+		trap 'release_activation_lock "$publication_lock" "$publication_owner" 2>/dev/null || true' EXIT
 	fi
 	info "Installing $KUNAI_PACKAGE with bun..."
 	if [[ "$resolved" == latest ]]; then
@@ -1522,11 +1540,13 @@ install_bun() {
 	resolved="$(finalize_package_active_version bun "$resolved")" || exit 1
 	if [[ "$DRY" == 1 ]]; then launcher="kunai"; else launcher="$(resolve_owned_package_launcher bun)" || exit 1; fi
 	write_manifest bun-global "${resolved}" "$launcher"
+	[[ "$DRY" == 1 ]] || release_activation_lock "$publication_lock" "$publication_owner"
+	[[ "$DRY" == 1 ]] || trap - EXIT
 	[[ "$DRY" == 1 ]] || path_hint "$(dirname "$launcher")"
 }
 
 install_source() {
-	local source_path data_path config_path cache_path resolved
+	local source_path data_path config_path cache_path resolved publication_lock="$DATA_DIR/locks/activation.lock" publication_owner publication_version
 	if [[ "$VERSION" != latest ]]; then
 		resolved="$(normalize_requested_version "$VERSION")" || {
 			err "Invalid version: $VERSION (expected exact major.minor.patch)."
@@ -1545,6 +1565,14 @@ install_source() {
 	if [[ "$source_path" == "$data_path" || "$source_path" == "$config_path" || "$source_path" == "$cache_path" ]]; then
 		err "Source checkout path must not equal Kunai data, config, or cache paths."
 		exit 1
+	fi
+	if [[ "$DRY" == 0 ]]; then
+		publication_version="$resolved"
+		[[ "$publication_version" == latest ]] && publication_version="0.0.0"
+		mkdir -p "$DATA_DIR/locks" || exit 1
+		acquire_activation_lock "$publication_version" "$publication_lock" || exit 1
+		publication_owner="$ACTIVATION_LOCK_OWNER_ID"
+		trap 'release_activation_lock "$publication_lock" "$publication_owner" 2>/dev/null || true' EXIT
 	fi
 
 	require git
@@ -1567,6 +1595,8 @@ install_source() {
 	fi
 	resolved="$(finalize_package_active_version source "$resolved")" || exit 1
 	write_manifest source "$resolved" "$(command -v kunai || echo kunai)"
+	[[ "$DRY" == 1 ]] || release_activation_lock "$publication_lock" "$publication_owner"
+	[[ "$DRY" == 1 ]] || trap - EXIT
 }
 
 install_optional_deps() {


### PR DESCRIPTION
## Summary

- prefer deterministic `.tar.gz`/`.zip` platform archives from the release and retain raw-asset compatibility only when the archive manifest is absent (HTTP 404/410)
- verify archive manifest checksum and size, extract exactly one expected executable with bounded in-process parsers, then verify the extracted bytes against raw `SHA256SUMS` before the existing activation transaction
- record archive and extracted-binary provenance in install manifest schema v2 while migrating schema v1 and preserving doctor/rollback behavior
- cover Linux/macOS tar.gz and Windows zip semantics, traversal/symlink/member-count/CRC/size/decompression limits, migration, install, diagnostic, and updater integration paths

## Stack

Depends on #180 (`fix/installer-activation-lock`). This is the native-updater consumption slice of #132; installer shell/PowerShell archive consumption remains separate.

## Verification

- focused activation + updater suite: 161 passed, 1 expected skip, 0 failed
- `bun run test`: 23/23 workspace tasks passed
- `bun run typecheck`: 14/14 passed
- `bun run lint`: 12/12 passed, zero warnings
- `bun run fmt:check`: 26/26 passed
- `bun run verify:doc-paths`: 48 docs and 1,972 source paths passed
- `bun run build`: host binary plus raw/archive release manifests built successfully
- `bun run pkg:check`: 4-file npm package passed size/content guard
- `bun run release:dry-run`: passed
- `git diff --check`: passed
- range-diff confirms the rebased stack preserves the single updater commit exactly

No release, merge, publication, or attestation action was performed.