### PR TITLE
test(live): surface VidLink stream reachability, retire the vidking alias

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -76,7 +76,6 @@
     "test:live:offline-beta": "bun -e \"await import('./test/live/offline-beta.smoke.ts')\"",
     "test:live:videasy": "bun test/live/videasy-bloodhounds.smoke.ts",
     "test:live:videasy:suite": "KUNAI_VIDEASY_LIVE_SUITE=1 bun test/live/videasy-bloodhounds.smoke.ts",
-    "test:live:vidking": "bun run test:live:videasy",
     "test:vhs:setup": "vhs test/vhs/setup.tape",
     "test:vhs:offline": "vhs test/vhs/offline-library.tape",
     "test:vhs:palette": "vhs test/vhs/command-palette.tape",

--- a/apps/cli/test/live/miruro-demonslayer.smoke.ts
+++ b/apps/cli/test/live/miruro-demonslayer.smoke.ts
@@ -1,9 +1,5 @@
 import type { TitleInfo } from "@/domain/types";
-import {
-  clearMiruroCachesForTest,
-  isStreamReachableForResolve,
-  probeStreamReachability,
-} from "@kunai/providers";
+import { clearMiruroCachesForTest, probeStreamReachability } from "@kunai/providers";
 
 import {
   buildProviderSmokePayload,
@@ -11,6 +7,7 @@ import {
   providerSmokeError,
   providerSmokeProfilePayload,
   resolveProviderSmokeStream,
+  smokeStreamReachable,
 } from "./provider-smoke";
 import { directSmokeArgs } from "./smoke-argv";
 
@@ -88,7 +85,7 @@ const streamProbe = stream?.url
       timeoutMs: 5_000,
     })
   : null;
-const streamReachable = streamProbe ? isStreamReachableForResolve(streamProbe) : false;
+const streamReachable = smokeStreamReachable(streamProbe);
 
 const payload = {
   ...buildProviderSmokePayload({
@@ -115,7 +112,7 @@ console.log(JSON.stringify(payload, null, 2));
 
 // Pass on measured reachability, not on resolver attestation — a resolver that
 // correctly declines to attest an unprobed stream must still be able to pass.
-if (!stream?.url || !streamReachable) {
+if (!stream?.url || streamReachable === false) {
   // Let stdout flush so the matrix parent can retain structured failure evidence.
   process.exitCode = 1;
 }

--- a/apps/cli/test/live/provider-smoke.ts
+++ b/apps/cli/test/live/provider-smoke.ts
@@ -13,6 +13,7 @@ import {
   type CoreProviderManifest,
   type ProviderTraceEventSummary,
 } from "@kunai/core";
+import type { StreamReachabilityProbeResult } from "@kunai/providers";
 import { getKunaiPaths, type StoragePlatform } from "@kunai/storage";
 import type { ProviderResolveResult, StartupPriority } from "@kunai/types";
 
@@ -220,4 +221,32 @@ export function providerSmokeError(
     lastTraceEvent: traceSummary.lastEvent,
     sourceAttempts: traceSummary.sourceAttempts,
   };
+}
+
+/**
+ * Tri-state reachability for a smoke payload: was playback actually evidenced?
+ *
+ * `isStreamReachableForResolve` is a *gate* predicate and is permissive on
+ * purpose -- it answers "should the resolve be allowed to proceed?", returning
+ * true for a timeout and for a non-definitive unreachable so a slow CDN is not
+ * condemned. Reporting that value as `streamReachable` claims playback was
+ * verified when it was not, which is the false green these probes exist to
+ * catch.
+ *
+ * Reporting needs the stricter question, and three outcomes rather than two:
+ *
+ * - `true`  -- the probe served bytes
+ * - `false` -- the probe was refused; evidence the stream will not play
+ * - `null`  -- inconclusive (timed out, or never ran), so nothing is claimed
+ *
+ * Callers gate on `=== false` so only evidence fails a smoke; `null` stays
+ * neutral and leaves the resolution check to decide.
+ */
+export function smokeStreamReachable(
+  probe: StreamReachabilityProbeResult | null | undefined,
+): boolean | null {
+  if (!probe) return null;
+  if (probe.status === "reachable") return true;
+  if (probe.status === "unreachable") return false;
+  return null;
 }

--- a/apps/cli/test/live/release-provider-signoff.smoke.ts
+++ b/apps/cli/test/live/release-provider-signoff.smoke.ts
@@ -17,12 +17,13 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { isStreamReachableForResolve, probeStreamReachability } from "@kunai/providers";
+import { probeStreamReachability } from "@kunai/providers";
 
 import {
   createProviderSmokeProfile,
   providerSmokeError,
   resolveProviderSmokeStream,
+  smokeStreamReachable,
 } from "./provider-smoke";
 import {
   buildReleaseProviderRouteCases,
@@ -148,7 +149,7 @@ async function resolveRoute(
       })
     : null;
   const streamReachable = streamProbe
-    ? isStreamReachableForResolve(streamProbe)
+    ? smokeStreamReachable(streamProbe)
     : streamUrl
       ? false
       : null;

--- a/apps/cli/test/live/videasy-bloodhounds.smoke.ts
+++ b/apps/cli/test/live/videasy-bloodhounds.smoke.ts
@@ -16,7 +16,7 @@
  *   KITSUNE_SMOKE_STARTUP_PRIORITY=fast|balanced|quality-first
  */
 import type { TitleInfo } from "@/domain/types";
-import { isStreamReachableForResolve, probeStreamReachability } from "@kunai/providers";
+import { probeStreamReachability } from "@kunai/providers";
 import type { StartupPriority } from "@kunai/types";
 
 import {
@@ -25,6 +25,7 @@ import {
   providerSmokeError,
   providerSmokeProfilePayload,
   resolveProviderSmokeStream,
+  smokeStreamReachable,
 } from "./provider-smoke";
 import {
   type VideasyLiveFixture,
@@ -210,12 +211,14 @@ async function runVideasyFixtureSmoke({
       })
     : null;
 
-  const streamReachable = streamProbe ? isStreamReachableForResolve(streamProbe) : false;
+  const streamReachable = smokeStreamReachable(streamProbe);
 
   const assertion = evaluateVideasyLiveSmoke({
     fixture,
     streamResolved: Boolean(stream?.url),
-    streamReachable,
+    // The assertion is boolean; `null` means inconclusive, which must not read
+    // as "not playable". Only measured evidence fails.
+    streamReachable: streamReachable !== false,
     streamCandidates,
     resolveDurationMs,
     selectedSourceLabel,
@@ -236,7 +239,7 @@ async function runVideasyFixtureSmoke({
 
   const payload = {
     ...base,
-    ok: assertion.ok && base.ok && streamReachable,
+    ok: assertion.ok && base.ok && streamReachable !== false,
     fixtureId: fixture.id,
     mediaKind: fixture.mediaKind,
     knownGoodLabels: fixture.knownGoodLabels,
@@ -270,7 +273,7 @@ async function runVideasyFixtureSmoke({
     payload,
     assertion: {
       ...assertion,
-      ok: assertion.ok && Boolean(stream?.url) && streamReachable,
+      ok: assertion.ok && Boolean(stream?.url) && streamReachable !== false,
     },
   };
 }

--- a/apps/cli/test/live/vidlink-inception.smoke.ts
+++ b/apps/cli/test/live/vidlink-inception.smoke.ts
@@ -7,6 +7,7 @@
  * It covers a movie by default; pass season/episode to exercise the series path.
  */
 import type { TitleInfo } from "@/domain/types";
+import { isStreamReachableForResolve, probeStreamReachability } from "@kunai/providers";
 
 import {
   buildProviderSmokePayload,
@@ -70,6 +71,24 @@ const { stream, resolveDurationMs } = await resolveProviderSmokeStream({
     return { stream: null, resolveDurationMs: null };
   });
 
+// Resolving a URL and serving bytes are separate claims, and for VidLink they
+// have diverged: the CDN rate-limits CLI probes, so a resolve can now succeed
+// while playback still answers 429. Measure it and put it in the payload so the
+// distinction is visible, rather than letting `streamResolved` imply playback.
+//
+// Reported, not enforced: the exit code deliberately still turns on resolution
+// alone. A single probe is exactly the transient signal this chain decided must
+// not condemn a live source, so failing the smoke on it would re-introduce the
+// behaviour that was just removed.
+const streamProbe = stream?.url
+  ? await probeStreamReachability({
+      url: stream.url,
+      headers: stream.headers,
+      timeoutMs: 5_000,
+    })
+  : null;
+const streamReachable = streamProbe ? isStreamReachableForResolve(streamProbe) : null;
+
 const payload = {
   ...buildProviderSmokePayload({
     provider: "vidlink",
@@ -82,6 +101,8 @@ const payload = {
   failureCodes,
   failureMessages,
   streamCandidates,
+  streamProbe,
+  streamReachable,
   // Last on purpose: on a rejected resolve the locals above are still empty and
   // would otherwise blank out the real failure codes this carries.
   ...(resolveError ? providerSmokeError(resolveError) : {}),

--- a/apps/cli/test/live/vidlink-inception.smoke.ts
+++ b/apps/cli/test/live/vidlink-inception.smoke.ts
@@ -7,7 +7,7 @@
  * It covers a movie by default; pass season/episode to exercise the series path.
  */
 import type { TitleInfo } from "@/domain/types";
-import { isStreamReachableForResolve, probeStreamReachability } from "@kunai/providers";
+import { probeStreamReachability } from "@kunai/providers";
 
 import {
   buildProviderSmokePayload,
@@ -15,6 +15,7 @@ import {
   providerSmokeError,
   providerSmokeProfilePayload,
   resolveProviderSmokeStream,
+  smokeStreamReachable,
 } from "./provider-smoke";
 import { directSmokeArgs } from "./smoke-argv";
 
@@ -87,7 +88,7 @@ const streamProbe = stream?.url
       timeoutMs: 5_000,
     })
   : null;
-const streamReachable = streamProbe ? isStreamReachableForResolve(streamProbe) : null;
+const streamReachable = streamProbe ? smokeStreamReachable(streamProbe) : null;
 
 const payload = {
   ...buildProviderSmokePayload({

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "test:live:offline-beta": "bun run --cwd apps/cli test:live:offline-beta",
     "test:live:videasy": "bun run --cwd apps/cli test:live:videasy",
     "test:live:videasy:suite": "bun run --cwd apps/cli test:live:videasy:suite",
-    "test:live:vidking": "bun run --cwd apps/cli test:live:videasy",
     "ci": "turbo run typecheck lint fmt:check test --summarize",
     "ci:affected": "turbo run typecheck lint fmt:check test --affected --summarize",
     "build": "turbo run build build:binary:host --filter=@kitsunekode/kunai",


### PR DESCRIPTION
Two small gaps on top of the VidLink smoke this chain already added (`vidlink-inception.smoke.ts`, from *"stop transient probe failures condemning live sources"*).

Rebased onto the provider chain tip so it extends that smoke rather than duplicating it.

## 1. Reachability is measured and reported

Resolving a URL and serving bytes are separate claims, and for VidLink they had diverged — the CDN rate-limits CLI probes, so on `main` every resolve was discarded at the reachability gate.

**This chain repairs that, and the smoke now demonstrates it.** Three consecutive runs on the chain tip:

| Run | streamResolved | probe status | streamReachable | resolve |
| --- | --- | --- | --- | --- |
| 1 | true | reachable | true | 2008 ms |
| 2 | true | reachable | true | 1311 ms |
| 3 | true | reachable | true | 1375 ms |

The same smoke on `main` answers HTTP 429. So this is evidence the chain's transient-probe fix works, not just an assertion that it should.

**Reported, not enforced.** The exit code still turns on resolution alone. A single probe is exactly the transient signal this chain decided must not condemn a live source, so failing the smoke on it would re-introduce the behaviour that was just removed. The payload carries the truth; the gate keeps the chain's policy. Worth a reviewer's opinion on whether that's the right split.

## 2. Retires the dead `test:live:vidking` alias

```jsonc
"test:live:vidking": "bun run test:live:videasy"   // names a provider not in the tree; runs a different one
```

There is no `vidking` module. The one script that looked like vidking coverage exercised videasy. Remaining references are confined to `.archive/` (no authority) and `CHANGELOG.md` (history), both left alone.

## Gates

`typecheck` clean, `lint` 0 warnings across all 9 packages, `fmt`, plus the `guard` hook on `apps/cli/package.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved live stream checks by reporting whether resolved streams are reachable, including probe details in test results.
  - Increased the documentation test timeout to 20 seconds to reduce failures during longer-running test scenarios.

- **Documentation**
  - Clarified timeout guidance, including platform-specific testing considerations and when longer timeouts apply.

- **Chores**
  - Removed the obsolete VidLink live-test command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->