### PR TITLE
feat(search): warm the top anime result's episode cache on search

### DIFF
--- a/.changeset/warm-search-cache.md
+++ b/.changeset/warm-search-cache.md
@@ -1,0 +1,13 @@
+---
+"@kitsunekode/kunai": minor
+---
+
+Warm the top anime result's episode cache during search.
+
+### Features
+
+- After an anime search, Kunai warms the persistent episode cache for the single
+  top anime result in the background, so the Cloudflare-gated catalog fetch
+  (~6s) is already paid by the time you pick it. It is fire-and-forget — it never
+  blocks, delays, or fails the search — deduped so a title is warmed once per
+  session, and limited to one gated call per search to stay gentle on the WAF.

--- a/apps/cli/src/app/search/SearchPhase.ts
+++ b/apps/cli/src/app/search/SearchPhase.ts
@@ -107,6 +107,7 @@ import {
   titleInfoFromQueuePlaybackLaunch,
 } from "@/app-shell/root-queue-bridge";
 import { SEARCH_BROWSE_COMMAND_IDS } from "@/app-shell/search-browse-command-ids";
+import { warmTopAnimeEpisodeCache } from "@/services/providers/warm-episode-cache";
 
 export { SEARCH_BROWSE_COMMAND_IDS };
 
@@ -142,6 +143,28 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
   name = "search";
   private hasQueuedStartupReleaseReconciliation = false;
   private hasHealedHistoryMetadata = false;
+  /** Titles already warmed this session, so a search never re-fetches one. */
+  private readonly warmedAnimeEpisodeCaches = new Set<string>();
+
+  /**
+   * Warm the top anime result's episode catalog in the background so the
+   * Cloudflare-gated fetch is already paid when the user picks it. Anime mode
+   * only; a series/movie search has no such cost.
+   */
+  private warmAnimeEpisodesForResults(
+    context: PhaseContext,
+    results: readonly SearchResult[],
+  ): void {
+    const { providerRegistry, config } = context.container;
+    if (context.container.stateManager.getState().mode !== "anime") return;
+    warmTopAnimeEpisodeCache({
+      results,
+      provider: providerRegistry.getDefault(true),
+      audioPreference: config.animeLanguageProfile.audio,
+      subtitlePreference: config.animeLanguageProfile.subtitle,
+      warmed: this.warmedAnimeEpisodeCaches,
+    });
+  }
 
   constructor(
     private readonly dependencies: SearchPhaseDependencies = DEFAULT_SEARCH_PHASE_DEPENDENCIES,
@@ -376,6 +399,7 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
           }
           initialSearchError = undefined;
           const results = search.results;
+          this.warmAnimeEpisodesForResults(context, results);
           pendingSearchEvidence = search.evidence;
           pendingSearchWarnings = searchIntent.warnings;
 
@@ -744,6 +768,7 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
             }
             initialSearchError = undefined;
             const results = search.results;
+            this.warmAnimeEpisodesForResults(context, results);
 
             logger.info("Search complete", {
               query,

--- a/apps/cli/src/services/providers/warm-episode-cache.ts
+++ b/apps/cli/src/services/providers/warm-episode-cache.ts
@@ -1,0 +1,54 @@
+import type { SearchResult, TitleInfo } from "@/domain/types";
+
+import type { Provider } from "./Provider";
+
+/**
+ * Warm the persistent episode cache for the top anime result of a search, in
+ * the background, so the ~6s Cloudflare-gated catalog fetch is already paid by
+ * the time the user picks it.
+ *
+ * Deliberately conservative:
+ * - Only the single top anime result is warmed — one gated call per search, not
+ *   a barrage that would provoke the WAF for titles the user scrolls past.
+ * - `warmed` dedupes across searches so the same title is not re-fetched.
+ * - Fire-and-forget: a warm must never block, delay, or fail the search, so
+ *   every failure is swallowed.
+ *
+ * It calls the provider's `listEpisodes`, which resolves through the
+ * cache-carrying runtime context and populates `provider_cache` as a side
+ * effect. Nothing here reads the result.
+ */
+export function warmTopAnimeEpisodeCache(input: {
+  readonly results: readonly SearchResult[];
+  readonly provider: Provider | undefined;
+  readonly audioPreference: string;
+  readonly subtitlePreference: string;
+  readonly warmed: Set<string>;
+  readonly signal?: AbortSignal;
+}): void {
+  const { results, provider, warmed } = input;
+  if (!provider?.listEpisodes) return;
+
+  const top = results.find((result) => result.isAnime && result.id.trim().length > 0);
+  if (!top || warmed.has(top.id)) return;
+  warmed.add(top.id);
+
+  const title: TitleInfo = {
+    id: top.id,
+    type: top.type,
+    name: top.title,
+    isAnime: true,
+    externalIds: top.externalIds,
+  };
+
+  void provider
+    .listEpisodes(
+      {
+        title,
+        audioPreference: input.audioPreference,
+        subtitlePreference: input.subtitlePreference,
+      },
+      input.signal,
+    )
+    .catch(() => undefined);
+}

--- a/apps/cli/test/unit/services/providers/warm-episode-cache.test.ts
+++ b/apps/cli/test/unit/services/providers/warm-episode-cache.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+
+import type { SearchResult } from "@/domain/types";
+import type { Provider } from "@/services/providers/Provider";
+import { warmTopAnimeEpisodeCache } from "@/services/providers/warm-episode-cache";
+
+function result(over: Partial<SearchResult>): SearchResult {
+  return {
+    id: "anilist:21",
+    type: "series",
+    title: "One Piece",
+    isAnime: true,
+    ...over,
+  } as SearchResult;
+}
+
+function stubProvider(calls: string[]): Provider {
+  return {
+    listEpisodes: async (req: { title: { id: string } }) => {
+      calls.push(req.title.id);
+      return [];
+    },
+  } as unknown as Provider;
+}
+
+function warm(over: Partial<Parameters<typeof warmTopAnimeEpisodeCache>[0]>) {
+  warmTopAnimeEpisodeCache({
+    results: [result({})],
+    provider: undefined,
+    audioPreference: "original",
+    subtitlePreference: "en",
+    warmed: new Set(),
+    ...over,
+  });
+}
+
+describe("warmTopAnimeEpisodeCache", () => {
+  test("warms the top anime result via listEpisodes", async () => {
+    const calls: string[] = [];
+    warm({ provider: stubProvider(calls) });
+    await Promise.resolve();
+    expect(calls).toEqual(["anilist:21"]);
+  });
+
+  test("only the single top anime result is warmed, not the whole list", async () => {
+    const calls: string[] = [];
+    warm({
+      provider: stubProvider(calls),
+      results: [result({ id: "anilist:21" }), result({ id: "anilist:20" })],
+    });
+    await Promise.resolve();
+    expect(calls).toEqual(["anilist:21"]);
+  });
+
+  test("dedupes across calls with a shared warmed set", async () => {
+    const calls: string[] = [];
+    const warmed = new Set<string>();
+    warm({ provider: stubProvider(calls), warmed });
+    warm({ provider: stubProvider(calls), warmed });
+    await Promise.resolve();
+    expect(calls).toEqual(["anilist:21"]);
+  });
+
+  test("skips non-anime results", async () => {
+    const calls: string[] = [];
+    warm({ provider: stubProvider(calls), results: [result({ isAnime: false })] });
+    await Promise.resolve();
+    expect(calls).toEqual([]);
+  });
+
+  test("no-op when the provider cannot list episodes", () => {
+    expect(() => warm({ provider: {} as Provider })).not.toThrow();
+  });
+
+  test("a rejecting listEpisodes never surfaces (fire-and-forget)", async () => {
+    const provider = {
+      listEpisodes: async () => {
+        throw new Error("network down");
+      },
+    } as unknown as Provider;
+    expect(() => warm({ provider })).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+});


### PR DESCRIPTION
Builds on #206's persistent cache seam (now merged). After an anime search, warms the persistent episode cache for the single top anime result in the background, so the ~6s Cloudflare-gated catalog fetch is already paid by the time the user picks it.

## Design (conservative by intent)
- **Fire-and-forget** — never blocks, delays, or fails the search; every failure is swallowed.
- **Anime mode only** — a series/movie search has no such cost.
- **One gated call per search** — only the single top anime result, deduped across searches via a session Set, so it never becomes a barrage that would provoke the Cloudflare WAF for titles the user scrolls past.
- Populates `provider_cache` as a side effect of `listEpisodes` through the cache-carrying runtime context; nothing here reads the result.

## Verification
- `packages/providers` 505/0; `apps/cli` provider suite green; typecheck (forced), lint, warm-episode-cache unit tests (6) all pass.

Cherry-picked onto main after #206; the shared cache-seam commits are already upstream. Includes a changeset (minor).

https://claude.ai/code/session_01WtmQpQfZUSXUAoS58hs1A8