### PR TITLE
feat(search): warm the top anime result's episode cache on search

### DIFF
--- a/.docs/testing-strategy.md
+++ b/.docs/testing-strategy.md
@@ -130,12 +130,12 @@ Differences from `ink-testing-library`'s `Instance`:
 
 ### Per-test timeout budget
 
-Bun's default is 5000ms. That is ample on Linux and wrong on the Windows runner,
-where the SQLite-backed suites open a fresh database per test and the temp-store
-registry forces a synchronous full GC per teardown so Windows releases the file
-handles. Under full-suite load a test drifts past 5s and **which** test loses
-moves between runs — one storage test measured 6428ms on one run and 16549ms on
-the next.
+Bun's default is 5000ms. That is too low for two deliberate integration costs:
+the docs idempotence test runs the generator twice and can cross 5s under a full
+parallel Turbo run, while the Windows SQLite-backed suites open a fresh database
+per test and the temp-store registry forces a synchronous full GC per teardown
+so Windows releases the file handles. Under full-suite load a test drifts past
+5s; one storage test measured 6428ms on one run and 16549ms on the next.
 
 The budget lives on the suite scripts, because that is the one place every
 caller shares:
@@ -144,12 +144,14 @@ caller shares:
 | ----------------------------- | ------- |
 | `apps/cli` `test:unit`        | 20000ms |
 | `apps/cli` `test:integration` | 20000ms |
+| `apps/docs` `test`            | 20000ms |
 | `packages/storage` `test`     | 30000ms |
 
 `KUNAI_TEST_TIMEOUT_MS` still overrides the `apps/cli` pair, because
 `run-default-tests.ts` appends its `--timeout=` after the scripted one and Bun
 applies the last flag on the command line. It does not reach
-`packages/storage`, which is why that package carries its own value.
+`apps/docs` or `packages/storage`, which is why those packages carry their own
+values.
 
 Do not reach for the alternatives — both were tried and rejected:
 `bunfig.toml`'s `[test] timeout` is ignored outright by Bun 1.3.14, and a

--- a/apps/cli/src/app/search/SearchPhase.ts
+++ b/apps/cli/src/app/search/SearchPhase.ts
@@ -107,6 +107,7 @@ import {
   titleInfoFromQueuePlaybackLaunch,
 } from "@/app-shell/root-queue-bridge";
 import { SEARCH_BROWSE_COMMAND_IDS } from "@/app-shell/search-browse-command-ids";
+import { warmTopAnimeEpisodeCache } from "@/services/providers/warm-episode-cache";
 
 export { SEARCH_BROWSE_COMMAND_IDS };
 
@@ -142,6 +143,28 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
   name = "search";
   private hasQueuedStartupReleaseReconciliation = false;
   private hasHealedHistoryMetadata = false;
+  /** Titles already warmed this session, so a search never re-fetches one. */
+  private readonly warmedAnimeEpisodeCaches = new Set<string>();
+
+  /**
+   * Warm the top anime result's episode catalog in the background so the
+   * Cloudflare-gated fetch is already paid when the user picks it. Anime mode
+   * only; a series/movie search has no such cost.
+   */
+  private warmAnimeEpisodesForResults(
+    context: PhaseContext,
+    results: readonly SearchResult[],
+  ): void {
+    const { providerRegistry, config } = context.container;
+    if (context.container.stateManager.getState().mode !== "anime") return;
+    warmTopAnimeEpisodeCache({
+      results,
+      provider: providerRegistry.getDefault(true),
+      audioPreference: config.animeLanguageProfile.audio,
+      subtitlePreference: config.animeLanguageProfile.subtitle,
+      warmed: this.warmedAnimeEpisodeCaches,
+    });
+  }
 
   constructor(
     private readonly dependencies: SearchPhaseDependencies = DEFAULT_SEARCH_PHASE_DEPENDENCIES,
@@ -376,6 +399,7 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
           }
           initialSearchError = undefined;
           const results = search.results;
+          this.warmAnimeEpisodesForResults(context, results);
           pendingSearchEvidence = search.evidence;
           pendingSearchWarnings = searchIntent.warnings;
 
@@ -744,6 +768,7 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
             }
             initialSearchError = undefined;
             const results = search.results;
+            this.warmAnimeEpisodesForResults(context, results);
 
             logger.info("Search complete", {
               query,

--- a/apps/cli/src/container/bootstrap-providers.ts
+++ b/apps/cli/src/container/bootstrap-providers.ts
@@ -7,6 +7,7 @@ import {
   type ProviderPriorityInput,
 } from "@kunai/core";
 import { buildProviderRelayRegistry, createRelayFetchPort } from "@kunai/relay";
+import { ProviderCacheRepository } from "@kunai/storage";
 
 import { PlaybackResolveCoordinator } from "../services/playback/PlaybackResolveCoordinator";
 import { PlaybackResolveWorkService } from "../services/playback/PlaybackResolveWorkService";
@@ -16,6 +17,7 @@ import {
   resolveProviderMaxAttempts,
 } from "../services/playback/provider-resolve-budget-policy";
 import { StreamHealthService } from "../services/playback/StreamHealthService";
+import { createProviderCachePort } from "../services/providers/provider-cache-port";
 import { createProviderPrioritySnapshot } from "../services/providers/provider-priority";
 import type { ProviderRegistry } from "../services/providers/ProviderRegistry";
 import { createProviderRegistry } from "../services/providers/ProviderRegistry";
@@ -101,6 +103,9 @@ export async function bootstrapProviders(
         token: process.env.KUNAI_RELAY_TOKEN,
       },
     });
+  const providerCachePort = createProviderCachePort(
+    new ProviderCacheRepository(persistence.cacheDb),
+  );
   const engine = createProviderEngine({
     modules: providerModules,
     attemptTimeoutMs: resolveProviderAttemptTimeoutMs(config.startupPriority),
@@ -108,6 +113,7 @@ export async function bootstrapProviders(
     hedgeDelayMs: resolveProviderHedgeDelayMs(config.startupPriority),
     fetch: createProviderFetchPort,
     endpointHealth,
+    cache: providerCachePort,
     titleBridge: titleBridgePort,
     auth: {
       getSecret(providerId, key) {

--- a/apps/cli/src/services/providers/provider-cache-port.ts
+++ b/apps/cli/src/services/providers/provider-cache-port.ts
@@ -1,0 +1,37 @@
+import type { ProviderCacheRepository } from "@kunai/storage";
+import type { ProviderCachePort } from "@kunai/types";
+
+/**
+ * Back the provider cache port with the SQLite `provider_cache` table.
+ *
+ * The repository is synchronous (bun:sqlite), but the port is async so a future
+ * backing store need not be. Every operation degrades to `null` / no-op on a
+ * store error: a broken cache must slow a resolve down, never fail it. JSON is
+ * the wire format, and `ttlMs` becomes an absolute `expiresAt` here so the
+ * provider never has to know the clock.
+ */
+export function createProviderCachePort(
+  repository: ProviderCacheRepository,
+  now: () => Date = () => new Date(),
+): ProviderCachePort {
+  return {
+    async read<T = unknown>(namespace: string, key: string): Promise<T | null> {
+      try {
+        const payload = repository.read(namespace, key, now());
+        if (payload === null) return null;
+        return JSON.parse(payload) as T;
+      } catch {
+        return null;
+      }
+    },
+    async write(namespace: string, key: string, value: unknown, ttlMs: number): Promise<void> {
+      try {
+        const nowDate = now();
+        const expiresAt = new Date(nowDate.getTime() + Math.max(0, ttlMs)).toISOString();
+        repository.write(namespace, key, JSON.stringify(value), expiresAt, nowDate.toISOString());
+      } catch {
+        // A cache write must never fail the resolve that produced the value.
+      }
+    },
+  };
+}

--- a/apps/cli/src/services/providers/warm-episode-cache.ts
+++ b/apps/cli/src/services/providers/warm-episode-cache.ts
@@ -1,0 +1,54 @@
+import type { SearchResult, TitleInfo } from "@/domain/types";
+
+import type { Provider } from "./Provider";
+
+/**
+ * Warm the persistent episode cache for the top anime result of a search, in
+ * the background, so the ~6s Cloudflare-gated catalog fetch is already paid by
+ * the time the user picks it.
+ *
+ * Deliberately conservative:
+ * - Only the single top anime result is warmed — one gated call per search, not
+ *   a barrage that would provoke the WAF for titles the user scrolls past.
+ * - `warmed` dedupes across searches so the same title is not re-fetched.
+ * - Fire-and-forget: a warm must never block, delay, or fail the search, so
+ *   every failure is swallowed.
+ *
+ * It calls the provider's `listEpisodes`, which resolves through the
+ * cache-carrying runtime context and populates `provider_cache` as a side
+ * effect. Nothing here reads the result.
+ */
+export function warmTopAnimeEpisodeCache(input: {
+  readonly results: readonly SearchResult[];
+  readonly provider: Provider | undefined;
+  readonly audioPreference: string;
+  readonly subtitlePreference: string;
+  readonly warmed: Set<string>;
+  readonly signal?: AbortSignal;
+}): void {
+  const { results, provider, warmed } = input;
+  if (!provider?.listEpisodes) return;
+
+  const top = results.find((result) => result.isAnime && result.id.trim().length > 0);
+  if (!top || warmed.has(top.id)) return;
+  warmed.add(top.id);
+
+  const title: TitleInfo = {
+    id: top.id,
+    type: top.type,
+    name: top.title,
+    isAnime: true,
+    externalIds: top.externalIds,
+  };
+
+  void provider
+    .listEpisodes(
+      {
+        title,
+        audioPreference: input.audioPreference,
+        subtitlePreference: input.subtitlePreference,
+      },
+      input.signal,
+    )
+    .catch(() => undefined);
+}

--- a/apps/cli/test/unit/architecture/test-timeout-budget.test.ts
+++ b/apps/cli/test/unit/architecture/test-timeout-budget.test.ts
@@ -2,12 +2,12 @@ import { expect, test } from "bun:test";
 import { resolve } from "node:path";
 
 /**
- * Bun's default per-test timeout is 5000ms. That is ample on Linux and wrong on
- * the Windows runner, where the SQLite-backed suites open a fresh database per
- * test and the temp-store registry forces a synchronous full GC per teardown so
- * Windows actually releases the file handles. Under full-suite load a single
- * test drifts past 5s and *which* test loses varies run to run — one storage
- * test was measured at 6428ms on one run and 16549ms on the next.
+ * Bun's default per-test timeout is 5000ms. That is too low for the docs
+ * idempotence test, which runs code generation twice under parallel Turbo load,
+ * and for the Windows runner, where the SQLite-backed suites open a fresh
+ * database per test and the temp-store registry forces a synchronous full GC
+ * per teardown so Windows actually releases the file handles. One storage test
+ * was measured at 6428ms on one run and 16549ms on the next.
  *
  * The budget therefore has to live on the suite scripts, because that is the one
  * place every caller shares: Turborepo runs `test:unit` / `test:integration`
@@ -36,11 +36,13 @@ function timeoutOf(script: string): number | null {
 
 test("suite scripts that touch SQLite or spawn shells carry an explicit per-test timeout", async () => {
   const cli = await scriptsOf("../../../package.json");
+  const docs = await scriptsOf("../../../../docs/package.json");
   const storage = await scriptsOf("../../../../../packages/storage/package.json");
 
   const budgeted: ReadonlyArray<readonly [string, string | undefined]> = [
     ["apps/cli test:unit", cli["test:unit"]],
     ["apps/cli test:integration", cli["test:integration"]],
+    ["apps/docs test", docs.test],
     ["packages/storage test", storage.test],
   ];
 

--- a/apps/cli/test/unit/services/providers/miruro-persistent-cache.test.ts
+++ b/apps/cli/test/unit/services/providers/miruro-persistent-cache.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+
+import { createProviderCachePort } from "@/services/providers/provider-cache-port";
+import type { MiruroEpisodesResponse } from "@kunai/providers/miruro";
+import { getMiruroEpisodesResponse } from "@kunai/providers/miruro";
+import { openKunaiDatabase, ProviderCacheRepository, runMigrations } from "@kunai/storage";
+import type { ProviderRuntimeContext } from "@kunai/types";
+
+// A stub that returns a valid episodes payload once, then fails — so a second
+// resolve can only succeed if it read from the persistent cache.
+function oneShotPipeContext(cache: ProviderRuntimeContext["cache"], onFetch: () => void) {
+  let served = false;
+  return {
+    providerId: "miruro",
+    now: () => new Date().toISOString(),
+    cache,
+    fetch: {
+      runtime: "direct-http",
+      fetch: async (_url: string) => {
+        onFetch();
+        if (served) return new Response("gone", { status: 500 });
+        served = true;
+        // Not a decodable pipe body — getMiruroEpisodesResponse would throw. We
+        // instead pre-seed the persistent cache below and assert the SECOND
+        // call reads it without touching the network at all.
+        return new Response("gone", { status: 500 });
+      },
+    },
+  } as unknown as ProviderRuntimeContext;
+}
+
+describe("miruro episode catalog persists across sessions", () => {
+  test("a second context backed by the same store skips the network", async () => {
+    const db = openKunaiDatabase(":memory:");
+    runMigrations(db, "cache");
+    const repo = new ProviderCacheRepository(db);
+    const port = createProviderCachePort(repo);
+
+    const catalog: MiruroEpisodesResponse = {
+      providers: { kiwi: { episodes: { sub: [{ id: "e1", number: 1 }] } } },
+    } as unknown as MiruroEpisodesResponse;
+
+    // "Session 1" resolved and persisted the catalog (simulated by a direct write).
+    await port.write("miruro:episodes", "21", catalog, 12 * 60 * 60 * 1000);
+
+    // "Session 2": a brand-new context (fresh in-memory cache) — the module
+    // cache is cold, so a hit can only come from the persistent store. The fetch
+    // stub throws if called.
+    let fetched = 0;
+    const ctx = oneShotPipeContext(port, () => {
+      fetched += 1;
+    });
+
+    const result = await getMiruroEpisodesResponse(ctx, "21");
+    expect(result?.providers?.kiwi).toBeDefined();
+    expect(fetched).toBe(0); // never hit the network
+  });
+});

--- a/apps/cli/test/unit/services/providers/provider-cache-port.test.ts
+++ b/apps/cli/test/unit/services/providers/provider-cache-port.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import { createProviderCachePort } from "@/services/providers/provider-cache-port";
+import { openKunaiDatabase, ProviderCacheRepository, runMigrations } from "@kunai/storage";
+
+function backedPort(): { repo: ProviderCacheRepository; db: ReturnType<typeof openKunaiDatabase> } {
+  const db = openKunaiDatabase(":memory:");
+  runMigrations(db, "cache");
+  return { repo: new ProviderCacheRepository(db), db };
+}
+
+describe("createProviderCachePort", () => {
+  test("write then read round-trips a structured value", async () => {
+    const { repo } = backedPort();
+    const port = createProviderCachePort(repo);
+    await port.write("miruro:episodes", "21", { providers: { kiwi: 1 } }, 60_000);
+    expect(await port.read<{ providers: Record<string, number> }>("miruro:episodes", "21")).toEqual(
+      { providers: { kiwi: 1 } },
+    );
+  });
+
+  test("survives across contexts backed by the same store (the cross-session guarantee)", async () => {
+    const { repo } = backedPort();
+    // One "session" writes.
+    await createProviderCachePort(repo).write("ns", "k", { v: 42 }, 60_000);
+    // A fresh port over the same store — as a new process would see it — reads it.
+    expect(await createProviderCachePort(repo).read<{ v: number }>("ns", "k")).toEqual({ v: 42 });
+  });
+
+  test("an expired entry reads as null", async () => {
+    const { repo } = backedPort();
+    let clock = new Date("2026-01-01T00:00:00Z");
+    const port = createProviderCachePort(repo, () => clock);
+    await port.write("ns", "k", { v: 1 }, 1_000);
+    clock = new Date("2026-01-01T00:00:05Z"); // 5s later, past the 1s TTL
+    expect(await port.read("ns", "k")).toBeNull();
+  });
+
+  test("a broken store degrades to null / no-op, never throws", async () => {
+    const broken = {
+      read() {
+        throw new Error("db down");
+      },
+      write() {
+        throw new Error("db down");
+      },
+    } as unknown as ProviderCacheRepository;
+    const port = createProviderCachePort(broken);
+    expect(await port.read("ns", "k")).toBeNull();
+    // Must not throw — a cache failure cannot fail the resolve.
+    await port.write("ns", "k", { v: 1 }, 1_000);
+  });
+
+  test("a corrupt payload reads as null instead of throwing", async () => {
+    const { repo, db } = backedPort();
+    db.query(
+      "INSERT INTO provider_cache (namespace, cache_key, payload_json, expires_at, created_at) VALUES (?, ?, ?, ?, ?)",
+    ).run(
+      "ns",
+      "k",
+      "not-json{",
+      new Date(Date.now() + 60_000).toISOString(),
+      new Date().toISOString(),
+    );
+    expect(await createProviderCachePort(repo).read("ns", "k")).toBeNull();
+  });
+});

--- a/apps/cli/test/unit/services/providers/warm-episode-cache.test.ts
+++ b/apps/cli/test/unit/services/providers/warm-episode-cache.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+
+import type { SearchResult } from "@/domain/types";
+import type { Provider } from "@/services/providers/Provider";
+import { warmTopAnimeEpisodeCache } from "@/services/providers/warm-episode-cache";
+
+function result(over: Partial<SearchResult>): SearchResult {
+  return {
+    id: "anilist:21",
+    type: "series",
+    title: "One Piece",
+    isAnime: true,
+    ...over,
+  } as SearchResult;
+}
+
+function stubProvider(calls: string[]): Provider {
+  return {
+    listEpisodes: async (req: { title: { id: string } }) => {
+      calls.push(req.title.id);
+      return [];
+    },
+  } as unknown as Provider;
+}
+
+function warm(over: Partial<Parameters<typeof warmTopAnimeEpisodeCache>[0]>) {
+  warmTopAnimeEpisodeCache({
+    results: [result({})],
+    provider: undefined,
+    audioPreference: "original",
+    subtitlePreference: "en",
+    warmed: new Set(),
+    ...over,
+  });
+}
+
+describe("warmTopAnimeEpisodeCache", () => {
+  test("warms the top anime result via listEpisodes", async () => {
+    const calls: string[] = [];
+    warm({ provider: stubProvider(calls) });
+    await Promise.resolve();
+    expect(calls).toEqual(["anilist:21"]);
+  });
+
+  test("only the single top anime result is warmed, not the whole list", async () => {
+    const calls: string[] = [];
+    warm({
+      provider: stubProvider(calls),
+      results: [result({ id: "anilist:21" }), result({ id: "anilist:20" })],
+    });
+    await Promise.resolve();
+    expect(calls).toEqual(["anilist:21"]);
+  });
+
+  test("dedupes across calls with a shared warmed set", async () => {
+    const calls: string[] = [];
+    const warmed = new Set<string>();
+    warm({ provider: stubProvider(calls), warmed });
+    warm({ provider: stubProvider(calls), warmed });
+    await Promise.resolve();
+    expect(calls).toEqual(["anilist:21"]);
+  });
+
+  test("skips non-anime results", async () => {
+    const calls: string[] = [];
+    warm({ provider: stubProvider(calls), results: [result({ isAnime: false })] });
+    await Promise.resolve();
+    expect(calls).toEqual([]);
+  });
+
+  test("no-op when the provider cannot list episodes", () => {
+    expect(() => warm({ provider: {} as Provider })).not.toThrow();
+  });
+
+  test("a rejecting listEpisodes never surfaces (fire-and-forget)", async () => {
+    const provider = {
+      listEpisodes: async () => {
+        throw new Error("network down");
+      },
+    } as unknown as Provider;
+    expect(() => warm({ provider })).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+});

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,7 +1,7 @@
 {
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceFingerprint": "f5b32cafc80befd7a8960408c4e1dba5b464a627c65c1c26a2613e4875a1fd14",
+  "cliSourceFingerprint": "f070e5474cc74547ac1a405abc9de4d25398218f1673f515d9ecb37e7bb23cb4",
   "docsContentFingerprint": "83329f5e42767962e2d987fdd1de02b25a13a14fa61e4df87d918367580dda00",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 81,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -15,7 +15,7 @@
     "lighthouse:docs": "bun run scripts/lighthouse-docs.ts",
     "fmt": "oxfmt --write .",
     "fmt:check": "oxfmt --check .",
-    "test": "bun test test",
+    "test": "bun test test --timeout=20000",
     "clean": "rm -rf .next dist .source"
   },
   "dependencies": {

--- a/packages/core/src/provider-engine.ts
+++ b/packages/core/src/provider-engine.ts
@@ -1,4 +1,5 @@
 import type {
+  ProviderCachePort,
   EndpointHealthPort,
   ProviderFailure,
   ProviderId,
@@ -40,6 +41,7 @@ export interface ProviderEngineOptions {
   readonly auth?: ProviderAuthPort;
   readonly fetch?: ProviderFetchPort | ProviderFetchPortFactory;
   readonly endpointHealth?: EndpointHealthPort;
+  readonly cache?: ProviderCachePort;
   readonly titleBridge?: ProviderTitleBridgePort;
   /**
    * How many consecutive providers must fail with reliable offline-evidence
@@ -164,6 +166,7 @@ export class ProviderEngine {
   private readonly auth?: ProviderAuthPort;
   private readonly fetch?: ProviderFetchPort | ProviderFetchPortFactory;
   private readonly endpointHealth?: EndpointHealthPort;
+  private readonly cache?: ProviderCachePort;
   private readonly titleBridge?: ProviderTitleBridgePort;
   private readonly consecutiveOfflineThreshold: number;
   private readonly hedgeDelayMs: number;
@@ -185,6 +188,7 @@ export class ProviderEngine {
     this.auth = opts.auth;
     this.fetch = opts.fetch;
     this.endpointHealth = opts.endpointHealth;
+    this.cache = opts.cache;
     this.titleBridge = opts.titleBridge;
 
     for (const module of opts.modules) {
@@ -225,6 +229,7 @@ export class ProviderEngine {
         ? guardEndpointHealthAgainstCancellation(this.endpointHealth, signal)
         : undefined,
       titleBridge: this.titleBridge,
+      cache: this.cache,
     });
   }
 

--- a/packages/core/src/provider-engine.ts
+++ b/packages/core/src/provider-engine.ts
@@ -672,6 +672,7 @@ export class ProviderEngine {
         ? guardEndpointHealthAgainstCancellation(this.endpointHealth, attemptSignal)
         : undefined,
       titleBridge: this.titleBridge,
+      cache: this.cache,
       emit: (event) => traceEvents.push(event),
     });
 

--- a/packages/core/src/provider-sdk.ts
+++ b/packages/core/src/provider-sdk.ts
@@ -1,6 +1,7 @@
 import type {
   EndpointHealthPort,
   ProviderAuthPort,
+  ProviderCachePort,
   ProviderFetchPort,
   ProviderId,
   ProviderModule,
@@ -33,6 +34,7 @@ export function createProviderRuntimeContext({
   auth,
   endpointHealth,
   titleBridge,
+  cache,
   emit,
 }: {
   readonly now?: () => string;
@@ -43,6 +45,7 @@ export function createProviderRuntimeContext({
   readonly auth?: ProviderAuthPort;
   readonly endpointHealth?: EndpointHealthPort;
   readonly titleBridge?: ProviderTitleBridgePort;
+  readonly cache?: ProviderCachePort;
   readonly emit?: (event: ProviderTraceEvent) => void;
 } = {}): ProviderRuntimeContext {
   return {
@@ -54,6 +57,7 @@ export function createProviderRuntimeContext({
     auth,
     endpointHealth,
     titleBridge,
+    cache,
     emit,
   };
 }

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -137,6 +137,54 @@ test("ProviderEngine aliases legacy vidking id to the videasy module", () => {
   expect(engine.getManifest("vidking")?.id).toBe("videasy");
 });
 
+test("ProviderEngine passes the cache port to the module resolve context", async () => {
+  // Regression: the cache was wired into createRuntimeContext but not the
+  // attempt context that engine.resolve() actually builds for module.resolve,
+  // so production resolution silently bypassed the persistent cache.
+  let seenCache: unknown = "unset";
+  const module: CoreProviderModule = {
+    providerId: "videasy",
+    manifest: { ...vidkingManifest, id: "videasy", displayName: "Videasy" },
+    async resolve(_input, context) {
+      seenCache = context.cache;
+      return {
+        status: "exhausted",
+        providerId: "videasy",
+        sources: [],
+        variants: [],
+        streams: [],
+        subtitles: [],
+        trace: {
+          id: "t",
+          startedAt: "2026-06-08T00:00:00.000Z",
+          cacheHit: false,
+          title: { id: "1", kind: "movie", title: "X" },
+          steps: [],
+          failures: [],
+        },
+        failures: [],
+      };
+    },
+  };
+  const cache = { read: async () => null, write: async () => {} };
+  const engine = createProviderEngine({ modules: [module], cache });
+  // The exhausted result makes engine.resolve reject, but module.resolve still
+  // ran and captured the context — which is all this asserts.
+  await engine
+    .resolve(
+      {
+        mediaKind: "movie",
+        title: { id: "tmdb:1", title: "X" },
+        allowedRuntimes: ["direct-http"],
+        qualityPreference: "best",
+        startupPriority: "balanced",
+      } as never,
+      "videasy",
+    )
+    .catch(() => undefined);
+  expect(seenCache).toBe(cache);
+});
+
 test("vidking manifest declares capability, cache, and runtime boundaries", () => {
   expect(vidkingManifest.id).toBe("vidking");
   expect(vidkingManifest.mediaKinds).toContain("movie");

--- a/packages/providers/src/miruro/direct.ts
+++ b/packages/providers/src/miruro/direct.ts
@@ -1193,12 +1193,16 @@ export function resolveMiruroAnilistId(title: TitleIdentity): string | null {
 }
 
 /**
- * Persistent cache namespace + TTL for the episode catalog. The catalog is
- * stable, so a long TTL is safe — and the whole point is to skip the ~6s
- * Cloudflare-gated pipe call on the next session, not just the next minute.
+ * Persistent cache namespace + TTL for the episode catalog.
+ *
+ * 2 hours, not 12: the catalog is stable for finished shows, but for a
+ * currently-airing one a new episode would not appear until the entry expired.
+ * 2h still covers the case that matters — a binge or a same-afternoon restart
+ * skips the ~6s Cloudflare-gated pipe call — while keeping a newly-aired episode
+ * at most 2h stale rather than half a day.
  */
 const MIRURO_EPISODES_CACHE_NAMESPACE = "miruro:episodes";
-const MIRURO_EPISODES_PERSIST_TTL_MS = 12 * 60 * 60 * 1000;
+const MIRURO_EPISODES_PERSIST_TTL_MS = 2 * 60 * 60 * 1000;
 
 /** Shared episode list fetch for listEpisodes + resolve. */
 export async function getMiruroEpisodesResponse(

--- a/packages/providers/src/miruro/direct.ts
+++ b/packages/providers/src/miruro/direct.ts
@@ -1192,18 +1192,50 @@ export function resolveMiruroAnilistId(title: TitleIdentity): string | null {
   return parsePositiveDecimalId(title.id.slice(MIRURO_ANILIST_ID_PREFIX.length));
 }
 
-/** Shared episode list fetch for listEpisodes + resolve (30m TTL). */
+/**
+ * Persistent cache namespace + TTL for the episode catalog. The catalog is
+ * stable, so a long TTL is safe — and the whole point is to skip the ~6s
+ * Cloudflare-gated pipe call on the next session, not just the next minute.
+ */
+const MIRURO_EPISODES_CACHE_NAMESPACE = "miruro:episodes";
+const MIRURO_EPISODES_PERSIST_TTL_MS = 12 * 60 * 60 * 1000;
+
+/** Shared episode list fetch for listEpisodes + resolve. */
 export async function getMiruroEpisodesResponse(
   context: ProviderRuntimeContext,
   anilistId: string,
   signal?: AbortSignal,
 ): Promise<MiruroEpisodesResponse | null> {
   const cacheKey = `episodes:${anilistId}`;
-  const cached = episodeCache.get(cacheKey) as MiruroEpisodesResponse | null;
-  if (cached) return cached;
 
+  // 1. In-memory: instant within a session.
+  const memoryHit = episodeCache.get(cacheKey) as MiruroEpisodesResponse | null;
+  if (memoryHit) return memoryHit;
+
+  // 2. Persistent: survives a restart, so the cold ~6s pipe call is paid once
+  //    per catalog per TTL rather than once per session.
+  const persistentHit = await context.cache?.read<MiruroEpisodesResponse>(
+    MIRURO_EPISODES_CACHE_NAMESPACE,
+    anilistId,
+  );
+  if (persistentHit) {
+    episodeCache.set(cacheKey, persistentHit);
+    return persistentHit;
+  }
+
+  // 3. Network.
   const epData = await pipeCall(context, "episodes", { anilistId: Number(anilistId) }, signal);
   episodeCache.set(cacheKey, epData);
+  if (epData?.providers) {
+    // Only persist a real catalog; an empty/failed body must not be cached as
+    // "this show has no episodes" for 12 hours.
+    void context.cache?.write(
+      MIRURO_EPISODES_CACHE_NAMESPACE,
+      anilistId,
+      epData,
+      MIRURO_EPISODES_PERSIST_TTL_MS,
+    );
+  }
   return epData;
 }
 

--- a/packages/providers/src/miruro/direct.ts
+++ b/packages/providers/src/miruro/direct.ts
@@ -1226,9 +1226,10 @@ export async function getMiruroEpisodesResponse(
   // 3. Network.
   const epData = await pipeCall(context, "episodes", { anilistId: Number(anilistId) }, signal);
   episodeCache.set(cacheKey, epData);
-  if (epData?.providers) {
-    // Only persist a real catalog; an empty/failed body must not be cached as
-    // "this show has no episodes" for 12 hours.
+  if (selectMiruroEpisodeCatalogEntries(epData).length > 0) {
+    // Only persist a catalog that actually has episodes. `providers: {}` is
+    // truthy, so guarding on it alone would cache an empty body as "this show
+    // has no episodes" for 12 hours and starve every later resolve.
     void context.cache?.write(
       MIRURO_EPISODES_CACHE_NAMESPACE,
       anilistId,

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -92,6 +92,7 @@ export type {
 } from "./repositories/offline-maintenance-jobs";
 export { ProviderHealthRepository } from "./repositories/provider-health";
 export { ProviderEndpointHealthRepository } from "./repositories/provider-endpoint-health";
+export { ProviderCacheRepository } from "./repositories/provider-cache";
 export { YoutubeMetadataCacheRepository } from "./repositories/youtube-metadata-cache";
 export type { YoutubeMetadataCacheRecord } from "./repositories/youtube-metadata-cache";
 export { TitleProviderHealthRepository } from "./repositories/title-provider-health";

--- a/packages/storage/src/maintenance.ts
+++ b/packages/storage/src/maintenance.ts
@@ -20,6 +20,7 @@ export interface CacheMaintenancePruneCounts {
   readonly scheduleCache: number;
   readonly youtubeMetadataCache: number;
   readonly catalogCrosswalk: number;
+  readonly providerCache: number;
   readonly resolveTraces: number;
   readonly providerHealth: number;
   readonly titleProviderHealth: number;
@@ -42,6 +43,7 @@ const EMPTY_PRUNE_COUNTS: CacheMaintenancePruneCounts = {
   scheduleCache: 0,
   youtubeMetadataCache: 0,
   catalogCrosswalk: 0,
+  providerCache: 0,
   resolveTraces: 0,
   providerHealth: 0,
   titleProviderHealth: 0,
@@ -143,6 +145,14 @@ function pruneCacheTables(
       `,
       options.maxResolveTraces,
     );
+    // The provider cache treats expired rows as misses on read; without this
+    // sweep a large episode catalog (One Piece is ~9MB) would linger past its
+    // TTL for the life of the cache DB.
+    const providerCache = deleteRows(
+      db,
+      "DELETE FROM provider_cache WHERE expires_at <= ?",
+      nowIso,
+    );
     const providerHealth = deleteRows(
       db,
       "DELETE FROM provider_health WHERE checked_at <= ?",
@@ -192,6 +202,7 @@ function pruneCacheTables(
       scheduleCache,
       youtubeMetadataCache,
       catalogCrosswalk,
+      providerCache,
       resolveTraces,
       providerHealth,
       titleProviderHealth,

--- a/packages/storage/src/migrations.ts
+++ b/packages/storage/src/migrations.ts
@@ -979,6 +979,23 @@ export const cacheMigrations: readonly Migration[] = [
         ON catalog_id_crosswalk(expires_at);
     `,
   },
+  {
+    id: "016_cache_provider_cache",
+    database: "cache",
+    sql: `
+      CREATE TABLE IF NOT EXISTS provider_cache (
+        namespace TEXT NOT NULL,
+        cache_key TEXT NOT NULL,
+        payload_json TEXT NOT NULL,
+        expires_at TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (namespace, cache_key)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_provider_cache_expires_at
+        ON provider_cache(expires_at);
+    `,
+  },
 ];
 
 export function runMigrations(

--- a/packages/storage/src/repositories/provider-cache.ts
+++ b/packages/storage/src/repositories/provider-cache.ts
@@ -24,7 +24,14 @@ export class ProviderCacheRepository {
       .get(namespace, cacheKey);
     if (!row) return null;
     if (isExpired(row.expires_at, now)) {
-      this.delete(namespace, cacheKey);
+      // Delete only if this exact expired row still stands: another process may
+      // have refreshed it between this read and the delete, and dropping that
+      // fresh value would reintroduce the cold cost we are avoiding.
+      this.db
+        .query(
+          "DELETE FROM provider_cache WHERE namespace = ? AND cache_key = ? AND expires_at = ?",
+        )
+        .run(namespace, cacheKey, row.expires_at);
       return null;
     }
     return row.payload_json;

--- a/packages/storage/src/repositories/provider-cache.ts
+++ b/packages/storage/src/repositories/provider-cache.ts
@@ -1,0 +1,61 @@
+import type { KunaiDatabase } from "../sqlite";
+import { isExpired } from "../ttl";
+
+interface ProviderCacheRow {
+  readonly payload_json: string;
+  readonly expires_at: string;
+}
+
+/**
+ * Generic per-provider key/value cache backing `ProviderCachePort`.
+ *
+ * Providers own no storage, so this is how a provider's expensive, stable
+ * intermediate data (a Cloudflare-gated episode catalog) survives a restart.
+ * Keys are scoped by `namespace` so two providers cannot collide.
+ */
+export class ProviderCacheRepository {
+  constructor(private readonly db: KunaiDatabase) {}
+
+  read(namespace: string, cacheKey: string, now = new Date()): string | null {
+    const row = this.db
+      .query<ProviderCacheRow, [string, string]>(
+        "SELECT payload_json, expires_at FROM provider_cache WHERE namespace = ? AND cache_key = ?",
+      )
+      .get(namespace, cacheKey);
+    if (!row) return null;
+    if (isExpired(row.expires_at, now)) {
+      this.delete(namespace, cacheKey);
+      return null;
+    }
+    return row.payload_json;
+  }
+
+  write(
+    namespace: string,
+    cacheKey: string,
+    payloadJson: string,
+    expiresAt: string,
+    now = new Date().toISOString(),
+  ): void {
+    this.db
+      .query(
+        `INSERT INTO provider_cache (namespace, cache_key, payload_json, expires_at, created_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(namespace, cache_key) DO UPDATE SET
+           payload_json = excluded.payload_json,
+           expires_at = excluded.expires_at,
+           created_at = excluded.created_at`,
+      )
+      .run(namespace, cacheKey, payloadJson, expiresAt, now);
+  }
+
+  delete(namespace: string, cacheKey: string): void {
+    this.db
+      .query("DELETE FROM provider_cache WHERE namespace = ? AND cache_key = ?")
+      .run(namespace, cacheKey);
+  }
+
+  pruneExpired(now = new Date().toISOString()): void {
+    this.db.query("DELETE FROM provider_cache WHERE expires_at <= ?").run(now);
+  }
+}

--- a/packages/storage/test/provider-cache.test.ts
+++ b/packages/storage/test/provider-cache.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+
+import { openKunaiDatabase, ProviderCacheRepository, runMigrations } from "@kunai/storage";
+
+function repo() {
+  const db = openKunaiDatabase(":memory:");
+  runMigrations(db, "cache");
+  return new ProviderCacheRepository(db);
+}
+
+const future = new Date(Date.now() + 60_000).toISOString();
+const past = new Date(Date.now() - 60_000).toISOString();
+
+describe("ProviderCacheRepository", () => {
+  test("round-trips a value under a namespace and key", () => {
+    const r = repo();
+    r.write("miruro:episodes", "21", '{"providers":{"kiwi":{}}}', future);
+    expect(r.read("miruro:episodes", "21")).toBe('{"providers":{"kiwi":{}}}');
+  });
+
+  test("a miss returns null", () => {
+    expect(repo().read("miruro:episodes", "missing")).toBeNull();
+  });
+
+  test("namespaces do not collide", () => {
+    const r = repo();
+    r.write("a", "k", "from-a", future);
+    r.write("b", "k", "from-b", future);
+    expect(r.read("a", "k")).toBe("from-a");
+    expect(r.read("b", "k")).toBe("from-b");
+  });
+
+  test("an expired entry reads as null and is dropped", () => {
+    const r = repo();
+    r.write("ns", "k", "stale", past);
+    expect(r.read("ns", "k")).toBeNull();
+  });
+
+  test("writing the same key overwrites", () => {
+    const r = repo();
+    r.write("ns", "k", "v1", future);
+    r.write("ns", "k", "v2", future);
+    expect(r.read("ns", "k")).toBe("v2");
+  });
+
+  test("pruneExpired removes only expired rows", () => {
+    const r = repo();
+    r.write("ns", "live", "keep", future);
+    r.write("ns", "dead", "drop", past);
+    r.pruneExpired();
+    expect(r.read("ns", "live")).toBe("keep");
+    expect(r.read("ns", "dead")).toBeNull();
+  });
+});

--- a/packages/storage/test/storage-maintenance.test.ts
+++ b/packages/storage/test/storage-maintenance.test.ts
@@ -33,6 +33,7 @@ test("cache maintenance prunes disposable expired rows without touching durable 
     scheduleCache: 1,
     youtubeMetadataCache: 1,
     catalogCrosswalk: 1,
+    providerCache: 1,
     resolveTraces: 1,
     providerHealth: 1,
     titleProviderHealth: 0,
@@ -49,6 +50,7 @@ test("cache maintenance prunes disposable expired rows without touching durable 
   expect(count(cacheDb, "schedule_cache")).toBe(1);
   expect(count(cacheDb, "youtube_metadata_cache")).toBe(1);
   expect(count(cacheDb, "catalog_id_crosswalk")).toBe(1);
+  expect(count(cacheDb, "provider_cache")).toBe(1);
   expect(count(cacheDb, "resolve_traces")).toBe(2);
   expect(count(cacheDb, "provider_health")).toBe(1);
   expect(count(cacheDb, "diagnostic_events")).toBe(1);
@@ -205,6 +207,14 @@ function seedCacheData(db: KunaiDatabase): void {
       VALUES ('anilist', 'fresh', '{}', 'high', ?, ?)
     `,
   ).run("2026-05-17T00:00:00.000Z", "2026-05-18T00:00:00.000Z");
+  db.query(
+    `INSERT INTO provider_cache (namespace, cache_key, payload_json, expires_at, created_at)
+     VALUES ('miruro:episodes', 'expired', '{}', ?, ?)`,
+  ).run("2026-05-16T00:00:00.000Z", "2026-05-15T00:00:00.000Z");
+  db.query(
+    `INSERT INTO provider_cache (namespace, cache_key, payload_json, expires_at, created_at)
+     VALUES ('miruro:episodes', 'fresh', '{}', ?, ?)`,
+  ).run("2026-05-18T00:00:00.000Z", "2026-05-17T00:00:00.000Z");
 }
 
 function seedExpiringCacheTable(

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -428,6 +428,22 @@ export interface EndpointHealthPort {
   recordSuccess(providerId: ProviderId, endpoint: string): void;
 }
 
+/**
+ * A persistent key/value cache a provider may use for expensive, stable
+ * intermediate data (a Cloudflare-gated episode catalog, a signed manifest).
+ *
+ * Providers are pure and own no storage, so without this seam a provider's only
+ * cache is process-local and dies on exit — every session re-pays the cold
+ * network cost. The app backs this with SQLite. Values are JSON-serialisable;
+ * `namespace` scopes keys per provider/purpose so two providers cannot collide.
+ * Reads return `null` on a miss or an expired entry; a backing-store error must
+ * degrade to `null`/no-op rather than fail the resolve.
+ */
+export interface ProviderCachePort {
+  read<T = unknown>(namespace: string, key: string): Promise<T | null>;
+  write(namespace: string, key: string, value: unknown, ttlMs: number): Promise<void>;
+}
+
 export interface ProviderRuntimePort {
   readonly runtime: ProviderRuntime;
   readonly operations: readonly ProviderOperation[];
@@ -555,6 +571,7 @@ export interface ProviderRuntimeContext {
   readonly auth?: ProviderAuthPort;
   readonly endpointHealth?: EndpointHealthPort;
   readonly titleBridge?: ProviderTitleBridgePort;
+  readonly cache?: ProviderCachePort;
   now(): string;
   emit?(event: ProviderTraceEvent): void;
 }


### PR DESCRIPTION
Stacked on #206 (the persistent cache port). Refs #205.

When an anime search returns results, the **top** result's episode catalog is fetched in the background, so the ~6s Cloudflare-gated call is already paid by the time the user picks it — turning even a first-ever watch into a warm resolve.

Deliberately conservative (per the WAF-politeness reasoning on #205):
- **Only the single top anime result** is warmed — one gated call per search, not a barrage for titles the user scrolls past.
- A session-scoped set **dedupes** across searches.
- **Fire-and-forget** — never blocks, delays, or fails the search; every failure is swallowed.
- Anime mode only.

It calls `listEpisodes`, which resolves through the cache-carrying context (#206) and populates `provider_cache` as a side effect — no new plumbing.

The service is unit-tested: top-only, dedup, non-anime skip, no-op without listEpisodes, and the fire-and-forget safety (a rejecting listEpisodes never surfaces).

Gate: typecheck 14/14, tests 23/23 forced, zero lint errors.

https://claude.ai/code/session_01BkWab6pnVL5vMsVGRv9TVp