### PR TITLE
feat(docs): report Core Web Vitals with Vercel Speed Insights

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -6,6 +6,7 @@ import { fontClassNames } from "@/lib/fonts";
 /* eslint-enable import/no-unassigned-import */
 import { docsSiteUrl } from "@/lib/site";
 import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
@@ -52,6 +53,7 @@ export default function RootLayout({ children }: { readonly children: ReactNode 
           <TooltipProvider>{children}</TooltipProvider>
         </RootProvider>
         <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -23,6 +23,7 @@
     "@kunai/design": "workspace:*",
     "@tabler/icons-react": "catalog:web",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "catalog:web",
     "clsx": "catalog:web",
     "fumadocs-core": "catalog:web",

--- a/bun.lock
+++ b/bun.lock
@@ -72,6 +72,7 @@
         "@kunai/design": "workspace:*",
         "@tabler/icons-react": "catalog:web",
         "@vercel/analytics": "^2.0.1",
+        "@vercel/speed-insights": "^2.0.0",
         "class-variance-authority": "catalog:web",
         "clsx": "catalog:web",
         "fumadocs-core": "catalog:web",
@@ -859,6 +860,8 @@
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 
     "@vercel/analytics": ["@vercel/analytics@2.0.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g=="],
+
+    "@vercel/speed-insights": ["@vercel/speed-insights@2.0.0", "", { "peerDependencies": { "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w=="],
 
     "@yuku-analyzer/binding-darwin-arm64": ["@yuku-analyzer/binding-darwin-arm64@0.6.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-xhM6mCZ94kx7L5D4fJEVqqeXS4eGAz+ngWhbM2y7r8Ix2Lc43j6Osyw4KGGTQi1XTy3MKgs6x5DaCe1vw0i3tQ=="],
 


### PR DESCRIPTION
```tsx
import { SpeedInsights } from "@vercel/speed-insights/next";
…
<Analytics />
<SpeedInsights />
```

The docs site already reports page views through `@vercel/analytics` — so it could tell **how many** people reached a page, but nothing about whether the page was **fast** for them. Speed Insights adds the field measurements (LCP, CLS, INP), which is the half that decides whether someone reads the install instructions or leaves.

Mounted next to `<Analytics />` in the root layout. That is the whole integration for the App Router: the component injects the collection script and reports from **real navigations**, not a synthetic lab run.

## Next.js review while here — nothing to fix

Checked the docs app against the framework guidance rather than assuming:

| Check | Result |
| --- | --- |
| Fonts | Already `next/font/google` — self-hosted, no layout shift |
| Images | No raw `<img>` bypassing `next/image` |
| `useSearchParams` outside Suspense | None (would force a CSR bailout) |
| Route rendering | Already `force-static` / SSG where possible |

The one thing worth noting: `next.config.mjs` documents that `outputFileTracingIncludes` and `…Excludes` were both deliberately removed once request-time filesystem reads were eliminated. That reasoning still holds — nothing here reintroduces a runtime read.

## Gates

typecheck 14/14 · lint 0 warnings · docs build clean (cache-forced, 4/4 tasks).

Reporting starts once this deploys, and the data shows up in the project's Speed Insights tab.
