### PR TITLE
fix(providers): discover curl-impersonate from PATH instead of a frozen list

### DIFF
--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -983,10 +983,13 @@ Miruro resolves entirely through `GET /api/secure/pipe?e=…` on `www.miruro.bz`
   envelope (`?e=base64url({path,method,query,body,version})`, e.g.
   `{"path":"episodes","query":{"anilistId":"21"},"version":"0.2.0"}`) answers
   200 with `x-obfuscated: 2` while plain curl gets CF HTML — intermittent by
-  network. The curl fallback now reuses the AniDB curl-impersonate candidate
-  list (`shared/curl-impersonate.ts`): with `curl_chrome136`/`curl_firefox135`
-  installed, the pipe request carries a browser TLS fingerprint and clears the
-  gate. Without an impersonate build, a WAF 403 is expected behavior, not a bug.
+  network. The curl fallback reuses the shared AniDB resolver
+  (`shared/curl-impersonate.ts`), which **discovers** impersonate wrappers from
+  `PATH` rather than matching a hardcoded list — newest desktop build wins,
+  ranked family-first (chrome → firefox → safari → edge), with mobile and tor
+  builds excluded. With any current build installed the pipe request carries a
+  browser TLS fingerprint and clears the gate. Without an impersonate build, a
+  WAF 403 is expected behavior, not a bug.
 - **Per-server failures are not provider failures.** Miruro's site marks single
   servers under maintenance ("Some servers are under maintenance. Please switch
   servers if needed.") while others keep working. Kunai mirrors that: after the

--- a/.docs/quickstart.md
+++ b/.docs/quickstart.md
@@ -21,10 +21,18 @@ Use this doc for setup, local execution, and common environment issues. Architec
 - `ffprobe` optional—used only for quick validation of finished files, not downloading
 - `curl` for anime mode: AniDB is the default anime provider and sits behind
   Cloudflare, which frequently blocks Bun's own fetch. Without a `curl` on
-  `PATH`, anime search can come back empty. A curl-impersonate build
-  (`curl_chrome136`, `curl_firefox135`, …) is preferred where available, since it
-  matches a browser TLS handshake; plain `curl` is used otherwise. `kunai doctor`
-  reports this as `curl=ok` / `curl=missing`.
+  `PATH`, anime search can come back empty — and **plain curl is often not
+  enough**, because Cloudflare fingerprints the TLS handshake, not just the
+  User-Agent. Kunai discovers curl-impersonate wrappers from `PATH`
+  (`curl_<browser><version>`, e.g. `curl_chrome150`) and picks the newest desktop
+  build automatically; plain `curl` is the fallback. `kunai doctor` distinguishes
+  the three states: `curl=ok (chrome150)`, `curl=plain (no CF bypass)`, and
+  `curl=missing`.
+
+  Install curl-impersonate with `brew install lexiforest/tap/curl-impersonate`
+  (macOS) or `sudo pacman -S curl-impersonate` (Arch). There is no Debian,
+  Fedora, or Windows package — use the prebuilt binaries at
+  <https://github.com/lexiforest/curl-impersonate/releases>.
 
 Deeper reference for terminal graphics, env overrides, and testing: [.docs/poster-image-rendering.md](poster-image-rendering.md).
 

--- a/apps/cli/src/app-shell/setup-shell.tsx
+++ b/apps/cli/src/app-shell/setup-shell.tsx
@@ -255,12 +255,20 @@ function SystemSlide({
       install: "Install ffprobe from your platform media-tools package when needed",
     },
     {
-      name: "curl",
-      status: snapshot.curl ? "ok" : "optional-missing",
-      detail: snapshot.curl
-        ? "Anime search ready"
-        : "Needed by AniDB, the default anime provider — anime search may return nothing",
-      install: "brew install curl  ·  pacman -S curl  ·  apt install curl",
+      // Three states, not two. Plain curl exists nearly everywhere, so folding
+      // it in with an impersonate build showed a green tick on a machine whose
+      // anime search would come back empty — the failure this row exists to
+      // warn about. `snapshot.curl` is an object now: never test it for
+      // truthiness, which is always true and silently reports "ok".
+      name: "curl-impersonate",
+      status: snapshot.curl.impersonates ? "ok" : "optional-missing",
+      detail: snapshot.curl.impersonates
+        ? `Anime search ready — matching ${snapshot.curl.profile}`
+        : snapshot.curl.present
+          ? "Only plain curl — Cloudflare may still block AniDB and Miruro"
+          : "No curl at all — AniDB, the default anime provider, needs one",
+      install:
+        "brew install lexiforest/tap/curl-impersonate  ·  pacman -S curl-impersonate  ·  else: github.com/lexiforest/curl-impersonate/releases",
     },
     {
       name: "posters",

--- a/apps/cli/src/services/update/native-installer/doctor.ts
+++ b/apps/cli/src/services/update/native-installer/doctor.ts
@@ -4,7 +4,7 @@ import { dirname as nodeDirname, win32 } from "node:path";
 
 const { W_OK } = fsConstants;
 
-import type { CapabilitySnapshot } from "@/ui";
+import type { CapabilitySnapshot, CurlCapability } from "@/ui";
 
 import {
   inspectInstallManifest,
@@ -594,6 +594,16 @@ export async function buildDoctorReport(input: BuildDoctorReportInput = {}): Pro
 }
 
 /** Human-readable doctor output covering the same fields as the JSON report. */
+/**
+ * `ok` is reserved for a curl that can actually clear a Cloudflare challenge.
+ * Plain curl reports `plain` rather than `ok`, because reporting it as healthy
+ * is what let an empty AniDB search look like a working install.
+ */
+function describeCurl(curl: CurlCapability): string {
+  if (!curl.present) return "missing";
+  return curl.impersonates ? `ok (${curl.profile ?? "impersonate"})` : "plain (no CF bypass)";
+}
+
 export function formatDoctorReportText(report: DoctorReport): string {
   const lines: string[] = [];
   lines.push("Kunai doctor");
@@ -684,7 +694,10 @@ export function formatDoctorReportText(report: DoctorReport): string {
   lines.push("");
   lines.push("Dependencies");
   lines.push(
-    `  mpv=${report.dependencies.mpv ? "ok" : "missing"} yt-dlp=${report.dependencies.ytDlp ? "ok" : "missing"} ffprobe=${report.dependencies.ffprobe ? "ok" : "missing"} curl=${report.dependencies.curl ? "ok" : "missing"}`,
+    // curl reports what it can actually do, not merely that it exists: plain
+    // curl is present nearly everywhere and still gets challenged by Cloudflare,
+    // so `curl=ok` on its own was a misleading line in a health report.
+    `  mpv=${report.dependencies.mpv ? "ok" : "missing"} yt-dlp=${report.dependencies.ytDlp ? "ok" : "missing"} ffprobe=${report.dependencies.ffprobe ? "ok" : "missing"} curl=${describeCurl(report.dependencies.curl)}`,
   );
   lines.push("");
   lines.push("Storage");

--- a/apps/cli/src/ui.ts
+++ b/apps/cli/src/ui.ts
@@ -11,10 +11,33 @@ import { getKunaiPaths } from "@kunai/storage";
 export type CapabilitySeverity = "fatal" | "degraded";
 
 export interface CapabilityIssue {
-  readonly id: "mpv-missing" | "yt-dlp-missing" | "curl-missing" | "poster-rendering-unavailable";
+  readonly id:
+    | "mpv-missing"
+    | "yt-dlp-missing"
+    | "curl-missing"
+    | "curl-impersonate-missing"
+    | "poster-rendering-unavailable";
   readonly severity: CapabilitySeverity;
   readonly message: string;
   readonly remediation: readonly string[];
+}
+
+/**
+ * What kind of curl AniDB and Miruro can actually drive.
+ *
+ * A boolean was not enough and the gap was user-visible: plain curl is present
+ * on nearly every machine, so `curl: true` reported "anime search ready" while
+ * Cloudflare challenged every request and search came back empty with no
+ * diagnostic anywhere. Presence and capability are different facts; both are
+ * carried.
+ */
+export interface CurlCapability {
+  /** Any usable curl — plain or an impersonate build. */
+  readonly present: boolean;
+  /** True only when a curl-impersonate build was selected. */
+  readonly impersonates: boolean;
+  /** Selected browser profile (`chrome150`), or `null` for plain curl / none. */
+  readonly profile: string | null;
 }
 
 export interface CapabilitySnapshot {
@@ -23,11 +46,11 @@ export interface CapabilitySnapshot {
   readonly ffprobe: boolean;
   readonly ytDlp: boolean;
   /**
-   * A curl the AniDB provider can use — plain `curl` or a curl-impersonate
-   * build. AniDB is the default anime provider and anidb.app sits behind
-   * Cloudflare, so this is a real dependency of the default route, not a nicety.
+   * The curl the AniDB provider can use. AniDB is the default anime provider and
+   * anidb.app sits behind Cloudflare, so this is a real dependency of the
+   * default route, not a nicety — and plain curl frequently is not enough.
    */
-  readonly curl: boolean;
+  readonly curl: CurlCapability;
   readonly image: ImageCapability;
   readonly issues: readonly CapabilityIssue[];
 }
@@ -45,7 +68,8 @@ function capabilityFingerprint(snapshot: CapabilitySnapshot): string {
     .map((issue) => `${issue.id}:${issue.severity}`)
     .sort()
     .join(",");
-  return `mpv:${snapshot.mpv ? "1" : "0"}|ffprobe:${snapshot.ffprobe ? "1" : "0"}|ytDlp:${snapshot.ytDlp ? "1" : "0"}|curl:${snapshot.curl ? "1" : "0"}|image:${snapshot.image.renderer}|terminal:${snapshot.image.terminal}|issues:${issueBits}`;
+  const curlBits = `${snapshot.curl.present ? "1" : "0"}:${snapshot.curl.profile ?? "plain"}`;
+  return `mpv:${snapshot.mpv ? "1" : "0"}|ffprobe:${snapshot.ffprobe ? "1" : "0"}|ytDlp:${snapshot.ytDlp ? "1" : "0"}|curl:${curlBits}|image:${snapshot.image.renderer}|terminal:${snapshot.image.terminal}|issues:${issueBits}`;
 }
 
 async function loadCapabilityNoticeState(): Promise<CapabilityNoticeState | null> {
@@ -68,6 +92,19 @@ async function saveCapabilityNoticeState(state: CapabilityNoticeState): Promise<
 }
 
 /**
+ * Verified against upstream on 2026-08-25. curl-impersonate has **no** package
+ * on Windows, Debian, or Fedora — only Homebrew (a tap, not core) and Arch — so
+ * everywhere else has to be the releases page. A plausible-looking
+ * `apt install curl-impersonate` would be a command that does not exist, which
+ * is worse than no hint at all.
+ */
+const CURL_IMPERSONATE_REMEDIATION = [
+  "macOS:  brew install lexiforest/tap/curl-impersonate",
+  "Arch:   sudo pacman -S curl-impersonate",
+  "Other:  prebuilt binaries at https://github.com/lexiforest/curl-impersonate/releases",
+] as const;
+
+/**
  * Read-only dependency/capability probe. Never persists notice state.
  * Prefer this for doctor and other inspection-only callers.
  */
@@ -76,6 +113,8 @@ export async function probeCapabilities(
     requireYtDlp?: boolean;
     /** PATH lookup seam; defaults to the real one. Injected by tests. */
     which?: (command: string) => string | null;
+    /** PATH listing seam for curl-impersonate discovery. Injected by tests. */
+    listPathEntries?: () => readonly string[];
   } = {},
 ): Promise<CapabilitySnapshot> {
   const requireYtDlp = options.requireYtDlp ?? false;
@@ -84,10 +123,19 @@ export async function probeCapabilities(
   const mpv = Boolean(which("mpv"));
   const ffprobe = Boolean(which("ffprobe"));
   const ytDlp = Boolean(which("yt-dlp"));
-  // Ask the provider which binaries it can actually drive: it prefers a
-  // curl-impersonate build over plain curl, so probing for the literal "curl"
-  // would report missing on a host that is fully capable.
-  const curl = resolveAnidbCurl(which) !== null;
+  // Ask the provider which binary it would actually drive rather than probing
+  // for the literal "curl": it discovers curl-impersonate builds from PATH and
+  // prefers them, so a literal probe both under-reports a capable host and
+  // over-reports one carrying only plain curl.
+  const resolvedCurl = resolveAnidbCurl({
+    which,
+    ...(options.listPathEntries ? { listPathEntries: options.listPathEntries } : {}),
+  });
+  const curl: CurlCapability = {
+    present: resolvedCurl !== null,
+    impersonates: resolvedCurl?.impersonates ?? false,
+    profile: resolvedCurl?.profile ?? null,
+  };
   const image = detectImageCapability();
 
   if (!mpv) {
@@ -123,7 +171,7 @@ export async function probeCapabilities(
     });
   }
 
-  if (!curl) {
+  if (!curl.present) {
     issues.push({
       id: "curl-missing",
       // Anime is one mode, so this degrades that route rather than blocking the
@@ -138,8 +186,20 @@ export async function probeCapabilities(
         "Fedora: sudo dnf install curl",
         "macOS:  brew install curl",
         "Windows: curl.exe ships with Windows 10 1803+",
-        "Best:   install a curl-impersonate build to match a browser TLS handshake",
+        ...CURL_IMPERSONATE_REMEDIATION,
       ],
+    });
+  } else if (!curl.impersonates) {
+    issues.push({
+      id: "curl-impersonate-missing",
+      // Plain curl is present, so this is not "missing a dependency" — it is a
+      // capability gap that only shows up as empty anime search results. It was
+      // previously invisible: `curl: true` reported ready and the user had no
+      // way to learn why AniDB returned nothing.
+      severity: "degraded",
+      message:
+        "Only plain curl found — Cloudflare fingerprints the TLS handshake, so AniDB and Miruro may still be challenged. A curl-impersonate build matches a real browser.",
+      remediation: [...CURL_IMPERSONATE_REMEDIATION],
     });
   }
 

--- a/apps/cli/test/unit/app-shell/setup-without-mpv.useinput.test.tsx
+++ b/apps/cli/test/unit/app-shell/setup-without-mpv.useinput.test.tsx
@@ -10,7 +10,7 @@ const MISSING_MPV: CapabilitySnapshot = {
   mpv: false,
   ffprobe: false,
   ytDlp: true,
-  curl: true,
+  curl: { present: true, impersonates: true, profile: "chrome150" },
   image: {
     terminal: "unknown",
     protocol: "none",

--- a/apps/cli/test/unit/capability-curl.test.ts
+++ b/apps/cli/test/unit/capability-curl.test.ts
@@ -3,36 +3,63 @@ import { describe, expect, test } from "bun:test";
 import { __testing, probeCapabilities } from "@/ui";
 
 /**
- * A PATH stub: every listed command resolves, everything else is absent.
+ * A synthetic PATH: the listed commands are the only executables that exist.
  *
- * The real probe reads the host's PATH, so without this seam these assertions
- * would depend on whatever the developer happens to have installed.
+ * Both seams are injected together on purpose. `which` alone is no longer
+ * enough now that curl-impersonate builds are *discovered* by listing PATH
+ * rather than looked up by name — leaving `listPathEntries` to its default
+ * would let whatever the developer happens to have installed decide the result,
+ * which is exactly the non-determinism this stub exists to prevent.
  */
 function pathWith(...commands: readonly string[]) {
-  return (command: string) => (commands.includes(command) ? `/usr/bin/${command}` : null);
+  return {
+    which: (command: string) => (commands.includes(command) ? `/usr/bin/${command}` : null),
+    listPathEntries: () => commands,
+  };
 }
 
 describe("probeCapabilities — curl for the default anime provider", () => {
-  test("reports curl present when plain curl is on PATH", async () => {
-    const snapshot = await probeCapabilities({ which: pathWith("curl") });
+  test("reports plain curl as present but not impersonating", async () => {
+    const snapshot = await probeCapabilities(pathWith("curl"));
 
-    expect(snapshot.curl).toBe(true);
+    expect(snapshot.curl.present).toBe(true);
+    expect(snapshot.curl.impersonates).toBe(false);
+    expect(snapshot.curl.profile).toBeNull();
     expect(snapshot.issues.map((issue) => issue.id)).not.toContain("curl-missing");
   });
 
-  test("reports curl present when only a curl-impersonate build is on PATH", async () => {
-    // AniDB prefers an impersonate build over plain curl, so probing for the
-    // literal "curl" would report missing on a host that is fully capable.
-    const snapshot = await probeCapabilities({ which: pathWith("curl_chrome136") });
+  test("reports an impersonate build with the profile it selected", async () => {
+    const snapshot = await probeCapabilities(pathWith("curl_chrome150"));
 
-    expect(snapshot.curl).toBe(true);
+    expect(snapshot.curl).toEqual({
+      present: true,
+      impersonates: true,
+      profile: "chrome150",
+    });
     expect(snapshot.issues.map((issue) => issue.id)).not.toContain("curl-missing");
+    expect(snapshot.issues.map((issue) => issue.id)).not.toContain("curl-impersonate-missing");
+  });
+
+  // The regression that motivated widening this field. Plain curl exists on
+  // nearly every machine, so the old boolean reported "ready" while Cloudflare
+  // challenged every request and anime search silently returned nothing.
+  test("raises a degraded issue when only plain curl is available", async () => {
+    const snapshot = await probeCapabilities(pathWith("curl", "mpv"));
+
+    const issue = snapshot.issues.find((c) => c.id === "curl-impersonate-missing");
+    expect(issue).toBeDefined();
+    expect(issue?.severity).toBe("degraded");
+    // The remediation must be actionable and must not invent a package that
+    // does not exist — upstream ships no Debian, Fedora, or Windows package.
+    expect(issue?.remediation.join("\n")).toContain("brew install lexiforest/tap/curl-impersonate");
+    expect(issue?.remediation.join("\n")).toContain("pacman -S curl-impersonate");
+    expect(issue?.remediation.join("\n")).not.toContain("apt install curl-impersonate");
   });
 
   test("raises a degraded issue when no curl variant exists", async () => {
-    const snapshot = await probeCapabilities({ which: pathWith("mpv", "yt-dlp", "ffprobe") });
+    const snapshot = await probeCapabilities(pathWith("mpv", "yt-dlp", "ffprobe"));
 
-    expect(snapshot.curl).toBe(false);
+    expect(snapshot.curl.present).toBe(false);
     const issue = snapshot.issues.find((candidate) => candidate.id === "curl-missing");
     expect(issue).toBeDefined();
     // Anime is one mode, so a missing curl degrades rather than blocks the shell.
@@ -41,32 +68,46 @@ describe("probeCapabilities — curl for the default anime provider", () => {
     // gives the user no reason to care.
     expect(issue?.message).toContain("AniDB");
     expect(issue?.remediation.length).toBeGreaterThan(0);
+    // Only one curl issue at a time, or the notice reads as two problems.
+    expect(snapshot.issues.map((i) => i.id)).not.toContain("curl-impersonate-missing");
   });
 
   test("probes each dependency independently", async () => {
-    const snapshot = await probeCapabilities({ which: pathWith("curl") });
+    const snapshot = await probeCapabilities(pathWith("curl"));
 
     expect(snapshot.mpv).toBe(false);
     expect(snapshot.ytDlp).toBe(false);
     expect(snapshot.ffprobe).toBe(false);
-    expect(snapshot.curl).toBe(true);
+    expect(snapshot.curl.present).toBe(true);
   });
 
   test("defaults to the real PATH when no probe is injected", async () => {
     const snapshot = await probeCapabilities();
 
-    expect(typeof snapshot.curl).toBe("boolean");
+    expect(typeof snapshot.curl.present).toBe("boolean");
+    expect(typeof snapshot.curl.impersonates).toBe("boolean");
   });
 
-  test("the probed flag reaches the capability fingerprint", async () => {
+  test("the probed capability reaches the capability fingerprint", async () => {
     // The fingerprint decides whether the remediation notice is shown again, so
     // a curl that appears or disappears has to change it — otherwise the user
     // installs curl and is still told it is missing, or vice versa.
-    const withCurl = await probeCapabilities({ which: pathWith("curl") });
-    const withoutCurl = await probeCapabilities({ which: pathWith("mpv") });
+    const withCurl = await probeCapabilities(pathWith("curl"));
+    const withoutCurl = await probeCapabilities(pathWith("mpv"));
 
     expect(__testing.capabilityFingerprint(withCurl)).not.toBe(
       __testing.capabilityFingerprint(withoutCurl),
+    );
+  });
+
+  // Installing curl-impersonate alongside an existing plain curl changes what
+  // Kunai can do, so it has to re-show the notice rather than staying quiet.
+  test("upgrading from plain curl to an impersonate build changes the fingerprint", async () => {
+    const plain = await probeCapabilities(pathWith("curl"));
+    const impersonating = await probeCapabilities(pathWith("curl", "curl_chrome150"));
+
+    expect(__testing.capabilityFingerprint(plain)).not.toBe(
+      __testing.capabilityFingerprint(impersonating),
     );
   });
 });

--- a/apps/cli/test/unit/run-doctor.test.ts
+++ b/apps/cli/test/unit/run-doctor.test.ts
@@ -21,7 +21,7 @@ function emptyCapabilities(): CapabilitySnapshot {
     mpv: true,
     ffprobe: true,
     ytDlp: true,
-    curl: true,
+    curl: { present: true, impersonates: true, profile: "chrome150" },
     image: {
       terminal: "unknown",
       protocol: "none",

--- a/apps/cli/test/unit/services/update/native-installer/doctor.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/doctor.test.ts
@@ -36,7 +36,7 @@ function emptyCapabilities(overrides: Partial<CapabilitySnapshot> = {}): Capabil
     mpv: true,
     ffprobe: true,
     ytDlp: true,
-    curl: true,
+    curl: { present: true, impersonates: true, profile: "chrome150" },
     image: {
       terminal: "unknown",
       protocol: "none",

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -5,6 +5,8 @@ import {
   curlCipherArgs,
   isCloudflareChallengeText,
   resolveCurlCandidate,
+  type CurlCandidate,
+  type CurlEnvironment,
 } from "../shared/curl-impersonate";
 import { expandHlsMasterPlaylist } from "../shared/hls-ladder";
 import { markupToPlainText } from "../shared/markup-text";
@@ -108,21 +110,22 @@ export type AnidbEpisodeStreamResolution = {
 };
 
 /**
- * curl-impersonate resolution lives in `shared/curl-impersonate.ts` (Miruro's
- * Cloudflare pipe fallback uses the same candidates). Keep the anidb-named
- * exports as thin delegates for the existing consumers.
+ * curl-impersonate resolution lives in `shared/curl-impersonate.ts`, which
+ * discovers wrappers from PATH rather than matching a fixed list (Miruro's
+ * Cloudflare pipe fallback shares it). Keep the anidb-named exports as thin
+ * delegates for the existing consumers.
  */
 export const anidbCipherArgs = curlCipherArgs;
 
-export function resolveAnidbCurl(
-  which: (command: string) => string | null = Bun.which,
-): { readonly path: string; readonly impersonates: boolean } | null {
-  return resolveCurlCandidate(which);
+export function resolveAnidbCurl(environment: Partial<CurlEnvironment> = {}): CurlCandidate | null {
+  return resolveCurlCandidate(environment);
 }
 
 /**
- * anidb.app HTML/JSON often CF-blocks Bun fetch. Prefer curl with a browser UA
- * (ani-cli uses curl / curl-impersonate; plain curl works on this machine).
+ * anidb.app HTML/JSON often CF-blocks Bun fetch. Prefer curl with a browser UA.
+ * An impersonate build is used when one is on PATH; plain curl is the fallback
+ * and is frequently still challenged, since Cloudflare fingerprints the TLS
+ * handshake rather than trusting the User-Agent.
  */
 export async function anidbFetchText(
   url: string,

--- a/packages/providers/src/shared/curl-impersonate.ts
+++ b/packages/providers/src/shared/curl-impersonate.ts
@@ -3,21 +3,119 @@
  *
  * Cloudflare fingerprints the TLS handshake, so a browser User-Agent over
  * plain curl's handshake is frequently still challenged. Where an impersonate
- * build exists we use it; the candidate order matches ani-cli v5's
- * `dep_ch_failover` list, most-recent browser first, then plain curl.
+ * build exists we use it.
+ *
+ * Candidates are **discovered from PATH**, not listed here. A hardcoded
+ * allowlist was the previous design and it rotted exactly as you would expect:
+ * it named `curl_firefox135` / `curl_chrome136` and so kept selecting a stale
+ * fingerprint on a machine carrying `curl_chrome150` and `curl_firefox147`,
+ * while `curl_ff117` — lwthiker-era naming the maintained lexiforest fork never
+ * ships — could never match at all. Upstream documents the wrapper naming as
+ * `curl_<browser><version>[_os]`, so the shape is stable even though the
+ * versions turn over every few weeks; discovery tracks it without edits.
  */
-const CURL_IMPERSONATE_CANDIDATES = [
-  "curl_firefox135",
-  "curl_chrome136",
-  "curl_chrome116",
-  "curl_ff117",
-  "curl",
-] as const;
+import { readdirSync } from "node:fs";
+import { delimiter as PATH_DELIMITER, join } from "node:path";
 
 export type CurlCandidate = {
   readonly path: string;
   readonly impersonates: boolean;
+  /**
+   * Browser profile of the selected impersonate build (`chrome150`), or `null`
+   * for plain curl. Carried so capability reporting can distinguish "a curl" from
+   * "a curl that clears Cloudflare" instead of collapsing both to a green tick.
+   */
+  readonly profile: string | null;
 };
+
+/**
+ * Seam for PATH inspection. Tests supply their own so a ranking assertion does
+ * not depend on what happens to be installed on the machine running them.
+ */
+export type CurlEnvironment = {
+  /** Absolute-path lookup for a bare command name. */
+  readonly which: (command: string) => string | null;
+  /** Executable basenames visible on PATH, in PATH order. */
+  readonly listPathEntries: () => readonly string[];
+};
+
+/**
+ * Desktop families only, most-camouflaged first.
+ *
+ * Chrome leads because it carries the largest share of real browser traffic, so
+ * its fingerprint is the least remarkable thing a WAF can see. Mobile builds
+ * (`_android`, `_ios`) are deliberately excluded: a desktop CLI presenting a
+ * phone's handshake is a mismatch a fingerprinter can notice. `curl_tor*` is
+ * excluded for the same reason, more so.
+ */
+const FAMILY_RANK = ["chrome", "firefox", "ff", "safari", "edge"] as const;
+
+/** `curl_chrome150`, `curl_chrome133a`, `curl_firefox147`, `curl_safari260_ios`. */
+const WRAPPER_PATTERN = /^curl_([a-z]+?)(\d+)([a-z]*)(?:_(android|ios))?(?:\.exe)?$/i;
+
+type ParsedWrapper = {
+  readonly name: string;
+  readonly family: string;
+  readonly version: number;
+  readonly revision: string;
+};
+
+function parseWrapper(entry: string): ParsedWrapper | null {
+  const match = WRAPPER_PATTERN.exec(entry);
+  if (!match) return null;
+  const [, rawFamily = "", rawVersion = "", revision = "", mobile] = match;
+  if (mobile) return null;
+  const family = rawFamily.toLowerCase();
+  if (!FAMILY_RANK.includes(family as (typeof FAMILY_RANK)[number])) return null;
+  const version = Number.parseInt(rawVersion, 10);
+  if (!Number.isFinite(version)) return null;
+  return { name: entry, family, version, revision: revision.toLowerCase() };
+}
+
+/**
+ * Best build wins within a family, then the most-camouflaged family wins.
+ *
+ * Ranking across families numerically would be meaningless — Safari's `260`
+ * and Chrome's `150` do not live on one scale — so family is the outer key.
+ */
+function betterThan(a: ParsedWrapper, b: ParsedWrapper): boolean {
+  const rankA = FAMILY_RANK.indexOf(a.family as (typeof FAMILY_RANK)[number]);
+  const rankB = FAMILY_RANK.indexOf(b.family as (typeof FAMILY_RANK)[number]);
+  if (rankA !== rankB) return rankA < rankB;
+  if (a.version !== b.version) return a.version > b.version;
+  return a.revision > b.revision;
+}
+
+function readPathEntries(): readonly string[] {
+  const raw = process.env.PATH ?? "";
+  const entries: string[] = [];
+  for (const dir of raw.split(PATH_DELIMITER)) {
+    if (!dir) continue;
+    try {
+      for (const entry of readdirSync(dir)) {
+        // Cheap prefix gate before the regex — a PATH directory can hold
+        // thousands of entries and this runs on the capability-probe path.
+        if (entry.startsWith("curl_")) entries.push(entry);
+      }
+    } catch {
+      // An unreadable or absent PATH directory is normal, not an error.
+    }
+  }
+  return entries;
+}
+
+/**
+ * PATH does not change under a running process, and this is read from the
+ * capability probe as well as from two providers, so the scan is paid once.
+ * Injected environments bypass the cache — a test must never see another
+ * test's PATH.
+ */
+let cachedPathEntries: readonly string[] | null = null;
+
+function defaultListPathEntries(): readonly string[] {
+  cachedPathEntries ??= readPathEntries();
+  return cachedPathEntries;
+}
 
 /**
  * ani-cli sets cipher flags only on Darwin, and that restriction is
@@ -44,15 +142,44 @@ export function curlCipherArgs(
 }
 
 export function resolveCurlCandidate(
-  which: (command: string) => string | null = Bun.which,
+  environment: Partial<CurlEnvironment> = {},
 ): CurlCandidate | null {
-  for (const candidate of CURL_IMPERSONATE_CANDIDATES) {
-    const path = which(candidate);
-    if (path) return { path, impersonates: candidate !== "curl" };
+  const which = environment.which ?? ((command: string) => Bun.which(command));
+  const listPathEntries = environment.listPathEntries ?? defaultListPathEntries;
+
+  let best: ParsedWrapper | null = null;
+  for (const entry of listPathEntries()) {
+    const parsed = parseWrapper(entry);
+    if (!parsed) continue;
+    if (!best || betterThan(parsed, best)) best = parsed;
   }
-  return null;
+
+  if (best) {
+    const resolved = which(best.name);
+    if (resolved) {
+      return {
+        path: resolved,
+        impersonates: true,
+        profile: `${best.family}${best.version}${best.revision}`,
+      };
+    }
+  }
+
+  const plain = which("curl");
+  return plain ? { path: plain, impersonates: false, profile: null } : null;
 }
 
 export function isCloudflareChallengeText(text: string): boolean {
   return /just a moment/i.test(text);
 }
+
+/** Test-only: drop the memoized PATH scan. */
+export const __testing = {
+  resetPathCache(): void {
+    cachedPathEntries = null;
+  },
+  parseWrapper,
+  readPathEntries,
+  /** Absolute path a discovered wrapper would resolve to, for probe seams. */
+  joinPathEntry: join,
+};

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -293,31 +293,94 @@ describe("anidb curl selection", () => {
   // which fingerprints the TLS handshake, so a browser UA over curl's own
   // handshake still gets challenged -- and a challenge page parses to zero
   // search results, which is a release blocker for the default provider.
+  /** A synthetic PATH: `names` are the only executables visible. */
+  function onPath(names: readonly string[]) {
+    const present = new Set(names);
+    return {
+      which: (cmd: string) => (present.has(cmd) ? `/usr/bin/${cmd}` : null),
+      listPathEntries: () => names,
+    };
+  }
+
   test("prefers the newest curl-impersonate build over plain curl", () => {
-    const present = new Set(["curl", "curl_chrome116", "curl_firefox135"]);
-    expect(resolveAnidbCurl((cmd) => (present.has(cmd) ? `/usr/bin/${cmd}` : null))).toEqual({
-      path: "/usr/bin/curl_firefox135",
+    expect(resolveAnidbCurl(onPath(["curl", "curl_chrome116", "curl_chrome150"]))).toEqual({
+      path: "/usr/bin/curl_chrome150",
       impersonates: true,
+      profile: "chrome150",
     });
   });
 
-  test("falls back through older impersonate builds before plain curl", () => {
-    const present = new Set(["curl", "curl_ff117"]);
-    expect(resolveAnidbCurl((cmd) => (present.has(cmd) ? `/usr/bin/${cmd}` : null))).toEqual({
-      path: "/usr/bin/curl_ff117",
+  // The bug this whole resolver was rewritten for. The old design hardcoded
+  // ["curl_firefox135", "curl_chrome136", "curl_chrome116", "curl_ff117"], so a
+  // machine carrying only builds newer than that list matched nothing and fell
+  // through to plain curl -- silently losing Cloudflare bypass while capability
+  // reporting still showed a green tick.
+  test("discovers builds newer than any list could have been written against", () => {
+    const future = ["curl", "curl_chrome199", "curl_firefox210"];
+    expect(resolveAnidbCurl(onPath(future))).toEqual({
+      path: "/usr/bin/curl_chrome199",
       impersonates: true,
+      profile: "chrome199",
+    });
+  });
+
+  // Safari's 260 and Chrome's 150 are not on one scale, so family is the outer
+  // ranking key and version only orders builds within a family.
+  test("ranks family before version so a high Safari number cannot outrank Chrome", () => {
+    expect(resolveAnidbCurl(onPath(["curl_safari260", "curl_chrome150"]))).toEqual({
+      path: "/usr/bin/curl_chrome150",
+      impersonates: true,
+      profile: "chrome150",
+    });
+  });
+
+  test("orders a revision suffix above the bare version", () => {
+    expect(resolveAnidbCurl(onPath(["curl_chrome133", "curl_chrome133a"]))).toEqual({
+      path: "/usr/bin/curl_chrome133a",
+      impersonates: true,
+      profile: "chrome133a",
+    });
+  });
+
+  // A desktop CLI presenting a phone's handshake is a mismatch a fingerprinter
+  // can notice, so mobile wrappers are skipped even when they are the newest.
+  test("skips mobile builds in favour of an older desktop one", () => {
+    expect(resolveAnidbCurl(onPath(["curl", "curl_chrome131_android", "curl_chrome116"]))).toEqual({
+      path: "/usr/bin/curl_chrome116",
+      impersonates: true,
+      profile: "chrome116",
+    });
+  });
+
+  test("never selects a tor build", () => {
+    expect(resolveAnidbCurl(onPath(["curl", "curl_tor145"]))).toEqual({
+      path: "/usr/bin/curl",
+      impersonates: false,
+      profile: null,
     });
   });
 
   test("marks plain curl as non-impersonating so cipher flags are applied", () => {
-    expect(resolveAnidbCurl((cmd) => (cmd === "curl" ? "/usr/bin/curl" : null))).toEqual({
+    expect(resolveAnidbCurl(onPath(["curl"]))).toEqual({
       path: "/usr/bin/curl",
       impersonates: false,
+      profile: null,
     });
   });
 
+  test("falls back to plain curl when a discovered wrapper is not executable", () => {
+    // Listed on PATH but `which` cannot resolve it -- a dangling symlink or a
+    // non-executable file. Discovery must not strand the caller with nothing.
+    expect(
+      resolveAnidbCurl({
+        which: (cmd: string) => (cmd === "curl" ? "/usr/bin/curl" : null),
+        listPathEntries: () => ["curl", "curl_chrome150"],
+      }),
+    ).toEqual({ path: "/usr/bin/curl", impersonates: false, profile: null });
+  });
+
   test("reports no curl at all so the caller can fall back to fetch", () => {
-    expect(resolveAnidbCurl(() => null)).toBeNull();
+    expect(resolveAnidbCurl(onPath([]))).toBeNull();
   });
 
   // ani-cli sets cipher flags only on Darwin. Windows curl.exe links Schannel,


### PR DESCRIPTION
## What

`resolveCurlCandidate` matched a hardcoded allowlist:

```ts
["curl_firefox135", "curl_chrome136", "curl_chrome116", "curl_ff117", "curl"]
```

It now **discovers** curl-impersonate wrappers from `PATH`.

## Why

Two failure modes, both silent, both reproduced on a machine running
`curl-impersonate 2.1.0`:

1. **It picked a stale fingerprint.** That PATH carries `curl_chrome150`,
   `curl_chrome146`, `curl_firefox147`, `curl_safari260` and more — the resolver
   selected `curl_firefox135` and left a dozen newer builds unused.
2. **A current-only install matched nothing.** It fell through to plain `curl`,
   losing Cloudflare bypass entirely. `curl_ff117` is lwthiker-era naming that
   the maintained lexiforest fork never ships, so that entry could never match.

Capability reporting hid both. `CapabilitySnapshot.curl` was a boolean built
from `resolveAnidbCurl(...) !== null`, so a machine with only plain curl
reported **`✓ curl — Anime search ready`** and then returned nothing from AniDB,
with no diagnostic anywhere. Plain curl is present nearly everywhere, so that
green tick was the common case, not the edge case.

## How

Upstream documents the wrapper naming as `curl_<browser><version>[_os]`, so the
shape is stable even though versions turn over every few weeks. Discovery
tracks it without edits:

- scan `PATH`, memoized per process
- rank family-first (chrome → firefox → safari → edge), then newest version
  within a family — Safari's `260` and Chrome's `150` are not on one scale, so
  family has to be the outer key
- exclude mobile (`_android` / `_ios`) and `curl_tor*`: a desktop CLI presenting
  a phone's handshake is a mismatch a fingerprinter can notice
- fall back to plain `curl`, including when a discovered wrapper turns out not
  to be executable

`CapabilitySnapshot.curl` now carries presence, whether the selected build
impersonates, and which profile was chosen. Consumers report three states:

| Surface | Before | After |
| --- | --- | --- |
| setup | `✓ curl — Anime search ready` | `Only plain curl — Cloudflare may still block AniDB and Miruro` |
| `kunai doctor` | `curl=ok` | `curl=ok (chrome150)` / `curl=plain (no CF bypass)` / `curl=missing` |
| issues | — | new `curl-impersonate-missing` degraded issue with install instructions |

## Install instructions are verified, not guessed

Checked against upstream on 2026-08-25: curl-impersonate has **no Debian,
Fedora, or Windows package** — only a Homebrew tap and Arch. Everywhere else
points at the releases page rather than naming a command that does not exist.

```
macOS:  brew install lexiforest/tap/curl-impersonate
Arch:   sudo pacman -S curl-impersonate
Other:  https://github.com/lexiforest/curl-impersonate/releases
```

## Verification

- `bun run typecheck --force` — 14/14
- `bun run lint --force` — 0 warnings, 0 errors
- `bun run test --force` — 23/23 tasks, 0 fail (cache bypassed deliberately; a
  cached replay is not evidence)
- `bun run verify:doc-paths` — all paths resolve
- Real-machine check: `resolveCurlCandidate()` returns
  `{ path: "/usr/bin/curl_chrome150", impersonates: true, profile: "chrome150" }`
  where it previously returned `curl_firefox135`

New resolver tests cover newest-wins, discovery of builds newer than any list
could have been written against, family-before-version ranking, revision
suffixes (`133a` > `133`), mobile and tor exclusion, the non-executable
fallback, and the empty PATH. Both test seams are injected together so results
never depend on what the developer happens to have installed.

## Note for reviewers

Widening `curl` from `boolean` to an object left one reader —
`setup-shell.tsx:259` — as `snapshot.curl ? "ok" : …`, which is **always
truthy**. TypeScript cannot catch that, and it would have made the dependency
row permanently green. It is fixed here; the class is worth watching for in
review.

Spec: `.plans/2026-08-25-setup-wizard-redesign.md` (this is PR 1 of 3).
