### PR TITLE
fix(diagnostics): stop redacting Kunai's own job and correlation ids

### DIFF
--- a/apps/cli/src/services/diagnostics/redaction.ts
+++ b/apps/cli/src/services/diagnostics/redaction.ts
@@ -138,7 +138,27 @@ function redactUrl(value: string): string {
 const OPAQUE_MIN_LENGTH = 16;
 const OPAQUE_MIN_UNBROKEN_RUN = 12;
 
+/**
+ * A canonical UUID — Kunai's own job, download, and correlation ids.
+ *
+ * These are generated locally by `crypto.randomUUID()`, identify nothing but a
+ * row in the user's own database, and are the primary key for correlating a
+ * failure across a trace. Redacting them removes the one field that makes a
+ * support bundle answer "which job?" while protecting nothing.
+ *
+ * They are also structurally distinguishable from a bearer token rather than
+ * merely allow-listed by name: 8-4-4-4-12 hex with a version nibble, so the
+ * longest unbroken run is always exactly 12. A CDN token that happened to be
+ * dash-separated into identical groups would still be an id-shaped string; a
+ * real one never is, because its entropy arrives as one long run.
+ */
+const CANONICAL_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 export function isOpaqueQueryValue(value: string): boolean {
+  // Checked before the length gate on purpose: a UUID clears every other test
+  // here — 36 chars, hex alphabet, mixed classes, and a trailing run of exactly
+  // OPAQUE_MIN_UNBROKEN_RUN — so it is redacted by one character of margin.
+  if (CANONICAL_UUID.test(value)) return false;
   if (value.length < OPAQUE_MIN_LENGTH) return false;
   // Base64url / hex alphabet, plus any padding the CDN left on.
   if (!/^[A-Za-z0-9_.~=-]+$/.test(value)) return false;

--- a/apps/cli/src/services/download/DownloadService.ts
+++ b/apps/cli/src/services/download/DownloadService.ts
@@ -2000,7 +2000,6 @@ async function readUtf8Stream(reader: {
   }
 }
 
-
 function buildDownloadQueueAggregateMessage(failures: readonly unknown[]): string {
   const summaries = failures.map((failure) => {
     const name = redactDownloadQueueAggregateText(

--- a/apps/cli/test/unit/services/diagnostics/redaction.test.ts
+++ b/apps/cli/test/unit/services/diagnostics/redaction.test.ts
@@ -164,3 +164,46 @@ describe("opaque query values", () => {
     );
   });
 });
+
+describe("Kunai's own identifiers survive redaction", () => {
+  test("a job UUID stays readable in a diagnostic context", () => {
+    // Regression: the opaque-value heuristic redacted every canonical UUID.
+    // A v4 uuid is 36 chars of hex, mixes letters and digits, and its last
+    // group is always exactly OPAQUE_MIN_UNBROKEN_RUN long — so it cleared
+    // every gate by a single character and `jobId` came back "[redacted]",
+    // removing the one field that answers "which job failed?".
+    expect(
+      redactDiagnosticValue({
+        source: "download-manager",
+        jobId: "b3c1d4a1-4d8b-4b66-ad78-7d5adc2a0e8d",
+      }),
+    ).toEqual({
+      source: "download-manager",
+      jobId: "b3c1d4a1-4d8b-4b66-ad78-7d5adc2a0e8d",
+    });
+  });
+
+  test("every uuid version Kunai can generate is preserved", () => {
+    for (const id of [
+      crypto.randomUUID(),
+      crypto.randomUUID(),
+      "00000000-0000-4000-8000-000000000000",
+      "FFFFFFFF-FFFF-4FFF-BFFF-FFFFFFFFFFFF",
+    ]) {
+      expect(redactDiagnosticValue({ id })).toEqual({ id });
+    }
+  });
+
+  test("the exemption is shape-bound and still redacts real secrets", () => {
+    // The point of the carve-out is that a bearer token cannot wear a uuid's
+    // shape: its entropy arrives as one unbroken run. If this ever passes
+    // through, the exemption has been widened too far.
+    for (const secret of [
+      "dQw4w9WgXcQ1a2b3c4d5e6f7g8h9i0jK",
+      "b3c1d4a14d8b4b66ad787d5adc2a0e8d",
+      "b3c1d4a1-4d8b-4b66-ad78-7d5adc2a0e8dEXTRA",
+    ]) {
+      expect(redactDiagnosticValue({ token: secret })).toEqual({ token: "[redacted]" });
+    }
+  });
+});


### PR DESCRIPTION
**`main` is red.** Two `DownloadService` tests assert a `jobId` in a diagnostic context and receive `"[redacted]"`.

## Neither PR was wrong

- **#181** added `isOpaqueQueryValue` — a shape-based heuristic that redacts long, mixed-class, base64url-alphabet strings.
- **#163** added a queue-failure diagnostic context carrying `jobId`.

Each was green in isolation, and they never touched the same lines. **The collision is semantic**, so no merge — and no per-branch gate — could have detected it. It only appears once both are on `main`.

## The bug is wider than the two failing tests

A canonical v4 UUID clears every gate in `isOpaqueQueryValue` by exactly one character:

| Gate | UUID |
| --- | --- |
| `length >= 16` | 36 ✅ |
| base64url/hex alphabet | ✅ (hex + dashes) |
| mixes letters and digits | ✅ |
| longest unbroken run `>= 12` | **exactly 12** ✅ |

That last one isn't a coincidence — a v4 UUID's final group is *always* 12 hex chars. Verified across generated ids: the longest run is **always** 12.

So this redacted **every** job, download, and correlation id in every diagnostic context — not just the one these tests happened to catch.

These ids come from `crypto.randomUUID()`, identify nothing but a row in the user's own database, and are the primary key for correlating a failure across a trace. Redacting them removed the one field that answers *"which job failed?"* while protecting nothing.

## The carve-out is shape-bound, not name-bound

Exempting by key name (`jobId`, `downloadJobId`, …) would rot the moment a new field appears. Instead the exemption matches the canonical UUID **shape**, including the version and variant nibbles.

A bearer token cannot wear that shape: its entropy arrives as **one long run**, not five dash-separated groups of fixed width. A test pins this — if a 32-char token, a dash-free hex string, or a UUID-with-a-suffix ever survives redaction, the exemption has been widened too far.

## Gates

typecheck 14/14 · lint 0 warnings · **6180 pass / 0 fail** cache-forced · `download-service.test.ts` 55/55 · full diagnostics suite 112/112.

One unrelated flake appeared on the first full run (`AllManga … aborts a slow optional adapter after its wait budget`, a timing test). It passed **3/3 in isolation** and on the re-run — load-sensitive, not caused by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Diagnostic output now preserves valid Kunai job, download, and correlation IDs instead of redacting them.
  * Other opaque tokens and secret-like values continue to be protected.

* **Tests**
  * Added coverage for supported UUID formats and boundary cases, including invalid or high-entropy values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->