### PR TITLE
fix(storage): make secret writes owner-only on Windows and durable everywhere

### DIFF
--- a/apps/cli/src/infra/fs/atomic-write.ts
+++ b/apps/cli/src/infra/fs/atomic-write.ts
@@ -1,4 +1,5 @@
-import { chmod, lstat, mkdir, rename, unlink } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { access, chmod, lstat, mkdir, open, rename, unlink } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 
 function tempPath(targetPath: string): string {
@@ -102,6 +103,96 @@ async function atomicMove(
   }
 }
 
+/**
+ * Restrict a secret file to the current user on Windows.
+ *
+ * NTFS ignores POSIX mode bits, so `chmod 0o600` is a no-op there and the file
+ * keeps whatever the parent directory's inherited ACL grants. `%APPDATA%` is
+ * user-scoped by default, which is what most CLIs lean on -- but that is an
+ * inherited default, not something this process established. Dropping
+ * inheritance and granting only the current user costs one `icacls` call on a
+ * path written at connect time, never in a hot loop.
+ *
+ * Best effort by construction: a machine without `icacls`, or a policy that
+ * refuses the change, must not fail the write -- the file is then no wider than
+ * the directory already was. If the new ACL somehow locks this process out, the
+ * inherited ACL is restored rather than leaving an unreadable secret behind.
+ */
+async function restrictWindowsSecretAcl(path: string): Promise<void> {
+  const account = process.env.USERNAME?.trim();
+  if (!account) return;
+  const domain = process.env.USERDOMAIN?.trim();
+  const principal = domain ? `${domain}\\${account}` : account;
+
+  try {
+    const granted = Bun.spawn(["icacls", path, "/inheritance:r", "/grant:r", `${principal}:F`], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    if ((await granted.exited) !== 0) return;
+
+    await access(path, fsConstants.R_OK | fsConstants.W_OK);
+  } catch {
+    // Either icacls is unavailable, or it applied an ACL this process cannot
+    // use. Restoring inheritance is the only outcome worse than doing nothing.
+    try {
+      const reset = Bun.spawn(["icacls", path, "/reset"], { stdout: "ignore", stderr: "ignore" });
+      await reset.exited;
+    } catch {
+      /* nothing further to try; the caller still gets a written file */
+    }
+  }
+}
+
+/**
+ * Write `contents` to `path` and flush it to disk before returning.
+ *
+ * Temp-file-plus-rename keeps readers from ever seeing a half-written file, but
+ * on its own it is not durable: the rename can reach the filesystem journal
+ * while the data blocks are still in the page cache, so a power loss leaves a
+ * correctly named, zero-length config. Flushing the file before it is renamed
+ * into place is what makes the replacement survive a crash rather than merely
+ * look atomic to concurrent readers.
+ *
+ * `mode` is applied at creation so a secret file is never briefly visible with
+ * the process umask's permissions; it is re-applied explicitly because the
+ * umask can only narrow the creation mode, never widen it.
+ */
+async function writeAndFlush(path: string, contents: string | Uint8Array, mode?: number) {
+  const handle = await open(path, "w", mode);
+  try {
+    await handle.writeFile(contents);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  if (mode !== undefined && process.platform !== "win32") await chmod(path, mode);
+}
+
+/**
+ * Flush the directory entry so a completed rename survives a crash.
+ *
+ * POSIX only: Windows has no directory handle to sync, and its rename is
+ * already recorded by the time it returns. Best effort -- a filesystem that
+ * refuses to open or sync a directory must not fail an otherwise good write.
+ */
+async function flushDirectory(dir: string): Promise<void> {
+  if (process.platform === "win32") return;
+  let handle: Awaited<ReturnType<typeof open>>;
+  try {
+    handle = await open(dir, fsConstants.O_RDONLY);
+  } catch {
+    return;
+  }
+  try {
+    await handle.sync();
+  } catch {
+    /* directory syncing is unsupported on some filesystems */
+  } finally {
+    await handle.close();
+  }
+}
+
 async function writeAtomicTextWithMode(
   targetPath: string,
   contents: string,
@@ -112,14 +203,15 @@ async function writeAtomicTextWithMode(
   const tmp = tempPath(targetPath);
 
   try {
-    await Bun.write(tmp, contents);
     // Secret-bearing files must be private before they become visible at the
     // destination. Applying the mode after rename leaves a crash window where
     // the process umask may have created a world-readable config.
-    if (posixMode !== undefined && process.platform !== "win32") {
-      await chmod(tmp, posixMode);
+    await writeAndFlush(tmp, contents, posixMode);
+    if (posixMode !== undefined && process.platform === "win32") {
+      await restrictWindowsSecretAcl(tmp);
     }
     await atomicMove(tmp, targetPath);
+    await flushDirectory(dir);
   } catch (e) {
     await unlink(tmp).catch(() => {});
     throw e;
@@ -141,8 +233,15 @@ export async function writeAtomicBytes(
   const tmp = tempPath(targetPath);
 
   try {
-    await Bun.write(tmp, data);
+    const bytes =
+      data instanceof Blob
+        ? new Uint8Array(await data.arrayBuffer())
+        : data instanceof Uint8Array
+          ? data
+          : new Uint8Array(data);
+    await writeAndFlush(tmp, bytes);
     await atomicMove(tmp, targetPath);
+    await flushDirectory(dir);
   } catch (e) {
     await unlink(tmp).catch(() => {});
     throw e;
@@ -153,14 +252,17 @@ export async function writeAtomicJson(targetPath: string, value: unknown): Promi
   await writeAtomicText(targetPath, JSON.stringify(value, null, 2));
 }
 
-/** Like writeAtomicText with mode 0o600 applied before rename on POSIX. */
+/**
+ * Like writeAtomicText, restricted to the owner before the rename makes it
+ * visible: mode `0o600` on POSIX, an inheritance-free user-only ACL on Windows.
+ */
 export async function writeAtomicSecretText(targetPath: string, contents: string): Promise<void> {
   await writeAtomicTextWithMode(targetPath, contents, 0o600);
 }
 
-/** Write secret-bearing JSON atomically with owner-only POSIX permissions. */
+/** Write secret-bearing JSON atomically, readable only by the owning user. */
 export async function writeAtomicSecretJson(targetPath: string, value: unknown): Promise<void> {
   await writeAtomicSecretText(targetPath, JSON.stringify(value, null, 2));
 }
 
-export const __testing = { atomicMove };
+export const __testing = { atomicMove, flushDirectory, restrictWindowsSecretAcl, writeAndFlush };

--- a/apps/cli/test/unit/infra/fs/atomic-write.test.ts
+++ b/apps/cli/test/unit/infra/fs/atomic-write.test.ts
@@ -4,7 +4,15 @@ import { lstat, mkdir, mkdtemp, readFile, rename, rm, unlink, writeFile } from "
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
-import { __testing } from "@/infra/fs/atomic-write";
+import {
+  __testing,
+  writeAtomicBytes,
+  writeAtomicJson,
+  writeAtomicSecretJson,
+} from "@/infra/fs/atomic-write";
+
+/** POSIX-only: NTFS ignores mode bits, so asserting them there proves nothing. */
+const testPosixMode = process.platform === "win32" ? test.skip : test;
 
 const roots: string[] = [];
 
@@ -162,5 +170,81 @@ describe("atomicMove", () => {
     expect(existsSync(target)).toBe(false);
     expect(existsSync(tmp)).toBe(false);
     expect(await readFile(backup, "utf8")).toBe("old");
+  });
+});
+
+describe("secret and durable writes", () => {
+  async function makeRoot(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), "kunai-atomic-secret-"));
+    roots.push(root);
+    return root;
+  }
+
+  testPosixMode("a secret write is owner-only before it is ever visible", async () => {
+    const root = await makeRoot();
+    const target = join(root, "sync-tokens.json");
+    await writeAtomicSecretJson(target, { anilist: { accessToken: "t", userId: 1 } });
+
+    const stats = await lstat(target);
+    expect(stats.mode & 0o777).toBe(0o600);
+  });
+
+  testPosixMode(
+    "a secret rewrite stays owner-only when the previous file was wide open",
+    async () => {
+      const root = await makeRoot();
+      const target = join(root, "config.json");
+      await writeFile(target, "{}", { mode: 0o666 });
+
+      await writeAtomicSecretJson(target, { videasySessionToken: "s" });
+
+      const stats = await lstat(target);
+      expect(stats.mode & 0o777).toBe(0o600);
+    },
+  );
+
+  testPosixMode("an ordinary write is not silently narrowed to owner-only", async () => {
+    const root = await makeRoot();
+    const target = join(root, "plain.json");
+    await writeAtomicJson(target, { ok: true });
+
+    const stats = await lstat(target);
+    expect(stats.mode & 0o600).toBe(0o600);
+    expect(JSON.parse(await readFile(target, "utf8"))).toEqual({ ok: true });
+  });
+
+  test("writeAtomicBytes round-trips every accepted payload shape", async () => {
+    const root = await makeRoot();
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+
+    for (const [name, payload] of [
+      ["uint8array", bytes],
+      ["arraybuffer", bytes.buffer.slice(0)],
+      ["blob", new Blob([bytes])],
+    ] as const) {
+      const target = join(root, `${name}.bin`);
+      await writeAtomicBytes(target, payload);
+      expect(new Uint8Array(await readFile(target))).toEqual(bytes);
+    }
+  });
+
+  test("a directory flush never fails a write that already landed", async () => {
+    const root = await makeRoot();
+    await expect(__testing.flushDirectory(join(root, "does-not-exist"))).resolves.toBeUndefined();
+  });
+
+  test("Windows ACL hardening is skipped rather than guessed when the user is unknown", async () => {
+    const root = await makeRoot();
+    const target = join(root, "secret.json");
+    await writeFile(target, "{}");
+
+    const previousUser = process.env.USERNAME;
+    delete process.env.USERNAME;
+    try {
+      await expect(__testing.restrictWindowsSecretAcl(target)).resolves.toBeUndefined();
+      expect(await readFile(target, "utf8")).toBe("{}");
+    } finally {
+      if (previousUser !== undefined) process.env.USERNAME = previousUser;
+    }
   });
 });


### PR DESCRIPTION
Refs #179. This is the proportionate slice of the credential-vault work — the part that measurably improves security without coupling a keychain migration to the updater and rollback paths this release is already rewriting.

`writeAtomicSecretJson` is the single path that persists AniList and TMDB tokens (`sync-tokens.json`) and the Videasy session token (`config.json`). It had two gaps.

### 1. Windows got no restriction at all

```ts
if (posixMode !== undefined && process.platform !== "win32") {
  await chmod(tmp, posixMode);
}
```

NTFS ignores POSIX mode bits, so on Windows the token file simply kept whatever `%APPDATA%` inherited. That is user-scoped by default — which is what most CLIs lean on — but it was an inherited default this process never established.

Now an inheritance-free, user-only ACL is applied via `icacls` **before** the rename. It is best-effort by construction: no `icacls`, or a policy that refuses, must not fail the write. If the new ACL would lock this process out, inheritance is restored rather than leaving an unreadable secret behind.

### 2. Nothing was ever flushed — on any platform

Temp-file-plus-rename stops readers seeing a half-written file, but on its own it is not durable. The rename can reach the filesystem journal while the data blocks are still in the page cache, so a power loss leaves a **correctly named, zero-length config**. `FileStorage.ts` already has a corrupt-config recovery path, which suggests this has been hit.

- the file is flushed before the rename makes it visible
- the directory entry is flushed after the rename (POSIX; Windows has no directory handle to sync)
- the mode is now set at creation, closing the window where a secret briefly existed with the process umask's permissions

### Coverage

The existing tests only exercised `atomicMove`. Added: secret writes are `0o600`; a rewrite over a `0o666` file narrows it; ordinary writes are not silently narrowed; `writeAtomicBytes` round-trips `Uint8Array` / `ArrayBuffer` / `Blob`; a directory flush never fails a landed write; ACL hardening is skipped rather than guessed when the user is unknown.

Gate: typecheck 14/14, lint 0 warnings, **5709 pass / 0 fail**, cache-forced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-save durability to help prevent data loss after crashes or interruptions.
  * Strengthened protection for secret files across operating systems.
  * Ensured text, JSON, and binary file writes consistently preserve their contents.
* **Tests**
  * Expanded coverage for file durability, permissions, secret-file protection, and binary data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->