### PR TITLE
fix(anidb): retry a timed-out curl attempt once before failing

### DIFF
--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -181,23 +181,54 @@ export async function anidbFetchText(
     ...anidbCipherArgs(curl.impersonates),
     url,
   ];
-  const proc = Bun.spawn(args, {
-    stdout: "pipe",
-    stderr: "pipe",
-    signal: options.signal,
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
-  if (exitCode !== 0) {
-    throw new Error(stderr.trim() || `curl exit ${exitCode}`);
-  }
+  const stdout = await runAnidbCurlWithRetry(args, options.signal);
   if (isCloudflareChallengeText(stdout)) {
     throw new Error("anidb blocked by Cloudflare (try curl-impersonate)");
   }
   return stdout;
+}
+
+const ANIDB_CURL_TIMEOUT_EXIT_CODE = 28;
+
+/**
+ * AniDB TTFB from constrained networks sits close to the curl budget, so a lone
+ * timed-out attempt is usually transient congestion rather than a dead route.
+ * Retry once on exit 28 (`--max-time` exceeded) only: every other exit code
+ * (DNS, refused, TLS) fails deterministically and a retry would just double the
+ * latency before the same error.
+ */
+export async function runAnidbCurlWithRetry(
+  args: readonly string[],
+  signal?: AbortSignal,
+  spawnOnce: (
+    args: readonly string[],
+    signal?: AbortSignal,
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number }> = defaultSpawnOnce,
+): Promise<string> {
+  let result = await spawnOnce(args, signal);
+  if (result.exitCode === ANIDB_CURL_TIMEOUT_EXIT_CODE) {
+    result = await spawnOnce(args, signal);
+  }
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr.trim() || `curl exit ${result.exitCode}`);
+  }
+  return result.stdout;
+}
+
+function defaultSpawnOnce(
+  args: readonly string[],
+  signal?: AbortSignal,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn([...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    signal,
+  });
+  return Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]).then(([stdout, stderr, exitCode]) => ({ stdout, stderr, exitCode }));
 }
 
 export async function searchAnidb(

--- a/packages/providers/src/anidb/direct.ts
+++ b/packages/providers/src/anidb/direct.ts
@@ -69,6 +69,7 @@ export {
   parseAnidbSeasonEvidence,
   anidbCipherArgs,
   resolveAnidbCurl,
+  runAnidbCurlWithRetry,
   resolveAnidbEpisodeStreams,
   searchAnidb,
   type AnidbSearchResult,

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -13,6 +13,7 @@ import {
   parseAnidbSeasonEvidence,
   anidbCipherArgs,
   resolveAnidbCurl,
+  runAnidbCurlWithRetry,
   resolveAnidbEpisodeStreams,
   searchAnidb,
 } from "../src/anidb/direct";
@@ -400,6 +401,65 @@ describe("anidb curl selection", () => {
   test("never overrides an impersonate build's own handshake", () => {
     for (const platform of ["darwin", "win32", "linux"] as const) {
       expect(anidbCipherArgs(true, platform)).toEqual([]);
+    }
+  });
+});
+
+describe("runAnidbCurlWithRetry", () => {
+  const ok = (stdout: string) => ({ stdout, stderr: "", exitCode: 0 });
+
+  test("returns the first successful attempt without spawning twice", async () => {
+    const runs: number[] = [];
+    const stdout = await runAnidbCurlWithRetry(
+      ["curl", "https://anidb.app"],
+      undefined,
+      async () => {
+        runs.push(1);
+        return ok("<html>page</html>");
+      },
+    );
+    expect(stdout).toBe("<html>page</html>");
+    expect(runs).toHaveLength(1);
+  });
+
+  test("retries exactly once when curl times out (exit 28), then succeeds", async () => {
+    let attempt = 0;
+    const attempts: number[] = [];
+    const stdout = await runAnidbCurlWithRetry(
+      ["curl", "https://anidb.app"],
+      undefined,
+      async () => {
+        attempt += 1;
+        attempts.push(attempt);
+        if (attempt === 1) return { stdout: "", stderr: "", exitCode: 28 };
+        return ok("<html>page after retry</html>");
+      },
+    );
+    expect(stdout).toBe("<html>page after retry</html>");
+    expect(attempts).toEqual([1, 2]);
+  });
+
+  test("a second consecutive timeout surfaces the error instead of retrying forever", async () => {
+    let calls = 0;
+    await expect(
+      runAnidbCurlWithRetry(["curl", "https://anidb.app"], undefined, async () => {
+        calls += 1;
+        return { stdout: "", stderr: "operation timed out", exitCode: 28 };
+      }),
+    ).rejects.toThrow("operation timed out");
+    expect(calls).toBe(2);
+  });
+
+  test("deterministic failures (DNS, TLS, refused) do not burn a retry", async () => {
+    for (const exitCode of [6, 7, 35]) {
+      let calls = 0;
+      await expect(
+        runAnidbCurlWithRetry(["curl", "https://anidb.app"], undefined, async () => {
+          calls += 1;
+          return { stdout: "", stderr: `curl exit ${exitCode}`, exitCode };
+        }),
+      ).rejects.toThrow(`curl exit ${exitCode}`);
+      expect(calls).toBe(1);
     }
   });
 });


### PR DESCRIPTION
## Summary

- AniDB TTFB on constrained networks sits close to the 12s curl `--max-time` budget, so a lone curl exit 28 was surfacing as a full provider failure on roughly every other resolve (observed alternating pass/fail across consecutive live smokes).
- `runAnidbCurlWithRetry` retries **exactly once**, **only** on exit 28 (`--max-time` exceeded). Every other exit code (DNS, refused, TLS) is deterministic and skips the retry rather than doubling latency before the same error.
- Spawn is injected as a seam so the retry policy is unit-tested without network.
- No changes to crypto or decoder constants — ani-cli parity surface is untouched.

## Verification

- `packages/providers`: 58 tests pass, including 4 new retry-policy tests (first-attempt success spawns once; timeout→retry succeeds; double-timeout errors after exactly 2 attempts; deterministic codes never retry).
- Typecheck, oxlint, oxfmt clean.
- Live direct smoke (no relay), 3 consecutive runs: all pass, 3.1–3.6s, zero failure codes.

Live-provider and manual terminal smoke remain release gates. No release is performed by this PR.

## Note for reviewers

The pre-push full-suite gate currently trips over a pre-existing, environment-dependent `DownloadService` failure also present on clean `main` (disk-headroom dependent) — tracked separately, unrelated to this change.