### PR TITLE
fix(diagnostics): surface measured stage durations in summarised traces

### DIFF
--- a/apps/cli/test/live/provider-smoke.ts
+++ b/apps/cli/test/live/provider-smoke.ts
@@ -114,8 +114,17 @@ export function buildProviderSmokePayload({
   readonly resolveDurationMs?: number | null;
 }): ProviderSmokePayload {
   const engine = stream?.providerResolveResult?.trace.runtime ?? null;
+  // Summarise the trace on success too. It used to be attached only by
+  // `providerSmokeError`, so a resolve that worked reported one total duration
+  // and nothing about where the time went -- exactly backwards, since the
+  // latency worth attributing lives in successful resolves. On failure
+  // `providerSmokeError` is spread after this and still wins.
+  const traceSummary = summarizeProviderTraceEvents(stream?.providerResolveResult?.trace.events);
   return {
     ok: Boolean(stream?.url),
+    traceEventCount: traceSummary.eventCount,
+    lastTraceEvent: traceSummary.lastEvent,
+    sourceAttempts: traceSummary.sourceAttempts,
     skipped: false,
     provider,
     providerId: provider,

--- a/packages/core/src/trace-summary.ts
+++ b/packages/core/src/trace-summary.ts
@@ -10,6 +10,17 @@ export type ProviderTraceEventSummary = {
   readonly failureClass?: string | number | boolean | null;
   readonly serverId?: string | number | boolean | null;
   readonly stage?: string;
+  /**
+   * Milliseconds the stage took, when the provider timed it.
+   *
+   * Providers already emit `durationMs` on the event, but the summary dropped
+   * it, so every consumer of a summarised trace -- the live smokes and the
+   * diagnostics panel alike -- could see *that* a stage ran and never *how long
+   * it took*. Attributing provider latency then meant re-reading raw events by
+   * hand, which is exactly the measurement the timing instrumentation exists to
+   * make routine.
+   */
+  readonly durationMs?: number;
   readonly at: string;
 };
 
@@ -23,12 +34,23 @@ export function summarizeProviderTraceEvents(
   events: readonly ProviderTraceEvent[] | undefined,
 ): ProviderTraceSummary {
   const traceEvents = events ?? [];
+  // `source:success` belongs here too. Timed stages report their duration on
+  // the event that ends them, and a stage that ends *well* ends on success --
+  // so filtering to start/failed kept every successful stage's timing out of
+  // the summary, which is the majority of the latency on a healthy resolve.
   const sourceEvents = traceEvents.filter(
-    (event) => event.type === "source:start" || event.type === "source:failed",
+    (event) =>
+      event.type === "source:start" ||
+      event.type === "source:failed" ||
+      event.type === "source:success",
   );
+  // A measured stage is canonical on its own. Stage timings carry no attempt,
+  // server, or failure class, so keying "canonical" on those alone discarded
+  // them whenever any per-attempt event existed alongside.
   const canonicalSourceEvents = sourceEvents.filter(
     (event) =>
       typeof event.attempt === "number" ||
+      typeof event.durationMs === "number" ||
       event.attributes?.serverId !== undefined ||
       event.attributes?.failureClass !== undefined,
   );
@@ -57,6 +79,7 @@ export function summarizeProviderTraceEvent(
     failureClass: event.attributes?.failureClass,
     serverId: event.attributes?.serverId,
     stage: typeof event.attributes?.stage === "string" ? event.attributes.stage : undefined,
+    durationMs: event.durationMs,
     at: event.at,
   };
 }

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -1541,6 +1541,48 @@ test("summarizeProviderTraceEvents exports source attempt breadcrumbs", () => {
   ]);
 });
 
+test("summarizeProviderTraceEvents keeps measured stage durations alongside attempt events", () => {
+  // The real Miruro shape: stages report `durationMs` on the event that ends
+  // them, and a healthy stage ends on `source:success` carrying no attempt,
+  // server, or failure class. Both of those used to disqualify it.
+  const summary = summarizeProviderTraceEvents([
+    {
+      type: "source:success",
+      providerId: "miruro",
+      sourceId: "source:miruro:episodes",
+      at: "2026-08-24T00:00:01.000Z",
+      message: "Fetched Miruro episode catalog",
+      durationMs: 4841,
+      attributes: { providers: 7 },
+    },
+    {
+      type: "source:failed",
+      providerId: "miruro",
+      sourceId: "source:miruro:kiwi",
+      at: "2026-08-24T00:00:06.000Z",
+      attempt: 1,
+      message: "kiwi timed out",
+      attributes: { failureClass: "candidate-timeout" },
+    },
+    {
+      type: "source:success",
+      providerId: "miruro",
+      sourceId: "source:miruro:source-cycle",
+      at: "2026-08-24T00:00:07.000Z",
+      message: "Resolved a Miruro source",
+      durationMs: 5840,
+    },
+  ]);
+
+  expect(
+    summary.sourceAttempts.map((event) => [event.sourceId, event.durationMs] as const),
+  ).toEqual([
+    ["source:miruro:episodes", 4841],
+    ["source:miruro:kiwi", undefined],
+    ["source:miruro:source-cycle", 5840],
+  ]);
+});
+
 test("summarizeProviderTraceEvents prefers canonical cycle events over provider-local source notes", () => {
   const summary = summarizeProviderTraceEvents([
     {


### PR DESCRIPTION
Closes the "instrumentation with no reader" gap on PR #200's per-stage timings.

#200 added `durationMs` to Miruro's stage events. Nothing downstream could read it, so the instrumentation could not answer the question it was added for — attributing Miruro's latency still meant re-reading raw trace events by hand.

## Three independent drops, each sufficient on its own

1. **`summarizeProviderTraceEvent` never mapped it.** It carried `failureClass`, `serverId` and `stage` across from the event, but not `durationMs`. (It is a top-level field on `ProviderTraceEvent`, not an attribute.)
2. **The source-event filter excluded `source:success`.** Timed stages report their duration on the event that *ends* them — and a stage that ends well ends on success. Filtering to `source:start` / `source:failed` therefore dropped every healthy stage's timing, which is most of the latency on a successful resolve.
3. **The smoke payload only attached the summary on failure.** `providerSmokeError` was the sole path that called `summarizeProviderTraceEvents`, so a resolve that *worked* reported one total duration and nothing about where it went — exactly backwards, since the latency worth attributing lives in successful resolves.

A measured stage is now canonical in its own right. Stage timings carry no attempt, server, or failure class, so keying "canonical" on those alone discarded them whenever any per-attempt event existed alongside.

## Result — Miruro now attributes its own latency

```
total resolveDurationMs: 9017
  source:miruro:episodes        3139 ms
  source:miruro:source-cycle    5874 ms
  source:miruro:pipe:kiwi:sub        candidate-timeout
  source:miruro:pipe:pewe:sub        (success)
```

3139 + 5874 ≈ the full 9017 ms. The two stages plus the dead `kiwi` candidate inside the cycle now explain the whole resolve, from the payload alone — which means CI can finally regress-test the latency #200 was written to attribute.

## Scope

The fix is in `summarizeProviderTraceEvents`, so it reaches **every** consumer of a summarised trace — the live smokes and the diagnostics panel alike — rather than being patched into one smoke.

## Gates

typecheck 14/14, **5814 pass / 0 fail** (cache-forced), lint identical to the chain baseline (2 + 7 pre-existing warnings, none introduced). New unit test pins the real Miruro event shape so all three drops stay closed.
