### PR TITLE
feat(playback): tell the user when audio was downgraded

### DIFF
--- a/apps/cli/src/app/playback/PlaybackPhase.ts
+++ b/apps/cli/src/app/playback/PlaybackPhase.ts
@@ -137,7 +137,11 @@ import {
   type RecentPlaybackStreamProvenance,
   type RecentPlaybackStreamRecord,
 } from "@/app/playback/recent-playback-stream";
-import { createResolveTraceStub, finalizeResolveTrace } from "@/app/playback/resolve-trace";
+import {
+  audioFallbackNoticeFromTrace,
+  createResolveTraceStub,
+  finalizeResolveTrace,
+} from "@/app/playback/resolve-trace";
 import { runMpvPlaybackSession } from "@/app/playback/run-mpv-playback-session";
 import { planEpisodeIterationDirective } from "@/app/playback/run-playback-episode-iteration";
 import {
@@ -1897,6 +1901,15 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
             }
 
             if (stream?.providerResolveResult) {
+              // Surface a silent audio downgrade (e.g. dub requested, only sub
+              // available) so the user is told why the language changed rather
+              // than just hearing the wrong one.
+              const audioFallbackNote = audioFallbackNoticeFromTrace(
+                stream.providerResolveResult.trace.events,
+              );
+              if (audioFallbackNote) {
+                this.updatePlaybackFeedback(context, { note: audioFallbackNote });
+              }
               diagnosticsService.record({
                 ...playbackCorrelation,
                 category: "provider",

--- a/apps/cli/src/app/playback/resolve-trace.ts
+++ b/apps/cli/src/app/playback/resolve-trace.ts
@@ -1,5 +1,5 @@
 import type { EpisodeInfo, ShellMode, TitleInfo } from "@/domain/types";
-import type { ProviderFailure, ProviderId, ResolveTrace } from "@kunai/types";
+import type { ProviderFailure, ProviderId, ProviderTraceEvent, ResolveTrace } from "@kunai/types";
 
 export function createResolveTraceStub({
   title,
@@ -76,4 +76,31 @@ export function finalizeResolveTrace(
     cacheHit: outcome.cacheHit,
     failures: outcome.failures,
   };
+}
+
+/**
+ * A human-facing note for an audio downgrade, or null when the requested audio
+ * was honoured.
+ *
+ * Providers emit an `audio:fallback` trace event when they resolve a different
+ * audio presentation than the one requested (e.g. a dub was asked for but only a
+ * sub server answered). Without surfacing it the user just gets the wrong
+ * language with no explanation — the silent no-op the project treats as its
+ * house failure mode.
+ */
+export function audioFallbackNoticeFromTrace(
+  events: readonly ProviderTraceEvent[] | undefined,
+): string | null {
+  const event = events?.find((entry) => entry.type === "audio:fallback");
+  if (!event) return null;
+  const requested = presentationLabel(event.attributes?.requested);
+  const resolved = presentationLabel(event.attributes?.resolved);
+  if (!requested || !resolved) return null;
+  return `${requested} unavailable — playing ${resolved}`;
+}
+
+function presentationLabel(value: unknown): string | null {
+  if (value === "dub") return "Dub";
+  if (value === "sub") return "Sub";
+  return null;
 }

--- a/apps/cli/test/unit/app/resolve-trace.test.ts
+++ b/apps/cli/test/unit/app/resolve-trace.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { createResolveTraceStub, finalizeResolveTrace } from "@/app/playback/resolve-trace";
+import {
+  audioFallbackNoticeFromTrace,
+  createResolveTraceStub,
+  finalizeResolveTrace,
+} from "@/app/playback/resolve-trace";
 import type { TitleInfo } from "@/domain/types";
 import type { ProviderFailure } from "@kunai/types";
 
@@ -84,5 +88,45 @@ describe("finalizeResolveTrace", () => {
 
     expect(finished.steps).toHaveLength(1);
     expect(finished.startedAt).toBeTruthy();
+  });
+});
+
+describe("audioFallbackNoticeFromTrace", () => {
+  const at = new Date().toISOString();
+
+  test("a dub->sub downgrade produces a user-facing notice", () => {
+    const note = audioFallbackNoticeFromTrace([
+      {
+        type: "audio:fallback",
+        providerId: "miruro",
+        at,
+        message: "requested dub, resolved sub",
+        attributes: { requested: "dub", resolved: "sub" },
+      },
+    ]);
+    expect(note).toBe("Dub unavailable — playing Sub");
+  });
+
+  test("no audio:fallback event means no notice", () => {
+    expect(
+      audioFallbackNoticeFromTrace([
+        { type: "provider:success", providerId: "miruro", at, message: "ok" },
+      ]),
+    ).toBeNull();
+    expect(audioFallbackNoticeFromTrace(undefined)).toBeNull();
+  });
+
+  test("an event with unknown presentations is ignored, not mislabelled", () => {
+    expect(
+      audioFallbackNoticeFromTrace([
+        {
+          type: "audio:fallback",
+          providerId: "miruro",
+          at,
+          message: "weird",
+          attributes: { requested: "external", resolved: "sub" },
+        },
+      ]),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
Stacked on #201 (→ #200 → #199 → #198 → #197 → #185). Closes #193.

The final piece of #193. #201 made Miruro emit an `audio:fallback` trace when it walks a dub request to a sub (dub server down); this surfaces it to the user.

On resolve, the playback phase reads that event and, when present, shows a one-line notice — **"Dub unavailable — playing Sub"** — through the existing playback-feedback channel (`updatePlaybackFeedback`, the same one that shows "Preparing playback"). No new UI surface, no change to the playback machinery.

The extraction is a pure helper, `audioFallbackNoticeFromTrace`, unit-tested including the mislabel and unknown-presentation cases (the mislabel test fails if sub/dub labels are swapped).

**Contention note:** touches `PlaybackPhase.ts` (contended by #178/#156), but the change is a small additive block at the existing trace-read site — a clean merge. The pure helper lives in the uncontended `resolve-trace.ts`.

This closes the last silent-wrong-audio gap for 0.3.0.

Gate: typecheck 14/14, tests 23/23 forced (isolated runner), zero lint errors.

https://claude.ai/code/session_01BkWab6pnVL5vMsVGRv9TVp