### PR TITLE
docs(release): add the runbook for withdrawing a released version

### DIFF
--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -301,3 +301,75 @@ bun run test:live:youtube
 ```
 
 Expected: `ok: true`, `streamResolved: true`, `streamHost` contains `youtube.com`. When yt-dlp is intentionally absent on the runner, `skipped: true` is acceptable.
+
+## Withdrawing a Released Version
+
+Every gate above exists to stop a bad release shipping. This section is for when
+one ships anyway. Rehearse it before tagging, not during an incident.
+
+Nothing here needs a code change. Both update channels resolve a *server-side
+mutable pointer*, so withdrawal is a metadata edit and is reversible.
+
+| Channel | Pointer read at runtime | Read by |
+| ------- | ----------------------- | ------- |
+| `binary` | `https://api.github.com/repos/KitsuneKode/kunai/releases/latest` → `tag_name` | `apps/cli/src/services/update/latest-version.ts` |
+| `npm-global`, `bun-global` | `https://registry.npmjs.org/@kitsunekode%2fkunai/latest` | `apps/cli/src/services/update/UpdateService.ts` |
+
+`apps/cli/src/services/update/resolve-latest-version.ts` is the single entry
+point that routes an install method to its channel.
+
+### 1. Stop the binary channel
+
+`parseVersionFromTag` rejects prerelease tags, so marking the GitHub release as
+a prerelease removes it from `releases/latest` and clients resolve the previous
+stable release instead.
+
+```sh
+gh release edit v0.3.0 --prerelease
+```
+
+Do not delete the release or its assets. Anyone already pinned to that version
+still needs the assets to reinstall or roll back, and deletion is not
+reversible.
+
+### 2. Stop the npm channel
+
+Move `latest` back and mark the bad version deprecated. Prefer this over
+`npm unpublish`, which is only permitted within 72 hours and hard-breaks anyone
+who pinned the version.
+
+```sh
+npm dist-tag add @kitsunekode/kunai@<previous-good-version> latest
+npm deprecate @kitsunekode/kunai@0.3.0 "Withdrawn — run: kunai rollback"
+```
+
+The platform packages are exact-version `optionalDependencies` of the launcher,
+so moving the launcher's `latest` tag is sufficient; the matching platform
+package is pinned by the launcher version that resolves.
+
+### 3. Recover users already on the bad version
+
+`kunai rollback` restores the previously activated version from the versioned
+install layout. Verify the real rollback, not only `--dry-run` — it is the
+least-exercised path that matters most, and it runs when everything else has
+already failed.
+
+```sh
+kunai rollback --list
+kunai rollback
+```
+
+### 4. Say so where people look
+
+Release notes, `README.md`, and the docs site. A withdrawn version that is
+withdrawn silently gets reinstalled from a cached tarball, a pinned CI file, or
+a blog post.
+
+### Rehearsal
+
+Before tagging, confirm on the candidate that:
+
+- `kunai rollback --list` shows the previous version
+- a real `kunai rollback` restores a working launcher and manifest
+- `kunai --version` reports the restored version afterwards
+- the native installer Docker lifecycle passes (`bun run test:installer:docker`)

--- a/.plans/2026-08-24-0-3-0-merge-train.md
+++ b/.plans/2026-08-24-0-3-0-merge-train.md
@@ -1,0 +1,124 @@
+# 0.3.0 Merge Train — Execution Board
+
+Status: active
+Owner: release
+Created: 2026-08-24
+
+The 0.3.0 work is written. The bottleneck is **publication and merge order**,
+not engineering. This board tracks getting it merged without losing CI signal.
+
+## Why order matters here
+
+Forty-one PRs sit in two stacks, one eight deep. In a stack, **every merge
+invalidates its children's CI** — a green check on a stacked PR was computed
+against a base that will not exist once its parent merges. Merging bottom-up
+one PR at a time therefore costs a retarget-and-rerun cycle per PR and proves
+nothing that the integrated head has not already proven.
+
+Chain B was restacked onto the fixed #180 head on 2026-08-24 and is green end
+to end. Chain A is still local-only.
+
+## Wave 1 — independent, mergeable now
+
+These target `main`, are CLEAN, and touch nothing either stack depends on.
+No ordering constraint between them.
+
+- [ ] #210 `fix(player)` ytdl-format on the persistent path — closes #196
+- [ ] #211 `fix(storage)` owner-only Windows ACL + durable secret writes — refs #179
+- [ ] #212 `docs(release)` withdraw-a-release runbook
+- [ ] #123 `fix(presence)` malformed Discord frame — closes #94
+- [ ] #156 `fix(history)` direct-id metadata — closes #154
+- [ ] #202 `fix(shell)` Sakura loader on resolve
+
+## Wave 2 — CI foundation, strictly ordered
+
+`#208` currently contains `#141`'s commit. Rebase `#208` onto `#141` first so
+both keep their review history and `#141` does not become an empty PR.
+
+- [ ] Rebase #208 onto #141
+- [ ] #141 `fix(ci)` test:file timeout
+- [ ] #208 `ci` paths-filter v4 + docs codegen budget
+- [ ] #158 `fix(ci)` codegen freshness gate order
+
+## Wave 3 — publish chain A
+
+26 commits of security and reliability work, proven green together locally
+(typecheck 14/14, lint 0 warnings, 5864 pass / 0 fail, cache-forced) and
+invisible to GitHub. This is the largest block of idle value in the repo.
+
+- [ ] Force-push the chain-A branches with `--force-with-lease`
+- [ ] Retarget PR bases to match the local linear order
+- [ ] Confirm exact-head CI on every branch
+- [ ] Re-request review — CodeRabbit skips stacked non-`main` bases
+
+Chain A order: #208 → #141 → #158 → #164 → #165 → #160 → #161 → #162 → #170 →
+#209 → #181 → #173 → #163 → #176.
+
+**#209 is red for an inherited reason.** Its docs-codegen test fails at
+5026 ms against Bun's 5 s default; `origin/main` still lacks the
+`--timeout=20000` that every stack tip carries. It needs the rebase, not a fix.
+
+## Wave 4 — provider chain
+
+- [ ] #185 `fix(providers)` anime source reliability — also closes #188 entirely
+- [ ] #197 → #198 → #199 → #200 → #201 → #203, retargeting each to `main` as its
+      parent merges
+
+## Wave 5 — native release train
+
+Restacked and green as of 2026-08-24. Merge in chain order.
+
+- [ ] #180 → #184 → #204 → #182 → #183
+
+## Wave 6 — last
+
+- [ ] #159 `docs` parity sweep — merges last so it reconciles against the final
+      tree instead of conflicting repeatedly
+
+## Regression watch
+
+Areas where this release is most likely to break something, and what proves it
+did not.
+
+| Area | Why it is at risk | Proof |
+| ---- | ----------------- | ----- |
+| Secret file writes | #211 changed the write path used by config **and** tokens | `atomic-write.test.ts`; connect a tracker, restart, confirm the session survives |
+| Persistent mpv playback | #210 changed the loadfile option map | Play a YouTube title through the persistent session; confirm the quality ceiling now applies |
+| Installer activation lock | Cross-language protocol touched by #180 | Windows + macOS CLI parity; `test:installer:docker` full lifecycle |
+| Updater rollback | #184/#204 rewrote archive consumption | A **real** `kunai rollback`, not `--dry-run` |
+| Relay transport | #170 is seven stacked commits | Opt-in relay smoke with a local server |
+| Provider cache keys | #197 changed key composition | Resolve the same title at two quality preferences; confirm no cross-contamination |
+| Windows suite timing | SQLite teardown starves under load | Re-run before treating a Windows red as a regression — see below |
+
+### Telling a flake from a regression on Windows
+
+A Windows failure in the SQLite-backed suites is a flake when **all** hold:
+
+1. the failing test's duration is a multiple of its budget (seen: 84,901 ms
+   against 20,000 ms), not a near-miss;
+2. the failing tests are unrelated to the PR's subject;
+3. a descendant PR containing the same commits passed.
+
+#182 hit all three on 2026-08-24 and a re-run came back clean. Treat that
+signature as starvation and re-run; do not relax a budget to make it pass.
+
+## Before tagging
+
+- [ ] Rehearse the withdraw runbook in
+      [`.docs/release-reliability-gate.md`](../.docs/release-reliability-gate.md),
+      including a real rollback
+- [ ] Review the immutability freeze list — releases API URL, npm package name,
+      release asset naming, attestation trust root. Published binaries cannot be
+      changed, so these freeze into every installed copy at tag time
+- [ ] Confirm #186's issue-to-code closure rather than assuming #185 covered it
+- [ ] Decide #179 explicitly: #211 took the proportionate wins; the OS keychain
+      itself stays deferred
+
+## Deliberately not in 0.3.0
+
+- **#179 OS credential vault.** On Linux an unlocked keyring is readable by any
+  process running as that user, so it adds little over `0600` against the same
+  attacker. Its migration would also have to survive the updater and rollback
+  paths this release is rewriting. #211 took the cheap, real wins instead.
+- **#130 Bun code splitting.** A measured 0.3.1 experiment.
+- **#189–#195.** Provider follow-ups with no user-visible defect.

--- a/.plans/roadmap.md
+++ b/.plans/roadmap.md
@@ -57,6 +57,7 @@ archive and put only the residue here.
 
 | Track                        | Remaining                                                | Plan                                                                                             |
 | ---------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| 0.3.0 merge train            | Merge order, chain-A publication, regression watch       | [2026-08-24-0-3-0-merge-train.md](./2026-08-24-0-3-0-merge-train.md)                             |
 | Provider-independent offline | Keep downloads playable after provider retirement        | [offline-provider-independent-playback.md](./offline-provider-independent-playback.md)           |
 | Offline artwork cache        | Library previews                                         | [offline-artwork-cache-and-library-previews.md](./offline-artwork-cache-and-library-previews.md) |
 | Boundary + downloads         | Reviewed adaptive-download design, not started           | [boundary-hardening-and-adaptive-downloads.md](./boundary-hardening-and-adaptive-downloads.md)   |


### PR DESCRIPTION
`.docs/release-reliability-gate.md` covers install, update, rollback and uninstall. It had no section on what to do when a bad release ships anyway — the one runbook you cannot write calmly during an incident.

**No code was needed.** Both update channels already resolve a server-side mutable pointer, so withdrawal is a reversible metadata edit:

| Channel | Pointer | Read by |
| --- | --- | --- |
| `binary` | GitHub `releases/latest` → `tag_name` | `latest-version.ts` |
| `npm-global` / `bun-global` | `registry.npmjs.org/@kitsunekode%2fkunai/latest` | `UpdateService.ts` |

Two properties make this work, both verified in the source rather than assumed:

- `parseVersionFromTag` **rejects prerelease tags**, so `gh release edit v0.3.0 --prerelease` drops the release out of `releases/latest` and clients resolve the previous stable one.
- Moving the npm `latest` dist-tag does the same for npm/bun without `npm unpublish`, which is 72-hour limited and hard-breaks pinned users.

The runbook also records two things that are easy to get wrong under pressure:

- **Do not delete the release or its assets.** Anyone pinned to that version still needs them to roll back, and deletion is not reversible.
- **Rehearse a real `kunai rollback`, not just `--dry-run`** — it is the least-exercised path that matters most, and it runs precisely when everything else has already failed.

Gates: `verify:doc-paths` (48 docs, 1962 source files, all paths resolve), `verify:doc-coverage`, `fmt:check`.
