### PR TITLE
test(live): probe stream reachability in the rivestream, allanime and youtube smokes

### DIFF
--- a/apps/cli/test/live/allanime-demonslayer.smoke.ts
+++ b/apps/cli/test/live/allanime-demonslayer.smoke.ts
@@ -1,4 +1,5 @@
 import { searchTitles } from "@/services/search/SearchRoutingService";
+import { isStreamReachableForResolve, probeStreamReachability } from "@kunai/providers";
 
 import {
   buildProviderSmokePayload,
@@ -123,6 +124,15 @@ const { stream, resolveDurationMs } = await resolveProviderSmokeStream({
     return { stream: null, resolveDurationMs: null };
   });
 
+const streamProbe = stream?.url
+  ? await probeStreamReachability({
+      url: stream.url,
+      headers: stream.headers,
+      timeoutMs: 5_000,
+    })
+  : null;
+const streamReachable = streamProbe ? isStreamReachableForResolve(streamProbe) : null;
+
 const payload = {
   ...buildProviderSmokePayload({
     provider: provider.metadata.id,
@@ -142,12 +152,18 @@ const payload = {
   failureCodes,
   failureMessages,
   streamCandidates,
+  streamProbe,
+  streamReachable,
   ...providerSmokeProfilePayload(profile),
   subtitleUrl: stream?.subtitle ?? null,
 };
 
 console.log(JSON.stringify(payload, null, 2));
 
-if (!stream?.url) {
+// A resolved URL that does not serve bytes is the false green this probe
+// exists to catch, so a *measured* failure fails the smoke. `null` means the
+// probe never ran (nothing resolved), which the line above already covers --
+// only `false` is evidence of an unplayable stream.
+if (!stream?.url || streamReachable === false) {
   process.exit(1);
 }

--- a/apps/cli/test/live/rivestream-breakingbad.smoke.ts
+++ b/apps/cli/test/live/rivestream-breakingbad.smoke.ts
@@ -1,4 +1,5 @@
 import type { TitleInfo } from "@/domain/types";
+import { isStreamReachableForResolve, probeStreamReachability } from "@kunai/providers";
 
 import {
   buildProviderSmokePayload,
@@ -60,6 +61,15 @@ const { stream, resolveDurationMs } = await resolveProviderSmokeStream({
     return { stream: null, resolveDurationMs: null };
   });
 
+const streamProbe = stream?.url
+  ? await probeStreamReachability({
+      url: stream.url,
+      headers: stream.headers,
+      timeoutMs: 5_000,
+    })
+  : null;
+const streamReachable = streamProbe ? isStreamReachableForResolve(streamProbe) : null;
+
 const payload = {
   ...buildProviderSmokePayload({
     provider: "rivestream",
@@ -73,12 +83,18 @@ const payload = {
   failureCodes,
   failureMessages,
   streamCandidates,
+  streamProbe,
+  streamReachable,
   ...providerSmokeProfilePayload(profile),
   cacheCleared: clearCache,
 };
 
 console.log(JSON.stringify(payload, null, 2));
 
-if (!stream?.url) {
+// A resolved URL that does not serve bytes is the false green this probe
+// exists to catch, so a *measured* failure fails the smoke. `null` means the
+// probe never ran (nothing resolved), which the line above already covers --
+// only `false` is evidence of an unplayable stream.
+if (!stream?.url || streamReachable === false) {
   process.exit(1);
 }

--- a/apps/cli/test/live/youtube.smoke.ts
+++ b/apps/cli/test/live/youtube.smoke.ts
@@ -1,4 +1,5 @@
 import type { TitleInfo } from "@/domain/types";
+import { isStreamReachableForResolve, probeStreamReachability } from "@kunai/providers";
 
 import {
   buildProviderSmokePayload,
@@ -72,6 +73,15 @@ const { stream, resolveDurationMs } = await resolveProviderSmokeStream({
     return { stream: null, resolveDurationMs: null };
   });
 
+const streamProbe = stream?.url
+  ? await probeStreamReachability({
+      url: stream.url,
+      headers: stream.headers,
+      timeoutMs: 5_000,
+    })
+  : null;
+const streamReachable = streamProbe ? isStreamReachableForResolve(streamProbe) : null;
+
 const payload = buildProviderSmokePayload({
   provider: "youtube",
   title,
@@ -84,12 +94,17 @@ console.log(
     ...payload,
     skipped: false,
     failureCodes,
+    streamProbe,
+    streamReachable,
     error: resolveError instanceof Error ? resolveError.message : undefined,
     ...providerSmokeProfilePayload(profile),
   }),
 );
 
-if (!payload.ok) {
+// A resolved URL that does not serve bytes is the false green this probe
+// exists to catch, so a *measured* failure fails the smoke. `null` means the
+// probe never ran, which `payload.ok` already covers.
+if (!payload.ok || streamReachable === false) {
   console.error(providerSmokeError(payload));
   process.exit(1);
 }


### PR DESCRIPTION
Stacked on #214.

Only `videasy` and `miruro` measured whether a resolved URL actually serves bytes. The other three asserted **resolution alone**, so a route that resolves a dead URL passed the release matrix — the exact false green VidLink proved is possible, where a well-formed URL is answered `429` by the CDN.

## What changed

`rivestream`, `allanime` and `youtube` now probe and report `streamProbe` / `streamReachable`, and a **measured** failure fails the smoke.

The guard is deliberately `streamReachable === false`, not `!streamReachable`:

- `false` → positive evidence the stream will not play → fail
- `null` → the probe never ran because nothing resolved → the existing resolution check already covers it, so it must not double-fail

## Verified live on the chain tip

| Smoke | streamResolved | probe | streamReachable |
| --- | --- | --- | --- |
| rivestream | true | `reachable` | **true** |
| youtube | true | `reachable` | **true** |
| allanime | false | — | **null** (captcha gate leaves no stream to probe; still fails on resolution, as before) |

## On the rivestream `not-found` noise — deliberately not "fixed"

The five codes on every successful run are **accurate**: `apex`, `pulse`, `solstice`, `quasar` and `horizon` genuinely return no sources, and `primevids` succeeds. Two reasons to leave them:

1. They cost no latency. `buildRivestreamCycleCandidates` documents that *"every candidate is prefetched in parallel regardless"* — the whole resolve is 1060 ms, the fastest of any provider.
2. They are real signal about which Rivestream mirrors are alive. Suppressing them to quieten the payload would trade a true diagnostic for a cosmetic one.

The reachability guard above is what actually closes the "a real fault could hide in here" concern, since the smoke now fails on evidence rather than on resolution.

## Gates

typecheck 14/14, **5814 pass / 0 fail** (cache-forced), lint identical to the chain baseline (2 + 7 pre-existing, none introduced).
