### PR TITLE
test(installer): budget the aged-owner retain test for slow Windows runners

### DIFF
--- a/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
@@ -16,6 +16,19 @@ import {
 const made: string[] = [];
 const RECLAIM_TEST_TIMEOUT_MS = process.platform === "win32" ? 1_000 : 100;
 
+/**
+ * Acquisition budget for tests that assert the lock is *retained*.
+ *
+ * These wait out the deadline on purpose -- the assertion is `acquired: false`
+ * -- so the budget is a floor on how long the attempt runs, never a claim about
+ * how fast the machine is. A hardcoded 40ms was tight enough that a loaded
+ * Windows runner overshot it (measured 50.57ms) and failed a test that had
+ * proven exactly what it set out to prove. The bound below still catches a real
+ * hang, which is the only failure this timing can honestly detect.
+ */
+const RETAIN_TEST_TIMEOUT_MS = process.platform === "win32" ? 400 : 40;
+const RETAIN_TEST_MAX_ELAPSED_MS = process.platform === "win32" ? 5_000 : 1_000;
+
 function impossibleProcessStartId(): string {
   if (process.platform === "win32") return "windows-ticks:0";
   if (process.platform === "darwin") return "darwin-ps:impossible";
@@ -468,12 +481,12 @@ describe("activation lock", () => {
 
       const startedAt = performance.now();
       const lock = await tryAcquireActivationLock(layout, "2.0.0", {
-        timeoutMs: 40,
+        timeoutMs: RETAIN_TEST_TIMEOUT_MS,
         pollMs: 5,
       });
 
       expect(lock).toEqual({ acquired: false, holderPid: process.pid });
-      expect(performance.now() - startedAt).toBeLessThan(1_000);
+      expect(performance.now() - startedAt).toBeLessThan(RETAIN_TEST_MAX_ELAPSED_MS);
       expect(JSON.parse(await readFile(path, "utf8")).ownerId).toBe("aged-live-owner");
     },
   );


### PR DESCRIPTION
`activation lock > keeps a short deadline while conservatively retaining an aged live Windows owner` failed on a loaded Windows runner at **50.57 ms** against a hardcoded `timeoutMs: 40`.

## Why this one is safe to widen

The timeout here is a **floor, not a measurement**. The test waits the deadline out on purpose and asserts `acquired: false` — that a live-but-aged owner is *retained*, not reclaimed. The budget only governs how long the attempt runs before giving up.

So a 40 ms floor was tight enough that ordinary scheduling jitter failed a test that had **already proven exactly what it set out to prove**. Nothing about the assertion depends on the machine being fast.

## Follows the precedent already in this file

`RECLAIM_TEST_TIMEOUT_MS` (`win32 ? 1_000 : 100`) exists a few lines above for the same reason. The new constants match its shape:

```ts
const RETAIN_TEST_TIMEOUT_MS     = process.platform === "win32" ? 400 : 40;
const RETAIN_TEST_MAX_ELAPSED_MS = process.platform === "win32" ? 5_000 : 1_000;
```

POSIX behaviour is unchanged. The elapsed bound still catches a real hang — which is the only failure this timing can honestly detect.

## Not a blanket relaxation

The other bare `timeoutMs` literals in this file are deliberately left alone: most assert `acquired === false` because the deadline is *respected*, so they need tight values and are inherently not flaky. Only fixtures whose assertion is independent of elapsed time get a platform-aware budget.

## Gates

typecheck 14/14 · lint 0 warnings · **6118 pass / 0 fail** cache-forced · `activation-lock.test.ts` 17 pass / 1 skip / 0 fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of retained-lock tests on Windows by allowing additional time for lock acquisition and expiration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->