### PR TITLE
fix(setup): write what setup asks for, and make skipping mean recommended

### DIFF
--- a/apps/cli/src/app-shell/settings/registry/shared.ts
+++ b/apps/cli/src/app-shell/settings/registry/shared.ts
@@ -1,3 +1,7 @@
+import {
+  AUDIO_PREFERENCE_OPTIONS,
+  SUBTITLE_PREFERENCE_OPTIONS,
+} from "@/domain/media/media-preferences";
 import { getConfigMetadata } from "@/services/persistence/config-metadata";
 import type {
   DiscoverMode,
@@ -10,16 +14,9 @@ import type { StartupPriority } from "@kunai/types";
 
 import type { EnumOption } from "../types";
 
-export const SUBTITLE_SETTINGS_OPTIONS: readonly EnumOption[] = [
-  { value: "en", label: "English" },
-  { value: "interactive", label: "Pick interactively" },
-  { value: "none", label: "None" },
-  { value: "ar", label: "Arabic" },
-  { value: "fr", label: "French" },
-  { value: "de", label: "German" },
-  { value: "es", label: "Spanish" },
-  { value: "ja", label: "Japanese" },
-];
+// Setup and settings share one catalog (`domain/media/media-preferences.ts`).
+// Keeping a second copy here is what let the two surfaces drift apart.
+export const SUBTITLE_SETTINGS_OPTIONS: readonly EnumOption[] = SUBTITLE_PREFERENCE_OPTIONS;
 
 export const YOUTUBE_QUALITY_SETTINGS_OPTIONS: readonly EnumOption[] = [
   { value: "1080p", label: "1080p", detail: "Default — balances quality and bandwidth" },
@@ -30,12 +27,7 @@ export const YOUTUBE_QUALITY_SETTINGS_OPTIONS: readonly EnumOption[] = [
   { value: "480p", label: "480p", detail: "SD ceiling" },
 ];
 
-export const AUDIO_SETTINGS_OPTIONS: readonly EnumOption[] = [
-  { value: "original", label: "Original", detail: "Prefer original/native audio" },
-  { value: "en", label: "English", detail: "Prefer English audio when available" },
-  { value: "ja", label: "Japanese", detail: "Prefer Japanese audio when available" },
-  { value: "dub", label: "Dub", detail: "Prefer dubbed audio when available" },
-];
+export const AUDIO_SETTINGS_OPTIONS: readonly EnumOption[] = AUDIO_PREFERENCE_OPTIONS;
 
 export const ANIME_TITLE_SETTINGS_OPTIONS: readonly EnumOption[] = [
   { value: "english", label: "English", detail: "Prefer localized English titles when known" },

--- a/apps/cli/src/app-shell/setup-shell.tsx
+++ b/apps/cli/src/app-shell/setup-shell.tsx
@@ -1,8 +1,15 @@
 import { useDotMatrixAnimation, DotMatrixGrid } from "@/app-shell/dot-matrix-loader";
+import {
+  AUDIO_PREFERENCE_OPTIONS,
+  RECOMMENDED_AUDIO_PREFERENCE,
+  RECOMMENDED_SUBTITLE_PREFERENCE,
+  SUBTITLE_PREFERENCE_OPTIONS,
+} from "@/domain/media/media-preferences";
 import type { CapabilitySnapshot } from "@/ui";
 import { Box, Text, useInput } from "ink";
 import React, { useState } from "react";
 
+import packageJson from "../../package.json" with { type: "json" };
 import {
   BLOOM_FRAMES,
   reducedMotionEnabled,
@@ -39,41 +46,62 @@ const SLIDE_ORDER: Slide[] = [
 /** Step counter + indicator + padding above each slide body. */
 const SETUP_CHROME_ROWS = 5;
 
-export type SetupFlowResult = "completed" | "skipped";
+/**
+ * The consent screen must describe *this* machine. It used to print the literal
+ * `"version": "0.3.0", "os": "linux", "arch": "x64"`, which made the one screen
+ * that has to be exactly true a false statement on macOS and Windows.
+ */
+const KUNAI_VERSION: string = packageJson.version;
+
+/**
+ * Three outcomes, because "skipped" was doing two incompatible jobs.
+ *
+ * - `completed` — the user answered every step.
+ * - `defaults`  — the user waved past some or all of it. The recommended
+ *   configuration is written. Previously this wrote *nothing*: `skip()` built
+ *   prefs and the caller discarded them, so skipping setup left the install
+ *   unconfigured while telling the user it was set up.
+ * - `aborted`   — esc. Nothing is written but the onboarding version, so a
+ *   deliberate bail-out never rewrites settings the user already had.
+ */
+export type SetupFlowResult = "completed" | "defaults" | "aborted";
 
 export interface SetupPrefs {
   audio: string;
   subtitle: string;
   downloadsEnabled: boolean;
-  /** Setup-time analytics choice before DO_NOT_TRACK / CI resolution. */
-  analyticsChoice: "enabled" | "disabled";
+  /**
+   * Setup-time analytics choice before DO_NOT_TRACK / CI resolution.
+   *
+   * `unchanged` is not "off" — it means the consent slide was never reached, so
+   * whatever the user already had must survive. Collapsing it into `disabled`
+   * would silently opt out someone who had previously opted in and then reran
+   * setup and pressed accept-all. Only a keystroke on the consent slide moves
+   * this value, in either direction.
+   */
+  analyticsChoice: "enabled" | "disabled" | "unchanged";
 }
 
 // ─── Option data ──────────────────────────────────────────────────────────────
 
-const AUDIO_OPTS = [
-  {
-    value: "original",
-    label: "Original",
-    detail: "Use the native language from the provider",
-  },
-  { value: "en", label: "English dub", detail: "Prefer English audio when available" },
-  { value: "ja", label: "Japanese", detail: "Prefer Japanese audio (anime-first)" },
-  { value: "dub", label: "Any dub", detail: "Prefer any dubbed track over original" },
-] as const;
+// One catalog, shared with `/settings` — see `domain/media/media-preferences.ts`.
+const AUDIO_OPTS = AUDIO_PREFERENCE_OPTIONS;
+const SUBTITLE_OPTS = SUBTITLE_PREFERENCE_OPTIONS;
 
-const SUBTITLE_OPTS = [
-  { value: "en", label: "English", detail: "English subtitles by default" },
-  { value: "none", label: "None", detail: "No subtitles unless you enable per-episode" },
-  {
-    value: "interactive",
-    label: "Ask me each time",
-    detail: "Pick subtitles interactively per episode",
-  },
-  { value: "ja", label: "Japanese", detail: "Japanese subtitles" },
-  { value: "es", label: "Spanish", detail: "Spanish subtitles" },
-  { value: "fr", label: "French", detail: "French subtitles" },
-] as const;
+/** Index of the recommended value, or 0 when it somehow left the catalog. */
+function recommendedIndex(
+  options: readonly { readonly value: string }[],
+  recommended: string,
+): number {
+  const index = options.findIndex((option) => option.value === recommended);
+  return index >= 0 ? index : 0;
+}
+
+const DOWNLOADS_ON_INDEX = 0;
+const DOWNLOADS_OFF_INDEX = 1;
+/** "Turn it on" leads the consent slide — see AnalyticsSlide for why. */
+const ANALYTICS_ON_INDEX = 0;
+const ANALYTICS_OFF_INDEX = 1;
 
 // ─── Shared layout helpers ────────────────────────────────────────────────────
 
@@ -94,7 +122,8 @@ function SlideLayout({
   // paddingTop, hint) and this container adds a paddingTop of its own. At a
   // reserve of 4 the box overflows by exactly one row and the hint line is
   // clipped at every terminal height — which on the analytics slide would
-  // silently drop "skip (keeps it off)", the one line that must never be lost.
+  // silently drop "[s] keep it off", the one escape hatch that must never be
+  // lost from a consent screen.
   const contentHeight = Math.max(4, rows - 5);
   return (
     <Box
@@ -165,7 +194,8 @@ function WelcomeSlide({ width, rows }: { width: number; rows: number }) {
         <FooterHint
           parts={[
             { key: "Enter", label: "start setup" },
-            { key: "s", label: "skip to search" },
+            { key: "S", label: "use recommended" },
+            { key: "esc", label: "skip setup" },
           ]}
         />
       }
@@ -294,7 +324,7 @@ function SystemSlide({
           <FooterHint
             parts={[
               { key: "Enter", label: "continue anyway" },
-              { key: "s", label: "skip setup" },
+              { key: "S", label: "use recommended" },
             ]}
           />
         ) : (
@@ -302,7 +332,7 @@ function SystemSlide({
             parts={[
               { key: "Enter", label: "next" },
               { key: "←/b", label: "back" },
-              { key: "s", label: "skip" },
+              { key: "S", label: "use recommended" },
             ]}
           />
         )
@@ -383,7 +413,7 @@ function PickerSlide({
             { key: "Enter", label: "confirm & next" },
             { key: "↑↓", label: "choose" },
             { key: "←/b", label: "back" },
-            { key: "s", label: "skip" },
+            { key: "s", label: "use recommended" },
           ]}
         />
       }
@@ -450,7 +480,7 @@ function DownloadsSlide({
             { key: "Enter", label: "confirm & next" },
             { key: "↑↓", label: "choose" },
             { key: "←/b", label: "back" },
-            { key: "s", label: "skip" },
+            { key: "s", label: "use recommended" },
           ]}
         />
       }
@@ -521,14 +551,18 @@ export function AnalyticsSlide({
   const bloom = still ? STATIC_PETAL : (BLOOM_FRAMES[tick % BLOOM_FRAMES.length] ?? STATIC_PETAL);
   const sidePetal = still || tick % 2 === 0 ? "✿" : " ";
 
+  // Recommended first, and index 0 is now "on". `s` on this slide still selects
+  // OFF and no accept-all path reaches it — see ANALYTICS_ON_INDEX and the
+  // input handler. A recommendation the user pressed a key on is consent; a
+  // default they never saw is not.
   const opts = [
     {
-      label: "Keep analytics off",
-      detail: "No network calls. No install id stored on disk.",
+      label: "Turn it on",
+      detail: "One ping a day. Counts unique installs, not people.",
     },
     {
-      label: "Turn on analytics",
-      detail: "Sends one bounded anonymous ping per day.",
+      label: "Keep it off",
+      detail: "No network calls. No install id stored on disk.",
     },
   ];
 
@@ -541,7 +575,7 @@ export function AnalyticsSlide({
           parts={[
             { key: "Enter", label: "confirm" },
             { key: "←/b", label: "back" },
-            { key: "s", label: "skip (keeps it off)" },
+            { key: "s", label: "keep it off" },
           ]}
         />
       }
@@ -556,10 +590,7 @@ export function AnalyticsSlide({
         <Text color={palette.dim}>{sidePetal}</Text>
       </Box>
 
-      <SlideTitle
-        text=""
-        sub="Off by default. Turn it on only if you want to share bounded anonymous usage."
-      />
+      <SlideTitle text="" sub="Recommended. Nothing is sent until you confirm here." />
 
       <Box flexDirection="column">
         {opts.map((opt, i) => {
@@ -574,7 +605,7 @@ export function AnalyticsSlide({
               <Box flexDirection="column">
                 <Text color={palette.text} bold={selected}>
                   {opt.label}
-                  {i === 0 ? "   ← default" : ""}
+                  {i === ANALYTICS_ON_INDEX ? "   ← recommended" : ""}
                 </Text>
                 <Text color={selected ? palette.muted : palette.dim} dimColor={!selected}>
                   {"  "}
@@ -587,13 +618,18 @@ export function AnalyticsSlide({
       </Box>
 
       <Box flexDirection="column" marginTop={1} paddingLeft={2}>
-        <Text color={palette.muted}>Exactly what is sent</Text>
+        <Text color={palette.muted}>Exactly what is sent, from this machine</Text>
         <Text color={palette.text}>
-          {'{ "installId": "<sha256 of a local id>", "version": "0.3.0",'}
+          {`{ "installId": "<sha256 of a local id>", "version": "${KUNAI_VERSION}",`}
         </Text>
-        <Text color={palette.text}>{'  "os": "linux", "arch": "x64", "ts": 0 }'}</Text>
+        <Text color={palette.text}>
+          {`  "os": "${process.platform}", "arch": "${process.arch}", "ts": 0 }`}
+        </Text>
         <Text color={palette.dim} dimColor>
-          Never: titles · queries · providers · URLs · paths
+          Never: titles · queries · providers · URLs · paths · your IP
+        </Text>
+        <Text color={palette.dim} dimColor>
+          The raw id never leaves this machine. Off in /settings deletes it.
         </Text>
       </Box>
     </SlideLayout>
@@ -679,11 +715,24 @@ export function SetupShell({
   const { cols, rows } = useShellDimensions();
 
   const [slideIdx, setSlideIdx] = useState(0);
-  const [audioIdx, setAudioIdx] = useState(0);
-  const [subtitleIdx, setSubtitleIdx] = useState(0);
-  const [downloadsIdx, setDownloadsIdx] = useState(0);
-  // Index 0 keeps analytics off. Enabling must be an explicit setup choice.
-  const [analyticsIdx, setAnalyticsIdx] = useState(0);
+  // Every picker opens on its recommended option, so Enter-through produces the
+  // configuration the defaults table promises rather than whatever sits first.
+  const [audioIdx, setAudioIdx] = useState(() =>
+    recommendedIndex(AUDIO_OPTS, RECOMMENDED_AUDIO_PREFERENCE),
+  );
+  const [subtitleIdx, setSubtitleIdx] = useState(() =>
+    recommendedIndex(SUBTITLE_OPTS, RECOMMENDED_SUBTITLE_PREFERENCE),
+  );
+  // Downloads follow what is installed. Defaulting to "Enable" on a machine
+  // with no yt-dlp pre-selected the one option that cannot work.
+  const [downloadsIdx, setDownloadsIdx] = useState(() =>
+    snapshot.ytDlp ? DOWNLOADS_ON_INDEX : DOWNLOADS_OFF_INDEX,
+  );
+  // Index 0 is "turn it on" — the recommendation. It is only ever committed by
+  // a keystroke on this slide: `s` selects off, and accept-all stops here.
+  const [analyticsIdx, setAnalyticsIdx] = useState(ANALYTICS_ON_INDEX);
+  /** True once the user has actually seen the consent slide. */
+  const [analyticsSeen, setAnalyticsSeen] = useState(false);
 
   const slide = SLIDE_ORDER[slideIdx] as Slide;
   const isPickerSlide =
@@ -692,20 +741,31 @@ export function SetupShell({
     slide === "downloads" ||
     slide === "analytics";
 
-  function buildPrefs(): SetupPrefs {
+  /**
+   * `consented` is passed explicitly rather than read from state because the
+   * accept-all path has to build prefs for slides the user never reached, and
+   * analytics is the one value a never-reached slide must not be able to set.
+   */
+  function buildPrefs(consented: boolean): SetupPrefs {
     return {
-      audio: AUDIO_OPTS[audioIdx]?.value ?? "original",
-      subtitle: SUBTITLE_OPTS[subtitleIdx]?.value ?? "en",
-      downloadsEnabled: downloadsIdx === 0,
-      analyticsChoice: analyticsIdx === 1 ? "enabled" : "disabled",
+      audio: AUDIO_OPTS[audioIdx]?.value ?? RECOMMENDED_AUDIO_PREFERENCE,
+      subtitle: SUBTITLE_OPTS[subtitleIdx]?.value ?? RECOMMENDED_SUBTITLE_PREFERENCE,
+      downloadsEnabled: downloadsIdx === DOWNLOADS_ON_INDEX,
+      analyticsChoice: !consented
+        ? "unchanged"
+        : analyticsIdx === ANALYTICS_ON_INDEX
+          ? "enabled"
+          : "disabled",
     };
   }
 
   function advance() {
     if (slideIdx < SLIDE_ORDER.length - 1) {
+      const next = SLIDE_ORDER[slideIdx + 1];
+      if (next === "analytics") setAnalyticsSeen(true);
       setSlideIdx((current) => current + 1);
     } else {
-      finish("completed", buildPrefs());
+      finish("completed", buildPrefs(analyticsSeen));
     }
   }
 
@@ -713,30 +773,53 @@ export function SetupShell({
     if (slideIdx > 0) setSlideIdx((i) => i - 1);
   }
 
-  function skip() {
-    finish("skipped", buildPrefs());
+  /**
+   * Accept every remaining step's recommendation and finish.
+   *
+   * Analytics is deliberately excluded when the consent slide has not been
+   * reached: a blanket "yes to everything" is not consent to send data. This is
+   * the outward-facing rule — no skip path may enable analytics, start an OAuth
+   * handoff, or touch presence IPC.
+   */
+  function acceptRemainingDefaults() {
+    finish("defaults", buildPrefs(analyticsSeen));
+  }
+
+  /** esc — leave settings exactly as they were. */
+  function abort() {
+    finish("aborted", buildPrefs(false));
   }
 
   useInput((input, key) => {
     if (key.escape) {
-      skip();
+      abort();
       return;
     }
 
-    if (input === "s" || input === "S") {
-      // On the analytics slide, `s` accepts the safe default and continues
-      // setup without turning analytics on.
+    // `S` — accept every remaining recommendation and finish. On the consent
+    // slide it advances instead of passing through, so analytics is never
+    // enabled by a keystroke aimed at everything else.
+    if (input === "S") {
       if (slide === "analytics") {
-        setAnalyticsIdx(0);
+        setAnalyticsIdx(ANALYTICS_OFF_INDEX);
         advance();
         return;
       }
-      skip();
+      acceptRemainingDefaults();
+      return;
+    }
+
+    // `s` — take this step's recommendation and move on. It no longer ends the
+    // wizard: waving past one question you do not care about should not cost
+    // you the rest of setup.
+    if (input === "s") {
+      if (slide === "analytics") setAnalyticsIdx(ANALYTICS_OFF_INDEX);
+      advance();
       return;
     }
 
     if (input === "q" || input === "Q") {
-      skip();
+      abort();
       return;
     }
 
@@ -870,13 +953,15 @@ export function runSetupFlow(snapshot: CapabilitySnapshot): {
     renderContent: (finish) => (
       <SetupShell snapshot={snapshot} finish={(outcome, prefs) => finish({ outcome, prefs })} />
     ),
+    // Ink teardown settles here. That is not a user decision, so it must not
+    // write settings — `aborted` leaves the existing config alone.
     fallbackValue: {
-      outcome: "skipped",
+      outcome: "aborted",
       prefs: {
-        audio: "original",
-        subtitle: "en",
+        audio: RECOMMENDED_AUDIO_PREFERENCE,
+        subtitle: RECOMMENDED_SUBTITLE_PREFERENCE,
         downloadsEnabled: false,
-        analyticsChoice: "disabled",
+        analyticsChoice: "unchanged",
       },
     },
   });

--- a/apps/cli/src/app-shell/workflows/setup-workflows.ts
+++ b/apps/cli/src/app-shell/workflows/setup-workflows.ts
@@ -2,7 +2,11 @@ import { dirname, join } from "node:path";
 
 import { chooseFromListShell } from "@/app-shell/pickers";
 import { describeKunaiHandoffLaunch, type KunaiHandoffLaunch } from "@/app/bootstrap/handoff-url";
-import { shouldRunSetupWizard, type SetupWizardResult } from "@/app/bootstrap/startup-setup";
+import {
+  ONBOARDING_VERSION,
+  shouldRunSetupWizard,
+  type SetupWizardResult,
+} from "@/app/bootstrap/startup-setup";
 import type { Container } from "@/container";
 import { getKunaiPaths } from "@/services/storage/storage-read-models";
 import { probeCapabilities } from "@/ui";
@@ -65,30 +69,43 @@ export async function runSetupWizard({
   const { outcome, prefs } = await result;
   // One writer: the service owns what a consent choice means in config, and
   // `consentPatch` is pure so it folds into the single batched update below.
-  // Aborting a rerun is not a consent choice. Preserve whatever the user had
-  // already chosen; only completing the analytics slide may change it.
+  // Aborting is not a consent choice. Preserve whatever the user already had;
+  // only reaching the analytics slide may change it.
+  // Two ways to reach "leave it alone": aborting, and finishing without ever
+  // reaching the consent slide. Neither is a consent decision, and writing
+  // `disabled` for either would silently opt out a user who had opted in and
+  // then reran setup.
   const analyticsPatch =
-    outcome === "skipped" ? {} : container.usageAnalytics.consentPatch(prefs.analyticsChoice);
+    outcome === "aborted" || prefs.analyticsChoice === "unchanged"
+      ? {}
+      : container.usageAnalytics.consentPatch(prefs.analyticsChoice);
 
-  if (outcome === "skipped") {
+  if (outcome === "aborted") {
+    // esc, `q`, or an Ink teardown. Record that onboarding was offered so the
+    // wizard does not ambush the next launch, and touch nothing else.
     await container.config.update({
-      onboardingVersion: 2,
+      onboardingVersion: ONBOARDING_VERSION,
       downloadOnboardingDismissed: true,
-      ...analyticsPatch,
     });
     await container.config.save();
   } else {
+    // `completed` and `defaults` write the same shape. That is the point:
+    // skipping used to build prefs and discard them here, leaving the install
+    // unconfigured while telling the user setup was done.
     const downloadsEnabled = prefs.downloadsEnabled;
     const downloadPath = downloadsEnabled
       ? current.downloadPath || defaultDownloadPath
       : current.downloadPath;
 
     await container.config.update({
-      onboardingVersion: 2,
+      onboardingVersion: ONBOARDING_VERSION,
       downloadOnboardingDismissed: true,
       downloadsEnabled,
       downloadPath,
       ...analyticsPatch,
+      // Audio reaches all three lanes. It previously landed on anime only,
+      // while the slide asked which audio Kunai should prefer generally — so a
+      // user who chose English still got original audio for films and shows.
       animeLanguageProfile: {
         ...current.animeLanguageProfile,
         audio: prefs.audio,
@@ -96,10 +113,12 @@ export async function runSetupWizard({
       },
       seriesLanguageProfile: {
         ...current.seriesLanguageProfile,
+        audio: prefs.audio,
         subtitle: prefs.subtitle,
       },
       movieLanguageProfile: {
         ...current.movieLanguageProfile,
+        audio: prefs.audio,
         subtitle: prefs.subtitle,
       },
     });
@@ -113,15 +132,22 @@ export async function runSetupWizard({
 
   container.diagnosticsService.record({
     category: "session",
-    message: outcome === "completed" ? "Setup wizard completed" : "Setup wizard skipped",
+    message:
+      outcome === "completed"
+        ? "Setup wizard completed"
+        : outcome === "defaults"
+          ? "Setup wizard accepted recommended defaults"
+          : "Setup wizard aborted",
     context: {
       outcome,
       force,
-      analytics: outcome === "skipped" ? current.analytics : analyticsPatch.analytics,
+      analytics: analyticsPatch.analytics ?? current.analytics,
     },
   });
 
-  return outcome === "completed" ? "completed" : "skipped";
+  // `defaults` reports as completed to the caller: a recommended configuration
+  // was written, which is what "completed" means to everything downstream.
+  return outcome === "aborted" ? "cancelled" : "completed";
 }
 
 function closeActiveOverlays(container: Container): void {

--- a/apps/cli/src/app/bootstrap/startup-setup.ts
+++ b/apps/cli/src/app/bootstrap/startup-setup.ts
@@ -11,14 +11,40 @@ export type SetupWorkflowLoader = () => Promise<{
   runSetupWizard(input: { container: Container; force?: boolean }): Promise<SetupWizardResult>;
 }>;
 
+/**
+ * Current onboarding revision.
+ *
+ * Anyone already at 2 has been onboarded and is left alone. Bumping this alone
+ * would drag every existing install back through the wizard on upgrade, which
+ * is the most annoying thing an upgrade can do to someone who already
+ * configured Kunai the way they wanted. New screens reach them through
+ * `/setup`, not by ambush.
+ */
+export const ONBOARDING_VERSION = 3;
+
+/** Below this, an install has never been offered setup. */
+const ONBOARDED_FLOOR = 2;
+
 export function shouldRunSetupWizard({
   force,
   config,
+  interactive = true,
 }: {
   readonly force: boolean;
   readonly config: StartupSetupState;
+  /**
+   * A TTY on both stdin and stdout. The wizard is an Ink surface driven by
+   * `useInput`; mounting one where nothing can type at it leaves the process
+   * waiting on a keystroke that cannot arrive.
+   */
+  readonly interactive?: boolean;
 }): boolean {
-  return force || config.onboardingVersion < 2 || !config.downloadOnboardingDismissed;
+  if (!interactive) return false;
+  if (force) return true;
+  // One gate, not two. `downloadOnboardingDismissed` also used to gate this, so
+  // an install that finished the wizard could still be re-shown it whenever that
+  // second flag was false — two gates answering one question.
+  return config.onboardingVersion < ONBOARDED_FLOOR;
 }
 
 export async function maybeRunStartupSetup({
@@ -26,13 +52,15 @@ export async function maybeRunStartupSetup({
   config,
   container,
   loadSetupWorkflow,
+  interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY),
 }: {
   readonly force: boolean;
   readonly config: StartupSetupState;
   readonly container: Container;
   readonly loadSetupWorkflow: SetupWorkflowLoader;
+  readonly interactive?: boolean;
 }): Promise<SetupWizardResult> {
-  if (!shouldRunSetupWizard({ force, config })) return "skipped";
+  if (!shouldRunSetupWizard({ force, config, interactive })) return "skipped";
   const { runSetupWizard } = await loadSetupWorkflow();
   return runSetupWizard({ container, force });
 }

--- a/apps/cli/src/domain/media/media-preferences.ts
+++ b/apps/cli/src/domain/media/media-preferences.ts
@@ -1,3 +1,57 @@
+/**
+ * The catalog of audio/subtitle choices Kunai offers, and which one it
+ * recommends.
+ *
+ * One list, two surfaces. Setup and `/settings` each used to carry their own:
+ * setup offered en/none/interactive/ja/es/fr while settings offered
+ * en/interactive/none/ar/fr/de/es/ja, with different ordering and different
+ * labels for the same value ("Ask me each time" vs "Pick interactively"). A user
+ * who set a language in setup could not find the same wording again in settings.
+ *
+ * This lives in `domain/` because it is pure vocabulary with no I/O, which is
+ * also what lets both app-shell consumers import it without either one owning
+ * the other. The shape is structurally compatible with the settings registry's
+ * `EnumOption`.
+ */
+export type MediaPreferenceOption = {
+  readonly value: string;
+  readonly label: string;
+  readonly detail: string;
+};
+
+export const AUDIO_PREFERENCE_OPTIONS: readonly MediaPreferenceOption[] = [
+  {
+    value: "original",
+    label: "Original",
+    detail: "Use the language the title was made in",
+  },
+  { value: "en", label: "English", detail: "Prefer English audio when available" },
+  { value: "ja", label: "Japanese", detail: "Prefer Japanese audio when available" },
+  { value: "dub", label: "Any dub", detail: "Prefer any dubbed track over the original" },
+];
+
+export const SUBTITLE_PREFERENCE_OPTIONS: readonly MediaPreferenceOption[] = [
+  { value: "en", label: "English", detail: "English subtitles by default" },
+  { value: "interactive", label: "Pick each time", detail: "Choose subtitles per episode" },
+  { value: "none", label: "None", detail: "No subtitles unless you turn them on" },
+  { value: "ar", label: "Arabic", detail: "Arabic subtitles" },
+  { value: "de", label: "German", detail: "German subtitles" },
+  { value: "es", label: "Spanish", detail: "Spanish subtitles" },
+  { value: "fr", label: "French", detail: "French subtitles" },
+  { value: "ja", label: "Japanese", detail: "Japanese subtitles" },
+];
+
+/**
+ * What setup pre-selects, and what skipping a step writes.
+ *
+ * `original` rather than a named language on purpose: it already resolves to
+ * Japanese for anime and to the native track for everything else, so one value
+ * is right across all three lanes without asking which lane the user cares
+ * about.
+ */
+export const RECOMMENDED_AUDIO_PREFERENCE = "original";
+export const RECOMMENDED_SUBTITLE_PREFERENCE = "en";
+
 export type MediaPreferenceKind = "audio" | "subtitle";
 
 export type MediaPreference = {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -644,6 +644,16 @@ export async function runCli(argv = process.argv.slice(2)): Promise<void> {
     process.stdout.write(`${await formatVersionLine(KUNAI_VERSION)}\n`);
     return;
   }
+  // Asking for the wizard where nothing can drive it is a mistake worth naming.
+  // Silently continuing would leave the user believing setup ran; mounting it
+  // anyway would block on a keystroke that can never arrive.
+  if (args.setup && !(process.stdin.isTTY && process.stdout.isTTY)) {
+    console.error(
+      "kunai --setup needs an interactive terminal. Run it directly rather than through a pipe, and unset CI if it is set.",
+    );
+    process.exitCode = 1;
+    return;
+  }
   if (args.installProtocolHandler) {
     const { buildProtocolHandlerInstallPlan, installKunaiProtocolHandler } =
       await import("./infra/os/protocol-handler");
@@ -747,8 +757,14 @@ export async function runCli(argv = process.argv.slice(2)): Promise<void> {
       };
     }
   })();
+  // Interactivity is part of the question: this decides whether `checkDeps`
+  // stays silent because the wizard will show the same information visually. In
+  // a pipe the wizard never mounts, so the console remediation is the only
+  // channel left and must not be suppressed.
+  const setupIsInteractive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
   const onboardingWillRun = shouldRunSetupWizard({
     force: args.setup,
+    interactive: setupIsInteractive,
     config: {
       onboardingVersion: configJson.onboardingVersion ?? 0,
       downloadOnboardingDismissed: configJson.downloadOnboardingDismissed ?? false,

--- a/apps/cli/test/unit/app-shell/analytics-consent-slide.test.tsx
+++ b/apps/cli/test/unit/app-shell/analytics-consent-slide.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { AnalyticsSlide } from "@/app-shell/setup-shell";
 import React from "react";
 
+import packageJson from "../../../package.json" with { type: "json" };
 import { captureFrame } from "../../harness/render-capture";
 
 /**
@@ -17,8 +18,10 @@ function frame(selectedIndex = 0): string {
 }
 
 describe("analytics consent slide", () => {
-  test("states that skipping keeps analytics off", () => {
-    expect(frame()).toContain("skip (keeps it off)");
+  test("offers a key that keeps analytics off without leaving setup", () => {
+    // The one escape hatch that must never be lost to clipping: `s` here means
+    // "keep it off", not "skip the wizard".
+    expect(frame()).toContain("keep it off");
   });
 
   test("shows the exact payload inline, not behind another command", () => {
@@ -34,16 +37,40 @@ describe("analytics consent slide", () => {
     expect(rendered).toContain("titles");
   });
 
-  test("index 0 keeps analytics off and is marked as the default", () => {
+  test("leads with the recommendation and marks it as such", () => {
     const rendered = frame();
-    expect(rendered).toContain("Keep analytics off");
-    expect(rendered).toContain("← default");
+    expect(rendered).toContain("Turn it on");
+    expect(rendered).toContain("← recommended");
   });
 
-  test("requires an explicit choice to turn analytics on", () => {
+  test("still offers keeping it off, and says nothing is sent until confirmed", () => {
+    // Recommending is not deciding. The slide has to state plainly that the
+    // keystroke is what enables it, or a pre-selected option reads as opt-out.
     const rendered = frame();
-    expect(rendered).toContain("Off by default");
-    expect(rendered).toContain("Turn on analytics");
+    expect(rendered).toContain("Keep it off");
+    expect(rendered).toContain("until you confirm");
+  });
+
+  test("frames the count as installs rather than people", () => {
+    expect(frame()).toContain("unique installs, not people");
+  });
+
+  test("describes this machine, not a hardcoded one", () => {
+    // The payload preview used to be the literal string
+    // `"version": "0.3.0", "os": "linux", "arch": "x64"`, which made the one
+    // screen that must be exactly true a false statement on macOS and Windows.
+    //
+    // Asserted as "matches the real values" rather than "is not 0.3.0": the
+    // shipped version happens to be 0.3.0 today, so an absence check would pass
+    // for the wrong reason now and fail for the wrong reason after a bump.
+    const rendered = frame();
+    expect(rendered).toContain(`"${process.platform}"`);
+    expect(rendered).toContain(`"${process.arch}"`);
+    expect(rendered).toContain(`"${packageJson.version}"`);
+  });
+
+  test("says the raw id never leaves the machine", () => {
+    expect(frame()).toContain("never leaves this machine");
   });
 
   test("reduced motion renders the static petal only", () => {

--- a/apps/cli/test/unit/app-shell/setup-analytics-consent.test.ts
+++ b/apps/cli/test/unit/app-shell/setup-analytics-consent.test.ts
@@ -23,7 +23,7 @@ test("skipping a forced setup rerun preserves an existing analytics opt-in", asy
       mpv: true,
       ffprobe: true,
       ytDlp: true,
-      curl: true,
+      curl: { present: true, impersonates: true, profile: "chrome150" },
       image: {
         terminal: "unknown",
         protocol: "none",
@@ -46,17 +46,80 @@ test("skipping a forced setup rerun preserves an existing analytics opt-in", asy
   const pending = runSetupWizard({ container, force: true });
   expect(
     forceCloseRootContent({
-      outcome: "skipped",
+      outcome: "aborted",
       prefs: {
         audio: "original",
         subtitle: "en",
         downloadsEnabled: false,
-        analyticsChoice: "disabled",
+        analyticsChoice: "unchanged",
       },
     }),
   ).toBe(true);
 
-  await expect(pending).resolves.toBe("skipped");
+  await expect(pending).resolves.toBe("cancelled");
   expect(config.analytics).toBe("enabled");
   expect(config.installId).toBe("existing-install-id");
+});
+
+test("accepting recommended defaults without reaching consent leaves an opt-in alone", async () => {
+  // `S` on an early slide finishes setup without the consent slide ever being
+  // shown. That is not a decision about analytics, so an existing opt-in must
+  // survive it — the mirror of the rule that a skip may never opt someone IN.
+  let config = {
+    ...DEFAULT_CONFIG,
+    analytics: "enabled" as const,
+    installId: "existing-install-id",
+  };
+  const container = {
+    config: {
+      getRaw: () => config,
+      update: async (patch: Partial<typeof config>) => {
+        config = { ...config, ...patch };
+      },
+      save: async () => undefined,
+    },
+    capabilitySnapshot: {
+      mpv: true,
+      ffprobe: true,
+      ytDlp: true,
+      curl: { present: true, impersonates: true, profile: "chrome150" },
+      image: {
+        terminal: "unknown",
+        protocol: "none",
+        renderer: "none",
+        available: false,
+        reason: "test fixture",
+      },
+      issues: [],
+    },
+    usageAnalytics: {
+      consentPatch: (choice: "enabled" | "disabled") =>
+        choice === "enabled"
+          ? { analytics: "enabled" as const, installId: config.installId }
+          : { analytics: "disabled" as const, installId: "" },
+    },
+    diagnosticsService: { record: () => undefined },
+    analyticsDisclosurePending: false,
+  } as unknown as Container;
+
+  const pending = runSetupWizard({ container, force: true });
+  expect(
+    forceCloseRootContent({
+      outcome: "defaults",
+      prefs: {
+        audio: "original",
+        subtitle: "en",
+        downloadsEnabled: true,
+        analyticsChoice: "unchanged",
+      },
+    }),
+  ).toBe(true);
+
+  await expect(pending).resolves.toBe("completed");
+  expect(config.analytics).toBe("enabled");
+  expect(config.installId).toBe("existing-install-id");
+  // The rest of the recommended configuration still lands.
+  expect(config.downloadsEnabled).toBe(true);
+  expect(config.seriesLanguageProfile.audio).toBe("original");
+  expect(config.movieLanguageProfile.audio).toBe("original");
 });

--- a/apps/cli/test/unit/app-shell/setup-analytics-consent.test.ts
+++ b/apps/cli/test/unit/app-shell/setup-analytics-consent.test.ts
@@ -123,3 +123,67 @@ test("accepting recommended defaults without reaching consent leaves an opt-in a
   expect(config.seriesLanguageProfile.audio).toBe("original");
   expect(config.movieLanguageProfile.audio).toBe("original");
 });
+
+test("a fresh install that never reaches consent stays unset, with no install id", async () => {
+  // The primary direction of the opt-in contract, and the one the recommended-
+  // first consent slide makes worth pinning: analytics leads and is marked
+  // recommended, so nothing but a keystroke on that slide may enable it. A
+  // fresh install that skips setup, or accepts defaults before the slide is
+  // reached, must come out `unset` with no `installId` written at all —
+  // `unset` is not `disabled`, and a config Kunai never wrote is the only
+  // honest record of a decision the user never made.
+  let config = { ...DEFAULT_CONFIG };
+  const patches: Partial<typeof config>[] = [];
+  const container = {
+    config: {
+      getRaw: () => config,
+      update: async (patch: Partial<typeof config>) => {
+        patches.push(patch);
+        config = { ...config, ...patch };
+      },
+      save: async () => undefined,
+    },
+    capabilitySnapshot: {
+      mpv: true,
+      ffprobe: true,
+      ytDlp: true,
+      curl: { present: true, impersonates: true, profile: "chrome150" },
+      image: {
+        terminal: "unknown",
+        protocol: "none",
+        renderer: "none",
+        available: false,
+        reason: "test fixture",
+      },
+      issues: [],
+    },
+    usageAnalytics: {
+      consentPatch: (choice: "enabled" | "disabled") =>
+        choice === "enabled"
+          ? { analytics: "enabled" as const, installId: "generated-install-id" }
+          : { analytics: "disabled" as const, installId: "" },
+    },
+    diagnosticsService: { record: () => undefined },
+    analyticsDisclosurePending: false,
+  } as unknown as Container;
+
+  const pending = runSetupWizard({ container, force: true });
+  expect(
+    forceCloseRootContent({
+      outcome: "defaults",
+      prefs: {
+        audio: "original",
+        subtitle: "en",
+        downloadsEnabled: true,
+        analyticsChoice: "unchanged",
+      },
+    }),
+  ).toBe(true);
+
+  await expect(pending).resolves.toBe("completed");
+  expect(config.analytics).toBe(DEFAULT_CONFIG.analytics);
+  expect(config.installId).toBe(DEFAULT_CONFIG.installId);
+  // Stronger than the values above: no write may even mention analytics, so a
+  // future patch cannot satisfy this by writing `unset` back over itself.
+  expect(patches.some((patch) => "analytics" in patch || "installId" in patch)).toBe(false);
+});

--- a/apps/cli/test/unit/app-shell/setup-write-map.test.ts
+++ b/apps/cli/test/unit/app-shell/setup-write-map.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  AUDIO_SETTINGS_OPTIONS,
+  SUBTITLE_SETTINGS_OPTIONS,
+} from "@/app-shell/settings/registry/shared";
+import { shouldRunSetupWizard, ONBOARDING_VERSION } from "@/app/bootstrap/startup-setup";
+import {
+  AUDIO_PREFERENCE_OPTIONS,
+  RECOMMENDED_AUDIO_PREFERENCE,
+  RECOMMENDED_SUBTITLE_PREFERENCE,
+  SUBTITLE_PREFERENCE_OPTIONS,
+} from "@/domain/media/media-preferences";
+
+/**
+ * Silent no-ops are the house failure mode — settings collected and dropped,
+ * options declared in one surface and contradicted in another. These are the
+ * structural guards, not a checklist someone has to remember to re-read.
+ */
+
+describe("setup option catalogs are one source of truth", () => {
+  test("settings and setup offer the identical audio catalog", () => {
+    // Not "equivalent" — identical. Two hand-maintained lists is how setup came
+    // to offer en/none/interactive/ja/es/fr while settings offered a different
+    // set in a different order with different labels for the same value.
+    expect(AUDIO_SETTINGS_OPTIONS).toBe(AUDIO_PREFERENCE_OPTIONS);
+  });
+
+  test("settings and setup offer the identical subtitle catalog", () => {
+    expect(SUBTITLE_SETTINGS_OPTIONS).toBe(SUBTITLE_PREFERENCE_OPTIONS);
+  });
+
+  test("every recommended value exists in the catalog it belongs to", () => {
+    // A recommendation naming a value nobody offers silently falls back to
+    // whatever sits at index 0, which is how a "recommended default" quietly
+    // becomes something else.
+    expect(AUDIO_PREFERENCE_OPTIONS.map((o) => o.value)).toContain(RECOMMENDED_AUDIO_PREFERENCE);
+    expect(SUBTITLE_PREFERENCE_OPTIONS.map((o) => o.value)).toContain(
+      RECOMMENDED_SUBTITLE_PREFERENCE,
+    );
+  });
+
+  test("no catalog carries a duplicate value", () => {
+    for (const catalog of [AUDIO_PREFERENCE_OPTIONS, SUBTITLE_PREFERENCE_OPTIONS]) {
+      const values = catalog.map((option) => option.value);
+      expect(new Set(values).size).toBe(values.length);
+    }
+  });
+
+  test("every option is labelled and explained", () => {
+    for (const catalog of [AUDIO_PREFERENCE_OPTIONS, SUBTITLE_PREFERENCE_OPTIONS]) {
+      for (const option of catalog) {
+        expect(option.label.length).toBeGreaterThan(0);
+        expect(option.detail.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe("shouldRunSetupWizard", () => {
+  const fresh = { onboardingVersion: 0, downloadOnboardingDismissed: false };
+  const onboarded = { onboardingVersion: 2, downloadOnboardingDismissed: true };
+
+  test("runs on a fresh install", () => {
+    expect(shouldRunSetupWizard({ force: false, config: fresh })).toBe(true);
+  });
+
+  test("does not re-onboard an install that already finished setup", () => {
+    // Bumping ONBOARDING_VERSION must never drag existing users back through
+    // the wizard on upgrade. Version 2 counts as done.
+    expect(shouldRunSetupWizard({ force: false, config: onboarded })).toBe(false);
+    expect(ONBOARDING_VERSION).toBeGreaterThan(onboarded.onboardingVersion);
+  });
+
+  test("an unfinished download prompt no longer re-triggers the whole wizard", () => {
+    // Two gates for one question: `downloadOnboardingDismissed` used to force
+    // the wizard back on an install that had already completed onboarding.
+    expect(
+      shouldRunSetupWizard({
+        force: false,
+        config: { onboardingVersion: 2, downloadOnboardingDismissed: false },
+      }),
+    ).toBe(false);
+  });
+
+  test("force re-runs it for an already-onboarded install", () => {
+    expect(shouldRunSetupWizard({ force: true, config: onboarded })).toBe(true);
+  });
+
+  test("never mounts without an interactive terminal, even when forced", () => {
+    // The wizard is an Ink surface driven by useInput. Mounting one where
+    // nothing can type at it waits forever on a keystroke that cannot arrive.
+    expect(shouldRunSetupWizard({ force: false, config: fresh, interactive: false })).toBe(false);
+    expect(shouldRunSetupWizard({ force: true, config: fresh, interactive: false })).toBe(false);
+  });
+});

--- a/apps/cli/test/unit/app/bootstrap/startup-setup.test.ts
+++ b/apps/cli/test/unit/app/bootstrap/startup-setup.test.ts
@@ -16,12 +16,15 @@ describe("startup setup policy", () => {
         config: { onboardingVersion: 1, downloadOnboardingDismissed: true },
       }),
     ).toBe(true);
+    // An unfinished download prompt no longer drags the whole wizard back:
+    // `downloadOnboardingDismissed` was a second gate answering the same
+    // question, so a completed onboarding could still be re-shown.
     expect(
       shouldRunSetupWizard({
         force: false,
         config: { onboardingVersion: 2, downloadOnboardingDismissed: false },
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   test("completed onboarding skips the workflow import", async () => {
@@ -47,6 +50,9 @@ describe("startup setup policy", () => {
       force: false,
       config: { onboardingVersion: 1, downloadOnboardingDismissed: false },
       container: {} as never,
+      // The default reads the real stdin, which is not a TTY under the test
+      // runner. Stating it keeps this test about the onboarding gate.
+      interactive: true,
       loadSetupWorkflow: async () => {
         loads += 1;
         return {
@@ -61,5 +67,25 @@ describe("startup setup policy", () => {
     expect(result).toBe("completed");
     expect(loads).toBe(1);
     expect(runs).toBe(1);
+  });
+
+  test("a non-interactive session never imports or mounts the wizard", async () => {
+    // The wizard is an Ink surface driven by useInput. In a pipe or under CI it
+    // would wait forever on a keystroke that cannot arrive, so the guard has to
+    // sit before the dynamic import, not inside the shell.
+    let loads = 0;
+    const result = await maybeRunStartupSetup({
+      force: true,
+      config: { onboardingVersion: 0, downloadOnboardingDismissed: false },
+      container: {} as never,
+      interactive: false,
+      loadSetupWorkflow: async () => {
+        loads += 1;
+        return { runSetupWizard: async () => "completed" as const };
+      },
+    });
+
+    expect(result).toBe("skipped");
+    expect(loads).toBe(0);
   });
 });


### PR DESCRIPTION
> Stacked on #223. Review that one first; this branch contains its commit.

## What

Five defects in the setup wizard, all of which let it report success while
doing less than it said.

### 1. Audio reached one lane of three

The slide asks which audio Kunai should prefer "when multiple options exist"
and wrote the answer only to `animeLanguageProfile`. A user who chose English
still got original audio for every film and show. Subtitles were already
written to all three profiles, so the asymmetry was not deliberate.

### 2. Skipping wrote nothing

`skip()` built prefs and `runSetupWizard` discarded them — waving past setup
left the install unconfigured while telling the user it was set up.

Three outcomes now, instead of two doing incompatible jobs:

| Outcome | Trigger | Writes |
| --- | --- | --- |
| `completed` | every step answered | full configuration |
| `defaults` | `s` / `S` | the recommended configuration |
| `aborted` | `esc` / `q` / Ink teardown | onboarding version only |

`s` takes the current step's recommendation and advances rather than ending the
wizard. `S` accepts every remaining recommendation and finishes. Pickers open
on their recommended option, so Enter-through produces the documented
configuration rather than whatever sat at index 0.

### 3. Downloads defaulted to the option that could not work

It pre-selected "Enable downloads" even when the slide's own subtitle said
yt-dlp was missing. It now follows what is installed.

### 4. The consent screen was false off Linux/x64

The payload preview was the literal `"version": "0.3.0", "os": "linux",
"arch": "x64"`. It is now built from the real package version,
`process.platform`, and `process.arch`.

### 5. Two catalogs for one concept

Setup offered en/none/interactive/ja/es/fr; `/settings` offered
en/interactive/none/ar/fr/de/es/ja — different members, order, and labels for
the same value ("Ask me each time" vs "Pick interactively"). Both now read one
catalog in `domain/media/media-preferences.ts`.

## Analytics

Recommended and pre-selected, per the amended contract, with one guardrail:
**no skip path may enable it.** `s` on the consent slide selects off, and `S`
stops there rather than passing through.

A third `unchanged` state exists because collapsing "never reached the slide"
into "disabled" would silently opt **out** a user who had previously opted in
and then reran setup — the mirror of the bug the guardrail prevents. This was
caught by an existing test asserting that skipping a forced rerun preserves an
opt-in; it was right, and the first draft of this change broke it. Only a
keystroke on that slide moves the value, in either direction.

## Onboarding gate

Two gates answered one question: `onboardingVersion < 2` **or**
`!downloadOnboardingDismissed`, so a completed onboarding could be re-shown
whenever the second flag was false. Collapsed to one.

`ONBOARDING_VERSION` is 3, and installs already at 2 are treated as done —
bumping it must never drag existing users back through the wizard on upgrade.

## Non-interactive sessions

The wizard is an Ink surface driven by `useInput`, and nothing guarded against
mounting one where no keystroke can arrive. A non-interactive session now skips
it *before* the dynamic import, and `kunai --setup` in a pipe exits 1 naming the
reason rather than hanging.

## Verification

- `bun run typecheck --force` — 14/14
- `bun run lint --force` — 0 warnings, 0 errors
- `bun run test --force` — 23/23 tasks, 0 fail
- Drove the real `SetupShell` through every path via the render harness:

```
S-from-welcome  defaults   analyticsChoice: unchanged   ← accept-all never enables
enter-through   completed  analyticsChoice: enabled     ← recommendation taken explicitly
s-at-consent    completed  analyticsChoice: disabled
s-all-the-way   completed  analyticsChoice: disabled
q-abort         aborted    analyticsChoice: unchanged
```

New `setup-write-map.test.ts` is the structural guard: catalogs must be
identical objects (not merely equivalent), every recommended value must exist
in its catalog, no duplicates, every option labelled and explained, and the
onboarding gate behaves for fresh / onboarded / forced / non-interactive.

**Not verified:** `esc` cannot be exercised through the capture harness, which
does not deliver a lone escape byte to Ink in a form `useInput` resolves. The
handler is byte-identical to `main`, and `q` covers the same abort path.

## Scope

Settings the wizard already collected. New questions — mode, auto-skip,
downloads quality, accounts — arrive with their screens in PR 3, per
`.plans/2026-08-25-setup-wizard-redesign.md`.
