### PR TITLE
fix(providers): bound the miruro and rivestream module caches

### DIFF
--- a/apps/cli/test/live/miruro-demonslayer.smoke.ts
+++ b/apps/cli/test/live/miruro-demonslayer.smoke.ts
@@ -1,5 +1,9 @@
 import type { TitleInfo } from "@/domain/types";
-import { isStreamReachableForResolve, probeStreamReachability } from "@kunai/providers";
+import {
+  clearMiruroCachesForTest,
+  isStreamReachableForResolve,
+  probeStreamReachability,
+} from "@kunai/providers";
 
 import {
   buildProviderSmokePayload,
@@ -30,6 +34,10 @@ if (!provider) {
 
 if (clearCache) {
   await container.cacheStore.clear();
+  // The CLI cache store is not the only place a stale answer hides — the Miruro
+  // module keeps its own episode/source caches. Clear those too, or a
+  // "cache cleared" run still reads from them.
+  clearMiruroCachesForTest();
 }
 
 const title: TitleInfo = {

--- a/packages/providers/src/miruro/direct.ts
+++ b/packages/providers/src/miruro/direct.ts
@@ -115,10 +115,33 @@ function detectCurlHttp2Support(): boolean {
   return curlSupportsHttp2;
 }
 
+/**
+ * Ceilings for the module-level caches. They were unbounded, so a long anime
+ * session accumulated one entry per title/episode probed and never freed them —
+ * the same growth class already bounded for the Videasy Wings transports.
+ */
+export const MIRURO_CACHE_LIMITS = {
+  episodeEntries: 128,
+  sourceEntries: 256,
+} as const;
+
 /** Cache episode lists per AniList ID. TTL 30 minutes (episode data is stable). */
-const episodeCache = new TTLCache<string, unknown>(1_800_000);
+const episodeCache = new TTLCache<string, unknown>(1_800_000, {
+  maxEntries: MIRURO_CACHE_LIMITS.episodeEntries,
+});
 /** Cache source responses per episode+category. TTL 5 minutes. */
-const sourceCache = new TTLCache<string, unknown>(300_000);
+const sourceCache = new TTLCache<string, unknown>(300_000, {
+  maxEntries: MIRURO_CACHE_LIMITS.sourceEntries,
+});
+
+/**
+ * Clear the module caches. The smoke's `KITSUNE_CLEAR_CACHE=1` cleared the CLI
+ * cache store but not these, so a "cache cleared" run still answered from them.
+ */
+export function clearMiruroCachesForTest(): void {
+  episodeCache.clear();
+  sourceCache.clear();
+}
 
 type MiruroPipeStream = {
   readonly url?: string;

--- a/packages/providers/src/rivestream/direct.ts
+++ b/packages/providers/src/rivestream/direct.ts
@@ -23,6 +23,7 @@ import type {
 
 import { ProviderHttpError, providerJson } from "../runtime/fetch";
 import { resolveTmdbCatalogId } from "../shared/catalog-id";
+import { TTLCache } from "../shared/provider-cache";
 import {
   findLastCycleFailure,
   providerFailureCodeFromCycleFailure,
@@ -55,8 +56,23 @@ export const RIVESTREAM_API_BASE = "https://www.rivestream.app/api/backendfetch"
 const USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
-/** Memoize secretKey per tmdbId — deterministic, expensive to recompute. */
-const secretKeyCache = new Map<string, string>();
+/**
+ * Failure sentinels from `generateSecretKey`. They must never be cached: a
+ * single transient generation error would otherwise pin a bad key for a title
+ * for the life of the process.
+ */
+const RIVESTREAM_SECRET_KEY_SENTINELS = new Set(["rive", "topSecret"]);
+
+/**
+ * Memoize secretKey per tmdbId — deterministic and expensive to recompute, but
+ * previously an unbounded Map that grew one entry per title for the whole
+ * session. A day-long TTL with a hard ceiling keeps it bounded without
+ * recomputing on every resolve.
+ */
+export const RIVESTREAM_SECRET_KEY_CACHE_LIMIT = 512;
+const secretKeyCache = new TTLCache<string, string>(24 * 60 * 60 * 1000, {
+  maxEntries: RIVESTREAM_SECRET_KEY_CACHE_LIMIT,
+});
 const RIVESTREAM_PROVIDER_SERVICES_TTL_MS = 24 * 60 * 60 * 1000;
 /**
  * Last-resort list for when service discovery is unreachable.
@@ -337,7 +353,9 @@ export const rivestreamProviderModule: CoreProviderModule = {
         secretKeyCache.get(tmdbId) ??
         (() => {
           const key = generateSecretKey(tmdbId);
-          secretKeyCache.set(tmdbId, key);
+          // A sentinel means generation fell back, not that this is the real
+          // key — caching it would serve a broken key until process exit.
+          if (!RIVESTREAM_SECRET_KEY_SENTINELS.has(key)) secretKeyCache.set(tmdbId, key);
           return key;
         })();
       const typeStr = input.mediaKind === "series" ? "tv" : "movie";

--- a/packages/providers/test/provider-cache-bounds.test.ts
+++ b/packages/providers/test/provider-cache-bounds.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { clearMiruroCachesForTest, MIRURO_CACHE_LIMITS } from "../src/miruro/direct";
+import {
+  buildRivestreamCycleCandidates,
+  RIVESTREAM_SECRET_KEY_CACHE_LIMIT,
+} from "../src/rivestream/direct";
+
+describe("provider cache bounds", () => {
+  test("miruro cache limits are finite and modest", () => {
+    expect(MIRURO_CACHE_LIMITS.episodeEntries).toBeGreaterThan(0);
+    expect(MIRURO_CACHE_LIMITS.episodeEntries).toBeLessThanOrEqual(1024);
+    expect(MIRURO_CACHE_LIMITS.sourceEntries).toBeGreaterThan(0);
+    expect(MIRURO_CACHE_LIMITS.sourceEntries).toBeLessThanOrEqual(1024);
+  });
+
+  test("clearMiruroCachesForTest is callable and idempotent", () => {
+    // The test seam the smoke relies on must exist and not throw on a cold cache.
+    expect(() => {
+      clearMiruroCachesForTest();
+      clearMiruroCachesForTest();
+    }).not.toThrow();
+  });
+
+  test("the rivestream secret-key cache has a hard ceiling", () => {
+    expect(RIVESTREAM_SECRET_KEY_CACHE_LIMIT).toBeGreaterThan(0);
+    expect(Number.isFinite(RIVESTREAM_SECRET_KEY_CACHE_LIMIT)).toBe(true);
+  });
+
+  test("the rivestream cycle builder still resolves (smoke that the module loads)", () => {
+    // Guards against the secret-key cache refactor breaking module load.
+    const candidates = buildRivestreamCycleCandidates(["flowcast"], undefined, undefined);
+    expect(candidates.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Stacked on #197 (→ #185). Closes #190.

All instances of the growth class already fixed for the Videasy Wings transports:

- **Miruro** `episodeCache`/`sourceCache` were `TTLCache`s with no ceiling → one entry per title/episode probed, never freed. Both now carry `maxEntries`.
- **Miruro** had no test seam, so the smoke's `KITSUNE_CLEAR_CACHE=1` cleared the CLI store but not the module caches. `clearMiruroCachesForTest` now exists and the smoke calls it.
- **Rivestream** `secretKeyCache` was an unbounded `Map` that also cached the `generateSecretKey` failure sentinels, so one transient error pinned a broken key until process exit. Now a bounded `TTLCache`, and sentinels are never cached.

`maxEntries` eviction is already covered in `provider-cache.test.ts`; new tests guard the wiring and the clear seam.

Gate: typecheck 14/14, tests 23/23 forced, zero lint errors.

https://claude.ai/code/session_01BkWab6pnVL5vMsVGRv9TVp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Miruro and Rivestream playback reliability by managing cached provider data within defined limits.
  * Prevented temporary Rivestream secret-generation failures from being reused.
  * Added safer cache clearing for Miruro-related playback data.

* **Tests**
  * Added coverage verifying cache limits, clearing behavior, and successful Rivestream playback candidate creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->