### PR TITLE
fix(player): send the YouTube format as ytdl-format on the persistent path

### DIFF
--- a/apps/cli/src/infra/player/mpv-stream-http-headers.ts
+++ b/apps/cli/src/infra/player/mpv-stream-http-headers.ts
@@ -56,6 +56,7 @@ export type PersistentLoadfileOptions = {
   readonly "http-header-fields-clr"?: string;
   readonly "tls-verify"?: string;
   readonly ytdl?: string;
+  readonly "ytdl-format"?: string;
   readonly "ytdl-raw-options"?: string;
   readonly "demuxer-lavf-o"?: string;
   readonly "demuxer-lavf-o-clr"?: string;
@@ -93,7 +94,12 @@ export function buildPersistentLoadfileOptions(
   }
 
   if (isYoutubeWatchUrl(url) || ytdlOptions?.requiresYtdl) {
-    loadOptions.ytdl = ytdlOptions?.ytdlFormat ?? "bv*+ba/b";
+    // `ytdl` is a yes/no flag; the format belongs in `ytdl-format`. Passing the
+    // format here made mpv answer "unsupported format for accessing property"
+    // and drop the option, so the quality ceiling silently never applied on the
+    // persistent path while the spawn path in mpv.ts got it right.
+    loadOptions.ytdl = "yes";
+    loadOptions["ytdl-format"] = ytdlOptions?.ytdlFormat ?? "bv*+ba/b";
     if (ytdlOptions?.ytdlRawOptions?.trim()) {
       loadOptions["ytdl-raw-options"] = ytdlOptions.ytdlRawOptions.trim();
     }

--- a/apps/cli/test/unit/infra/player/mpv-stream-http-headers.test.ts
+++ b/apps/cli/test/unit/infra/player/mpv-stream-http-headers.test.ts
@@ -73,6 +73,37 @@ describe("shouldDisableMpvTlsVerify", () => {
 });
 
 describe("buildPersistentLoadfileOptions", () => {
+  // mpv's `ytdl` is a yes/no Flag and `ytdl-format` is a String. Setting the
+  // format on `ytdl` made mpv answer "unsupported format for accessing
+  // property" over IPC and drop the option, so the ceiling never applied.
+  test("puts the YouTube format in ytdl-format and keeps ytdl a yes/no flag", () => {
+    const options = buildPersistentLoadfileOptions(
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      0,
+      undefined,
+      { ytdlFormat: "bv*[height<=1080]+ba/b" },
+    );
+
+    expect(options.ytdl).toBe("yes");
+    expect(options["ytdl-format"]).toBe("bv*[height<=1080]+ba/b");
+  });
+
+  test("falls back to the default format rather than leaving the ceiling unset", () => {
+    const options = buildPersistentLoadfileOptions("https://example.test/v", 0, undefined, {
+      requiresYtdl: true,
+    });
+
+    expect(options.ytdl).toBe("yes");
+    expect(options["ytdl-format"]).toBe("bv*+ba/b");
+  });
+
+  test("still disables ytdl outright for remote HLS manifests", () => {
+    const options = buildPersistentLoadfileOptions("https://cdn.example/a.m3u8", 0, undefined);
+
+    expect(options.ytdl).toBe("no");
+    expect(options["ytdl-format"]).toBeUndefined();
+  });
+
   test("includes file-local HTTP options for autoplay-chain replacements", () => {
     expect(
       buildPersistentLoadfileOptions("https://cdn.example/episode.m3u8", 0, {


### PR DESCRIPTION
Closes #196.

`buildPersistentLoadfileOptions` set the YouTube format string on mpv's `ytdl` option, but `ytdl` is a yes/no **Flag** and the format belongs in `ytdl-format` (a **String**). The spawn path in `apps/cli/src/mpv.ts` already used `--ytdl-format=`, so the two player paths disagreed.

### Verified against a live mpv IPC socket

The issue asked for the live IPC path to be driven before fixing, because the two plausible outcomes needed different fixes. mpv 0.41, real socket:

| `set_property` | Result |
| --- | --- |
| `ytdl` = `bv*+ba/b` | `"unsupported format for accessing property"` |
| `ytdl` = `yes` | `"success"` |
| `ytdl-format` = `bv*+ba/b` | `"success"` |

So mpv **rejects and drops** the option: the YouTube quality ceiling silently never applied on the persistent session path. That is the documented house failure mode — a silent no-op — rather than a hard playback failure.

`mpv --list-options` confirms the types: `--ytdl Flag (default: yes)`, `--ytdl-format String`.

### Coverage

The existing tests only asserted the HLS `ytdl: "no"` branch, so the YouTube branch had **no coverage at all** — which is how this shipped. Added three cases: the explicit format, the default fallback, and the unchanged remote-HLS behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved YouTube playback handling by applying the selected video format correctly.
  - Added a default format when no specific format is provided.
  - Ensured remote HLS streams are handled without unnecessary YouTube download processing.
- **Quality Improvements**
  - Added coverage for YouTube format selection, defaults, and remote HLS playback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->