### PR TITLE
chore(build): raise the development bundle ratchet for the native train

### DIFF
--- a/apps/cli/scripts/build-shared.ts
+++ b/apps/cli/scripts/build-shared.ts
@@ -246,8 +246,35 @@ export function totalMetafileInputBytes(metafile: BunBuildMetafile): number {
  * development bundle is 2,953,713 bytes, 36,367 below main's existing 2_920
  * KiB cap. Discord containment therefore does not raise the final ratchet.
  * This budget still applies only to the unpublished development bundle.
+ *
+ * Raised from 2_920 on 2026-08-25 for the native release train. `main` measured
+ * 2,988,548 bytes against the 2,990,080-byte cap -- 1.5 KiB of headroom, so the
+ * next change of any size was going to trip it regardless of what that change
+ * was.
+ *
+ * The whole remaining train was measured rather than the one PR that failed:
+ * building its tip (#183, containing #184, #204, #182 and #183) against its
+ * base gives 2,983,756 vs 2,967,004 bytes -- 16,752 bytes, 16.4 KiB. Nearly all
+ * of it is #184 alone (16,747 bytes measured separately); #204, #182 and #183
+ * are installer scripts, release workflows and attestation, which never enter
+ * the CLI graph. The 16.4 KiB is ordinary feature code: archive-aware rollback,
+ * version metadata, and the install/uninstall/upgrade paths that consume
+ * verified archives.
+ *
+ * 2_976 leaves ~41 KiB after the train lands, which restores real headroom
+ * rather than clearing one change. The security/reliability PRs still queued
+ * behind it are small bounded fixes and will be measured on their own terms if
+ * they ever approach this number again.
+ *
+ * Worth restating because it is what makes this safe: this number guards
+ * `dist/kunai.js`, which is published nowhere and is not the source of the
+ * compiled binaries either -- `compileBinaryBuildOptions` compiles from
+ * `src/main.ts`. What a user installs from npm is the ~9 KiB launcher, held by
+ * NPM_PACK_PACKED_BUDGET_BYTES / NPM_PACK_UNPACKED_BUDGET_BYTES, which this
+ * change does not touch and which the exact-tarball verification added in #166
+ * has since made stricter.
  */
-export const NPM_BUNDLE_BUDGET_KB = 2_920;
+export const NPM_BUNDLE_BUDGET_KB = 2_976;
 
 /** Packed-size ratchet for the public Node launcher manifest, script, and license. */
 export const NPM_PACK_PACKED_BUDGET_BYTES = 32 * 1024;

--- a/apps/cli/test/unit/scripts/build-shared.test.ts
+++ b/apps/cli/test/unit/scripts/build-shared.test.ts
@@ -127,8 +127,11 @@ describe("release build shared options", () => {
   });
 
   test("enforces npm bundle budget", () => {
-    expect(NPM_BUNDLE_BUDGET_KB).toBe(2_920);
-    expect(() => assertNpmBundleBudget(2_990_080)).not.toThrow();
-    expect(() => assertNpmBundleBudget(2_990_081)).toThrow("budget 2920 KiB");
+    // Pinned on purpose: raising the ratchet has to be a deliberate edit with a
+    // documented measurement in build-shared.ts, not a number that drifts up
+    // whenever a bundle grows.
+    expect(NPM_BUNDLE_BUDGET_KB).toBe(2_976);
+    expect(() => assertNpmBundleBudget(3_047_424)).not.toThrow();
+    expect(() => assertNpmBundleBudget(3_047_425)).toThrow("budget 2976 KiB");
   });
 });


### PR DESCRIPTION
`bun run build` fails on #184. Not because #184 is heavy — because `main` had **1.5 KiB** of headroom.

```
main:    2,988,548 bytes  (2918.5 KiB)   ← 1.5 KiB under the cap
budget:  2,990,080 bytes  (2920.0 KiB)
```

The next change of any size was going to trip this regardless of what that change was.

## Measured the whole train, not the one PR that failed

Building the old train tip (#183, which contains #184 + #204 + #182 + #183) against its base:

```
base (#180 tip): 2,967,004 bytes
tip  (#183):     2,983,756 bytes
train adds:         16,752 bytes  (16.4 KiB)
```

Nearly all of it is **#184 alone** — 16,747 bytes measured separately. #204, #182 and #183 are installer scripts, release workflows and attestation, which never enter the CLI graph.

The 16.4 KiB is ordinary feature code: archive-aware rollback, version metadata, and the install/uninstall/upgrade paths that consume verified archives.

## Why 2_976

Leaves **~41 KiB** after the train lands — real headroom, not a number that clears one change. Same standard the `2_800 → 2_880` and `2_880 → 2_920` steps were held to, and documented the same way in the source comment with the measurements above.

## Why this is safe rather than a rubber stamp

**This number guards a development artifact.** `dist/kunai.js` is published nowhere, and it is not the source of the compiled binaries either — `compileBinaryBuildOptions` compiles from `src/main.ts`.

What a user installs from npm is the **~9 KiB launcher**:

```
dist/npm/dist/npm-launcher.mjs (public launcher)   6.7 KiB
dist/npm public files total                        9.0 KiB
```

held by `NPM_PACK_PACKED_BUDGET_BYTES` (32 KiB) / `NPM_PACK_UNPACKED_BUDGET_BYTES` — untouched here, and made **stricter** by #166's exact-tarball byte verification.

## Also checked while here

- Build is minified by default and defines `NODE_ENV=production` — the graph pulls `react-reconciler.production.js`, not the dev build.
- `RELEASE_FORBIDDEN_INPUT_MARKERS` blocks `/test/`, `.test.`, `.spec.` from ever entering a release graph.
- The remaining weight is structural: ~516 KiB is Ink's renderer + yoga-layout wasm, unavoidable for a TUI.

## Pinned test moves deliberately

`build-shared.test.ts` pins the exact value and both boundaries. That is the point — raising the ratchet must be an explicit edit with a documented measurement, not a number that drifts up whenever a bundle grows.

## Gates

typecheck 14/14 · lint 0 warnings · **6009 pass / 0 fail** cache-forced (build task now runs again: 23/23 tasks vs 20/22 while blocked).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the allowed development bundle size to 2,976 KiB.
  * Clarified bundle-size documentation, including release measurements and scope.

* **Tests**
  * Updated bundle-size validation to reflect the new limit and corresponding error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->