### PR TITLE
feat(installer): consume verified native release archives

### DIFF
--- a/.changeset/tidy-cats-install.md
+++ b/.changeset/tidy-cats-install.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Install verified compressed native release assets from Bash and PowerShell, reject unsafe or oversized archive contents, and retain a 404/410-only fallback for older raw releases.

--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -57,24 +57,31 @@ asset name and no directory prefix; tar metadata is normalized with executable
 mode `0755`, while zip records that Unix mode but Windows extraction does not
 promise to restore it.
 
-The TypeScript native updater consumes these archives. It verifies the archive
-against `SHA256SUMS.archives`, parses tar/gzip or zip in-process without invoking
-an OS extractor, permits exactly one expected regular-file member, bounds both
-compressed and decompressed bytes, and then verifies that member against the
-legacy raw `SHA256SUMS` before version-store or launcher activation. Missing
-archive manifests on an older release fall back to its raw compatibility asset;
-a present but malformed or mismatched archive fails closed. Native
-`install.json` is schema 2 and records both archive transport and extracted
-binary provenance. Per-version `version.json` records the raw artifact as
-`artifactName`, `artifactSha256`, `sizeBytes`, and `sourceUrl`; archive installs
-add the all-or-none `archiveName`, `archiveSha256`, `archiveSizeBytes`, and
+The TypeScript native updater and both native installer scripts consume these
+archives. All three verify the archive against `SHA256SUMS.archives`, permit
+exactly one expected regular-file member, bound compressed and decompressed
+bytes, and then verify that member against the legacy raw `SHA256SUMS` before
+version-store or launcher activation. TypeScript parses tar/gzip and zip
+in-process; PowerShell uses bounded .NET zip streams; Bash validates the tar
+header, type, name, size, checksum, padding, and two-block trailer before asking
+the host `tar` to stream only the verified member. Absolute/traversal paths,
+links, reparse entries, duplicates, extra/missing/wrong payloads, malformed
+containers, and size bombs fail closed and leave no staging or activation state.
+
+Only HTTP 404/410 from `SHA256SUMS.archives` or the archive asset selects the raw
+compatibility path for older releases. Timeouts, 5xx responses, checksum
+mismatches, and malformed archives never fall back. Native `install.json` is
+schema 2 and records both archive transport and extracted-binary provenance.
+Per-version `version.json` records the raw artifact as `artifactName`,
+`artifactSha256`, `sizeBytes`, and `sourceUrl`; archive installs add the
+all-or-none `archiveName`, `archiveSha256`, `archiveSizeBytes`, and
 `archiveSourceUrl` quartet. Rollback republishes both groups into `install.json`
 (`artifactSizeBytes` and `artifactSourceUrl` are the manifest spellings).
 Schema-1 manifest migration is an explicit startup transition: it acquires the
 version and activation locks, which exclude uninstall through the lifecycle
 guard, then re-reads before publishing so a newer activation is not overwritten
-and a removed manifest is not recreated. The shell and PowerShell installer
-archive-consumption slices remain release blockers for issue #132.
+and a removed manifest is not recreated. Issue #132 and 0.3.0 dispatch remain
+blocked until this complete stack passes protected native release gates.
 
 ## Native Installer Activation Gate
 

--- a/.docs/repo-infrastructure.md
+++ b/.docs/repo-infrastructure.md
@@ -156,9 +156,9 @@ raw-binary hash, and keep a 404/410-only raw fallback for releases published
 before archives existed. TypeScript uses an in-process bounded parser,
 PowerShell uses bounded .NET zip streams, and Bash validates a bounded tar
 container before streaming its one expected member through the host `tar`.
-Malformed archives and all other download/integrity failures fail closed. Issue
-#132 and 0.3.0 release dispatch remain blocked until the stacked consumers are
-rebased onto the final activation-lock parent and pass protected native gates.
+Malformed archives and all other download/integrity failures fail closed. The
+archive-consuming updater and installers are stacked on the final activation-lock
+protocol; release promotion and attestation remain downstream protected gates.
 
 ### Windows parity
 

--- a/.docs/repo-infrastructure.md
+++ b/.docs/repo-infrastructure.md
@@ -150,13 +150,15 @@ bits. The build reconstructs and byte-compares each archive after preservation,
 then release confirmation and publication reverify the same bytes without a
 rebuild.
 
-The TypeScript native updater now consumes the platform archive, independently
-verifies its transport hash and its extracted raw-binary hash, and keeps a
-404/410-only raw fallback for releases published before archives existed. It
-uses an in-process, bounded one-member parser rather than an external tar/zip
-command. The Bash and PowerShell installers still follow the functional legacy
-raw-asset path until their later stacked consumption slice lands. Issue #132
-and 0.3.0 release dispatch remain blocked on that cross-language parity.
+The TypeScript native updater and the Bash/PowerShell installers consume the
+platform archive, independently verify its transport hash and extracted
+raw-binary hash, and keep a 404/410-only raw fallback for releases published
+before archives existed. TypeScript uses an in-process bounded parser,
+PowerShell uses bounded .NET zip streams, and Bash validates a bounded tar
+container before streaming its one expected member through the host `tar`.
+Malformed archives and all other download/integrity failures fail closed. Issue
+#132 and 0.3.0 release dispatch remain blocked until the stacked consumers are
+rebased onto the final activation-lock parent and pass protected native gates.
 
 ### Windows parity
 

--- a/apps/cli/test/docker/native-installer/README.md
+++ b/apps/cli/test/docker/native-installer/README.md
@@ -43,8 +43,8 @@ variants/gates fail validation.
 | ID                              | Gate    | Contract                                          |
 | ------------------------------- | ------- | ------------------------------------------------- |
 | `full-lifecycle`                | PR      | install → upgrade → doctor → rollback → uninstall |
-| `clean-install`                 | PR      | empty HOME → schema-1 layout, no residue          |
-| `checksum-rejection`            | PR      | corrupt asset fails; no launcher/manifest         |
+| `clean-install`                 | PR      | empty HOME → schema-2 archive layout, no residue  |
+| `checksum-rejection`            | PR      | corrupt archive fails; no launcher/manifest       |
 | `reinstall-idempotent`          | nightly | same-version reinstall stays consistent           |
 | `upgrade-rollback`              | nightly | retention + dry-run + default/`--to`              |
 | `stale-lock-recovery`           | nightly | dead lock/txn do not block install                |

--- a/apps/cli/test/docker/native-installer/prepare-fixture.sh
+++ b/apps/cli/test/docker/native-installer/prepare-fixture.sh
@@ -6,7 +6,9 @@
 #
 # Creates:
 #   <output>/download/v<ver>/<asset>
+#   <output>/download/v<ver>/<asset>.tar.gz
 #   <output>/download/v<ver>/SHA256SUMS
+#   <output>/download/v<ver>/SHA256SUMS.archives
 #   <output>/releases/latest.json   (tag_name = highest semver arg)
 set -euo pipefail
 
@@ -25,22 +27,25 @@ if [[ $# -lt 1 ]]; then
   exit 1
 fi
 
-sha256_of() {
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$1" | awk '{print $1}'
-  else
-    shasum -a 256 "$1" | awk '{print $1}'
+ARCHIVE="${BINARY}.tar.gz"
+RAW_SUMS="$(dirname "$BINARY")/SHA256SUMS"
+ARCHIVE_SUMS="$(dirname "$BINARY")/SHA256SUMS.archives"
+for required in "$ARCHIVE" "$RAW_SUMS" "$ARCHIVE_SUMS"; do
+  if [[ ! -f "$required" ]]; then
+    echo "prepare-fixture: release companion not found: $required" >&2
+    exit 1
   fi
-}
+done
 
 latest="$(printf '%s\n' "$@" | sort -V | tail -1)"
 for ver in "$@"; do
   dest="$OUT/download/v$ver"
   mkdir -p "$dest"
   cp "$BINARY" "$dest/$ASSET"
+  cp "$ARCHIVE" "$dest/$ASSET.tar.gz"
+  cp "$RAW_SUMS" "$dest/SHA256SUMS"
+  cp "$ARCHIVE_SUMS" "$dest/SHA256SUMS.archives"
   chmod 0755 "$dest/$ASSET"
-  hash="$(sha256_of "$dest/$ASSET")"
-  printf '%s  %s\n' "$hash" "$ASSET" >"$dest/SHA256SUMS"
 done
 
 mkdir -p "$OUT/releases"

--- a/apps/cli/test/docker/native-installer/smoke.sh
+++ b/apps/cli/test/docker/native-installer/smoke.sh
@@ -114,11 +114,11 @@ assert_no_operational_residue() {
   fi
 }
 
-assert_schema1_manifest() {
+assert_schema2_manifest() {
   local version="$1"
   local path="$KUNAI_CONFIG_DIR/install.json"
   [[ -f "$path" ]] || fail "install.json missing"
-  grep -qE '"schemaVersion"[[:space:]]*:[[:space:]]*1' "$path" || fail "install.json missing schemaVersion"
+  grep -qE '"schemaVersion"[[:space:]]*:[[:space:]]*2' "$path" || fail "install.json missing schemaVersion"
   grep -qE '"method"[[:space:]]*:[[:space:]]*"binary"' "$path" || fail "install.json method not binary"
   grep -qE "\"activeVersion\"[[:space:]]*:[[:space:]]*\"${version//./\\.}\"" "$path" ||
     fail "install.json activeVersion not $version"
@@ -127,6 +127,12 @@ assert_schema1_manifest() {
   grep -q '"versionedPath"' "$path" || fail "install.json versionedPath"
   grep -q '"managedPaths"' "$path" || fail "install.json managedPaths"
   grep -q '"artifactSha256"' "$path" || fail "install.json artifactSha256"
+  grep -q '"artifactName"' "$path" || fail "install.json artifactName"
+  grep -q '"artifactSizeBytes"' "$path" || fail "install.json artifactSizeBytes"
+  grep -q '"archiveName"' "$path" || fail "install.json archiveName"
+  grep -q '"archiveSha256"' "$path" || fail "install.json archiveSha256"
+  grep -q '"archiveSizeBytes"' "$path" || fail "install.json archiveSizeBytes"
+  grep -q '"archiveSourceUrl"' "$path" || fail "install.json archiveSourceUrl"
   grep -q '"target"' "$path" || fail "install.json target"
 }
 
@@ -188,11 +194,11 @@ scenario_clean_install() {
   start_fixture_server
   install_pinned 1.0.0
   assert_version_layout 1.0.0
-  assert_schema1_manifest 1.0.0
+  assert_schema2_manifest 1.0.0
   "$KUNAI_BIN_DIR/kunai" --version >/tmp/kunai-version.txt
   grep -qi '^kunai ' /tmp/kunai-version.txt || fail "kunai --version must print kunai semver"
   assert_no_operational_residue
-  pass "clean-install schema-1 ownership state"
+  pass "clean-install schema-2 archive ownership state"
 }
 
 scenario_checksum_rejection() {
@@ -204,8 +210,9 @@ scenario_checksum_rejection() {
   local writable
   writable="$(mktemp -d /tmp/kunai-corrupt-fixture.XXXXXX)"
   cp -a "$FIXTURE/." "$writable/"
-  # Corrupt the asset after SHA256SUMS was generated so checksum verification fails.
-  printf '\x00corrupt' >>"$writable/download/v1.0.0/$ASSET"
+  # Corrupt the archive after SHA256SUMS.archives was generated so transport
+  # verification fails before extraction or raw compatibility fallback.
+  printf '\x00corrupt' >>"$writable/download/v1.0.0/$ASSET.tar.gz"
   start_fixture_server "$writable"
 
   set +e
@@ -238,7 +245,7 @@ scenario_reinstall_idempotent() {
 
   install_pinned 1.0.0
   assert_version_layout 1.0.0
-  assert_schema1_manifest 1.0.0
+  assert_schema2_manifest 1.0.0
   local target_after
   target_after="$(readlink -f "$KUNAI_BIN_DIR/kunai")"
   [[ "$target_after" == "$target_before" ]] || fail "launcher target changed on reinstall"
@@ -297,7 +304,7 @@ scenario_stale_lock_recovery() {
 
   install_pinned 1.0.0
   assert_version_layout 1.0.0
-  assert_schema1_manifest 1.0.0
+  assert_schema2_manifest 1.0.0
   assert_no_operational_residue
   assert_user_data_preserved
   pass "stale-lock-recovery completed install"
@@ -347,7 +354,7 @@ scenario_custom_xdg_layout() {
   start_fixture_server
   install_pinned 1.0.0
   assert_version_layout 1.0.0
-  assert_schema1_manifest 1.0.0
+  assert_schema2_manifest 1.0.0
   [[ ! -d "$HOME/.config/kunai" ]] || fail "default ~/.config/kunai was created"
   [[ ! -d "$HOME/.local/share/kunai" ]] || fail "default ~/.local/share/kunai was created"
   [[ ! -d "$HOME/.cache/kunai" ]] || fail "default ~/.cache/kunai was created"
@@ -366,8 +373,8 @@ scenario_full_lifecycle() {
   start_fixture_server
   install_pinned 1.0.0
   assert_version_layout 1.0.0
-  assert_schema1_manifest 1.0.0
-  pass "install.sh created versioned layout (schema-1)"
+  assert_schema2_manifest 1.0.0
+  pass "install.sh created versioned layout (schema-2 archive provenance)"
 
   "$KUNAI_BIN_DIR/kunai" --version >/tmp/kunai-version.txt
   grep -qi '^kunai ' /tmp/kunai-version.txt || fail "kunai --version must print kunai semver"

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -569,6 +569,45 @@ describePwsh("install.ps1 release asset failures", () => {
     }
   });
 
+  test("rejects extracted binary checksum mismatch without raw fallback or residue", async () => {
+    const target = hostWindowsTarget();
+    const body = "MZ-archive-member";
+    const archive = createReleaseArchive(target, new TextEncoder().encode(body));
+    const archiveDigest = createHash("sha256").update(archive).digest("hex");
+    const sandbox = createInstallerSandbox("install-ps1-extracted-mismatch");
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${target.archiveName}`]: { body: archive },
+          "/download/v9.8.7/SHA256SUMS.archives": {
+            body: `${archiveDigest}  ${target.archiveName}\n`,
+          },
+          "/download/v9.8.7/SHA256SUMS": {
+            body: `${"0".repeat(64)}  ${target.out}\n`,
+          },
+          [`/download/v9.8.7/${target.out}`]: { body: "LEGACY-RAW-MUST-NOT-RUN" },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+
+          expect(result.status).not.toBe(0);
+          expect(`${result.stderr}${result.stdout}`).toContain(
+            `Checksum mismatch for extracted ${target.out}`,
+          );
+          expect(evidence.requests).not.toContain(`/download/v9.8.7/${target.out}`);
+          expect(existsSync(join(sandbox.binDir, "kunai.exe"))).toBe(false);
+          expect(existsSync(join(sandbox.configDir, "install.json"))).toBe(false);
+          expect(existsSync(join(sandbox.cacheDir, "staging", "9.8.7"))).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
   test("rejects zip archive and decompressed size bombs and cleans staging", async () => {
     const target = hostWindowsTarget();
     const body = "MZ-binary-larger-than-four-bytes";

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -208,6 +208,7 @@ function invalidZipArchive(
     | "absolute"
     | "case-variant"
     | "corrupt"
+    | "crc"
     | "extra"
     | "local-traversal"
     | "missing"
@@ -239,12 +240,18 @@ function invalidZipArchive(
   if (kind === "wrong") return rewriteZipNames(canonical, "wrong.exe");
   const output = new Uint8Array(canonical);
   const view = new DataView(output.buffer, output.byteOffset, output.byteLength);
+  const centralOffset = 30 + view.getUint16(26, true) + view.getUint32(18, true);
+  if (kind === "crc") {
+    const invalidCrc = (view.getUint32(14, true) ^ 1) >>> 0;
+    view.setUint32(14, invalidCrc, true);
+    view.setUint32(centralOffset + 16, invalidCrc, true);
+    return output;
+  }
   if (kind === "extra") {
     view.setUint16(output.length - 14, 2, true);
     view.setUint16(output.length - 12, 2, true);
     return output;
   }
-  const centralOffset = 30 + view.getUint16(26, true) + view.getUint32(18, true);
   const attributes = view.getUint32(centralOffset + 38, true);
   view.setUint32(
     centralOffset + 38,
@@ -470,6 +477,7 @@ describePwsh("install.ps1 release asset failures", () => {
     "absolute",
     "case-variant",
     "corrupt",
+    "crc",
     "extra",
     "local-traversal",
     "missing",
@@ -506,6 +514,7 @@ describePwsh("install.ps1 release asset failures", () => {
           });
 
           expect(result.status).not.toBe(0);
+          if (kind === "crc") expect(result.stderr).toMatch(/CRC/i);
           expect(evidence.requests).not.toContain(`/download/v9.8.7/${target.out}`);
           expect(existsSync(join(sandbox.binDir, "kunai.exe"))).toBe(false);
           expect(existsSync(join(sandbox.configDir, "install.json"))).toBe(false);

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -15,6 +15,9 @@ import {
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 
+import { RELEASE_BINARY_TARGETS } from "@/services/update/platform-assets";
+
+import { createReleaseArchive } from "../../scripts/build-release-archives";
 import {
   createInstallerSandbox,
   installCommandShim,
@@ -131,6 +134,64 @@ async function runInstallPs1Async(
 
 function hostWindowsAsset(): string {
   return process.arch === "arm64" ? "kunai-windows-arm64.exe" : "kunai-windows-x64.exe";
+}
+
+function hostWindowsTarget() {
+  const asset = hostWindowsAsset();
+  const target = RELEASE_BINARY_TARGETS.find((candidate) => candidate.out === asset);
+  if (!target) throw new Error(`Missing release target for ${asset}`);
+  return target;
+}
+
+function rewriteZipNames(archive: Uint8Array, replacement: string): Uint8Array {
+  const output = new Uint8Array(archive);
+  const view = new DataView(output.buffer, output.byteOffset, output.byteLength);
+  const localNameLength = view.getUint16(26, true);
+  const name = new TextEncoder().encode(
+    replacement.padEnd(localNameLength, "x").slice(0, localNameLength),
+  );
+  output.set(name, 30);
+  const centralOffset = 30 + localNameLength + view.getUint32(18, true);
+  output.set(name, centralOffset + 46);
+  return output;
+}
+
+function invalidZipArchive(
+  kind:
+    | "absolute"
+    | "corrupt"
+    | "extra"
+    | "missing"
+    | "reparse"
+    | "symlink"
+    | "traversal"
+    | "wrong",
+  canonical: Uint8Array,
+): Uint8Array {
+  if (kind === "corrupt") return new TextEncoder().encode("not-a-zip-archive");
+  if (kind === "missing") {
+    const empty = new Uint8Array(22);
+    new DataView(empty.buffer).setUint32(0, 0x06054b50, true);
+    return empty;
+  }
+  if (kind === "absolute") return rewriteZipNames(canonical, "C:\\kunai.exe");
+  if (kind === "traversal") return rewriteZipNames(canonical, "../kunai.exe");
+  if (kind === "wrong") return rewriteZipNames(canonical, "wrong.exe");
+  const output = new Uint8Array(canonical);
+  const view = new DataView(output.buffer, output.byteOffset, output.byteLength);
+  if (kind === "extra") {
+    view.setUint16(output.length - 14, 2, true);
+    view.setUint16(output.length - 12, 2, true);
+    return output;
+  }
+  const centralOffset = 30 + view.getUint16(26, true) + view.getUint32(18, true);
+  const attributes = view.getUint32(centralOffset + 38, true);
+  view.setUint32(
+    centralOffset + 38,
+    kind === "symlink" ? (0o120777 << 16) >>> 0 : attributes | 0x400,
+    true,
+  );
+  return output;
 }
 
 describePwsh("install.ps1 dry-run", () => {
@@ -282,6 +343,276 @@ describePwsh("install.ps1 activation identity", () => {
 });
 
 describePwsh("install.ps1 release asset failures", () => {
+  test("installs the verified zip member and records archive provenance", async () => {
+    const target = hostWindowsTarget();
+    const body = "MZ-archived-kunai";
+    const archive = createReleaseArchive(target, new TextEncoder().encode(body));
+    const binaryDigest = createHash("sha256").update(body).digest("hex");
+    const archiveDigest = createHash("sha256").update(archive).digest("hex");
+    const sandbox = createInstallerSandbox("install-ps1-archive-ok");
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${target.archiveName}`]: { body: archive },
+          "/download/v9.8.7/SHA256SUMS.archives": {
+            body: `${archiveDigest}  ${target.archiveName}\n`,
+          },
+          "/download/v9.8.7/SHA256SUMS": {
+            body: `${binaryDigest}  ${target.out}\n`,
+          },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+
+          expect(result.status, `${result.stderr}${result.stdout}`).toBe(0);
+          expect(evidence.requests).toEqual([
+            "/download/v9.8.7/SHA256SUMS.archives",
+            `/download/v9.8.7/${target.archiveName}`,
+            "/download/v9.8.7/SHA256SUMS",
+          ]);
+          expect(
+            readFileSync(join(sandbox.dataDir, "versions", "9.8.7", "kunai.exe"), "utf8"),
+          ).toBe(body);
+          const manifest = JSON.parse(
+            readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
+          ) as Record<string, unknown>;
+          expect(manifest).toMatchObject({
+            schemaVersion: 2,
+            artifactName: target.out,
+            artifactSha256: binaryDigest,
+            artifactSizeBytes: Buffer.byteLength(body),
+            archiveName: target.archiveName,
+            archiveSha256: archiveDigest,
+            archiveSizeBytes: archive.length,
+            archiveSourceUrl: `${baseUrl}/download/v9.8.7/${target.archiveName}`,
+          });
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test.each([
+    "absolute",
+    "corrupt",
+    "extra",
+    "missing",
+    "reparse",
+    "symlink",
+    "traversal",
+    "wrong",
+  ] as const)("rejects a %s zip archive without raw fallback or residue", async (kind) => {
+    const target = hostWindowsTarget();
+    const body = "MZ-safe-windows-binary";
+    const canonical = createReleaseArchive(target, new TextEncoder().encode(body));
+    const archive = invalidZipArchive(kind, canonical);
+    const archiveDigest = createHash("sha256").update(archive).digest("hex");
+    const binaryDigest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox(`install-ps1-archive-${kind}`);
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${target.archiveName}`]: { body: archive },
+          "/download/v9.8.7/SHA256SUMS.archives": {
+            body: `${archiveDigest}  ${target.archiveName}\n`,
+          },
+          "/download/v9.8.7/SHA256SUMS": {
+            body: `${binaryDigest}  ${target.out}\n`,
+          },
+          [`/download/v9.8.7/${target.out}`]: { body: "LEGACY-RAW-MUST-NOT-RUN" },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+
+          expect(result.status).not.toBe(0);
+          expect(evidence.requests).not.toContain(`/download/v9.8.7/${target.out}`);
+          expect(existsSync(join(sandbox.binDir, "kunai.exe"))).toBe(false);
+          expect(existsSync(join(sandbox.configDir, "install.json"))).toBe(false);
+          expect(existsSync(join(sandbox.cacheDir, "staging", "9.8.7"))).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("rejects zip checksum mismatch without raw fallback", async () => {
+    const target = hostWindowsTarget();
+    const archive = createReleaseArchive(target, new TextEncoder().encode("MZ-mismatch"));
+    const sandbox = createInstallerSandbox("install-ps1-archive-mismatch");
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${target.archiveName}`]: { body: archive },
+          "/download/v9.8.7/SHA256SUMS.archives": {
+            body: `${"0".repeat(64)}  ${target.archiveName}\n`,
+          },
+          [`/download/v9.8.7/${target.out}`]: { body: "legacy" },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+          expect(result.status).not.toBe(0);
+          expect(`${result.stderr}${result.stdout}`).toContain(
+            `Checksum mismatch for ${target.archiveName}`,
+          );
+          expect(evidence.requests).not.toContain(`/download/v9.8.7/${target.out}`);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("rejects zip archive and decompressed size bombs and cleans staging", async () => {
+    const target = hostWindowsTarget();
+    const body = "MZ-binary-larger-than-four-bytes";
+    const archive = createReleaseArchive(target, new TextEncoder().encode(body));
+    const archiveDigest = createHash("sha256").update(archive).digest("hex");
+    const binaryDigest = createHash("sha256").update(body).digest("hex");
+    for (const [label, env] of [
+      ["archive", { KUNAI_DOWNLOAD_ARCHIVE_MAX_BYTES: "8" }],
+      ["decompressed", { KUNAI_EXTRACTED_BINARY_MAX_BYTES: "4" }],
+    ] as const) {
+      const sandbox = createInstallerSandbox(`install-ps1-${label}-bomb`);
+      try {
+        await withReleaseFixture(
+          {
+            [`/download/v9.8.7/${target.archiveName}`]: { body: archive },
+            "/download/v9.8.7/SHA256SUMS.archives": {
+              body: `${archiveDigest}  ${target.archiveName}\n`,
+            },
+            "/download/v9.8.7/SHA256SUMS": {
+              body: `${binaryDigest}  ${target.out}\n`,
+            },
+          },
+          async (baseUrl) => {
+            const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+              ...sandbox.env,
+              ...env,
+              KUNAI_DL_BASE: baseUrl,
+              KUNAI_DOWNLOAD_MAX_ATTEMPTS: "1",
+            });
+            expect(result.status).not.toBe(0);
+            expect(`${result.stderr}${result.stdout}`).toMatch(/size|budget|exceeds/i);
+            expect(existsSync(join(sandbox.cacheDir, "staging", "9.8.7"))).toBe(false);
+          },
+        );
+      } finally {
+        sandbox.cleanup();
+      }
+    }
+  });
+
+  test.each([
+    ["checksum", 404],
+    ["checksum", 410],
+    ["archive", 404],
+    ["archive", 410],
+  ] as const)(
+    "falls back to the legacy raw zip asset only for %s HTTP %i",
+    async (missing, status) => {
+      const target = hostWindowsTarget();
+      const body = "MZ-legacy-raw-fallback";
+      const canonical = createReleaseArchive(target, new TextEncoder().encode(body));
+      const archiveDigest = createHash("sha256").update(canonical).digest("hex");
+      const binaryDigest = createHash("sha256").update(body).digest("hex");
+      const sandbox = createInstallerSandbox(`install-ps1-fallback-${missing}-${status}`);
+      try {
+        await withReleaseFixture(
+          {
+            [`/download/v9.8.7/${target.archiveName}`]:
+              missing === "archive" ? { status } : { body: canonical },
+            "/download/v9.8.7/SHA256SUMS.archives":
+              missing === "checksum"
+                ? { status }
+                : { body: `${archiveDigest}  ${target.archiveName}\n` },
+            "/download/v9.8.7/SHA256SUMS": {
+              body: `${binaryDigest}  ${target.out}\n`,
+            },
+            [`/download/v9.8.7/${target.out}`]: { body },
+          },
+          async (baseUrl, evidence) => {
+            const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+              ...sandbox.env,
+              KUNAI_DL_BASE: baseUrl,
+            });
+            expect(result.status, `${result.stderr}${result.stdout}`).toBe(0);
+            expect(evidence.requests).toContain(`/download/v9.8.7/${target.out}`);
+            expect(
+              readFileSync(join(sandbox.dataDir, "versions", "9.8.7", "kunai.exe"), "utf8"),
+            ).toBe(body);
+          },
+        );
+      } finally {
+        sandbox.cleanup();
+      }
+    },
+  );
+
+  test("does not use raw fallback for archive checksum HTTP 500", async () => {
+    const target = hostWindowsTarget();
+    const sandbox = createInstallerSandbox("install-ps1-archive-500");
+    try {
+      await withReleaseFixture(
+        {
+          "/download/v9.8.7/SHA256SUMS.archives": { status: 500 },
+          [`/download/v9.8.7/${target.out}`]: { body: "legacy" },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_DOWNLOAD_MAX_ATTEMPTS: "1",
+          });
+          expect(result.status).not.toBe(0);
+          expect(evidence.requests).not.toContain(`/download/v9.8.7/${target.out}`);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("does not use raw fallback when the archive checksum download stalls", async () => {
+    const target = hostWindowsTarget();
+    const sandbox = createInstallerSandbox("install-ps1-archive-stall");
+    try {
+      await withReleaseFixture(
+        {
+          "/download/v9.8.7/SHA256SUMS.archives": {
+            body: `${"a".repeat(64)}  ${target.archiveName}\n`,
+            chunkDelayMs: 150,
+            chunkSize: 1,
+          },
+          [`/download/v9.8.7/${target.out}`]: { body: "legacy" },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_DOWNLOAD_MAX_ATTEMPTS: "1",
+            KUNAI_DOWNLOAD_STALL_MS: "50",
+          });
+          expect(result.status).not.toBe(0);
+          expect(evidence.requests).not.toContain(`/download/v9.8.7/${target.out}`);
+          expect(existsSync(join(sandbox.cacheDir, "staging", "9.8.7"))).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
   test("pins a resolved latest binary and checksum to the immutable release URL", async () => {
     const asset = hostWindowsAsset();
     const body = "MZ-latest-fixture-payload";
@@ -309,6 +640,7 @@ describePwsh("install.ps1 release asset failures", () => {
           expect(result.stdout).toContain("PATH activation is environment-managed");
           expect(evidence.requests).toEqual([
             "/releases/latest",
+            "/download/v9.8.7/SHA256SUMS.archives",
             "/download/v9.8.7/SHA256SUMS",
             `/download/v9.8.7/${asset}`,
           ]);
@@ -427,6 +759,7 @@ describePwsh("install.ps1 release asset failures", () => {
           expect(result.status).toBe(0);
           expect(result.stdout).toContain(`Downloading ${asset} (v9.8.7)`);
           expect(evidence.requests).toEqual([
+            "/download/v9.8.7/SHA256SUMS.archives",
             "/download/v9.8.7/SHA256SUMS",
             `/download/v9.8.7/${asset}`,
           ]);
@@ -435,7 +768,7 @@ describePwsh("install.ps1 release asset failures", () => {
           const manifest = JSON.parse(
             readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
           ) as Record<string, unknown>;
-          expect(manifest.schemaVersion).toBe(1);
+          expect(manifest.schemaVersion).toBe(2);
           expect(manifest.method).toBe("binary");
           expect(manifest.activeVersion).toBe("9.8.7");
           expect(manifest.preferredChannel).toBe("stable");
@@ -445,6 +778,8 @@ describePwsh("install.ps1 release asset failures", () => {
           );
           expect(manifest.downloadBaseUrl).toBe(baseUrl);
           expect(manifest.artifactSha256).toBe(digest);
+          expect(manifest.artifactName).toBe(asset);
+          expect(manifest.artifactSizeBytes).toBe(Buffer.byteLength(body));
           expect(Array.isArray(manifest.managedPaths)).toBe(true);
           expect(existsSync(join(sandbox.dataDir, "versions", "9.8.7", "version.json"))).toBe(true);
           const versionMetadata = JSON.parse(

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -427,6 +427,20 @@ describePwsh("install.ps1 release asset failures", () => {
             artifactName: target.out,
             artifactSha256: binaryDigest,
             artifactSizeBytes: Buffer.byteLength(body),
+            artifactSourceUrl: `${baseUrl}/download/v9.8.7/${target.out}`,
+            archiveName: target.archiveName,
+            archiveSha256: archiveDigest,
+            archiveSizeBytes: archive.length,
+            archiveSourceUrl: `${baseUrl}/download/v9.8.7/${target.archiveName}`,
+          });
+          const metadata = JSON.parse(
+            readFileSync(join(sandbox.dataDir, "versions", "9.8.7", "version.json"), "utf8"),
+          ) as Record<string, unknown>;
+          expect(metadata).toMatchObject({
+            artifactName: target.out,
+            artifactSha256: binaryDigest,
+            sizeBytes: Buffer.byteLength(body),
+            sourceUrl: `${baseUrl}/download/v9.8.7/${target.out}`,
             archiveName: target.archiveName,
             archiveSha256: archiveDigest,
             archiveSizeBytes: archive.length,

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -156,14 +156,48 @@ function rewriteZipNames(archive: Uint8Array, replacement: string): Uint8Array {
   return output;
 }
 
+function rewriteZipLocalName(archive: Uint8Array, replacement: string): Uint8Array {
+  const output = new Uint8Array(archive);
+  const view = new DataView(output.buffer, output.byteOffset, output.byteLength);
+  const localNameLength = view.getUint16(26, true);
+  const name = new TextEncoder().encode(
+    replacement.padEnd(localNameLength, "x").slice(0, localNameLength),
+  );
+  output.set(name, 30);
+  return output;
+}
+
+function prefixZipArchive(archive: Uint8Array): Uint8Array {
+  const source = new DataView(archive.buffer, archive.byteOffset, archive.byteLength);
+  const centralOffset = 30 + source.getUint16(26, true) + source.getUint32(18, true);
+  const output = new Uint8Array(archive.length + 1);
+  output[0] = 0x0a;
+  output.set(archive, 1);
+  const view = new DataView(output.buffer, output.byteOffset, output.byteLength);
+  view.setUint32(centralOffset + 1 + 42, 1, true);
+  view.setUint32(output.length - 22 + 16, centralOffset + 1, true);
+  return output;
+}
+
+function appendZipTrailingData(archive: Uint8Array): Uint8Array {
+  const output = new Uint8Array(archive.length + 1);
+  output.set(archive);
+  output[archive.length] = 0x0a;
+  return output;
+}
+
 function invalidZipArchive(
   kind:
     | "absolute"
+    | "case-variant"
     | "corrupt"
     | "extra"
+    | "local-traversal"
     | "missing"
+    | "prefix"
     | "reparse"
     | "symlink"
+    | "trailing"
     | "traversal"
     | "wrong",
   canonical: Uint8Array,
@@ -175,6 +209,15 @@ function invalidZipArchive(
     return empty;
   }
   if (kind === "absolute") return rewriteZipNames(canonical, "C:\\kunai.exe");
+  if (kind === "case-variant") {
+    const view = new DataView(canonical.buffer, canonical.byteOffset, canonical.byteLength);
+    const localNameLength = view.getUint16(26, true);
+    const current = new TextDecoder().decode(canonical.subarray(30, 30 + localNameLength));
+    return rewriteZipNames(canonical, current.toUpperCase());
+  }
+  if (kind === "local-traversal") return rewriteZipLocalName(canonical, "../evil.exe");
+  if (kind === "prefix") return prefixZipArchive(canonical);
+  if (kind === "trailing") return appendZipTrailingData(canonical);
   if (kind === "traversal") return rewriteZipNames(canonical, "../kunai.exe");
   if (kind === "wrong") return rewriteZipNames(canonical, "wrong.exe");
   const output = new Uint8Array(canonical);
@@ -398,11 +441,15 @@ describePwsh("install.ps1 release asset failures", () => {
 
   test.each([
     "absolute",
+    "case-variant",
     "corrupt",
     "extra",
+    "local-traversal",
     "missing",
+    "prefix",
     "reparse",
     "symlink",
+    "trailing",
     "traversal",
     "wrong",
   ] as const)("rejects a %s zip archive without raw fallback or residue", async (kind) => {
@@ -436,6 +483,41 @@ describePwsh("install.ps1 release asset failures", () => {
           expect(existsSync(join(sandbox.binDir, "kunai.exe"))).toBe(false);
           expect(existsSync(join(sandbox.configDir, "install.json"))).toBe(false);
           expect(existsSync(join(sandbox.cacheDir, "staging", "9.8.7"))).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("rejects a case-variant checksum asset identity", async () => {
+    const target = hostWindowsTarget();
+    const body = "MZ-case-sensitive-checksum-name";
+    const archive = createReleaseArchive(target, new TextEncoder().encode(body));
+    const archiveDigest = createHash("sha256").update(archive).digest("hex");
+    const binaryDigest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-ps1-checksum-case-variant");
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${target.archiveName}`]: { body: archive },
+          "/download/v9.8.7/SHA256SUMS.archives": {
+            body: `${archiveDigest}  ${target.archiveName.toUpperCase()}\n`,
+          },
+          "/download/v9.8.7/SHA256SUMS": {
+            body: `${binaryDigest}  ${target.out}\n`,
+          },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+
+          expect(result.status).not.toBe(0);
+          expect(evidence.requests).not.toContain(`/download/v9.8.7/${target.out}`);
+          expect(existsSync(join(sandbox.binDir, "kunai.exe"))).toBe(false);
+          expect(existsSync(join(sandbox.configDir, "install.json"))).toBe(false);
         },
       );
     } finally {

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -15,6 +15,8 @@ import {
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 
+import type { InstallManifest } from "@/services/update/install-manifest";
+import { verifyStoredVersion } from "@/services/update/native-installer/version-metadata";
 import { RELEASE_BINARY_TARGETS } from "@/services/update/platform-assets";
 
 import { createReleaseArchive } from "../../scripts/build-release-archives";
@@ -30,6 +32,21 @@ import {
 
 const REPO_ROOT = join(import.meta.dirname, "../../../..");
 const INSTALL_PS1 = join(REPO_ROOT, "install.ps1");
+
+function readInstallerManifest(configDir: string): InstallManifest {
+  return JSON.parse(readFileSync(join(configDir, "install.json"), "utf8"));
+}
+
+async function readInstallerVersionMetadata(dataDir: string, version: string) {
+  const result = await verifyStoredVersion(
+    { versionsDir: join(dataDir, "versions"), binaryFileName: "kunai.exe" },
+    version,
+  );
+  if (result.status !== "verified") {
+    throw new Error(`Installer wrote invalid ${version} metadata: ${result.detail}`);
+  }
+  return result.metadata;
+}
 
 function impossibleProcessStartId(): string {
   if (process.platform === "win32") return "windows-ticks:0";
@@ -419,9 +436,7 @@ describePwsh("install.ps1 release asset failures", () => {
           expect(
             readFileSync(join(sandbox.dataDir, "versions", "9.8.7", "kunai.exe"), "utf8"),
           ).toBe(body);
-          const manifest = JSON.parse(
-            readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
-          ) as Record<string, unknown>;
+          const manifest = readInstallerManifest(sandbox.configDir);
           expect(manifest).toMatchObject({
             schemaVersion: 2,
             artifactName: target.out,
@@ -433,9 +448,7 @@ describePwsh("install.ps1 release asset failures", () => {
             archiveSizeBytes: archive.length,
             archiveSourceUrl: `${baseUrl}/download/v9.8.7/${target.archiveName}`,
           });
-          const metadata = JSON.parse(
-            readFileSync(join(sandbox.dataDir, "versions", "9.8.7", "version.json"), "utf8"),
-          ) as Record<string, unknown>;
+          const metadata = await readInstallerVersionMetadata(sandbox.dataDir, "9.8.7");
           expect(metadata).toMatchObject({
             artifactName: target.out,
             artifactSha256: binaryDigest,
@@ -781,9 +794,7 @@ describePwsh("install.ps1 release asset failures", () => {
           ]);
           expect(evidence.requests.some((path) => path.includes("/latest/download"))).toBe(false);
 
-          const metadata = JSON.parse(
-            readFileSync(join(sandbox.dataDir, "versions", "9.8.7", "version.json"), "utf8"),
-          ) as { sourceUrl: string };
+          const metadata = await readInstallerVersionMetadata(sandbox.dataDir, "9.8.7");
           expect(metadata.sourceUrl).toBe(`${baseUrl}/download/v9.8.7/${asset}`);
         },
       );
@@ -900,9 +911,7 @@ describePwsh("install.ps1 release asset failures", () => {
           ]);
           expect(existsSync(join(sandbox.binDir, "kunai.exe"))).toBe(true);
 
-          const manifest = JSON.parse(
-            readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
-          ) as Record<string, unknown>;
+          const manifest = readInstallerManifest(sandbox.configDir);
           expect(manifest.schemaVersion).toBe(2);
           expect(manifest.method).toBe("binary");
           expect(manifest.activeVersion).toBe("9.8.7");
@@ -917,9 +926,7 @@ describePwsh("install.ps1 release asset failures", () => {
           expect(manifest.artifactSizeBytes).toBe(Buffer.byteLength(body));
           expect(Array.isArray(manifest.managedPaths)).toBe(true);
           expect(existsSync(join(sandbox.dataDir, "versions", "9.8.7", "version.json"))).toBe(true);
-          const versionMetadata = JSON.parse(
-            readFileSync(join(sandbox.dataDir, "versions", "9.8.7", "version.json"), "utf8"),
-          ) as { sourceUrl: string };
+          const versionMetadata = await readInstallerVersionMetadata(sandbox.dataDir, "9.8.7");
           expect(versionMetadata.sourceUrl).toBe(`${baseUrl}/download/v9.8.7/${asset}`);
         },
       );
@@ -1263,10 +1270,9 @@ describePwsh("install.ps1 lifecycle contract", () => {
         expect(launcherBeforeRelease).toBe(false);
         expect(manifestBeforeRelease).toBe(false);
 
-        const manifest = JSON.parse(
-          readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
-        ) as { activeVersion: string; versionedPath: string };
-        expect(versions).toContain(manifest.activeVersion as (typeof versions)[number]);
+        const manifest = readInstallerManifest(sandbox.configDir);
+        expect(new Set<string>(versions).has(manifest.activeVersion)).toBe(true);
+        if (!manifest.versionedPath) throw new Error("Binary manifest omitted versionedPath");
         expect(manifest.versionedPath).toBe(
           join(sandbox.dataDir, "versions", manifest.activeVersion, "kunai.exe"),
         );
@@ -1733,9 +1739,7 @@ describePwsh("install.ps1 package activeVersion", () => {
 
       const result = runInstallPs1(["-Method", "npm", "-Yes"], env);
       expect(result.status).toBe(0);
-      const manifest = JSON.parse(
-        readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
-      ) as { activeVersion: string; method: string; launcherPath: string };
+      const manifest = readInstallerManifest(sandbox.configDir);
       expect(manifest.method).toBe("npm-global");
       expect(manifest.activeVersion).toBe("4.5.6");
       expect(manifest.activeVersion).not.toBe("latest");
@@ -1816,9 +1820,7 @@ describePwsh("install.ps1 package activeVersion", () => {
         const result = runInstallPs1(["-Method", method, "-Yes", "-Version", "4.5.6"], env);
         expect(result.status).toBe(0);
         expect(readFileSync(argvLog, "utf8").trim()).toBe(`install -g @kitsunekode/kunai@4.5.6`);
-        const manifest = JSON.parse(
-          readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
-        ) as { activeVersion: string; launcherPath: string };
+        const manifest = readInstallerManifest(sandbox.configDir);
         expect(manifest.activeVersion).toBe("4.5.6");
         // Each channel records its own owner's absolute launcher, not "kunai".
         expect(manifest.launcherPath).toBe(

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -458,6 +458,43 @@ describe("install.sh release asset failures", () => {
     }
   });
 
+  test("rejects extracted binary checksum mismatch without raw fallback or residue", async () => {
+    const target = hostInstallShTarget();
+    const body = "#!/bin/sh\necho archive-member\n";
+    const archive = createReleaseArchive(target, new TextEncoder().encode(body));
+    const archiveDigest = createHash("sha256").update(archive).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-extracted-mismatch");
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${target.archiveName}`]: { body: archive },
+          "/download/v9.8.7/SHA256SUMS.archives": {
+            body: `${archiveDigest}  ${target.archiveName}\n`,
+          },
+          "/download/v9.8.7/SHA256SUMS": {
+            body: `${"0".repeat(64)}  ${target.out}\n`,
+          },
+          [`/download/v9.8.7/${target.out}`]: { body: "LEGACY-RAW-MUST-NOT-RUN" },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+
+          expect(result.status).not.toBe(0);
+          expect(result.stderr).toContain(`Checksum mismatch for extracted ${target.out}`);
+          expect(evidence.requests).not.toContain(`/download/v9.8.7/${target.out}`);
+          expect(existsSync(join(sandbox.binDir, "kunai"))).toBe(false);
+          expect(existsSync(join(sandbox.configDir, "install.json"))).toBe(false);
+          expect(existsSync(join(sandbox.cacheDir, "staging", "9.8.7"))).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
   test("rejects archive and decompressed size bombs and cleans staging", async () => {
     const target = hostInstallShTarget();
     const body = "binary-larger-than-four-bytes";

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -62,6 +62,12 @@ function duplicateTarMember(archive: Uint8Array, bodyLength: number): Uint8Array
   return new Uint8Array(gzipSync(output));
 }
 
+function addNewlineTarPadding(archive: Uint8Array, bodyLength: number): Uint8Array {
+  const tar = new Uint8Array(gunzipSync(archive));
+  tar[512 + bodyLength] = 0x0a;
+  return new Uint8Array(gzipSync(tar));
+}
+
 function invalidTarArchive(
   kind:
     | "absolute"
@@ -69,6 +75,7 @@ function invalidTarArchive(
     | "extra"
     | "hardlink"
     | "missing"
+    | "newline-padding"
     | "symlink"
     | "traversal"
     | "wrong",
@@ -78,6 +85,7 @@ function invalidTarArchive(
   if (kind === "corrupt") return new TextEncoder().encode("not-a-gzip-archive");
   if (kind === "extra") return duplicateTarMember(canonical, bodyLength);
   if (kind === "missing") return new Uint8Array(gzipSync(new Uint8Array(1_024)));
+  if (kind === "newline-padding") return addNewlineTarPadding(canonical, bodyLength);
   return rewriteTarHeader(canonical, (header) => {
     if (kind === "symlink" || kind === "hardlink") {
       header[156] = (kind === "symlink" ? "2" : "1").charCodeAt(0);
@@ -365,6 +373,7 @@ describe("install.sh release asset failures", () => {
     "extra",
     "hardlink",
     "missing",
+    "newline-padding",
     "symlink",
     "traversal",
     "wrong",

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -18,6 +18,8 @@ import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { gunzipSync, gzipSync } from "node:zlib";
 
+import type { InstallManifest } from "@/services/update/install-manifest";
+import { verifyStoredVersion } from "@/services/update/native-installer/version-metadata";
 import { RELEASE_BINARY_TARGETS } from "@/services/update/platform-assets";
 import { getKunaiPaths } from "@kunai/storage";
 
@@ -35,6 +37,25 @@ import {
 
 const REPO_ROOT = join(import.meta.dirname, "../../../..");
 const INSTALL_SH = join(REPO_ROOT, "install.sh");
+
+function readInstallerManifest(configDir: string): InstallManifest {
+  return JSON.parse(readFileSync(join(configDir, "install.json"), "utf8"));
+}
+
+async function readInstallerVersionMetadata(dataDir: string, version: string) {
+  const result = await verifyStoredVersion(
+    { versionsDir: join(dataDir, "versions"), binaryFileName: "kunai" },
+    version,
+  );
+  if (result.status !== "verified") {
+    throw new Error(`Installer wrote invalid ${version} metadata: ${result.detail}`);
+  }
+  return result.metadata;
+}
+
+function quoteShellArgument(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
 
 function hostInstallShTarget() {
   const asset = hostInstallShAsset();
@@ -319,6 +340,8 @@ describe("install.sh release asset failures", () => {
     const archive = createReleaseArchive(target, new TextEncoder().encode(body));
     const binaryDigest = createHash("sha256").update(body).digest("hex");
     const archiveDigest = createHash("sha256").update(archive).digest("hex");
+    const realDd = Bun.which("dd");
+    if (!realDd) throw new Error("Archive fixture requires dd");
     const sandbox = createInstallerSandbox("install-sh-archive-ok");
     try {
       const shimDir = join(sandbox.root, "shims");
@@ -341,7 +364,7 @@ for arg in "$@"; do
   esac
 done
 [ "$bounded" != 1 ] || [ "$fullblock" = 1 ] || exit 64
-exec /usr/bin/dd "$@"
+exec ${quoteShellArgument(realDd)} "$@"
 `,
       );
       await withReleaseFixture(
@@ -370,9 +393,7 @@ exec /usr/bin/dd "$@"
           expect(readFileSync(join(sandbox.dataDir, "versions", "9.8.7", "kunai"), "utf8")).toBe(
             body,
           );
-          const manifest = JSON.parse(
-            readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
-          ) as Record<string, unknown>;
+          const manifest = readInstallerManifest(sandbox.configDir);
           expect(manifest).toMatchObject({
             schemaVersion: 2,
             artifactName: target.out,
@@ -384,9 +405,7 @@ exec /usr/bin/dd "$@"
             archiveSizeBytes: archive.length,
             archiveSourceUrl: `${baseUrl}/download/v9.8.7/${target.archiveName}`,
           });
-          const metadata = JSON.parse(
-            readFileSync(join(sandbox.dataDir, "versions", "9.8.7", "version.json"), "utf8"),
-          ) as Record<string, unknown>;
+          const metadata = await readInstallerVersionMetadata(sandbox.dataDir, "9.8.7");
           expect(metadata).toMatchObject({
             artifactName: target.out,
             artifactSha256: binaryDigest,
@@ -723,9 +742,7 @@ exec /usr/bin/dd "$@"
           ]);
           expect(evidence.requests.some((path) => path.includes("/latest/download"))).toBe(false);
 
-          const metadata = JSON.parse(
-            readFileSync(join(sandbox.dataDir, "versions", "9.8.7", "version.json"), "utf8"),
-          ) as { sourceUrl: string };
+          const metadata = await readInstallerVersionMetadata(sandbox.dataDir, "9.8.7");
           expect(metadata.sourceUrl).toBe(`${baseUrl}/download/v9.8.7/${asset}`);
         },
       );
@@ -839,9 +856,7 @@ exec /usr/bin/dd "$@"
           expect(existsSync(join(sandbox.binDir, "kunai"))).toBe(true);
           expect(result.stdout).toContain(`PATH winner: ${join(sandbox.binDir, "kunai")}`);
 
-          const manifest = JSON.parse(
-            readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
-          ) as Record<string, unknown>;
+          const manifest = readInstallerManifest(sandbox.configDir);
           expect(manifest.schemaVersion).toBe(2);
           expect(manifest.method).toBe("binary");
           expect(manifest.activeVersion).toBe("9.8.7");
@@ -855,12 +870,10 @@ exec /usr/bin/dd "$@"
           expect(Array.isArray(manifest.managedPaths)).toBe(true);
           expect(manifest.managedPaths).toContain(sandbox.dataDir);
           expect(manifest.managedPaths).toContain(sandbox.cacheDir);
-          expect(typeof manifest.installedAt).toBe("string");
-          expect(typeof manifest.updatedAt).toBe("string");
+          expect(Date.parse(manifest.installedAt)).not.toBeNaN();
+          expect(Date.parse(manifest.updatedAt)).not.toBeNaN();
           expect(existsSync(join(sandbox.dataDir, "versions", "9.8.7", "version.json"))).toBe(true);
-          const versionMetadata = JSON.parse(
-            readFileSync(join(sandbox.dataDir, "versions", "9.8.7", "version.json"), "utf8"),
-          ) as { sourceUrl: string };
+          const versionMetadata = await readInstallerVersionMetadata(sandbox.dataDir, "9.8.7");
           expect(versionMetadata.sourceUrl).toBe(`${baseUrl}/download/v9.8.7/${asset}`);
           expect(existsSync(join(sandbox.dataDir, "locks"))).toBe(true);
           expect(existsSync(join(sandbox.dataDir, "transactions"))).toBe(true);
@@ -1081,7 +1094,8 @@ describe("install.sh lifecycle contract", () => {
           if (existsSync(join(sandbox.cacheDir, "staging"))) {
             const leftover = readdirSync(join(sandbox.cacheDir, "staging"), {
               recursive: true,
-            }) as string[];
+              encoding: "utf8",
+            });
             expect(leftover.filter((e) => String(e).includes(asset))).toEqual([]);
           }
         },
@@ -1125,7 +1139,8 @@ describe("install.sh lifecycle contract", () => {
           if (existsSync(join(sandbox.cacheDir, "staging"))) {
             const leftover = readdirSync(join(sandbox.cacheDir, "staging"), {
               recursive: true,
-            }) as string[];
+              encoding: "utf8",
+            });
             expect(leftover.filter((e) => String(e).includes(asset))).toEqual([]);
           }
         },
@@ -1165,7 +1180,8 @@ describe("install.sh lifecycle contract", () => {
           if (existsSync(join(sandbox.cacheDir, "staging"))) {
             const leftover = readdirSync(join(sandbox.cacheDir, "staging"), {
               recursive: true,
-            }) as string[];
+              encoding: "utf8",
+            });
             expect(leftover.filter((e) => e.includes(asset) || e.endsWith("kunai"))).toEqual([]);
           }
         },
@@ -1271,10 +1287,9 @@ describe("install.sh lifecycle contract", () => {
         expect(launcherBeforeRelease).toBe(false);
         expect(manifestBeforeRelease).toBe(false);
 
-        const manifest = JSON.parse(
-          readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
-        ) as { activeVersion: string; versionedPath: string };
-        expect(versions).toContain(manifest.activeVersion as (typeof versions)[number]);
+        const manifest = readInstallerManifest(sandbox.configDir);
+        expect(new Set<string>(versions).has(manifest.activeVersion)).toBe(true);
+        if (!manifest.versionedPath) throw new Error("Binary manifest omitted versionedPath");
         expect(manifest.versionedPath).toBe(
           join(sandbox.dataDir, "versions", manifest.activeVersion, "kunai"),
         );
@@ -1789,9 +1804,7 @@ describe("install.sh package activeVersion", () => {
       });
 
       expect(result.status).toBe(0);
-      const manifest = JSON.parse(
-        readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
-      ) as { activeVersion: string; launcherPath: string; method: string };
+      const manifest = readInstallerManifest(sandbox.configDir);
       expect(manifest.method).toBe("npm-global");
       expect(manifest.activeVersion).toBe("4.5.6");
       expect(manifest.activeVersion).not.toBe("latest");
@@ -1826,9 +1839,7 @@ describe("install.sh package activeVersion", () => {
       });
 
       expect(result.status).toBe(0);
-      const manifest = JSON.parse(
-        readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
-      ) as { activeVersion: string; launcherPath: string; method: string };
+      const manifest = readInstallerManifest(sandbox.configDir);
       expect(manifest.method).toBe("bun-global");
       expect(manifest.activeVersion).toBe("7.8.9");
       expect(manifest.activeVersion).not.toBe("latest");
@@ -1921,12 +1932,11 @@ describe("install.sh consent without a terminal", () => {
         process.platform === "darwin"
           ? ["-q", "/dev/null", "bash", probePath]
           : ["-qfec", 'bash "$KUNAI_ASK_PROBE"', "/dev/null"];
+      const env: NodeJS.ProcessEnv = { ...process.env };
+      if (process.platform !== "darwin") env.KUNAI_ASK_PROBE = probePath;
       return spawnSync(scriptBin, args, {
         encoding: "utf8",
-        env: {
-          ...process.env,
-          ...(process.platform === "darwin" ? {} : { KUNAI_ASK_PROBE: probePath }),
-        },
+        env,
         stdio: ["ignore", "pipe", "pipe"],
         timeout: 2_000,
       });

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -321,6 +321,13 @@ describe("install.sh release asset failures", () => {
     const archiveDigest = createHash("sha256").update(archive).digest("hex");
     const sandbox = createInstallerSandbox("install-sh-archive-ok");
     try {
+      const shimDir = join(sandbox.root, "shims");
+      mkdirSync(shimDir, { recursive: true });
+      installCommandShim(
+        shimDir,
+        "head",
+        '#!/bin/sh\n[ "${1:-}" != "-c" ] || exit 64\nexec /usr/bin/head "$@"\n',
+      );
       await withReleaseFixture(
         {
           [`/download/v9.8.7/${target.archiveName}`]: { body: archive },
@@ -335,7 +342,7 @@ describe("install.sh release asset failures", () => {
           const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
             ...sandbox.env,
             KUNAI_DL_BASE: baseUrl,
-            PATH: `${sandbox.binDir}${delimiter}${sandbox.env.PATH ?? ""}`,
+            PATH: `${shimDir}${delimiter}${sandbox.binDir}${delimiter}${sandbox.env.PATH ?? ""}`,
           });
 
           expect(result.status, result.stderr).toBe(0);

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -328,6 +328,22 @@ describe("install.sh release asset failures", () => {
         "head",
         '#!/bin/sh\n[ "${1:-}" != "-c" ] || exit 64\nexec /usr/bin/head "$@"\n',
       );
+      installCommandShim(
+        shimDir,
+        "dd",
+        `#!/bin/sh
+bounded=0
+fullblock=0
+for arg in "$@"; do
+  case "$arg" in
+    of=*) bounded=1 ;;
+    iflag=fullblock) fullblock=1 ;;
+  esac
+done
+[ "$bounded" != 1 ] || [ "$fullblock" = 1 ] || exit 64
+exec /usr/bin/dd "$@"
+`,
+      );
       await withReleaseFixture(
         {
           [`/download/v9.8.7/${target.archiveName}`]: { body: archive },

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -16,9 +16,12 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
+import { gunzipSync, gzipSync } from "node:zlib";
 
+import { RELEASE_BINARY_TARGETS } from "@/services/update/platform-assets";
 import { getKunaiPaths } from "@kunai/storage";
 
+import { createReleaseArchive } from "../../scripts/build-release-archives";
 import { describePosixOnly as describe } from "../helpers/platform-gates";
 import {
   createInstallerSandbox,
@@ -32,6 +35,60 @@ import {
 
 const REPO_ROOT = join(import.meta.dirname, "../../../..");
 const INSTALL_SH = join(REPO_ROOT, "install.sh");
+
+function hostInstallShTarget() {
+  const asset = hostInstallShAsset();
+  const target = RELEASE_BINARY_TARGETS.find((candidate) => candidate.out === asset);
+  if (!target) throw new Error(`Missing release target for ${asset}`);
+  return target;
+}
+
+function rewriteTarHeader(archive: Uint8Array, mutate: (header: Uint8Array) => void): Uint8Array {
+  const tar = new Uint8Array(gunzipSync(archive));
+  const header = tar.subarray(0, 512);
+  mutate(header);
+  header.fill(0x20, 148, 156);
+  const sum = header.reduce((total, byte) => total + byte, 0);
+  header.set(new TextEncoder().encode(`${sum.toString(8).padStart(6, "0")}\0 `), 148);
+  return new Uint8Array(gzipSync(tar));
+}
+
+function duplicateTarMember(archive: Uint8Array, bodyLength: number): Uint8Array {
+  const tar = new Uint8Array(gunzipSync(archive));
+  const memberLength = 512 + Math.ceil(bodyLength / 512) * 512;
+  const output = new Uint8Array(memberLength * 2 + 1_024);
+  output.set(tar.subarray(0, memberLength), 0);
+  output.set(tar.subarray(0, memberLength), memberLength);
+  return new Uint8Array(gzipSync(output));
+}
+
+function invalidTarArchive(
+  kind:
+    | "absolute"
+    | "corrupt"
+    | "extra"
+    | "hardlink"
+    | "missing"
+    | "symlink"
+    | "traversal"
+    | "wrong",
+  canonical: Uint8Array,
+  bodyLength: number,
+): Uint8Array {
+  if (kind === "corrupt") return new TextEncoder().encode("not-a-gzip-archive");
+  if (kind === "extra") return duplicateTarMember(canonical, bodyLength);
+  if (kind === "missing") return new Uint8Array(gzipSync(new Uint8Array(1_024)));
+  return rewriteTarHeader(canonical, (header) => {
+    if (kind === "symlink" || kind === "hardlink") {
+      header[156] = (kind === "symlink" ? "2" : "1").charCodeAt(0);
+      return;
+    }
+    const name =
+      kind === "absolute" ? "/tmp/kunai" : kind === "traversal" ? "../kunai" : "wrong-binary";
+    header.fill(0, 0, 100);
+    header.set(new TextEncoder().encode(name), 0);
+  });
+}
 
 async function waitForPaths(paths: readonly string[]): Promise<void> {
   const deadline = Date.now() + 5_000;
@@ -248,6 +305,308 @@ describe("install.sh dry-run", () => {
 });
 
 describe("install.sh release asset failures", () => {
+  test("installs the verified tar.gz member and records archive provenance", async () => {
+    const target = hostInstallShTarget();
+    const body = "#!/bin/sh\necho archived-kunai\n";
+    const archive = createReleaseArchive(target, new TextEncoder().encode(body));
+    const binaryDigest = createHash("sha256").update(body).digest("hex");
+    const archiveDigest = createHash("sha256").update(archive).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-archive-ok");
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${target.archiveName}`]: { body: archive },
+          "/download/v9.8.7/SHA256SUMS.archives": {
+            body: `${archiveDigest}  ${target.archiveName}\n`,
+          },
+          "/download/v9.8.7/SHA256SUMS": {
+            body: `${binaryDigest}  ${target.out}\n`,
+          },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            PATH: `${sandbox.binDir}${delimiter}${sandbox.env.PATH ?? ""}`,
+          });
+
+          expect(result.status, result.stderr).toBe(0);
+          expect(evidence.requests).toEqual([
+            "/download/v9.8.7/SHA256SUMS.archives",
+            `/download/v9.8.7/${target.archiveName}`,
+            "/download/v9.8.7/SHA256SUMS",
+          ]);
+          expect(readFileSync(join(sandbox.dataDir, "versions", "9.8.7", "kunai"), "utf8")).toBe(
+            body,
+          );
+          const manifest = JSON.parse(
+            readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
+          ) as Record<string, unknown>;
+          expect(manifest).toMatchObject({
+            schemaVersion: 2,
+            artifactName: target.out,
+            artifactSha256: binaryDigest,
+            artifactSizeBytes: Buffer.byteLength(body),
+            archiveName: target.archiveName,
+            archiveSha256: archiveDigest,
+            archiveSizeBytes: archive.length,
+            archiveSourceUrl: `${baseUrl}/download/v9.8.7/${target.archiveName}`,
+          });
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test.each([
+    "absolute",
+    "corrupt",
+    "extra",
+    "hardlink",
+    "missing",
+    "symlink",
+    "traversal",
+    "wrong",
+  ] as const)("rejects a %s tar archive without raw fallback or residue", async (kind) => {
+    const target = hostInstallShTarget();
+    const body = "#!/bin/sh\necho safe-binary\n";
+    const canonical = createReleaseArchive(target, new TextEncoder().encode(body));
+    const archive = invalidTarArchive(kind, canonical, Buffer.byteLength(body));
+    const archiveDigest = createHash("sha256").update(archive).digest("hex");
+    const binaryDigest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox(`install-sh-archive-${kind}`);
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${target.archiveName}`]: { body: archive },
+          "/download/v9.8.7/SHA256SUMS.archives": {
+            body: `${archiveDigest}  ${target.archiveName}\n`,
+          },
+          "/download/v9.8.7/SHA256SUMS": {
+            body: `${binaryDigest}  ${target.out}\n`,
+          },
+          [`/download/v9.8.7/${target.out}`]: { body: "LEGACY-RAW-MUST-NOT-RUN" },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+
+          expect(result.status).not.toBe(0);
+          expect(evidence.requests).not.toContain(`/download/v9.8.7/${target.out}`);
+          expect(existsSync(join(sandbox.binDir, "kunai"))).toBe(false);
+          expect(existsSync(join(sandbox.configDir, "install.json"))).toBe(false);
+          expect(existsSync(join(sandbox.cacheDir, "staging", "9.8.7"))).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("rejects archive checksum mismatch without raw fallback", async () => {
+    const target = hostInstallShTarget();
+    const body = "archive-checksum-mismatch";
+    const archive = createReleaseArchive(target, new TextEncoder().encode(body));
+    const sandbox = createInstallerSandbox("install-sh-archive-mismatch");
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${target.archiveName}`]: { body: archive },
+          "/download/v9.8.7/SHA256SUMS.archives": {
+            body: `${"0".repeat(64)}  ${target.archiveName}\n`,
+          },
+          [`/download/v9.8.7/${target.out}`]: { body: "legacy" },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+          expect(result.status).not.toBe(0);
+          expect(result.stderr).toContain(`Checksum mismatch for ${target.archiveName}`);
+          expect(evidence.requests).not.toContain(`/download/v9.8.7/${target.out}`);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("rejects archive and decompressed size bombs and cleans staging", async () => {
+    const target = hostInstallShTarget();
+    const body = "binary-larger-than-four-bytes";
+    const archive = createReleaseArchive(target, new TextEncoder().encode(body));
+    const archiveDigest = createHash("sha256").update(archive).digest("hex");
+    const binaryDigest = createHash("sha256").update(body).digest("hex");
+    for (const [label, env] of [
+      ["archive", { KUNAI_DOWNLOAD_ARCHIVE_MAX_BYTES: "8" }],
+      ["decompressed", { KUNAI_EXTRACTED_BINARY_MAX_BYTES: "4" }],
+    ] as const) {
+      const sandbox = createInstallerSandbox(`install-sh-${label}-bomb`);
+      try {
+        await withReleaseFixture(
+          {
+            [`/download/v9.8.7/${target.archiveName}`]: { body: archive },
+            "/download/v9.8.7/SHA256SUMS.archives": {
+              body: `${archiveDigest}  ${target.archiveName}\n`,
+            },
+            "/download/v9.8.7/SHA256SUMS": {
+              body: `${binaryDigest}  ${target.out}\n`,
+            },
+          },
+          async (baseUrl) => {
+            const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+              ...sandbox.env,
+              ...env,
+              KUNAI_DL_BASE: baseUrl,
+              KUNAI_DOWNLOAD_MAX_ATTEMPTS: "1",
+            });
+            expect(result.status).not.toBe(0);
+            expect(`${result.stderr}${result.stdout}`).toMatch(/size|budget|exceeds/i);
+            expect(existsSync(join(sandbox.cacheDir, "staging", "9.8.7"))).toBe(false);
+          },
+        );
+      } finally {
+        sandbox.cleanup();
+      }
+    }
+  });
+
+  test("fails closed when the tar extractor is missing", async () => {
+    const target = hostInstallShTarget();
+    const body = "archive-needs-extractor";
+    const archive = createReleaseArchive(target, new TextEncoder().encode(body));
+    const archiveDigest = createHash("sha256").update(archive).digest("hex");
+    const binaryDigest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox("install-sh-missing-extractor");
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${target.archiveName}`]: { body: archive },
+          "/download/v9.8.7/SHA256SUMS.archives": {
+            body: `${archiveDigest}  ${target.archiveName}\n`,
+          },
+          "/download/v9.8.7/SHA256SUMS": {
+            body: `${binaryDigest}  ${target.out}\n`,
+          },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_ARCHIVE_TAR_COMMAND: "kunai-test-missing-tar",
+          });
+          expect(result.status).not.toBe(0);
+          expect(result.stderr).toContain("kunai-test-missing-tar is required");
+          expect(evidence.requests).not.toContain(`/download/v9.8.7/${target.out}`);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test.each([
+    ["checksum", 404],
+    ["checksum", 410],
+    ["archive", 404],
+    ["archive", 410],
+  ] as const)("falls back to the legacy raw asset only for %s HTTP %i", async (missing, status) => {
+    const target = hostInstallShTarget();
+    const body = "legacy-raw-fallback";
+    const canonical = createReleaseArchive(target, new TextEncoder().encode(body));
+    const archiveDigest = createHash("sha256").update(canonical).digest("hex");
+    const binaryDigest = createHash("sha256").update(body).digest("hex");
+    const sandbox = createInstallerSandbox(`install-sh-fallback-${missing}-${status}`);
+    try {
+      await withReleaseFixture(
+        {
+          [`/download/v9.8.7/${target.archiveName}`]:
+            missing === "archive" ? { status } : { body: canonical },
+          "/download/v9.8.7/SHA256SUMS.archives":
+            missing === "checksum"
+              ? { status }
+              : { body: `${archiveDigest}  ${target.archiveName}\n` },
+          "/download/v9.8.7/SHA256SUMS": {
+            body: `${binaryDigest}  ${target.out}\n`,
+          },
+          [`/download/v9.8.7/${target.out}`]: { body },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+          });
+          expect(result.status, result.stderr).toBe(0);
+          expect(evidence.requests).toContain(`/download/v9.8.7/${target.out}`);
+          expect(readFileSync(join(sandbox.dataDir, "versions", "9.8.7", "kunai"), "utf8")).toBe(
+            body,
+          );
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("does not use raw fallback for archive HTTP 500", async () => {
+    const target = hostInstallShTarget();
+    const sandbox = createInstallerSandbox("install-sh-archive-500");
+    try {
+      await withReleaseFixture(
+        {
+          "/download/v9.8.7/SHA256SUMS.archives": { status: 500 },
+          [`/download/v9.8.7/${target.out}`]: { body: "legacy" },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_DOWNLOAD_MAX_ATTEMPTS: "1",
+          });
+          expect(result.status).not.toBe(0);
+          expect(evidence.requests).not.toContain(`/download/v9.8.7/${target.out}`);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("does not use raw fallback when the archive checksum download stalls", async () => {
+    const target = hostInstallShTarget();
+    const sandbox = createInstallerSandbox("install-sh-archive-stall");
+    try {
+      await withReleaseFixture(
+        {
+          "/download/v9.8.7/SHA256SUMS.archives": {
+            body: `${"a".repeat(64)}  ${target.archiveName}\n`,
+            chunkDelayMs: 1_100,
+            chunkSize: 1,
+          },
+          [`/download/v9.8.7/${target.out}`]: { body: "legacy" },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runInstallShAsync(["--yes", "--skip-deps", "--version", "9.8.7"], {
+            ...sandbox.env,
+            KUNAI_DL_BASE: baseUrl,
+            KUNAI_DOWNLOAD_MAX_ATTEMPTS: "1",
+            KUNAI_DOWNLOAD_SPEED_LIMIT: "10",
+            KUNAI_DOWNLOAD_SPEED_TIME: "1",
+          });
+          expect(result.status).not.toBe(0);
+          expect(evidence.requests).not.toContain(`/download/v9.8.7/${target.out}`);
+          expect(existsSync(join(sandbox.cacheDir, "staging", "9.8.7"))).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
   test("pins a resolved latest binary and checksum to the immutable release URL", async () => {
     const asset = hostInstallShAsset();
     const body = "#!/bin/sh\necho kunai-fixture\n";
@@ -275,6 +634,7 @@ describe("install.sh release asset failures", () => {
           expect(result.stdout).toContain(`Downloading ${asset} (v9.8.7)`);
           expect(evidence.requests).toEqual([
             "/releases/latest",
+            "/download/v9.8.7/SHA256SUMS.archives",
             "/download/v9.8.7/SHA256SUMS",
             `/download/v9.8.7/${asset}`,
           ]);
@@ -389,6 +749,7 @@ describe("install.sh release asset failures", () => {
           expect(result.status).toBe(0);
           expect(result.stdout).toContain(`Downloading ${asset} (v9.8.7)`);
           expect(evidence.requests).toEqual([
+            "/download/v9.8.7/SHA256SUMS.archives",
             "/download/v9.8.7/SHA256SUMS",
             `/download/v9.8.7/${asset}`,
           ]);
@@ -398,7 +759,7 @@ describe("install.sh release asset failures", () => {
           const manifest = JSON.parse(
             readFileSync(join(sandbox.configDir, "install.json"), "utf8"),
           ) as Record<string, unknown>;
-          expect(manifest.schemaVersion).toBe(1);
+          expect(manifest.schemaVersion).toBe(2);
           expect(manifest.method).toBe("binary");
           expect(manifest.activeVersion).toBe("9.8.7");
           expect(manifest.preferredChannel).toBe("stable");
@@ -406,6 +767,8 @@ describe("install.sh release asset failures", () => {
           expect(manifest.versionedPath).toBe(join(sandbox.dataDir, "versions", "9.8.7", "kunai"));
           expect(manifest.downloadBaseUrl).toBe(baseUrl);
           expect(manifest.artifactSha256).toBe(digest);
+          expect(manifest.artifactName).toBe(asset);
+          expect(manifest.artifactSizeBytes).toBe(Buffer.byteLength(body));
           expect(Array.isArray(manifest.managedPaths)).toBe(true);
           expect(manifest.managedPaths).toContain(sandbox.dataDir);
           expect(manifest.managedPaths).toContain(sandbox.cacheDir);

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -94,6 +94,7 @@ function invalidTarArchive(
     | "absolute"
     | "corrupt"
     | "extra"
+    | "gzip-crc"
     | "hardlink"
     | "missing"
     | "newline-padding"
@@ -104,6 +105,11 @@ function invalidTarArchive(
   bodyLength: number,
 ): Uint8Array {
   if (kind === "corrupt") return new TextEncoder().encode("not-a-gzip-archive");
+  if (kind === "gzip-crc") {
+    const output = new Uint8Array(canonical);
+    output[output.length - 8] = (output[output.length - 8] ?? 0) ^ 1;
+    return output;
+  }
   if (kind === "extra") return duplicateTarMember(canonical, bodyLength);
   if (kind === "missing") return new Uint8Array(gzipSync(new Uint8Array(1_024)));
   if (kind === "newline-padding") return addNewlineTarPadding(canonical, bodyLength);
@@ -427,6 +433,7 @@ exec ${quoteShellArgument(realDd)} "$@"
     "absolute",
     "corrupt",
     "extra",
+    "gzip-crc",
     "hardlink",
     "missing",
     "newline-padding",
@@ -460,6 +467,7 @@ exec ${quoteShellArgument(realDd)} "$@"
           });
 
           expect(result.status).not.toBe(0);
+          if (kind === "gzip-crc") expect(result.stderr).toMatch(/gzip|decompress/i);
           expect(evidence.requests).not.toContain(`/download/v9.8.7/${target.out}`);
           expect(existsSync(join(sandbox.binDir, "kunai"))).toBe(false);
           expect(existsSync(join(sandbox.configDir, "install.json"))).toBe(false);

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -355,6 +355,20 @@ describe("install.sh release asset failures", () => {
             artifactName: target.out,
             artifactSha256: binaryDigest,
             artifactSizeBytes: Buffer.byteLength(body),
+            artifactSourceUrl: `${baseUrl}/download/v9.8.7/${target.out}`,
+            archiveName: target.archiveName,
+            archiveSha256: archiveDigest,
+            archiveSizeBytes: archive.length,
+            archiveSourceUrl: `${baseUrl}/download/v9.8.7/${target.archiveName}`,
+          });
+          const metadata = JSON.parse(
+            readFileSync(join(sandbox.dataDir, "versions", "9.8.7", "version.json"), "utf8"),
+          ) as Record<string, unknown>;
+          expect(metadata).toMatchObject({
+            artifactName: target.out,
+            artifactSha256: binaryDigest,
+            sizeBytes: Buffer.byteLength(body),
+            sourceUrl: `${baseUrl}/download/v9.8.7/${target.out}`,
             archiveName: target.archiveName,
             archiveSha256: archiveDigest,
             archiveSizeBytes: archive.length,

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceFingerprint": "409a48753e3800b84ce7ea659ecb9b6e6431d3bb64ba69b08098fb5b027264ff",
-  "docsContentFingerprint": "c595e28a2560e058ae230ca97f18a86f6d9764334262fccaec18e7c788e0f3d3",
+  "cliSourceFingerprint": "d0bb55845c6b6efcd21c817de8f80fe72d683bc2d1bbba72f5bcaf678936ac64",
+  "docsContentFingerprint": "3a4e0d03c02be0b3ac756b924362a6456b5afde733aadf33fdbf1839825165ac",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 81,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],
@@ -94,7 +94,7 @@
         "Mp4 (mp4upload scrape)",
         "Luf-Mp4",
         "Ak. Filemoon is gone.",
-        "2026-08: mkissa crypto requires buildId=119 (rotated from 81) + /client-crypto/v1/bootstrap (x-aa-boot)",
+        "2026-08: mkissa crypto rotates buildId + derivation constants (81 → 119 → 140; 140 added bootPrefix HMAC and group.host.lane.buildId.epoch payload) with /client-crypto/v1/bootstrap (x-aa-boot)",
         "7-day epochs. ani-cli v5 moved primary to anidb.app."
       ]
     },
@@ -113,7 +113,11 @@
         "Primary hosts: www.miruro.bz",
         "www.miruro.ru. Bare miruro.bz/.ru are 301 redirects to www. and still CF-block at the pipe path; miruro.com serves a different app shell with no /api/secure/pipe; miruro.tv/.to are TLS-dead — all stay off the resolve list.",
         "Uses Miruro pipe API with XOR/gzip decryption key 71951034f8fbcf53d89db52ceb3dc22c.",
-        "Not in the automatic anime lane: `animeProviderPriority` is `[anidb"
+        "The default anime priority names AniDB first; that list is ordering",
+        "not an allowlist",
+        "so Miruro remains a registered fallback and manually selectable when the curl/http2 path works.",
+        "May hit Cloudflare rate limits if called too frequently.",
+        "2026-08-17: curl --http2 with browser headers also receives CF 403 HTML from some networks; the WAF block message now carries a relay hint."
       ]
     },
     {

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceFingerprint": "d0bb55845c6b6efcd21c817de8f80fe72d683bc2d1bbba72f5bcaf678936ac64",
-  "docsContentFingerprint": "b2a5aab65a45b99e0cbbe04aa23ee5e81822379f460fc9f56792f6f520c3965f",
+  "cliSourceFingerprint": "409a48753e3800b84ce7ea659ecb9b6e6431d3bb64ba69b08098fb5b027264ff",
+  "docsContentFingerprint": "c595e28a2560e058ae230ca97f18a86f6d9764334262fccaec18e7c788e0f3d3",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 81,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],
@@ -94,7 +94,7 @@
         "Mp4 (mp4upload scrape)",
         "Luf-Mp4",
         "Ak. Filemoon is gone.",
-        "2026-08: mkissa crypto rotates buildId + derivation constants (81 → 119 → 140; 140 added bootPrefix HMAC and group.host.lane.buildId.epoch payload) with /client-crypto/v1/bootstrap (x-aa-boot)",
+        "2026-08: mkissa crypto requires buildId=119 (rotated from 81) + /client-crypto/v1/bootstrap (x-aa-boot)",
         "7-day epochs. ani-cli v5 moved primary to anidb.app."
       ]
     },
@@ -113,11 +113,7 @@
         "Primary hosts: www.miruro.bz",
         "www.miruro.ru. Bare miruro.bz/.ru are 301 redirects to www. and still CF-block at the pipe path; miruro.com serves a different app shell with no /api/secure/pipe; miruro.tv/.to are TLS-dead — all stay off the resolve list.",
         "Uses Miruro pipe API with XOR/gzip decryption key 71951034f8fbcf53d89db52ceb3dc22c.",
-        "The default anime priority names AniDB first; that list is ordering",
-        "not an allowlist",
-        "so Miruro remains a registered fallback and manually selectable when the curl/http2 path works.",
-        "May hit Cloudflare rate limits if called too frequently.",
-        "2026-08-17: curl --http2 with browser headers also receives CF 403 HTML from some networks; the WAF block message now carries a relay hint."
+        "Not in the automatic anime lane: `animeProviderPriority` is `[anidb"
       ]
     },
     {

--- a/docs/users/install-and-update.mdx
+++ b/docs/users/install-and-update.mdx
@@ -18,6 +18,13 @@ Default — downloads a verified release binary into a versioned store and links
 curl -fsSL https://kunai.kitsunekode.in/install.sh | bash
 ```
 
+The installer downloads the platform `.tar.gz`, verifies it with
+`SHA256SUMS.archives`, accepts exactly one expected regular-file member, and
+verifies the extracted binary again with `SHA256SUMS`. It needs the standard
+`gzip` and `tar` tools. Releases from before archive publication use the legacy
+raw binary only when the archive or archive-checksum endpoint returns HTTP 404
+or 410; integrity and network failures do not downgrade verification.
+
 Or from an existing Kunai binary:
 
 ```sh
@@ -54,6 +61,11 @@ Supported binary targets: `linux-x64`, `linux-arm64`, `linux-x64-musl`, `linux-a
 ```powershell
 irm https://kunai.kitsunekode.in/install.ps1 | iex
 ```
+
+PowerShell downloads the platform `.zip`, verifies the archive and its single
+`kunai.exe` member independently, and extracts through bounded .NET streams; no
+separate zip utility is required. The same HTTP 404/410-only legacy fallback
+rule applies.
 
 Installs to `%LOCALAPPDATA%\kunai\bin\kunai.exe`, prepends that directory to your **User** PATH so the native binary wins over an older npm/Bun shim, and records the install channel in `%APPDATA%\kunai\install.json`.
 
@@ -154,7 +166,7 @@ Release binaries are **not code-signed or notarized** today. That is intentional
 - **Windows:** SmartScreen may warn on first run. After download, `install.ps1` runs `Unblock-File` on the staged binary. You can also run `Unblock-File` manually on `kunai.exe`, or right-click → Properties → Unblock.
 - **macOS (Apple Silicon):** release binaries are cross-compiled on Linux, so they arrive **unsigned**, and arm64 macOS refuses to execute an unsigned Mach-O outright. The shell reports only `killed: 9` — no Gatekeeper dialog, and `xattr` does not help, because quarantine is not what failed. `install.sh` now ad-hoc signs the binary on your Mac (`codesign --force --sign -`); if `codesign` is unavailable it prints the exact command to run.
 - **macOS (Intel, or downloads outside the installer):** Gatekeeper quarantine can still block a manually downloaded binary. Clear it with `xattr -dr com.apple.quarantine ~/.local/bin/kunai` (or your install path).
-- **Linux:** No signing step; verify downloads against the `SHA256SUMS` file published on each GitHub Release.
+- **Linux:** No signing step. Archives are covered by `SHA256SUMS.archives`; the extracted executable is independently covered by `SHA256SUMS`.
 
 Production code signing and notarization are a post-beta goal, not a beta blocker.
 

--- a/docs/users/troubleshooting.mdx
+++ b/docs/users/troubleshooting.mdx
@@ -302,7 +302,7 @@ More: [Share links](/docs/users/share-links).
 
 3. **Ownership mismatch:** use the owner channel. Binary installs → `kunai upgrade` / `kunai uninstall`. npm → `npm uninstall -g @kitsunekode/kunai` or ownership-aware `kunai uninstall`. Do not delete a package-manager install with a raw `rm` of another channel's launcher.
 
-4. **Checksum / 404 on install or upgrade:** confirm the release tag exists and `SHA256SUMS` matches. Retry with `kunai install --force` or pin an explicit version (`kunai install --force X.Y.Z` / `install.sh … --version X.Y.Z`). A 404 usually means the asset for your target (for example musl vs glibc) is missing — check [Platforms](/docs/users/platforms).
+4. **Checksum / 404 on install or upgrade:** confirm the release tag exists and both `SHA256SUMS.archives` (downloaded archive) and `SHA256SUMS` (extracted binary) match. Retry with `kunai install --force` or pin an explicit version (`kunai install --force X.Y.Z` / `install.sh … --version X.Y.Z`). HTTP 404/410 on an archive endpoint may select the older raw compatibility asset; checksum failures, malformed archives, timeouts, and 5xx responses fail closed instead. A persistent 404 usually means the asset for your target (for example musl vs glibc) is missing — check [Platforms](/docs/users/platforms).
 
 5. **Rollback** to a previously verified local version (does not re-download):
 
@@ -324,7 +324,7 @@ More: [Share links](/docs/users/share-links).
 
    - **macOS Gatekeeper quarantine** (Intel, or a binary downloaded outside the installer): `xattr -dr com.apple.quarantine` on the install path.
    - **Windows SmartScreen:** `Unblock-File` on `kunai.exe`.
-   - **Linux:** verify against `SHA256SUMS`.
+   - **Linux:** verify the archive against `SHA256SUMS.archives` and the extracted binary against `SHA256SUMS`.
 
    Details: [Unsigned binaries](/docs/users/install-and-update#unsigned-binaries-beta).
 
@@ -338,7 +338,7 @@ More: [Share links](/docs/users/share-links).
 | --- | --- |
 | PATH candidates / winner | `kunai doctor` or `kunai doctor --json` |
 | Install channel / ownership | `~/.config/kunai/install.json` (Windows: `%APPDATA%\kunai\install.json`) |
-| Checksum / verification | doctor findings; GitHub Release `SHA256SUMS` |
+| Checksum / verification | doctor findings; GitHub Release `SHA256SUMS.archives` and `SHA256SUMS` |
 | Rollback candidates | `kunai rollback --list` |
 
 More: [Install and update](/docs/users/install-and-update), [Platforms](/docs/users/platforms).

--- a/install.ps1
+++ b/install.ps1
@@ -54,6 +54,8 @@ $DownloadConnectTimeoutSec = if ($env:KUNAI_DOWNLOAD_CONNECT_TIMEOUT) { [int]$en
 $DownloadTotalSeconds = if ($env:KUNAI_DOWNLOAD_TOTAL_SECONDS) { [int]$env:KUNAI_DOWNLOAD_TOTAL_SECONDS } else { 300 }
 $DownloadStallMs = if ($env:KUNAI_DOWNLOAD_STALL_MS) { [int]$env:KUNAI_DOWNLOAD_STALL_MS } else { 30000 }
 $DownloadMaxBytes = if ($env:KUNAI_DOWNLOAD_MAX_BYTES) { [long]$env:KUNAI_DOWNLOAD_MAX_BYTES } else { 268435456 }
+$DownloadArchiveMaxBytes = if ($env:KUNAI_DOWNLOAD_ARCHIVE_MAX_BYTES) { [long]$env:KUNAI_DOWNLOAD_ARCHIVE_MAX_BYTES } else { 67108864 }
+$ExtractedBinaryMaxBytes = if ($env:KUNAI_EXTRACTED_BINARY_MAX_BYTES) { [long]$env:KUNAI_EXTRACTED_BINARY_MAX_BYTES } else { 134217728 }
 $DownloadChecksumMaxBytes = if ($env:KUNAI_DOWNLOAD_CHECKSUM_MAX_BYTES) { [long]$env:KUNAI_DOWNLOAD_CHECKSUM_MAX_BYTES } else { 1048576 }
 $DownloadMaxAttempts = if ($env:KUNAI_DOWNLOAD_MAX_ATTEMPTS) { [int]$env:KUNAI_DOWNLOAD_MAX_ATTEMPTS } else { 3 }
 $DownloadRetryBaseMs = if ($env:KUNAI_DOWNLOAD_RETRY_BASE_MS) { [int]$env:KUNAI_DOWNLOAD_RETRY_BASE_MS } else { 1000 }
@@ -63,6 +65,7 @@ $ActivationLockCorruptGraceMs = if ($env:KUNAI_ACTIVATION_LOCK_CORRUPT_GRACE_MS)
 $ActivationLockTimeoutMs = [Math]::Max(0, $ActivationLockTimeoutMs)
 $ActivationLockPollMs = [Math]::Max(1, $ActivationLockPollMs)
 $ActivationLockCorruptGraceMs = [Math]::Max(0, $ActivationLockCorruptGraceMs)
+$script:LastDownloadHttpStatus = $null
 
 function Write-Utf8File([string]$Path, [string]$Content) {
   $encoding = New-Object System.Text.UTF8Encoding $false
@@ -227,6 +230,7 @@ function Invoke-BoundedDownload {
     [string]$Label = 'download'
   )
 
+  $script:LastDownloadHttpStatus = $null
   $started = [DateTime]::UtcNow
   $attempt = 1
   while ($attempt -le $DownloadMaxAttempts) {
@@ -255,6 +259,7 @@ function Invoke-BoundedDownload {
       ).GetAwaiter().GetResult()
 
       $status = [int]$response.StatusCode
+      $script:LastDownloadHttpStatus = $status
       if ($status -lt 200 -or $status -ge 300) {
         if ((Test-RetryableHttpStatus $status) -and $attempt -lt $DownloadMaxAttempts) {
           Write-Info "Retrying $Label (attempt $($attempt + 1)/$DownloadMaxAttempts) after HTTP $status..."
@@ -335,6 +340,96 @@ function Invoke-BoundedDownload {
   throw "Download failed for $Label after $DownloadMaxAttempts attempts."
 }
 
+function Get-ChecksumEntry([string]$ManifestPath, [string]$AssetName) {
+  $digests = @()
+  foreach ($line in Get-Content -LiteralPath $ManifestPath) {
+    if ($line -match '^([0-9A-Fa-f]{64})\s{2}([^\s]+)$' -and $Matches[2] -eq $AssetName) {
+      $digests += $Matches[1].ToLowerInvariant()
+      continue
+    }
+    if ($line -match "\s$([regex]::Escape($AssetName))\s*$") {
+      throw "Checksum manifest has a malformed entry for $AssetName."
+    }
+  }
+  if ($digests.Count -ne 1) {
+    throw "Checksum manifest must contain exactly one valid entry for $AssetName."
+  }
+  return [string]$digests[0]
+}
+
+function Expand-KunaiReleaseZip(
+  [string]$ArchivePath,
+  [string]$ExpectedName,
+  [string]$DestinationPath
+) {
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  $zip = $null
+  $input = $null
+  $output = $null
+  try {
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($ArchivePath)
+    if ($zip.Entries.Count -ne 1) {
+      throw 'Release archive must contain exactly one regular file.'
+    }
+    $entry = $zip.Entries[0]
+    $name = [string]$entry.FullName
+    if ([string]::IsNullOrEmpty($name) -or [System.IO.Path]::IsPathRooted($name) -or
+      $name.Contains('/') -or $name.Contains('\') -or $name -in @('.', '..')) {
+      throw "Archive contains an unsafe traversal or absolute-path entry: $name"
+    }
+    if ($name -ne $ExpectedName) {
+      throw "Archive contains unexpected entry '$name'; expected '$ExpectedName'."
+    }
+
+    $attributes = [uint32]([int64]$entry.ExternalAttributes -band 0xffffffffL)
+    $unixType = ($attributes -shr 16) -band 0xf000
+    $dosAttributes = $attributes -band 0xffff
+    if (($unixType -ne 0 -and $unixType -ne 0x8000) -or
+      (($dosAttributes -band 0x410) -ne 0)) {
+      throw 'Archive entry must be a regular file; symlink, directory, and reparse entries are forbidden.'
+    }
+    if ($entry.Length -le 0 -or $entry.Length -gt $ExtractedBinaryMaxBytes) {
+      throw "Extracted binary size $($entry.Length) exceeds the $ExtractedBinaryMaxBytes byte budget."
+    }
+    if ($entry.CompressedLength -gt $DownloadArchiveMaxBytes) {
+      throw "Compressed zip entry exceeds the $DownloadArchiveMaxBytes byte budget."
+    }
+
+    $input = $entry.Open()
+    $output = [System.IO.File]::Open(
+      $DestinationPath,
+      [System.IO.FileMode]::CreateNew,
+      [System.IO.FileAccess]::Write,
+      [System.IO.FileShare]::None
+    )
+    $buffer = New-Object byte[] 8192
+    $total = [long]0
+    while ($true) {
+      $read = $input.Read($buffer, 0, $buffer.Length)
+      if ($read -le 0) { break }
+      $total += $read
+      if ($total -gt $ExtractedBinaryMaxBytes) {
+        throw "Extracted binary exceeds the $ExtractedBinaryMaxBytes byte budget."
+      }
+      $output.Write($buffer, 0, $read)
+    }
+    if ($total -ne $entry.Length) {
+      throw "Extracted binary size $total does not match the zip entry size $($entry.Length)."
+    }
+  }
+  catch {
+    if (Test-Path -LiteralPath $DestinationPath) {
+      Remove-Item -LiteralPath $DestinationPath -Force -ErrorAction SilentlyContinue
+    }
+    throw
+  }
+  finally {
+    if ($null -ne $output) { $output.Dispose() }
+    if ($null -ne $input) { $input.Dispose() }
+    if ($null -ne $zip) { $zip.Dispose() }
+  }
+}
+
 function Write-Manifest(
   [string]$MethodName,
   [string]$Ver,
@@ -342,9 +437,15 @@ function Write-Manifest(
   [string]$VersionPath = '',
   [string]$Target = '',
   [string]$Sha256 = '',
-  [string]$PreviousVersion = ''
+  [string]$PreviousVersion = '',
+  [string]$ArtifactName = '',
+  [long]$ArtifactSizeBytes = 0,
+  [string]$ArchiveName = '',
+  [string]$ArchiveSha256 = '',
+  [long]$ArchiveSizeBytes = 0,
+  [string]$ArchiveSourceUrl = ''
 ) {
-  if ($DryRun) { Write-Info "[dry-run] would write schema-1 manifest ($MethodName)"; return }
+  if ($DryRun) { Write-Info "[dry-run] would write schema-2 manifest ($MethodName)"; return }
   New-Item -ItemType Directory -Force -Path $ConfigDir | Out-Null
   $manifestPath = Join-Path $ConfigDir 'install.json'
   $now = Get-IsoNow
@@ -363,7 +464,7 @@ function Write-Manifest(
   }
 
   $manifest = [ordered]@{
-    schemaVersion     = 1
+    schemaVersion     = 2
     method            = $MethodName
     activeVersion     = $Ver
     preferredChannel  = 'stable'
@@ -377,6 +478,14 @@ function Write-Manifest(
   if ($PreviousVersion) { $manifest.previousVersion = $PreviousVersion }
   if ($Target) { $manifest.target = $Target }
   if ($Sha256) { $manifest.artifactSha256 = $Sha256 }
+  if ($ArtifactName) { $manifest.artifactName = $ArtifactName }
+  if ($ArtifactSizeBytes -gt 0) { $manifest.artifactSizeBytes = $ArtifactSizeBytes }
+  if ($ArchiveName) {
+    $manifest.archiveName = $ArchiveName
+    $manifest.archiveSha256 = $ArchiveSha256
+    $manifest.archiveSizeBytes = $ArchiveSizeBytes
+    $manifest.archiveSourceUrl = $ArchiveSourceUrl
+  }
 
   $tmp = "$manifestPath.tmp-$PID"
   Write-Utf8File $tmp (($manifest | ConvertTo-Json -Depth 6) + "`n")
@@ -1222,10 +1331,15 @@ function Install-Binary {
   $target = "windows-$arch"
   $url = "$base/$asset"
   $sumsUrl = "$base/SHA256SUMS"
+  $archive = $asset.Substring(0, $asset.Length - 4) + '.zip'
+  $archiveUrl = "$base/$archive"
+  $archiveSumsUrl = "$base/SHA256SUMS.archives"
 
   Write-Info "Downloading $asset (v$resolved) ..."
   if ($DryRun) {
-    Write-Info "[dry-run] would download (bounded HttpClient), verify SHA256, install to $versionPath and $BinPath"
+    Write-Info "[dry-run] would download and verify $archive against SHA256SUMS.archives"
+    Write-Info "[dry-run] would safely extract $asset, verify it against SHA256SUMS, and install to $versionPath and $BinPath"
+    Write-Info '[dry-run] raw compatibility fallback is allowed only for archive HTTP 404/410'
     Write-Manifest 'binary' $resolved $BinPath $versionPath $target
     return
   }
@@ -1239,6 +1353,8 @@ function Install-Binary {
   $activationLockPath = Join-Path $LocksDir 'activation.lock'
   $stagedBin = Join-Path $staging $asset
   $stagedSums = Join-Path $staging 'SHA256SUMS'
+  $stagedArchive = Join-Path $staging $archive
+  $stagedArchiveSums = Join-Path $staging 'SHA256SUMS.archives'
   $metadataPath = Join-Path (Join-Path $VersionsDir $resolved) 'version.json'
 
   $cleanupDone = $false
@@ -1251,42 +1367,98 @@ function Install-Binary {
     New-Item -ItemType Directory -Force -Path $staging | Out-Null
     Begin-InstallTransaction $txnId $kind $resolved $staging $txnPath
 
+    $archiveAvailable = $true
+    $archiveGot = ''
+    $archiveSize = [long]0
+    $archiveSourceUrl = ''
+    $archiveNameUsed = ''
+    $artifactSourceUrl = $url
+    try {
+      Invoke-BoundedDownload -Url $archiveSumsUrl -DestinationPath $stagedArchiveSums `
+        -MaxBytes $DownloadChecksumMaxBytes -Label 'SHA256SUMS.archives'
+    }
+    catch {
+      if ($script:LastDownloadHttpStatus -in @(404, 410)) {
+        $archiveAvailable = $false
+        Write-Info "Archive checksums are unavailable for v$resolved; using the legacy raw asset."
+      }
+      else {
+        Write-Warn 'Download failed for SHA256SUMS.archives.'
+        Write-Warn 'Try: -Method npm | -Method bun | -Method source'
+        Write-Warn 'Or pin a version: -Version X.Y.Z'
+        throw
+      }
+    }
+
+    if ($archiveAvailable) {
+      try { $archiveWant = Get-ChecksumEntry $stagedArchiveSums $archive }
+      catch { throw "SHA256SUMS.archives must contain exactly one valid entry for $archive. $($_.Exception.Message)" }
+      try {
+        Invoke-BoundedDownload -Url $archiveUrl -DestinationPath $stagedArchive `
+          -MaxBytes $DownloadArchiveMaxBytes -Label $archive
+      }
+      catch {
+        if ($script:LastDownloadHttpStatus -in @(404, 410)) {
+          $archiveAvailable = $false
+          Write-Info "Archive asset is unavailable for v$resolved; using the legacy raw asset."
+        }
+        else {
+          Write-Warn "Download failed for $archive."
+          Write-Warn 'Try: -Method npm | -Method bun | -Method source'
+          Write-Warn 'Or pin a version: -Version X.Y.Z'
+          throw
+        }
+      }
+    }
+
+    if ($archiveAvailable) {
+      $archiveGot = (Get-FileHash -Path $stagedArchive -Algorithm SHA256).Hash.ToLowerInvariant()
+      if ($archiveWant -ne $archiveGot) {
+        throw "Checksum mismatch for $archive (expected '$archiveWant', got '$archiveGot')."
+      }
+      $archiveSize = [long](Get-Item -LiteralPath $stagedArchive).Length
+      $archiveSourceUrl = $archiveUrl
+      $archiveNameUsed = $archive
+      $artifactSourceUrl = $archiveUrl
+    }
+
     try {
       Invoke-BoundedDownload -Url $sumsUrl -DestinationPath $stagedSums -MaxBytes $DownloadChecksumMaxBytes -Label 'SHA256SUMS'
     }
     catch {
-      Write-Warn "Download failed for SHA256SUMS."
+      Write-Warn 'Download failed for SHA256SUMS.'
       Write-Warn 'Try: -Method npm | -Method bun | -Method source'
       Write-Warn 'Or pin a version: -Version X.Y.Z'
       throw
     }
+    try { $want = Get-ChecksumEntry $stagedSums $asset }
+    catch { throw "SHA256SUMS has no entry for $asset, or has duplicate/malformed entries. $($_.Exception.Message)" }
 
-    try {
-      Invoke-BoundedDownload -Url $url -DestinationPath $stagedBin -MaxBytes $DownloadMaxBytes -Label $asset
+    if ($archiveAvailable) {
+      Expand-KunaiReleaseZip $stagedArchive $asset $stagedBin
     }
-    catch {
-      Write-Warn "Download failed for $asset."
-      Write-Warn 'Try: -Method npm | -Method bun | -Method source'
-      Write-Warn 'Or pin a version: -Version X.Y.Z'
-      throw
-    }
-
-    if ((Get-Item -LiteralPath $stagedBin).Length -eq 0) {
-      throw "Downloaded asset $asset is empty; the release is incomplete. Try -Method npm, -Method bun, or -Method source."
-    }
-
-    $sumsText = Get-Content -LiteralPath $stagedSums -Raw
-    $want = ($sumsText -split "`n" |
-      Where-Object { $_ -match "\s$([regex]::Escape($asset))\s*$" }) -replace '\s.*', ''
-    $want = ([string]$want).Trim().ToLowerInvariant()
-
-    if ([string]::IsNullOrEmpty($want)) {
-      throw "SHA256SUMS has no entry for $asset; the release is incomplete. Try -Method npm, -Method bun, or -Method source."
+    else {
+      try {
+        Invoke-BoundedDownload -Url $url -DestinationPath $stagedBin -MaxBytes $DownloadMaxBytes -Label $asset
+      }
+      catch {
+        Write-Warn "Download failed for $asset."
+        Write-Warn 'Try: -Method npm | -Method bun | -Method source'
+        Write-Warn 'Or pin a version: -Version X.Y.Z'
+        throw
+      }
     }
 
+    $sizeBytes = [long](Get-Item -LiteralPath $stagedBin).Length
+    if ($sizeBytes -le 0) {
+      throw "Downloaded or extracted asset $asset is empty; the release is incomplete."
+    }
+    if ($sizeBytes -gt $ExtractedBinaryMaxBytes) {
+      throw "Binary size $sizeBytes exceeds the $ExtractedBinaryMaxBytes byte budget."
+    }
     $got = (Get-FileHash -Path $stagedBin -Algorithm SHA256).Hash.ToLowerInvariant()
     if ($want -ne $got) {
-      throw "Checksum mismatch for $asset (expected '$want', got '$got')."
+      throw "Checksum mismatch for extracted $asset (expected '$want', got '$got')."
     }
 
     New-Item -ItemType Directory -Force -Path (Split-Path $versionPath) | Out-Null
@@ -1295,9 +1467,8 @@ function Install-Binary {
     if ($OnWindows) { Unblock-File -Path $versionTmp -ErrorAction SilentlyContinue }
     Move-Item -Force -Path $versionTmp -Destination $versionPath
 
-    $sizeBytes = [long](Get-Item -LiteralPath $versionPath).Length
     Write-VersionMetadata -Ver $resolved -Target $target -ArtifactName $asset -Sha256 $got `
-      -SizeBytes $sizeBytes -SourceUrl $url -Path $metadataPath
+      -SizeBytes $sizeBytes -SourceUrl $artifactSourceUrl -Path $metadataPath
 
     $activationOwnerId = Acquire-ActivationLock $resolved $activationLockPath
     # Another version may have activated during this download. Read shared state
@@ -1312,7 +1483,10 @@ function Install-Binary {
 
       $prevArg = ''
       if ($activationPrevious -and $activationPrevious -ne $resolved) { $prevArg = $activationPrevious }
-      Write-Manifest 'binary' $resolved $BinPath $versionPath $target $got $prevArg
+      Write-Manifest -MethodName 'binary' -Ver $resolved -Launcher $BinPath `
+        -VersionPath $versionPath -Target $target -Sha256 $got -PreviousVersion $prevArg `
+        -ArtifactName $asset -ArtifactSizeBytes $sizeBytes -ArchiveName $archiveNameUsed `
+        -ArchiveSha256 $archiveGot -ArchiveSizeBytes $archiveSize -ArchiveSourceUrl $archiveSourceUrl
       $launcherActivated = $false
     }
     catch {

--- a/install.ps1
+++ b/install.ps1
@@ -550,6 +550,7 @@ function Write-Manifest(
   [string]$PreviousVersion = '',
   [string]$ArtifactName = '',
   [long]$ArtifactSizeBytes = 0,
+  [string]$ArtifactSourceUrl = '',
   [string]$ArchiveName = '',
   [string]$ArchiveSha256 = '',
   [long]$ArchiveSizeBytes = 0,
@@ -590,6 +591,7 @@ function Write-Manifest(
   if ($Sha256) { $manifest.artifactSha256 = $Sha256 }
   if ($ArtifactName) { $manifest.artifactName = $ArtifactName }
   if ($ArtifactSizeBytes -gt 0) { $manifest.artifactSizeBytes = $ArtifactSizeBytes }
+  if ($ArtifactSourceUrl) { $manifest.artifactSourceUrl = $ArtifactSourceUrl }
   if ($ArchiveName) {
     $manifest.archiveName = $ArchiveName
     $manifest.archiveSha256 = $ArchiveSha256
@@ -624,7 +626,11 @@ function Write-VersionMetadata {
     [string]$Sha256,
     [long]$SizeBytes,
     [string]$SourceUrl,
-    [string]$Path
+    [string]$Path,
+    [string]$ArchiveName = '',
+    [string]$ArchiveSha256 = '',
+    [long]$ArchiveSizeBytes = 0,
+    [string]$ArchiveSourceUrl = ''
   )
   $meta = [ordered]@{
     schemaVersion   = 1
@@ -636,6 +642,12 @@ function Write-VersionMetadata {
     sourceUrl       = $SourceUrl
     verification    = 'release-checksum'
     installedAt     = (Get-IsoNow)
+  }
+  if ($ArchiveName) {
+    $meta.archiveName = $ArchiveName
+    $meta.archiveSha256 = $ArchiveSha256
+    $meta.archiveSizeBytes = $ArchiveSizeBytes
+    $meta.archiveSourceUrl = $ArchiveSourceUrl
   }
   $tmp = "$Path.tmp-$PID"
   New-Item -ItemType Directory -Force -Path (Split-Path $Path) | Out-Null
@@ -1482,7 +1494,6 @@ function Install-Binary {
     $archiveSize = [long]0
     $archiveSourceUrl = ''
     $archiveNameUsed = ''
-    $artifactSourceUrl = $url
     try {
       Invoke-BoundedDownload -Url $archiveSumsUrl -DestinationPath $stagedArchiveSums `
         -MaxBytes $DownloadChecksumMaxBytes -Label 'SHA256SUMS.archives'
@@ -1529,7 +1540,6 @@ function Install-Binary {
       $archiveSize = [long](Get-Item -LiteralPath $stagedArchive).Length
       $archiveSourceUrl = $archiveUrl
       $archiveNameUsed = $archive
-      $artifactSourceUrl = $archiveUrl
     }
 
     try {
@@ -1578,7 +1588,8 @@ function Install-Binary {
     Move-Item -Force -Path $versionTmp -Destination $versionPath
 
     Write-VersionMetadata -Ver $resolved -Target $target -ArtifactName $asset -Sha256 $got `
-      -SizeBytes $sizeBytes -SourceUrl $artifactSourceUrl -Path $metadataPath
+      -SizeBytes $sizeBytes -SourceUrl $url -Path $metadataPath -ArchiveName $archiveNameUsed `
+      -ArchiveSha256 $archiveGot -ArchiveSizeBytes $archiveSize -ArchiveSourceUrl $archiveSourceUrl
 
     $activationOwnerId = Acquire-ActivationLock $resolved $activationLockPath
     # Another version may have activated during this download. Read shared state
@@ -1595,7 +1606,8 @@ function Install-Binary {
       if ($activationPrevious -and $activationPrevious -ne $resolved) { $prevArg = $activationPrevious }
       Write-Manifest -MethodName 'binary' -Ver $resolved -Launcher $BinPath `
         -VersionPath $versionPath -Target $target -Sha256 $got -PreviousVersion $prevArg `
-        -ArtifactName $asset -ArtifactSizeBytes $sizeBytes -ArchiveName $archiveNameUsed `
+        -ArtifactName $asset -ArtifactSizeBytes $sizeBytes -ArtifactSourceUrl $url `
+        -ArchiveName $archiveNameUsed `
         -ArchiveSha256 $archiveGot -ArchiveSizeBytes $archiveSize -ArchiveSourceUrl $archiveSourceUrl
       $launcherActivated = $false
     }

--- a/install.ps1
+++ b/install.ps1
@@ -464,6 +464,7 @@ function Assert-KunaiReleaseZipStructure(
     if ($null -ne $reader) { $reader.Dispose() }
     elseif ($null -ne $stream) { $stream.Dispose() }
   }
+  return [uint32]$centralCrc
 }
 
 function Expand-KunaiReleaseZip(
@@ -472,7 +473,48 @@ function Expand-KunaiReleaseZip(
   [string]$DestinationPath
 ) {
   Add-Type -AssemblyName System.IO.Compression.FileSystem
-  Assert-KunaiReleaseZipStructure $ArchivePath $ExpectedName
+  if (-not ('KunaiInstallerCrc32' -as [type])) {
+    Add-Type -TypeDefinition @'
+using System;
+
+public sealed class KunaiInstallerCrc32
+{
+    private static readonly uint[] Table = CreateTable();
+    private uint value = UInt32.MaxValue;
+
+    public void Append(byte[] buffer, int count)
+    {
+        if (buffer == null) throw new ArgumentNullException("buffer");
+        if (count < 0 || count > buffer.Length) throw new ArgumentOutOfRangeException("count");
+        for (int index = 0; index < count; index++)
+        {
+            value = (value >> 8) ^ Table[(value ^ buffer[index]) & 0xff];
+        }
+    }
+
+    public uint Complete()
+    {
+        return value ^ UInt32.MaxValue;
+    }
+
+    private static uint[] CreateTable()
+    {
+        uint[] table = new uint[256];
+        for (uint entry = 0; entry < table.Length; entry++)
+        {
+            uint remainder = entry;
+            for (int bit = 0; bit < 8; bit++)
+            {
+                remainder = (remainder >> 1) ^ (0xedb88320u & (uint)-(int)(remainder & 1));
+            }
+            table[entry] = remainder;
+        }
+        return table;
+    }
+}
+'@
+  }
+  $expectedCrc = Assert-KunaiReleaseZipStructure $ArchivePath $ExpectedName
   $zip = $null
   $input = $null
   $output = $null
@@ -513,6 +555,7 @@ function Expand-KunaiReleaseZip(
       [System.IO.FileShare]::None
     )
     $buffer = New-Object byte[] 8192
+    $crc = New-Object KunaiInstallerCrc32
     $total = [long]0
     while ($true) {
       $read = $input.Read($buffer, 0, $buffer.Length)
@@ -521,10 +564,15 @@ function Expand-KunaiReleaseZip(
       if ($total -gt $ExtractedBinaryMaxBytes) {
         throw "Extracted binary exceeds the $ExtractedBinaryMaxBytes byte budget."
       }
+      $crc.Append($buffer, $read)
       $output.Write($buffer, 0, $read)
     }
     if ($total -ne $entry.Length) {
       throw "Extracted binary size $total does not match the zip entry size $($entry.Length)."
+    }
+    $actualCrc = $crc.Complete()
+    if ($actualCrc -ne $expectedCrc) {
+      throw 'Extracted binary CRC does not match the zip entry CRC.'
     }
   }
   catch {

--- a/install.ps1
+++ b/install.ps1
@@ -343,11 +343,11 @@ function Invoke-BoundedDownload {
 function Get-ChecksumEntry([string]$ManifestPath, [string]$AssetName) {
   $digests = @()
   foreach ($line in Get-Content -LiteralPath $ManifestPath) {
-    if ($line -match '^([0-9A-Fa-f]{64})\s{2}([^\s]+)$' -and $Matches[2] -eq $AssetName) {
+    if ($line -cmatch '^([0-9A-Fa-f]{64})\s{2}([^\s]+)$' -and $Matches[2] -ceq $AssetName) {
       $digests += $Matches[1].ToLowerInvariant()
       continue
     }
-    if ($line -match "\s$([regex]::Escape($AssetName))\s*$") {
+    if ($line -cmatch "\s$([regex]::Escape($AssetName))\s*$") {
       throw "Checksum manifest has a malformed entry for $AssetName."
     }
   }
@@ -357,12 +357,122 @@ function Get-ChecksumEntry([string]$ManifestPath, [string]$AssetName) {
   return [string]$digests[0]
 }
 
+function Get-ZipUInt16([System.IO.BinaryReader]$Reader, [long]$Offset) {
+  $Reader.BaseStream.Position = $Offset
+  return $Reader.ReadUInt16()
+}
+
+function Get-ZipUInt32([System.IO.BinaryReader]$Reader, [long]$Offset) {
+  $Reader.BaseStream.Position = $Offset
+  return $Reader.ReadUInt32()
+}
+
+function Get-ZipEntryName(
+  [System.IO.BinaryReader]$Reader,
+  [long]$Offset,
+  [int]$Length
+) {
+  $Reader.BaseStream.Position = $Offset
+  $bytes = $Reader.ReadBytes($Length)
+  if ($bytes.Length -ne $Length) { throw 'Zip entry name is truncated.' }
+  return [System.Text.Encoding]::UTF8.GetString($bytes)
+}
+
+function Assert-KunaiReleaseZipStructure(
+  [string]$ArchivePath,
+  [string]$ExpectedName
+) {
+  $stream = $null
+  $reader = $null
+  try {
+    $stream = [System.IO.File]::Open(
+      $ArchivePath,
+      [System.IO.FileMode]::Open,
+      [System.IO.FileAccess]::Read,
+      [System.IO.FileShare]::Read
+    )
+    $reader = [System.IO.BinaryReader]::new($stream)
+    $archiveLength = $stream.Length
+    if ($archiveLength -lt 22) { throw 'Zip archive is truncated.' }
+
+    $endOffset = $archiveLength - 22
+    if ((Get-ZipUInt32 $reader $endOffset) -ne 0x06054b50) {
+      throw 'Zip archive contains trailing data or is missing its end record.'
+    }
+    if ((Get-ZipUInt16 $reader ($endOffset + 20)) -ne 0) {
+      throw 'Zip archive comments and trailing data are forbidden.'
+    }
+    if ((Get-ZipUInt16 $reader ($endOffset + 4)) -ne 0 -or
+      (Get-ZipUInt16 $reader ($endOffset + 6)) -ne 0) {
+      throw 'Multi-disk zip archives are forbidden.'
+    }
+    if ((Get-ZipUInt16 $reader ($endOffset + 8)) -ne 1 -or
+      (Get-ZipUInt16 $reader ($endOffset + 10)) -ne 1) {
+      throw 'Release archive must contain exactly one regular file.'
+    }
+
+    $centralSize = [long](Get-ZipUInt32 $reader ($endOffset + 12))
+    $centralOffset = [long](Get-ZipUInt32 $reader ($endOffset + 16))
+    if ($centralOffset -lt 30 -or $centralOffset + $centralSize -ne $endOffset) {
+      throw 'Zip archive has invalid central directory bounds.'
+    }
+    if ((Get-ZipUInt32 $reader $centralOffset) -ne 0x02014b50) {
+      throw 'Zip archive has an invalid central directory.'
+    }
+
+    $centralFlags = Get-ZipUInt16 $reader ($centralOffset + 8)
+    $centralMethod = Get-ZipUInt16 $reader ($centralOffset + 10)
+    $centralCrc = Get-ZipUInt32 $reader ($centralOffset + 16)
+    $compressedSize = [long](Get-ZipUInt32 $reader ($centralOffset + 20))
+    $binarySize = [long](Get-ZipUInt32 $reader ($centralOffset + 24))
+    $centralNameLength = [int](Get-ZipUInt16 $reader ($centralOffset + 28))
+    $centralExtraLength = [long](Get-ZipUInt16 $reader ($centralOffset + 30))
+    $centralCommentLength = [long](Get-ZipUInt16 $reader ($centralOffset + 32))
+    $localOffset = [long](Get-ZipUInt32 $reader ($centralOffset + 42))
+    if ($centralOffset + 46 + $centralNameLength + $centralExtraLength +
+      $centralCommentLength -ne $endOffset) {
+      throw 'Zip central directory contains unexpected records.'
+    }
+    if ($localOffset -ne 0 -or (Get-ZipUInt32 $reader $localOffset) -ne 0x04034b50) {
+      throw 'Zip archive contains an unsafe prefix or invalid local entry.'
+    }
+
+    $localFlags = Get-ZipUInt16 $reader ($localOffset + 6)
+    $localMethod = Get-ZipUInt16 $reader ($localOffset + 8)
+    $localCrc = Get-ZipUInt32 $reader ($localOffset + 14)
+    $localCompressedSize = [long](Get-ZipUInt32 $reader ($localOffset + 18))
+    $localBinarySize = [long](Get-ZipUInt32 $reader ($localOffset + 22))
+    $localNameLength = [int](Get-ZipUInt16 $reader ($localOffset + 26))
+    $localExtraLength = [long](Get-ZipUInt16 $reader ($localOffset + 28))
+    if ($localFlags -ne $centralFlags -or $localMethod -ne $centralMethod -or
+      $localCrc -ne $centralCrc -or $localCompressedSize -ne $compressedSize -or
+      $localBinarySize -ne $binarySize) {
+      throw 'Zip local entry does not match its central record.'
+    }
+
+    $localName = Get-ZipEntryName $reader ($localOffset + 30) $localNameLength
+    $centralName = Get-ZipEntryName $reader ($centralOffset + 46) $centralNameLength
+    if ($localName -cne $centralName -or $centralName -cne $ExpectedName) {
+      throw "Archive contains unexpected entry '$localName'; expected '$ExpectedName'."
+    }
+    $bodyStart = $localOffset + 30 + $localNameLength + $localExtraLength
+    if ($bodyStart + $compressedSize -ne $centralOffset) {
+      throw 'Zip archive contains unexpected local records.'
+    }
+  }
+  finally {
+    if ($null -ne $reader) { $reader.Dispose() }
+    elseif ($null -ne $stream) { $stream.Dispose() }
+  }
+}
+
 function Expand-KunaiReleaseZip(
   [string]$ArchivePath,
   [string]$ExpectedName,
   [string]$DestinationPath
 ) {
   Add-Type -AssemblyName System.IO.Compression.FileSystem
+  Assert-KunaiReleaseZipStructure $ArchivePath $ExpectedName
   $zip = $null
   $input = $null
   $output = $null
@@ -377,7 +487,7 @@ function Expand-KunaiReleaseZip(
       $name.Contains('/') -or $name.Contains('\') -or $name -in @('.', '..')) {
       throw "Archive contains an unsafe traversal or absolute-path entry: $name"
     }
-    if ($name -ne $ExpectedName) {
+    if ($name -cne $ExpectedName) {
       throw "Archive contains unexpected entry '$name'; expected '$ExpectedName'."
     }
 

--- a/install.sh
+++ b/install.sh
@@ -438,7 +438,7 @@ checksum_for_asset() {
 
 extract_release_tar_gz() {
 	local archive="$1" tar_path="$2" expected="$3" output="$4"
-	local tar_budget gzip_status head_status tar_size name prefix type size_field size
+	local tar_budget read_blocks gzip_status dd_status tar_size name prefix type size_field size
 	local checksum_field stored_checksum header_sum checksum_sum actual_checksum expected_tar_size
 	local -a pipeline_status
 
@@ -447,18 +447,22 @@ extract_release_tar_gz() {
 	require od
 
 	tar_budget=$((512 + ((EXTRACTED_BINARY_MAX_BYTES + 511) / 512) * 512 + 1024))
+	# macOS /usr/bin/head does not provide GNU `head -c`. Read one 512-byte
+	# block beyond the budget with POSIX dd instead; tar streams are themselves
+	# block-aligned, so any oversized container still crosses the exact bound.
+	read_blocks=$(((tar_budget + 512) / 512))
 	set +o pipefail
-	gzip -dc "$archive" 2>/dev/null | head -c "$((tar_budget + 1))" >"$tar_path"
+	gzip -dc "$archive" 2>/dev/null | dd of="$tar_path" bs=512 count="$read_blocks" 2>/dev/null
 	pipeline_status=("${PIPESTATUS[@]}")
 	gzip_status="${pipeline_status[0]}"
-	head_status="${pipeline_status[1]}"
+	dd_status="${pipeline_status[1]}"
 	set -o pipefail
 	tar_size="$(wc -c <"$tar_path" | tr -d ' ')"
 	if [[ "$tar_size" -gt "$tar_budget" ]]; then
 		err "Archive decompressed size exceeds the $tar_budget byte budget."
 		return 1
 	fi
-	if [[ "$gzip_status" -ne 0 || "$head_status" -ne 0 ]]; then
+	if [[ "$gzip_status" -ne 0 || "$dd_status" -ne 0 ]]; then
 		err "Archive is not a valid gzip stream."
 		return 1
 	fi

--- a/install.sh
+++ b/install.sh
@@ -448,11 +448,12 @@ extract_release_tar_gz() {
 
 	tar_budget=$((512 + ((EXTRACTED_BINARY_MAX_BYTES + 511) / 512) * 512 + 1024))
 	# macOS /usr/bin/head does not provide GNU `head -c`. Read one 512-byte
-	# block beyond the budget with POSIX dd instead; tar streams are themselves
-	# block-aligned, so any oversized container still crosses the exact bound.
+	# block beyond the budget with dd instead; fullblock is required because
+	# count otherwise measures short pipe reads rather than complete blocks.
+	# Tar streams are block-aligned, so an oversized container crosses the bound.
 	read_blocks=$(((tar_budget + 512) / 512))
 	set +o pipefail
-	gzip -dc "$archive" 2>/dev/null | dd of="$tar_path" bs=512 count="$read_blocks" 2>/dev/null
+	gzip -dc "$archive" 2>/dev/null | dd of="$tar_path" bs=512 count="$read_blocks" iflag=fullblock 2>/dev/null
 	pipeline_status=("${PIPESTATUS[@]}")
 	gzip_status="${pipeline_status[0]}"
 	dd_status="${pipeline_status[1]}"

--- a/install.sh
+++ b/install.sh
@@ -463,7 +463,7 @@ extract_release_tar_gz() {
 		return 1
 	fi
 	if [[ "$gzip_status" -ne 0 || "$dd_status" -ne 0 ]]; then
-		err "Archive is not a valid gzip stream."
+		err "Archive decompression failed (gzip status $gzip_status, bounded reader status $dd_status)."
 		return 1
 	fi
 	if [[ "$tar_size" -lt 1536 || $((tar_size % 512)) -ne 0 ]]; then

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@
 #   {dataDir}/transactions/{id}.json     install transaction
 #   {cacheDir}/staging/{semver}/txn-…    unique download staging
 #   {binDir}/kunai                       launcher symlink -> versioned binary
-#   {configDir}/install.json             schema-1 ownership manifest
+#   {configDir}/install.json             schema-2 ownership/provenance manifest
 set -euo pipefail
 
 KUNAI_REPO="${KUNAI_REPO:-https://github.com/KitsuneKode/kunai.git}"
@@ -37,6 +37,9 @@ DOWNLOAD_TOTAL_SECONDS="${KUNAI_DOWNLOAD_TOTAL_SECONDS:-300}"
 DOWNLOAD_SPEED_TIME="${KUNAI_DOWNLOAD_SPEED_TIME:-30}"
 DOWNLOAD_SPEED_LIMIT="${KUNAI_DOWNLOAD_SPEED_LIMIT:-1}"
 DOWNLOAD_MAX_BYTES="${KUNAI_DOWNLOAD_MAX_BYTES:-268435456}"
+DOWNLOAD_ARCHIVE_MAX_BYTES="${KUNAI_DOWNLOAD_ARCHIVE_MAX_BYTES:-67108864}"
+EXTRACTED_BINARY_MAX_BYTES="${KUNAI_EXTRACTED_BINARY_MAX_BYTES:-134217728}"
+ARCHIVE_TAR_COMMAND="${KUNAI_ARCHIVE_TAR_COMMAND:-tar}"
 DOWNLOAD_CHECKSUM_MAX_BYTES="${KUNAI_DOWNLOAD_CHECKSUM_MAX_BYTES:-1048576}"
 DOWNLOAD_MAX_ATTEMPTS="${KUNAI_DOWNLOAD_MAX_ATTEMPTS:-3}"
 DOWNLOAD_RETRY_BASE_MS="${KUNAI_DOWNLOAD_RETRY_BASE_MS:-1000}"
@@ -54,6 +57,7 @@ INSTALL_PRESERVE_LAUNCHER_SNAPSHOT=0
 LAUNCHER_SNAPSHOT_KIND="missing"
 LAUNCHER_SNAPSHOT_TARGET=""
 LAUNCHER_SNAPSHOT_BACKUP=""
+BOUNDED_DOWNLOAD_HTTP_STATUS=""
 
 case "$(uname -s)" in
 Darwin) HOST_OS="darwin" ;;
@@ -329,6 +333,7 @@ bounded_download() {
 	local url="$1" dest="$2" max_bytes="$3" label="${4:-download}"
 	local attempt=1 code curl_rc remaining started elapsed delay_ms
 	started="$(date +%s)"
+	BOUNDED_DOWNLOAD_HTTP_STATUS=""
 
 	while [[ "$attempt" -le "$DOWNLOAD_MAX_ATTEMPTS" ]]; do
 		elapsed=$(($(date +%s) - started))
@@ -354,6 +359,7 @@ bounded_download() {
 				-w "%{http_code}" \
 				"$url"
 		)" || curl_rc=$?
+		BOUNDED_DOWNLOAD_HTTP_STATUS="$code"
 		if [[ "$curl_rc" -ne 0 ]]; then
 			rm -f "$dest"
 			if [[ "$attempt" -ge "$DOWNLOAD_MAX_ATTEMPTS" ]]; then
@@ -415,11 +421,119 @@ bounded_download() {
 	return 1
 }
 
+checksum_for_asset() {
+	local manifest="$1" asset="$2"
+	awk -v asset="$asset" '
+		$2 == asset {
+			found++
+			if (NF != 2 || length($1) != 64 || $1 !~ /^[0-9A-Fa-f]+$/) invalid = 1
+			digest = tolower($1)
+		}
+		END {
+			if (found != 1 || invalid) exit 1
+			print digest
+		}
+	' "$manifest"
+}
+
+extract_release_tar_gz() {
+	local archive="$1" tar_path="$2" expected="$3" output="$4"
+	local tar_budget gzip_status head_status tar_size name prefix type size_field size
+	local checksum_field stored_checksum header_sum checksum_sum actual_checksum expected_tar_size
+	local -a pipeline_status
+
+	require gzip
+	require "$ARCHIVE_TAR_COMMAND"
+	require od
+
+	tar_budget=$((512 + ((EXTRACTED_BINARY_MAX_BYTES + 511) / 512) * 512 + 1024))
+	set +o pipefail
+	gzip -dc "$archive" 2>/dev/null | head -c "$((tar_budget + 1))" >"$tar_path"
+	pipeline_status=("${PIPESTATUS[@]}")
+	gzip_status="${pipeline_status[0]}"
+	head_status="${pipeline_status[1]}"
+	set -o pipefail
+	tar_size="$(wc -c <"$tar_path" | tr -d ' ')"
+	if [[ "$tar_size" -gt "$tar_budget" ]]; then
+		err "Archive decompressed size exceeds the $tar_budget byte budget."
+		return 1
+	fi
+	if [[ "$gzip_status" -ne 0 || "$head_status" -ne 0 ]]; then
+		err "Archive is not a valid gzip stream."
+		return 1
+	fi
+	if [[ "$tar_size" -lt 1536 || $((tar_size % 512)) -ne 0 ]]; then
+		err "Archive is not a valid one-member tar container."
+		return 1
+	fi
+
+	name="$(dd if="$tar_path" bs=1 count=100 2>/dev/null | tr -d '\000')"
+	prefix="$(dd if="$tar_path" bs=1 skip=345 count=155 2>/dev/null | tr -d '\000')"
+	type="$(od -An -tu1 -j 156 -N 1 "$tar_path" | tr -d '[:space:]')"
+	if [[ -n "$prefix" || "$name" == /* || "$name" == *"/"* || "$name" == *"\\"* || "$name" == . || "$name" == .. ]]; then
+		err "Archive contains an unsafe traversal or absolute-path entry."
+		return 1
+	fi
+	if [[ "$name" != "$expected" ]]; then
+		err "Archive contains unexpected entry '$name'; expected '$expected'."
+		return 1
+	fi
+	if [[ "$type" != 0 && "$type" != 48 ]]; then
+		err "Archive entry must be a regular file; links are forbidden."
+		return 1
+	fi
+
+	size_field="$(dd if="$tar_path" bs=1 skip=124 count=12 2>/dev/null | tr -d '\000 ')"
+	if [[ -z "$size_field" || "$size_field" == *[!0-7]* ]]; then
+		err "Archive has an invalid tar entry size."
+		return 1
+	fi
+	size=$((8#$size_field))
+	if [[ "$size" -le 0 || "$size" -gt "$EXTRACTED_BINARY_MAX_BYTES" ]]; then
+		err "Extracted binary size $size exceeds the $EXTRACTED_BINARY_MAX_BYTES byte budget."
+		return 1
+	fi
+
+	checksum_field="$(dd if="$tar_path" bs=1 skip=148 count=8 2>/dev/null | tr -d '\000 ')"
+	if [[ -z "$checksum_field" || "$checksum_field" == *[!0-7]* ]]; then
+		err "Archive has an invalid tar header checksum."
+		return 1
+	fi
+	stored_checksum=$((8#$checksum_field))
+	header_sum="$(od -An -tu1 -N 512 "$tar_path" | awk '{ for (i = 1; i <= NF; i++) sum += $i } END { print sum + 0 }')"
+	checksum_sum="$(od -An -tu1 -j 148 -N 8 "$tar_path" | awk '{ for (i = 1; i <= NF; i++) sum += $i } END { print sum + 0 }')"
+	actual_checksum=$((header_sum - checksum_sum + 256))
+	if [[ "$stored_checksum" -ne "$actual_checksum" ]]; then
+		err "Archive has an invalid tar header checksum."
+		return 1
+	fi
+
+	expected_tar_size=$((512 + ((size + 511) / 512) * 512 + 1024))
+	if [[ "$tar_size" -ne "$expected_tar_size" ]]; then
+		err "Release archive must contain exactly one regular file."
+		return 1
+	fi
+	if [[ -n "$(tail -c "+$((513 + size))" "$tar_path" | tr -d '\000')" ]]; then
+		err "Archive contains non-zero padding, extra entries, or trailing data."
+		return 1
+	fi
+	if ! "$ARCHIVE_TAR_COMMAND" -xOf "$tar_path" "$expected" >"$output" 2>/dev/null; then
+		err "Could not extract the verified archive member."
+		return 1
+	fi
+	if [[ "$(wc -c <"$output" | tr -d ' ')" -ne "$size" ]]; then
+		err "Extracted binary size does not match the tar header."
+		return 1
+	fi
+}
+
 write_manifest() {
 	local method="$1" version="$2" launcher="$3" versionpath="${4:-}" target="${5:-}" sha256="${6:-}"
-	local previous="${7:-}" now installed_at managed_json tmp manifest_path
+	local previous="${7:-}" artifact_name="${8:-}" artifact_size="${9:-}"
+	local archive_name="${10:-}" archive_sha256="${11:-}" archive_size="${12:-}" archive_source_url="${13:-}"
+	local now installed_at managed_json tmp manifest_path
 	if [[ "$DRY" == 1 ]]; then
-		info "[dry-run] would write schema-1 manifest ($method) to $CONFIG_DIR/install.json"
+		info "[dry-run] would write schema-2 manifest ($method) to $CONFIG_DIR/install.json"
 		return
 	fi
 	mkdir -p "$CONFIG_DIR" || return 1
@@ -442,7 +556,7 @@ write_manifest() {
 	tmp="${manifest_path}.tmp-$$"
 	{
 		printf '{\n'
-		printf '  "schemaVersion": 1,\n'
+		printf '  "schemaVersion": 2,\n'
 		printf '  "method": "%s",\n' "$(json_escape "$method")"
 		printf '  "activeVersion": "%s",\n' "$(json_escape "$version")"
 		printf '  "preferredChannel": "stable",\n'
@@ -459,6 +573,18 @@ write_manifest() {
 		fi
 		if [[ -n "$sha256" ]]; then
 			printf '  "artifactSha256": "%s",\n' "$(json_escape "$sha256")"
+		fi
+		if [[ -n "$artifact_name" ]]; then
+			printf '  "artifactName": "%s",\n' "$(json_escape "$artifact_name")"
+		fi
+		if [[ -n "$artifact_size" ]]; then
+			printf '  "artifactSizeBytes": %s,\n' "$artifact_size"
+		fi
+		if [[ -n "$archive_name" ]]; then
+			printf '  "archiveName": "%s",\n' "$(json_escape "$archive_name")"
+			printf '  "archiveSha256": "%s",\n' "$(json_escape "$archive_sha256")"
+			printf '  "archiveSizeBytes": %s,\n' "$archive_size"
+			printf '  "archiveSourceUrl": "%s",\n' "$(json_escape "$archive_source_url")"
 		fi
 		printf '  "downloadBaseUrl": "%s",\n' "$(json_escape "$KUNAI_DL_BASE")"
 		printf '  "installedAt": "%s",\n' "$(json_escape "$installed_at")"
@@ -1187,8 +1313,9 @@ read_previous_active_version() {
 }
 
 install_binary() {
-	local os arch translated asset base url sums resolved_version version_path versions_dir
-	local staging txn_id txn_path lock_path staged_bin staged_sums want got size_bytes
+	local os arch translated asset archive base url sums archive_url archive_sums resolved_version version_path versions_dir
+	local staging txn_id txn_path lock_path staged_bin staged_sums staged_archive staged_archive_sums staged_tar
+	local want got size_bytes archive_want archive_got archive_size archive_source_url artifact_source_url archive_available archive_name_used
 	local target previous activation_previous kind metadata_path
 	local activation_lock_path
 
@@ -1230,14 +1357,19 @@ install_binary() {
 	base="$KUNAI_DL_BASE/download/v$resolved_version"
 	url="$base/$asset"
 	sums="$base/SHA256SUMS"
+	archive="${asset}.tar.gz"
+	archive_url="$base/$archive"
+	archive_sums="$base/SHA256SUMS.archives"
 
 	versions_dir="$DATA_DIR/versions"
 	version_path="$versions_dir/$resolved_version/kunai"
 
 	if [[ "$DRY" == 1 ]]; then
 		info "Downloading $asset (v$resolved_version) ..."
-		info "[dry-run] curl (bounded) $url -o <staging>/$asset"
-		info "[dry-run] curl (bounded) $sums -o <staging>/SHA256SUMS"
+		info "[dry-run] curl (bounded) $archive_sums -o <staging>/SHA256SUMS.archives"
+		info "[dry-run] curl (bounded) $archive_url -o <staging>/$archive"
+		info "[dry-run] verify archive, safely extract $asset, then verify against $sums"
+		info "[dry-run] raw compatibility fallback is allowed only for archive HTTP 404/410"
 		write_manifest binary "$resolved_version" "$BIN_DIR/kunai" "$version_path" "$target"
 		info "Installed kunai → $BIN_DIR/kunai (v$resolved_version at $version_path)"
 		path_hint "$BIN_DIR"
@@ -1260,6 +1392,9 @@ install_binary() {
 	activation_lock_path="$DATA_DIR/locks/activation.lock"
 	staged_bin="$staging/$asset"
 	staged_sums="$staging/SHA256SUMS"
+	staged_archive="$staging/$archive"
+	staged_archive_sums="$staging/SHA256SUMS.archives"
+	staged_tar="$staging/$asset.tar"
 	metadata_path="$versions_dir/$resolved_version/version.json"
 	INSTALL_TXN_PATH="$txn_path"
 	INSTALL_VERSION_LOCK_PATH="$lock_path"
@@ -1300,33 +1435,81 @@ install_binary() {
 	begin_transaction "$txn_id" "$kind" "$resolved_version" "$staging" "$txn_path"
 
 	info "Downloading $asset (v$resolved_version) ..."
+	archive_available=1
+	archive_got=""
+	archive_size=""
+	archive_source_url=""
+	archive_name_used=""
+	artifact_source_url="$url"
+	if ! bounded_download "$archive_sums" "$staged_archive_sums" "$DOWNLOAD_CHECKSUM_MAX_BYTES" "SHA256SUMS.archives"; then
+		if [[ "$BOUNDED_DOWNLOAD_HTTP_STATUS" == 404 || "$BOUNDED_DOWNLOAD_HTTP_STATUS" == 410 ]]; then
+			archive_available=0
+			info "Archive checksums are unavailable for v$resolved_version; using the legacy raw asset."
+		else
+			download_failed_hint "SHA256SUMS.archives"
+			exit 1
+		fi
+	fi
+
+	if [[ "$archive_available" == 1 ]]; then
+		if ! archive_want="$(checksum_for_asset "$staged_archive_sums" "$archive")"; then
+			err "SHA256SUMS.archives must contain exactly one valid entry for $archive."
+			exit 1
+		fi
+		if ! bounded_download "$archive_url" "$staged_archive" "$DOWNLOAD_ARCHIVE_MAX_BYTES" "$archive"; then
+			if [[ "$BOUNDED_DOWNLOAD_HTTP_STATUS" == 404 || "$BOUNDED_DOWNLOAD_HTTP_STATUS" == 410 ]]; then
+				archive_available=0
+				info "Archive asset is unavailable for v$resolved_version; using the legacy raw asset."
+			else
+				download_failed_hint "$archive"
+				exit 1
+			fi
+		fi
+	fi
+
+	if [[ "$archive_available" == 1 ]]; then
+		archive_got="$(sha256_of "$staged_archive")"
+		if [[ "$archive_want" != "$archive_got" ]]; then
+			err "Checksum mismatch for $archive (expected $archive_want, got $archive_got)."
+			exit 1
+		fi
+		archive_name_used="$archive"
+	fi
+
 	if ! bounded_download "$sums" "$staged_sums" "$DOWNLOAD_CHECKSUM_MAX_BYTES" "SHA256SUMS"; then
 		download_failed_hint "SHA256SUMS"
 		exit 1
 	fi
-	if ! bounded_download "$url" "$staged_bin" "$DOWNLOAD_MAX_BYTES" "$asset"; then
-		download_failed_hint "$asset"
+	if ! want="$(checksum_for_asset "$staged_sums" "$asset")"; then
+		err "SHA256SUMS has no entry for $asset, or has duplicate/malformed entries; the release is incomplete."
 		exit 1
 	fi
 
+	if [[ "$archive_available" == 1 ]]; then
+		if ! extract_release_tar_gz "$staged_archive" "$staged_tar" "$asset" "$staged_bin"; then
+			exit 1
+		fi
+		archive_size="$(wc -c <"$staged_archive" | tr -d ' ')"
+		archive_source_url="$archive_url"
+		artifact_source_url="$archive_url"
+	else
+		if ! bounded_download "$url" "$staged_bin" "$DOWNLOAD_MAX_BYTES" "$asset"; then
+			download_failed_hint "$asset"
+			exit 1
+		fi
+	fi
 	if [[ ! -s "$staged_bin" ]]; then
-		err "Downloaded asset $asset is empty; the release is incomplete."
-		download_failed_hint "$asset"
+		err "Downloaded or extracted asset $asset is empty; the release is incomplete."
 		exit 1
 	fi
-
-	want="$(awk -v a="$asset" '$2==a {print $1}' "$staged_sums")"
 	got="$(sha256_of "$staged_bin")"
 	size_bytes="$(wc -c <"$staged_bin" | tr -d ' ')"
-
-	if [[ -z "$want" ]]; then
-		err "SHA256SUMS has no entry for $asset; the release is incomplete."
-		download_failed_hint "$asset"
+	if [[ "$size_bytes" -gt "$EXTRACTED_BINARY_MAX_BYTES" ]]; then
+		err "Binary size $size_bytes exceeds the $EXTRACTED_BINARY_MAX_BYTES byte budget."
 		exit 1
 	fi
-
 	if [[ "$want" != "$got" ]]; then
-		err "Checksum mismatch for $asset (expected $want, got $got)."
+		err "Checksum mismatch for extracted $asset (expected $want, got $got)."
 		exit 1
 	fi
 
@@ -1336,7 +1519,7 @@ install_binary() {
 	install -m 0755 "$staged_bin" "$version_tmp"
 	mv -f "$version_tmp" "$version_path"
 
-	write_version_metadata "$resolved_version" "$target" "$asset" "$got" "$size_bytes" "$url" "$metadata_path"
+	write_version_metadata "$resolved_version" "$target" "$asset" "$got" "$size_bytes" "$artifact_source_url" "$metadata_path"
 
 	if [[ "$os" == darwin ]]; then
 		xattr -d com.apple.quarantine "$version_path" 2>/dev/null || true
@@ -1381,7 +1564,8 @@ install_binary() {
 	if [[ -n "$activation_previous" && "$activation_previous" != "$resolved_version" ]]; then
 		prev_arg="$activation_previous"
 	fi
-	if ! write_manifest binary "$resolved_version" "$BIN_DIR/kunai" "$version_path" "$target" "$got" "$prev_arg"; then
+	if ! write_manifest binary "$resolved_version" "$BIN_DIR/kunai" "$version_path" "$target" "$got" "$prev_arg" \
+		"$asset" "$size_bytes" "$archive_name_used" "$archive_got" "$archive_size" "$archive_source_url"; then
 		err "Could not publish install.json; restoring the previous launcher."
 		if ! restore_launcher_snapshot "$BIN_DIR/kunai"; then
 			err "Launcher restoration failed; inspect $LAUNCHER_SNAPSHOT_BACKUP before retrying."

--- a/install.sh
+++ b/install.sh
@@ -531,7 +531,8 @@ extract_release_tar_gz() {
 write_manifest() {
 	local method="$1" version="$2" launcher="$3" versionpath="${4:-}" target="${5:-}" sha256="${6:-}"
 	local previous="${7:-}" artifact_name="${8:-}" artifact_size="${9:-}"
-	local archive_name="${10:-}" archive_sha256="${11:-}" archive_size="${12:-}" archive_source_url="${13:-}"
+	local artifact_source_url="${10:-}" archive_name="${11:-}" archive_sha256="${12:-}"
+	local archive_size="${13:-}" archive_source_url="${14:-}"
 	local now installed_at managed_json tmp manifest_path
 	if [[ "$DRY" == 1 ]]; then
 		info "[dry-run] would write schema-2 manifest ($method) to $CONFIG_DIR/install.json"
@@ -581,6 +582,9 @@ write_manifest() {
 		if [[ -n "$artifact_size" ]]; then
 			printf '  "artifactSizeBytes": %s,\n' "$artifact_size"
 		fi
+		if [[ -n "$artifact_source_url" ]]; then
+			printf '  "artifactSourceUrl": "%s",\n' "$(json_escape "$artifact_source_url")"
+		fi
 		if [[ -n "$archive_name" ]]; then
 			printf '  "archiveName": "%s",\n' "$(json_escape "$archive_name")"
 			printf '  "archiveSha256": "%s",\n' "$(json_escape "$archive_sha256")"
@@ -604,21 +608,28 @@ write_manifest() {
 
 write_version_metadata() {
 	local version="$1" target="$2" artifact="$3" sha256="$4" size="$5" source_url="$6" path="$7"
+	local archive_name="${8:-}" archive_sha256="${9:-}" archive_size="${10:-}" archive_source_url="${11:-}"
 	local tmp
 	tmp="${path}.tmp-$$"
-	cat >"$tmp" <<JSON
-{
-  "schemaVersion": 1,
-  "version": "$(json_escape "$version")",
-  "target": "$(json_escape "$target")",
-  "artifactName": "$(json_escape "$artifact")",
-  "artifactSha256": "$(json_escape "$sha256")",
-  "sizeBytes": $size,
-  "sourceUrl": "$(json_escape "$source_url")",
-  "verification": "release-checksum",
-  "installedAt": "$(iso_now)"
-}
-JSON
+	{
+		printf '{\n'
+		printf '  "schemaVersion": 1,\n'
+		printf '  "version": "%s",\n' "$(json_escape "$version")"
+		printf '  "target": "%s",\n' "$(json_escape "$target")"
+		printf '  "artifactName": "%s",\n' "$(json_escape "$artifact")"
+		printf '  "artifactSha256": "%s",\n' "$(json_escape "$sha256")"
+		printf '  "sizeBytes": %s,\n' "$size"
+		printf '  "sourceUrl": "%s",\n' "$(json_escape "$source_url")"
+		if [[ -n "$archive_name" ]]; then
+			printf '  "archiveName": "%s",\n' "$(json_escape "$archive_name")"
+			printf '  "archiveSha256": "%s",\n' "$(json_escape "$archive_sha256")"
+			printf '  "archiveSizeBytes": %s,\n' "$archive_size"
+			printf '  "archiveSourceUrl": "%s",\n' "$(json_escape "$archive_source_url")"
+		fi
+		printf '  "verification": "release-checksum",\n'
+		printf '  "installedAt": "%s"\n' "$(iso_now)"
+		printf '}\n'
+	} >"$tmp"
 	mv -f "$tmp" "$path"
 }
 
@@ -1316,7 +1327,7 @@ read_previous_active_version() {
 install_binary() {
 	local os arch translated asset archive base url sums archive_url archive_sums resolved_version version_path versions_dir
 	local staging txn_id txn_path lock_path staged_bin staged_sums staged_archive staged_archive_sums staged_tar
-	local want got size_bytes archive_want archive_got archive_size archive_source_url artifact_source_url archive_available archive_name_used
+	local want got size_bytes archive_want archive_got archive_size archive_source_url archive_available archive_name_used
 	local target previous activation_previous kind metadata_path
 	local activation_lock_path
 
@@ -1441,7 +1452,6 @@ install_binary() {
 	archive_size=""
 	archive_source_url=""
 	archive_name_used=""
-	artifact_source_url="$url"
 	if ! bounded_download "$archive_sums" "$staged_archive_sums" "$DOWNLOAD_CHECKSUM_MAX_BYTES" "SHA256SUMS.archives"; then
 		if [[ "$BOUNDED_DOWNLOAD_HTTP_STATUS" == 404 || "$BOUNDED_DOWNLOAD_HTTP_STATUS" == 410 ]]; then
 			archive_available=0
@@ -1492,7 +1502,6 @@ install_binary() {
 		fi
 		archive_size="$(wc -c <"$staged_archive" | tr -d ' ')"
 		archive_source_url="$archive_url"
-		artifact_source_url="$archive_url"
 	else
 		if ! bounded_download "$url" "$staged_bin" "$DOWNLOAD_MAX_BYTES" "$asset"; then
 			download_failed_hint "$asset"
@@ -1520,7 +1529,8 @@ install_binary() {
 	install -m 0755 "$staged_bin" "$version_tmp"
 	mv -f "$version_tmp" "$version_path"
 
-	write_version_metadata "$resolved_version" "$target" "$asset" "$got" "$size_bytes" "$artifact_source_url" "$metadata_path"
+	write_version_metadata "$resolved_version" "$target" "$asset" "$got" "$size_bytes" "$url" "$metadata_path" \
+		"$archive_name_used" "$archive_got" "$archive_size" "$archive_source_url"
 
 	if [[ "$os" == darwin ]]; then
 		xattr -d com.apple.quarantine "$version_path" 2>/dev/null || true
@@ -1566,7 +1576,7 @@ install_binary() {
 		prev_arg="$activation_previous"
 	fi
 	if ! write_manifest binary "$resolved_version" "$BIN_DIR/kunai" "$version_path" "$target" "$got" "$prev_arg" \
-		"$asset" "$size_bytes" "$archive_name_used" "$archive_got" "$archive_size" "$archive_source_url"; then
+		"$asset" "$size_bytes" "$url" "$archive_name_used" "$archive_got" "$archive_size" "$archive_source_url"; then
 		err "Could not publish install.json; restoring the previous launcher."
 		if ! restore_launcher_snapshot "$BIN_DIR/kunai"; then
 			err "Launcher restoration failed; inspect $LAUNCHER_SNAPSHOT_BACKUP before retrying."

--- a/install.sh
+++ b/install.sh
@@ -513,7 +513,8 @@ extract_release_tar_gz() {
 		err "Release archive must contain exactly one regular file."
 		return 1
 	fi
-	if [[ -n "$(tail -c "+$((513 + size))" "$tar_path" | tr -d '\000')" ]]; then
+	if od -An -v -tu1 -j "$((512 + size))" "$tar_path" |
+		awk '{ for (i = 1; i <= NF; i++) if ($i != 0) found = 1 } END { exit found ? 0 : 1 }'; then
 		err "Archive contains non-zero padding, extra entries, or trailing data."
 		return 1
 	fi

--- a/test/install/README.md
+++ b/test/install/README.md
@@ -35,8 +35,9 @@ test your current changes rather than a copy baked into the image.
 
 `install.sh` takes `KUNAI_DL_BASE`, `KUNAI_RELEASES_API`, `KUNAI_BIN_DIR` and
 `KUNAI_DATA_DIR` as overrides, and `curl` handles `file://` URLs. So
-`make-fake-release.sh` writes a release tree to disk and the installer consumes
-it directly — no HTTP server, no ports, no daemons, no network.
+`make-fake-release.sh` writes raw compatibility binaries, one-member `.tar.gz`
+archives, and both checksum manifests to a release tree on disk. The installer
+consumes it directly — no HTTP server, no ports, no daemons, no network.
 
 ## What these prove, and what they don't
 

--- a/test/install/make-fake-release.sh
+++ b/test/install/make-fake-release.sh
@@ -66,7 +66,11 @@ rm -f "$stub"
 ARCHIVES=()
 for asset in "${ASSETS[@]}"; do
 	archive="$asset.tar.gz"
-	tar -b 1 --format=ustar -czf "$DL_DIR/$archive" -C "$DL_DIR" "$asset"
+	# macOS bsdtar pads compressed archives after the gzip member, which makes
+	# strict gzip readers report trailing data. Stream the canonical ustar into
+	# gzip instead so the compressed container ends exactly with its footer.
+	COPYFILE_DISABLE=1 tar -b 1 --format=ustar -cf - -C "$DL_DIR" "$asset" |
+		gzip -n >"$DL_DIR/$archive"
 	ARCHIVES+=("$archive")
 done
 

--- a/test/install/make-fake-release.sh
+++ b/test/install/make-fake-release.sh
@@ -59,6 +59,17 @@ for asset in "${ASSETS[@]}"; do
 done
 rm -f "$stub"
 
+# Exercise the current archive-first installer path. Each tarball has exactly
+# one root member whose name matches the raw compatibility asset, just like the
+# canonical release archives. `ustar` avoids implementation-specific metadata
+# entries on both GNU tar and the BSD tar shipped by macOS.
+ARCHIVES=()
+for asset in "${ASSETS[@]}"; do
+	archive="$asset.tar.gz"
+	tar -b 1 --format=ustar -czf "$DL_DIR/$archive" -C "$DL_DIR" "$asset"
+	ARCHIVES+=("$archive")
+done
+
 # Two-field format: install.sh selects with `awk '$2==asset {print $1}'`.
 # macOS has no `sha256sum` — this harness runs there too, so prefer it when
 # present and fall back to BSD `shasum`, whose output format is identical.
@@ -68,6 +79,11 @@ rm -f "$stub"
 		sha256sum "${ASSETS[@]}" >SHA256SUMS
 	else
 		shasum -a 256 "${ASSETS[@]}" >SHA256SUMS
+	fi
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "${ARCHIVES[@]}" >SHA256SUMS.archives
+	else
+		shasum -a 256 "${ARCHIVES[@]}" >SHA256SUMS.archives
 	fi
 )
 


### PR DESCRIPTION
## Summary\n\n- install canonical tar.gz assets on Linux and macOS and zip assets on Windows\n- verify archive provenance and the extracted standalone binary independently before activation\n- reject unsafe or oversized archive containers and retain raw fallback only for legacy 404/410 releases\n- preserve archive provenance across install metadata for updater, rollback, and doctor\n\n## Safety\n\n- malformed archives, checksum failures, unexpected entries, links, traversal, and decompression bombs fail closed\n- archive failures never fall back to the raw asset\n- interrupted or failed extraction leaves no launcher, manifest, or staging residue\n\n## Verification\n\n- full pre-push gate: 23 tasks green\n- 4799 unit tests passed, 1 Windows-only skip\n- 233 integration tests passed, 24 opt-in skips\n- focused Bash installer suite: 77 passed\n- typecheck, lint with zero warnings, format, ShellCheck, shfmt, PowerShell parsing, and doc-path validation passed\n- macOS short-read regression requires a full-block bounded gzip reader\n\n## Stack\n\nDepends on #184, which depends on #180. Exact release promotion in #182 completes the remaining acceptance criteria for #132; native attestations in #183 remain downstream.\n\nPart of #132