### PR TITLE
fix(providers): wire the miruro subtitle boost, drop dead videasy constants

### DIFF
--- a/packages/providers/src/miruro/direct.ts
+++ b/packages/providers/src/miruro/direct.ts
@@ -1753,6 +1753,14 @@ export const miruroProviderModule: CoreProviderModule = {
         targetAudio,
         fallbackAudio,
         preferredSourceId: input.preferredSourceId,
+        // The builder gives hard-sub sub servers a priority boost, but this was
+        // never supplied, so the boost was dead. The adapter sets this to
+        // "hardcoded" for anime; `external` has no Miruro equivalent, so it maps
+        // to `unknown` and simply does not trigger the boost.
+        preferredSubtitleDelivery:
+          input.preferredSubtitleDelivery === "external"
+            ? "unknown"
+            : input.preferredSubtitleDelivery,
       });
       const sourceInventorySeeds = buildMiruroSourceInventoryCandidates(
         cycleCandidates,

--- a/packages/providers/src/videasy/direct.ts
+++ b/packages/providers/src/videasy/direct.ts
@@ -99,10 +99,6 @@ export const WINGS_API_BASE = "https://api.speedracelight.com";
 export const WINGS_API_FALLBACK_BASE = "https://api.wingsdatabase.com";
 /** TMDB proxy on the old domain (redirects to api.videasy.to/3). */
 export const VIDEASY_DB_BASE = "https://api.videasy.to/3";
-/** TMDB proxy on wingsdatabase (open, no auth). */
-export const WINGS_DB_BASE = "https://db.wingsdatabase.com/3";
-/** TMDB proxy sibling of the speedracelight stream API. */
-export const SPEEDRACE_DB_BASE = "https://db.speedracelight.com/3";
 
 /* ── Wings / SpeedRace endpoint mapping ──
  * Endpoints in the `wings-*` namespace are routed to the active stream API.

--- a/packages/providers/test/miruro-direct.test.ts
+++ b/packages/providers/test/miruro-direct.test.ts
@@ -177,6 +177,38 @@ describe("Miruro server order has one authority", () => {
     expect(catalogServers).toEqual([...EXPECTED_ORDER]);
   });
 
+  test("a hardcoded subtitle preference pulls sub servers ahead of dub", () => {
+    // The builder gives sub servers a -5000 boost when hard-sub is preferred.
+    // The resolve path never passed the preference, so the boost was dead code;
+    // this proves it now reorders when the preference is supplied.
+    const bothLangs = { sub: [{ id: "s-1", number: 1 }], dub: [{ id: "d-1", number: 1 }] };
+    const providers = { kiwi: { episodes: bothLangs } };
+
+    // The cycle engine orders by the `priority` field, so sort as it would.
+    const leader = (
+      candidates: ReturnType<typeof buildMiruroCycleCandidates>,
+    ): string | undefined => [...candidates].sort((a, b) => a.priority - b.priority)[0]?.groupId;
+
+    const withoutPreference = buildMiruroCycleCandidates({
+      providers,
+      episodeNum: 1,
+      targetAudio: "dub",
+      fallbackAudio: "sub",
+    });
+    // Default: dub (the target) is tried first.
+    expect(leader(withoutPreference)).toBe("dub");
+
+    const withHardsub = buildMiruroCycleCandidates({
+      providers,
+      episodeNum: 1,
+      targetAudio: "dub",
+      fallbackAudio: "sub",
+      preferredSubtitleDelivery: "hardcoded",
+    });
+    // With the preference honoured, the boosted sub server leads.
+    expect(leader(withHardsub)).toBe("sub");
+  });
+
   test("fallback construction with no discovered providers follows the canonical order", () => {
     const candidates = buildMiruroCycleCandidates({
       episodes,


### PR DESCRIPTION
Stacked on #198 (→ #197 → #185). Closes #191.

Two declarations with no reader (the documented house failure mode):

- **Miruro** gives hard-sub `sub` servers a −5000 priority boost, but the resolve path never passed `preferredSubtitleDelivery` into the builder, so it was dead. The adapter already sets it to `hardcoded` for anime; now threaded through. A test proves the boost reorders sub ahead of dub.
- **Videasy** exported `WINGS_DB_BASE`/`SPEEDRACE_DB_BASE`, read by nothing. Removed (`VIDEASY_DB_BASE` beside them has 4 callers, kept).

Not changed: the audit also flagged videasy's relay `upstreamHosts` as unread, but `packages/relay/src/registry.ts` matches request hosts against it and the list is accurate — it is wired.

Gate: typecheck 14/14, tests 23/23 forced, zero lint errors.

https://claude.ai/code/session_01BkWab6pnVL5vMsVGRv9TVp