### PR TITLE
test(installer): make the aged-owner retain test deterministic on Windows

### DIFF
--- a/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
@@ -527,6 +527,16 @@ describe("activation lock", () => {
       const lock = await tryAcquireActivationLock(layout, "2.0.0", {
         timeoutMs: RETAIN_TEST_TIMEOUT_MS,
         pollMs: 5,
+        // Confirm the owner is the same live process by returning its stored
+        // start id. Without an injected lookup this used the real Windows probe
+        // against an impossible stored id, so retention depended on whether the
+        // bounded probe returned in time (fast runner: reports the real id ->
+        // mismatch -> reclaim; slow runner: budget exceeded -> null -> retain) --
+        // a timing flake, not the invariant. The invariant is: a confirmed-live
+        // aged owner is retained within the short deadline. Injecting makes that
+        // deterministic; the real probe's own behavior is covered by the reclaim
+        // tests.
+        processStartIdLookup: () => impossibleProcessStartId(),
       });
 
       expect(lock).toEqual({ acquired: false, holderPid: process.pid });


### PR DESCRIPTION
The Windows-only `conservatively retaining an aged live owner` activation-lock test stored an impossible `processStartId` and used the **real** Windows process-start probe, so retention depended on whether the bounded probe returned within the 400ms deadline — fast runner reported the real id (mismatch → reclaim → `toEqual` failed), slow one exceeded budget (null → retain → passed). Timing, not the invariant. Observed failing intermittently on the Windows CLI parity job.

Injects a lookup returning the stored id, so the owner is confirmed the same live process and retention is deterministic. The invariant (a confirmed-live aged owner is retained within the short deadline, owner unchanged) is unchanged; the real probe's behavior stays covered by the reclaim tests. Same class of fix as #240.

Verified by temporarily forcing the win32-only test on Linux (1 pass); full activation-lock suite 17 pass / 1 skip / 0 fail.

https://claude.ai/code/session_01WtmQpQfZUSXUAoS58hs1A8