### PR TITLE
feat(docs): serve the installer from kunai.kitsunekode.in

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Self-contained binary — no Bun or Node needed (mpv is still required for playb
 **Linux / macOS**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash
+curl -fsSL https://kunai.kitsunekode.in/install.sh | bash
 ```
 
 **Windows (PowerShell)**
 
 ```powershell
-irm https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.ps1 | iex
+irm https://kunai.kitsunekode.in/install.ps1 | iex
 ```
 
 Then:
@@ -101,12 +101,12 @@ by OS** (`install.sh` vs `install.ps1`).
 
 ```bash
 # Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash
+curl -fsSL https://kunai.kitsunekode.in/install.sh | bash
 ```
 
 ```powershell
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.ps1 | iex
+irm https://kunai.kitsunekode.in/install.ps1 | iex
 ```
 
 > **Unsigned beta binaries** — Windows SmartScreen may warn on first run;
@@ -119,8 +119,8 @@ irm https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.ps1 | iex
 Inspect first (no dirs created), pin a version, or pick a channel:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash -s -- --dry-run
-curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash -s -- --version 0.3.0
+curl -fsSL https://kunai.kitsunekode.in/install.sh | bash -s -- --dry-run
+curl -fsSL https://kunai.kitsunekode.in/install.sh | bash -s -- --version 0.3.0
 ```
 
 Keep it current with `kunai upgrade`; remove it with ownership-aware `kunai uninstall`
@@ -218,7 +218,7 @@ winget install yt-dlp Gyan.FFmpeg
 
 ```bash
 apk add mpv yt-dlp ffmpeg
-curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash
+curl -fsSL https://kunai.kitsunekode.in/install.sh | bash
 kunai --version
 kunai --setup
 ```
@@ -234,7 +234,7 @@ Do not mix Windows-native `kunai.exe` / `mpv.exe` / `%APPDATA%` with WSL PATH or
 ```bash
 # Inside WSL (Debian/Ubuntu example)
 sudo apt install mpv yt-dlp ffmpeg
-curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash
+curl -fsSL https://kunai.kitsunekode.in/install.sh | bash
 kunai --version
 kunai --setup
 ```

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -96,7 +96,7 @@ Alpine:
 
 ```bash
 apk add mpv yt-dlp ffmpeg
-curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash
+curl -fsSL https://kunai.kitsunekode.in/install.sh | bash
 kunai --version
 kunai --setup
 ```

--- a/apps/cli/src/app/bootstrap/share-ref-from-context.ts
+++ b/apps/cli/src/app/bootstrap/share-ref-from-context.ts
@@ -18,8 +18,7 @@ export type KunaiHandoffLaunch = {
 };
 
 export const KUNAI_INSTALL_URL = "https://github.com/KitsuneKode/kunai#install";
-export const KUNAI_INSTALL_SCRIPT_URL =
-  "https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh";
+export const KUNAI_INSTALL_SCRIPT_URL = "https://kunai.kitsunekode.in/install.sh";
 
 export function parseKunaiHandoffUrl(value: string): KunaiHandoffLaunch | null {
   const parsed = parseKunaiShareUrl(value);

--- a/apps/cli/test/integration/helpers/readme-command-harness.ts
+++ b/apps/cli/test/integration/helpers/readme-command-harness.ts
@@ -60,8 +60,7 @@ export const README_QUICK_START_IDS = [
 
 export type ReadmeQuickStartId = (typeof README_QUICK_START_IDS)[number];
 
-const CANONICAL_INSTALL =
-  "curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash";
+const CANONICAL_INSTALL = "curl -fsSL https://kunai.kitsunekode.in/install.sh | bash";
 
 /**
  * Extract the canonical Quick Start journey from README markdown.
@@ -222,8 +221,13 @@ exit 0
 }
 
 /**
- * curl shim: rewrite raw.githubusercontent.com kunai install.sh URLs to the
- * local fixture HTTP server. All other URLs pass through to real curl.
+ * curl shim: rewrite the published install.sh URL to the local fixture HTTP
+ * server. All other URLs pass through to real curl.
+ *
+ * Both forms are matched. `kunai.kitsunekode.in/install.sh` is what the README
+ * documents; it redirects to the raw GitHub URL, which is still what an older
+ * quoted command uses -- and a shim that only knew the new one would let a
+ * stale command reach the network instead of the fixture.
  */
 export function installCurlShim(shimDir: string, fixtureBaseUrl: string): void {
   const realCurl = Bun.which("curl");
@@ -240,7 +244,7 @@ REAL_CURL=${JSON.stringify(realCurl)}
 FIXTURE=${JSON.stringify(fixtureBaseUrl.replace(/\/$/, ""))}
 for arg do
   case "$arg" in
-    https://raw.githubusercontent.com/KitsuneKode/kunai/*/install.sh)
+    https://kunai.kitsunekode.in/install.sh|https://raw.githubusercontent.com/KitsuneKode/kunai/*/install.sh)
       arg="$FIXTURE/install.sh"
       ;;
   esac

--- a/apps/cli/test/integration/readme-commands.test.ts
+++ b/apps/cli/test/integration/readme-commands.test.ts
@@ -9,7 +9,7 @@ const README_PATH = join(REPO_ROOT, "README.md");
 
 /** Canonical Quick Start journey — installer followed by Verify commands. */
 const EXPECTED_QUICK_START = [
-  "curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash",
+  "curl -fsSL https://kunai.kitsunekode.in/install.sh | bash",
   "kunai --version",
   "mpv --version",
   "kunai --setup",

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "d0bb55845c6b6efcd21c817de8f80fe72d683bc2d1bbba72f5bcaf678936ac64",
-  "docsContentFingerprint": "83329f5e42767962e2d987fdd1de02b25a13a14fa61e4df87d918367580dda00",
+  "docsContentFingerprint": "b2a5aab65a45b99e0cbbe04aa23ee5e81822379f460fc9f56792f6f520c3965f",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 81,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/apps/docs/lib/install-commands.ts
+++ b/apps/docs/lib/install-commands.ts
@@ -5,10 +5,9 @@
  * Source checkout is contributor-oriented.
  */
 export const NATIVE_INSTALL_SH =
-  "curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash" as const;
+  "curl -fsSL https://kunai.kitsunekode.in/install.sh | bash" as const;
 
-export const NATIVE_INSTALL_PS1 =
-  "irm https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.ps1 | iex" as const;
+export const NATIVE_INSTALL_PS1 = "irm https://kunai.kitsunekode.in/install.ps1 | iex" as const;
 
 export const NPM_PACKAGE_NAME = "@kitsunekode/kunai" as const;
 export const NPM_PACKAGE_URL = `https://www.npmjs.com/package/${NPM_PACKAGE_NAME}` as const;

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -33,6 +33,29 @@ const config = {
       // `/telemetry` was the old name for this page. In Kunai, "telemetry" means
       // local mpv playback state; the opt-in phone-home is "analytics".
       { source: "/telemetry", destination: "/analytics", permanent: true },
+
+      // Branded install entry points. These are what the README, the docs and
+      // anyone quoting them will use, so they have to keep working long after
+      // this deploy -- which is exactly why they redirect instead of serving a
+      // copy. A copy would need its own freshness gate and could silently drift
+      // from the script the repo actually ships; a redirect always resolves to
+      // the current `main`, and there is no second source of truth to keep in
+      // sync.
+      //
+      // Temporary, not permanent: a 301 is cached indefinitely by browsers and
+      // proxies, so moving these later (to a CDN, or to a release-pinned path)
+      // would strand every client that had already cached the old target.
+      // `curl -fsSL` and PowerShell `irm` both follow redirects by default.
+      {
+        source: "/install.sh",
+        destination: "https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh",
+        permanent: false,
+      },
+      {
+        source: "/install.ps1",
+        destination: "https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.ps1",
+        permanent: false,
+      },
     ];
   },
 };

--- a/docs/users/getting-started.mdx
+++ b/docs/users/getting-started.mdx
@@ -16,7 +16,7 @@ Kunai is a terminal-first media shell. You search for a title, pick what to watc
 Preferred Linux/macOS bootstrap (same command the steps above use):
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash
+curl -fsSL https://kunai.kitsunekode.in/install.sh | bash
 kunai --version
 mpv --version
 kunai --setup

--- a/docs/users/install-and-update.mdx
+++ b/docs/users/install-and-update.mdx
@@ -15,7 +15,7 @@ Kunai supports **zero-prerequisite compiled binaries** (default), global package
 Default — downloads a verified release binary into a versioned store and links `~/.local/bin/kunai`:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash
+curl -fsSL https://kunai.kitsunekode.in/install.sh | bash
 ```
 
 Or from an existing Kunai binary:
@@ -36,7 +36,7 @@ On-disk layout (binary channel):
 Dry run first when you want to inspect actions without creating directories or downloading:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash -s -- --dry-run
+curl -fsSL https://kunai.kitsunekode.in/install.sh | bash -s -- --dry-run
 ```
 
 If a release asset is missing or empty, the installer prints recovery options (`--method npm`, `--method bun`, `--method source`, or pin `--version X.Y.Z`).
@@ -52,7 +52,7 @@ Supported binary targets: `linux-x64`, `linux-arm64`, `linux-x64-musl`, `linux-a
 <Tab value="Windows">
 
 ```powershell
-irm https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.ps1 | iex
+irm https://kunai.kitsunekode.in/install.ps1 | iex
 ```
 
 Installs to `%LOCALAPPDATA%\kunai\bin\kunai.exe`, prepends that directory to your **User** PATH so the native binary wins over an older npm/Bun shim, and records the install channel in `%APPDATA%\kunai\install.json`.
@@ -220,7 +220,7 @@ You can snooze automatic checks for seven days or disable them from the update p
 
 ```sh
 apk add mpv yt-dlp ffmpeg
-curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash
+curl -fsSL https://kunai.kitsunekode.in/install.sh | bash
 kunai --version
 kunai --setup
 ```

--- a/docs/users/platforms.mdx
+++ b/docs/users/platforms.mdx
@@ -33,7 +33,7 @@ Missing `yt-dlp` or `ffprobe` should degrade gracefully — setup and diagnostic
 Recommended install (self-contained binary — Bun runtime embedded; you do not need Bun installed):
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash
+curl -fsSL https://kunai.kitsunekode.in/install.sh | bash
 kunai --version
 mpv --version
 kunai --setup
@@ -64,7 +64,7 @@ Alpine and other musl hosts use the `kunai-linux-*-musl` release assets. `instal
 
 ```sh
 apk add mpv yt-dlp ffmpeg
-curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash
+curl -fsSL https://kunai.kitsunekode.in/install.sh | bash
 kunai --version
 kunai --setup
 ```
@@ -77,7 +77,7 @@ Ensure `~/.local/bin` is on your shell `PATH` after install. Treat this as a nor
 Recommended install (beta binaries):
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash
+curl -fsSL https://kunai.kitsunekode.in/install.sh | bash
 kunai --setup
 ```
 
@@ -102,7 +102,7 @@ Kunai uses `open` for browser and folder handoffs. Protocol registration is Linu
 Recommended install (PowerShell; x64 beta, ARM64 experimental):
 
 ```powershell
-irm https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.ps1 | iex
+irm https://kunai.kitsunekode.in/install.ps1 | iex
 kunai --setup
 ```
 
@@ -126,7 +126,7 @@ WSL is a **Linux** environment. Install the Linux binary and Linux tools inside 
 ```sh
 # Inside WSL (Ubuntu/Debian example)
 sudo apt install mpv yt-dlp ffmpeg
-curl -fsSL https://raw.githubusercontent.com/KitsuneKode/kunai/main/install.sh | bash
+curl -fsSL https://kunai.kitsunekode.in/install.sh | bash
 kunai --version
 kunai --setup
 ```


### PR DESCRIPTION
```sh
curl -fsSL https://kunai.kitsunekode.in/install.sh | bash     # was raw.githubusercontent.com/…
irm https://kunai.kitsunekode.in/install.ps1 | iex
```

The documented install command pointed at `raw.githubusercontent.com`, so the first thing anyone saw of Kunai was a URL that names GitHub rather than the project — and one that cannot move without breaking every copy people have quoted in a blog post, a Dockerfile, or a CI script.

## Redirect, not a served copy

`/install.sh` and `/install.ps1` redirect from the docs domain to the script in `main`.

A **served copy** would be a second source of truth that can silently drift from the script the repo actually ships, and would need its own freshness gate to stay honest — the same class of problem #158 just fixed for generated docs. A **redirect** always resolves to the current script and has nothing to keep in sync.

This is also how the reference implementation works — `claude.ai/install.sh` answers `302` to `downloads.claude.ai/…/bootstrap.sh`. Verified directly rather than assumed.

`curl -fsSL` (the `-L`) and PowerShell `irm` both follow redirects by default.

## Temporary, not permanent

`permanent: false`. A 301 is cached indefinitely by browsers and proxies, so moving these later — to a CDN, or to a release-pinned path — would strand every client that had already cached the old target. The cost of a 302 is one extra hop on a command run once per machine.

## Test harness matches both forms

The README curl shim now matches the published URL **and** the raw GitHub one. The published URL is what the README documents; the GitHub one is still what an older quoted command uses, and a shim that only knew the new form would let a stale command reach the real network instead of the fixture.

## Scope

Canonical constants in `apps/docs/lib/install-commands.ts`, the CLI's own `share-ref-from-context.ts`, both READMEs, and the three user docs pages. `.archive/` is deliberately untouched — it is history and carries no authority.

## Gates

typecheck 14/14 · lint 0 warnings · **5904 pass / 0 fail** cache-forced · `verify:doc-paths` 48 docs / 1990 source files · `verify:readme:commands`.

## Note

The redirect only goes live once this deploys to the docs site, so the README should land together with a successful docs deploy rather than ahead of it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Linux, macOS, Windows, Alpine, and WSL installation instructions to use the official installer endpoints.
  - Updated quick-start, version-pinned, and dry-run examples with the latest installation URLs.
  - Refreshed CLI installation guidance to use the official Alpine installer address.

- **New Features**
  - Added convenient hosted routes for shell and PowerShell installers, while preserving compatibility with existing installation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->