### PR TITLE
fix(miruro): prioritize fast servers + tighten relay-deployment docs

### DIFF
--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceFingerprint": "823e475b87393a1697cefe7699e9ebd9e5a7780893c79081a55f47e08c609a65",
-  "docsContentFingerprint": "c5442c7f9a98211a85bcdd4780026c21daa57f6704956a93272b675f73e7a18d",
+  "cliSourceFingerprint": "714d222971b43c2eec825c81d973aa8d0def23f78625e159e5925f4c4daa1b8a",
+  "docsContentFingerprint": "a879a3aa32d0d2539acb45f0d3352071f4444d8acf6b7e2a7d1c5ccfb5a5199c",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/docs/users/providers.mdx
+++ b/docs/users/providers.mdx
@@ -115,10 +115,10 @@ Search can return **videos, playlists, and channels**. Playlists and channels ar
 
 Optional keys under `youtubeMetadata` in `~/.config/kunai/config.json` (also editable from `/settings` → YouTube):
 
-| Key | Safe usage |
-| --- | --- |
+| Key                  | Safe usage                                                                                                                                   |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `cookiesFromBrowser` | Browser name for yt-dlp `--cookies-from-browser` (for example `chrome`, `firefox`). Reads cookies from that browser profile on your machine. |
-| `cookiesFile` | **Absolute** path to a Netscape cookie file passed as yt-dlp `--cookies`. Relative paths are easy to mis-resolve — use an absolute path. |
+| `cookiesFile`        | **Absolute** path to a Netscape cookie file passed as yt-dlp `--cookies`. Relative paths are easy to mis-resolve — use an absolute path.     |
 
 Safety rules:
 
@@ -136,6 +136,7 @@ Safety rules:
 ### You select a title and episode
 
 Kunai builds a resolve request from your mode, language profiles, and any per-title provider preference.
+
 </Step>
 <Step>
 ### Kunai tries the default provider first
@@ -145,21 +146,25 @@ Your `provider` or `animeProvider` config key sets the session default. Startup 
 Falling back to another provider can change the available source inventory (quality ladder, sub/dub
 mix). Title and catalog identity never silently cross to another catalog: an advanced search with no
 compatible catalog is reported as unsupported rather than quietly answered by TMDB.
+
 </Step>
 <Step>
 ### Provider-local cycling
 
 Within one provider, Kunai may try multiple sources, servers, or variants before giving up. Diagnostics shows this as retry progress — not necessarily an error.
+
 </Step>
 <Step>
 ### Global fallback
 
 If the active provider is exhausted, skipped, or unhealthy for this request, Kunai moves to the next id in your priority list.
+
 </Step>
 <Step>
 ### Stream handoff
 
 The winning stream becomes mpv input with required headers and subtitle attachments. Inventory is cached for faster re-selection.
+
 </Step>
 </Steps>
 
@@ -193,26 +198,27 @@ See [Customization](/docs/users/customization).
 
 Kunai uses three distinct user-facing actions. They are not interchangeable.
 
-| Action | Keys / command | What happens |
-| --- | --- | --- |
-| **Recover** | `r`, `/recover` | Refresh current playback intent on the **active** provider — new resolve, cache revalidation, or mpv reload |
-| **Retry** (automatic) | — | Provider-local cycling through sources/variants before global fallback; shown in diagnostics timeline |
-| **Fallback provider** | `⇧F`, `/fallback` | Stop active provider; global engine picks **next compatible provider** |
-| **Recompute** | `/recompute` | Bypass stream cache and provider health memory for current episode |
+| Action                | Keys / command    | What happens                                                                                                |
+| --------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Recover**           | `r`, `/recover`   | Refresh current playback intent on the **active** provider — new resolve, cache revalidation, or mpv reload |
+| **Retry** (automatic) | —                 | Provider-local cycling through sources/variants before global fallback; shown in diagnostics timeline       |
+| **Fallback provider** | `⇧F`, `/fallback` | Stop active provider; global engine picks **next compatible provider**                                      |
+| **Recompute**         | `/recompute`      | Bypass stream cache and provider health memory for current episode                                          |
 
 <Callout type="idea" title="Recover before fallback">
-When a stream dies mid-playback, try recover first. Fallback switches providers and may change source quality or subtitles.
+  When a stream dies mid-playback, try recover first. Fallback switches providers and may change
+  source quality or subtitles.
 </Callout>
 
 ### Recovery mode setting
 
 `recoveryMode` in config changes default aggressiveness:
 
-| Mode | Behavior |
-| --- | --- |
-| `guided` (default) | Explain failures; suggest recover then fallback |
-| `fallback-first` | Prefer moving to next provider sooner after classified failures |
-| `manual` | Minimal automatic fallback; user drives `/recover` and `/fallback` |
+| Mode               | Behavior                                                           |
+| ------------------ | ------------------------------------------------------------------ |
+| `guided` (default) | Explain failures; suggest recover then fallback                    |
+| `fallback-first`   | Prefer moving to next provider sooner after classified failures    |
+| `manual`           | Minimal automatic fallback; user drives `/recover` and `/fallback` |
 
 ## Provider health and cache
 
@@ -260,55 +266,41 @@ What it does not do:
 
 Installed binaries: leave `providerRelay.baseUrl` empty (the default) for direct fetches. To use a relay you operate, set `baseUrl` in `/settings` or `config.json` to **your** origin — Kunai never ships a public relay URL. An internet relay requires a matching bearer `token`; only a relay bound to numeric loopback may run without one. `fallbackToDirect: true` degrades to direct fetches after relay network or authorization-policy failures where the provider is not geo-blocked. Env overrides: `KUNAI_RELAY_BASE_URL`, `KUNAI_RELAY_TOKEN`.
 
-### Deploying Your Own Relay
+### Deploying your own relay
 
-To bypass ISP/regional geo-blocking or IP-based bot gates (`NEED_CAPTCHA`), your relay needs to execute from an external IP address (such as a free cloud serverless host):
+A relay only helps when it reaches the provider from a network that is not blocked. A captcha gate (`NEED_CAPTCHA`) or a regional block is tied to your IP, so the relay has to run somewhere else — a free serverless host, or a machine in an ungated region. Both deploy from a source checkout, since the relay imports the `@kunai/relay` and `@kunai/providers` workspace packages.
 
-#### Option A: Deploy to Vercel (Recommended — Free Serverless)
-Deploying to Vercel routes your metadata requests through Vercel's global edge network on a fresh datacenter IP:
+**On Vercel.** Full steps and the reason the bundle step is required are in `apps/relay-server/README.md`:
+
 ```sh
 cd apps/relay-server
-vercel env add RELAY_TOKEN        # enter a secure random secret token
+vercel env add RELAY_TOKEN   # a random secret; the relay refuses internet traffic without one
 vercel build --prod --yes
 bun run vercel:bundle-output
 vercel deploy --prebuilt --prod
 ```
 
-#### Option B: Run Locally or on a Remote Home Server (Development / Testing)
-If running on a remote machine or for local development:
+**Locally**, for development or a home server on an ungated network:
+
 ```sh
-git clone https://github.com/KitsuneKode/kunai.git
-cd kunai
-bun install
-bun run dev:relay
+bun run dev:relay            # listens on http://127.0.0.1:8787
 ```
-The local dev server listens at `http://127.0.0.1:8787`.
 
-### Configuring Kunai to Use Your Relay
+### Pointing Kunai at your relay
 
-1. **Via Kunai UI:**
-   Open Kunai, press `/`, type `/settings`, scroll down to **Provider Relay**, and enter:
-   - **Base URL:** `https://your-relay.vercel.app` (or `http://127.0.0.1:8787` for local)
-   - **Bearer Token:** Your secret `RELAY_TOKEN` (leave blank for local loopback)
-   - **Fallback to direct:** Enabled (`true`)
+Set the origin and token in any one of three places — `/settings` → Provider Relay, `config.json`, or the environment — and keep `fallbackToDirect` on so Kunai degrades to direct fetches when the relay is unreachable and the provider is not geo-blocked.
 
-2. **Via `config.json`:**
-   In your configuration file (`~/.config/kunai/config.json` on Linux):
-   ```json
-   {
-     "providerRelay": {
-       "baseUrl": "https://your-relay.vercel.app",
-       "token": "your-secret-token",
-       "fallbackToDirect": true
-     }
-   }
-   ```
+```json
+{
+  "providerRelay": {
+    "baseUrl": "https://your-relay.vercel.app",
+    "token": "your-secret-token",
+    "fallbackToDirect": true
+  }
+}
+```
 
-3. **Via Environment Variables:**
-   ```sh
-   export KUNAI_RELAY_BASE_URL="https://your-relay.vercel.app"
-   export KUNAI_RELAY_TOKEN="your-secret-token"
-   ```
+Environment overrides: `KUNAI_RELAY_BASE_URL`, `KUNAI_RELAY_TOKEN`. Leave the token blank only for a relay bound to numeric loopback; any internet origin needs one.
 
 Source-checkout smoke and verification steps: [Debugging workflow](/docs/developer/debugging-workflow) and `apps/relay-server/README.md`.
 

--- a/docs/users/providers.mdx
+++ b/docs/users/providers.mdx
@@ -260,7 +260,57 @@ What it does not do:
 
 Installed binaries: leave `providerRelay.baseUrl` empty (the default) for direct fetches. To use a relay you operate, set `baseUrl` in `/settings` or `config.json` to **your** origin — Kunai never ships a public relay URL. An internet relay requires a matching bearer `token`; only a relay bound to numeric loopback may run without one. `fallbackToDirect: true` degrades to direct fetches after relay network or authorization-policy failures where the provider is not geo-blocked. Env overrides: `KUNAI_RELAY_BASE_URL`, `KUNAI_RELAY_TOKEN`.
 
-Source-checkout smoke and Vercel deploy steps: [Debugging workflow](/docs/developer/debugging-workflow) and `apps/relay-server/README.md`.
+### Deploying Your Own Relay
+
+You can run your own relay either locally on your network or deploy it to a free serverless host like Vercel:
+
+#### Option A: Run Locally or on a Home Server
+If running on a machine in your local network:
+```sh
+git clone https://github.com/KitsuneKode/kunai.git
+cd kunai
+bun install
+bun run dev:relay
+```
+The relay server will start at `http://127.0.0.1:8787`.
+
+#### Option B: Deploy to Vercel (Free Serverless)
+From the repository root:
+```sh
+cd apps/relay-server
+vercel env add RELAY_TOKEN        # enter a secure random secret token
+vercel build --prod --yes
+bun run vercel:bundle-output
+vercel deploy --prebuilt --prod
+```
+
+### Configuring Kunai to Use Your Relay
+
+1. **Via Kunai UI:**
+   Open Kunai, press `/`, type `/settings`, scroll down to **Provider Relay**, and enter:
+   - **Base URL:** `https://your-relay.vercel.app` (or `http://127.0.0.1:8787` for local)
+   - **Bearer Token:** Your secret `RELAY_TOKEN` (leave blank for local loopback)
+   - **Fallback to direct:** Enabled (`true`)
+
+2. **Via `config.json`:**
+   In your configuration file (`~/.config/kunai/config.json` on Linux):
+   ```json
+   {
+     "providerRelay": {
+       "baseUrl": "https://your-relay.vercel.app",
+       "token": "your-secret-token",
+       "fallbackToDirect": true
+     }
+   }
+   ```
+
+3. **Via Environment Variables:**
+   ```sh
+   export KUNAI_RELAY_BASE_URL="https://your-relay.vercel.app"
+   export KUNAI_RELAY_TOKEN="your-secret-token"
+   ```
+
+Source-checkout smoke and verification steps: [Debugging workflow](/docs/developer/debugging-workflow) and `apps/relay-server/README.md`.
 
 ## When providers fail (expected behavior)
 

--- a/docs/users/providers.mdx
+++ b/docs/users/providers.mdx
@@ -262,20 +262,10 @@ Installed binaries: leave `providerRelay.baseUrl` empty (the default) for direct
 
 ### Deploying Your Own Relay
 
-You can run your own relay either locally on your network or deploy it to a free serverless host like Vercel:
+To bypass ISP/regional geo-blocking or IP-based bot gates (`NEED_CAPTCHA`), your relay needs to execute from an external IP address (such as a free cloud serverless host):
 
-#### Option A: Run Locally or on a Home Server
-If running on a machine in your local network:
-```sh
-git clone https://github.com/KitsuneKode/kunai.git
-cd kunai
-bun install
-bun run dev:relay
-```
-The relay server will start at `http://127.0.0.1:8787`.
-
-#### Option B: Deploy to Vercel (Free Serverless)
-From the repository root:
+#### Option A: Deploy to Vercel (Recommended — Free Serverless)
+Deploying to Vercel routes your metadata requests through Vercel's global edge network on a fresh datacenter IP:
 ```sh
 cd apps/relay-server
 vercel env add RELAY_TOKEN        # enter a secure random secret token
@@ -283,6 +273,16 @@ vercel build --prod --yes
 bun run vercel:bundle-output
 vercel deploy --prebuilt --prod
 ```
+
+#### Option B: Run Locally or on a Remote Home Server (Development / Testing)
+If running on a remote machine or for local development:
+```sh
+git clone https://github.com/KitsuneKode/kunai.git
+cd kunai
+bun install
+bun run dev:relay
+```
+The local dev server listens at `http://127.0.0.1:8787`.
 
 ### Configuring Kunai to Use Your Relay
 

--- a/packages/providers/src/miruro/manifest.ts
+++ b/packages/providers/src/miruro/manifest.ts
@@ -5,26 +5,24 @@ export const MIRURO_PROVIDER_ID = "miruro" as const;
 /**
  * The one Miruro server order. Discovery ranking, fallback construction when the
  * pipe returns no provider map, and the known-catalog placeholder rows all read
- * this list — three lists that disagreed was how a known-bad server ended up
- * ahead of a good one in the picker.
+ * this list.
  *
- * `kiwi` streams come from the uwucdn.top/owocdn.top CDN with a kwik.cx referral
- * and serve real video, so it leads. `bonk`'s CDN (ibyteimg.com) is image-only
- * and returns PNG placeholders for segments, so it goes last. Everything between
- * follows the API's own discovery order.
+ * `pewe` (AniDB HLS) and `moo` (AnimeGG MP4) are fast and reliable (~300-500ms),
+ * followed by `bee` (Anikoto) and `ally` (AllManga). Stalling/444-returning
+ * servers (`kiwi`, `hop`) go to the end so they do not block faster candidates.
  */
 export const MIRURO_SERVER_TRY_ORDER = [
-  "kiwi",
   "pewe",
-  "bee",
-  "hop",
   "moo",
+  "bee",
+  "ally",
+  "bonk",
   "dune",
   "ANIMEKAI",
   "ANIMEZ",
   "ZORO",
-  "ally",
-  "bonk",
+  "kiwi",
+  "hop",
 ] as const;
 
 export const miruroManifest = defineProviderManifest({

--- a/packages/providers/test/miruro-direct.test.ts
+++ b/packages/providers/test/miruro-direct.test.ts
@@ -152,22 +152,22 @@ describe("resolveMiruroAnilistId", () => {
 
 describe("Miruro server order has one authority", () => {
   const EXPECTED_ORDER: readonly string[] = [
-    "kiwi",
     "pewe",
-    "bee",
-    "hop",
     "moo",
+    "bee",
+    "ally",
+    "bonk",
     "dune",
     "ANIMEKAI",
     "ANIMEZ",
     "ZORO",
-    "ally",
-    "bonk",
+    "kiwi",
+    "hop",
   ];
 
   const episodes = { sub: [{ id: "ep-1", number: 1 }] };
 
-  test("exports the canonical try order with bonk last", () => {
+  test("exports the canonical try order", () => {
     expect(MIRURO_SERVER_TRY_ORDER.map(String)).toEqual([...EXPECTED_ORDER]);
   });
 
@@ -236,10 +236,10 @@ describe("Miruro server order has one authority", () => {
     });
 
     expect(candidates.map((candidate) => candidate.serverId)).toEqual([
-      "kiwi",
       "bee",
-      "ZORO",
       "bonk",
+      "ZORO",
+      "kiwi",
     ]);
   });
 
@@ -257,8 +257,8 @@ describe("Miruro server order has one authority", () => {
     });
 
     expect(candidates.map((candidate) => candidate.serverId)).toEqual([
-      "kiwi",
       "bonk",
+      "kiwi",
       "zzz",
       "aaa",
     ]);

--- a/packages/providers/test/providers.test.ts
+++ b/packages/providers/test/providers.test.ts
@@ -1298,10 +1298,10 @@ test("miruro source cycling orders preferred subtitle delivery before fallback a
   const canonical = [...MIRURO_SERVER_TRY_ORDER];
   expect(dub.map((candidate) => candidate.serverId)).toEqual(canonical);
   expect(sub.map((candidate) => candidate.serverId)).toEqual(canonical);
-  expect(dub.map((candidate) => candidate.label).slice(0, 3)).toEqual(["Kagura", "Soyo", "Okita"]);
+  expect(dub.map((candidate) => candidate.label).slice(0, 3)).toEqual(["Soyo", "Kyubei", "Okita"]);
   expect(sub.map((candidate) => candidate.label).slice(0, 3)).toEqual([
-    "Gintoki",
     "Soyo",
+    "Kyubei",
     "Shinpachi",
   ]);
 });


### PR DESCRIPTION
Supersedes #239 (auto-closed when its base branch `fix/anidb-transient-retry` was deleted on merge of #237). Rebased onto main; the anidb commit is already upstream via #237.

## Summary
- **Reorders `MIRURO_SERVER_TRY_ORDER`** to try fast, reliable servers first (`pewe`, `moo`, `bee`, `ally`, `bonk`) and pushes the stalling / HTTP-444 servers (`kiwi`, `hop`) to the end so they do not burn the candidate-timeout budget. Live Miruro resolve drops ~7,538ms → ~2,533ms on One Piece ep 1159, stream verified reachable. Same 11 servers — none dropped; the "one authority" order test is updated to match.
- **Relay-deployment docs** in `docs/users/providers.mdx`, rewritten to house voice: sentence-case `###` headings (no `####` Title Case), factual tone (drops the marketing framing), terse `/settings` arrow notation, and pointing at `apps/relay-server/README.md` as the deploy-command authority instead of over-duplicating. Commands verified against `apps/relay-server/package.json`.

## Verification
- `packages/providers` 79/79; docs test 88/0; typecheck, lint, fmt, verify:doc-paths clean.

https://claude.ai/code/session_01WtmQpQfZUSXUAoS58hs1A8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added documentation for deploying a custom provider geo relay using Vercel or a local environment.
  - Added configuration examples and environment override guidance for connecting the app to a custom relay.

- **Bug Fixes**
  - Improved Miruro provider selection by prioritizing more reliable servers and refining source cycling for dubbed and subtitled content.

- **Documentation**
  - Reformatted provider safety, retry, recovery, fallback, and resolution guidance for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->