### PR TITLE
fix(security): bound provider relay inputs

### DIFF
--- a/.changeset/calm-hounds-redirect.md
+++ b/.changeset/calm-hounds-redirect.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Reject untrusted or downgraded HLS relay redirects before requesting them, and bound yt-dlp streaming output.

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -928,7 +928,8 @@ Miruro resolves entirely through `GET /api/secure/pipe?e=…` on `www.miruro.bz`
   at most three redirects itself, reapplying the exact uwucdn/owocdn allowlist before
   each request and rejecting HTTPS-to-HTTP downgrades. Curl never receives `-L`, so
   an allowlisted CDN response cannot redirect the local relay into another host or a
-  plaintext request. Relative playlist entries resolve from the final redirected URL.
+  plaintext request. Relative playlist entries resolve from the final redirected URL,
+  and the full redirect chain shares one 25-second deadline and 64 MiB response budget.
 - **Pipe decoding is endpoint-aware and every stage has its own code.**
   `decodeMiruroPipePayload({ body, obfuscationVersion, expectedKind, keyHex })` raises
   `MiruroPipeDecodeError` with one of `pipe-key-missing`, `pipe-version-mismatch`,

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -926,10 +926,11 @@ Miruro resolves entirely through `GET /api/secure/pipe?e=…` on `www.miruro.bz`
   candidate list is not reachability evidence.
 - **The fingerprint relay validates every redirect.** The loopback HLS relay follows
   at most three redirects itself, reapplying the exact uwucdn/owocdn allowlist before
-  each request and rejecting HTTPS-to-HTTP downgrades. Curl never receives `-L`, so
-  an allowlisted CDN response cannot redirect the local relay into another host or a
-  plaintext request. Relative playlist entries resolve from the final redirected URL,
-  and the full redirect chain shares one 25-second deadline and 64 MiB response budget.
+  each request and rejecting HTTPS-to-HTTP downgrades. Curl starts with `-q` to ignore
+  user config and receives `--no-location`, so neither command arguments nor `.curlrc`
+  can follow a redirect before Kunai validates it. Relative playlist entries resolve
+  from the final redirected URL, and the full redirect chain shares one monotonic
+  25-second deadline and 64 MiB response budget.
 - **Pipe decoding is endpoint-aware and every stage has its own code.**
   `decodeMiruroPipePayload({ body, obfuscationVersion, expectedKind, keyHex })` raises
   `MiruroPipeDecodeError` with one of `pipe-key-missing`, `pipe-version-mismatch`,

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -351,7 +351,7 @@ Third lane provider for standalone videos, playlists, and channels.
 - **Detail/quality:** `yt-dlp -J` on cache miss (SQLite `youtube_metadata_cache`, 15-minute TTL). Resolve fails with `yt-dlp-missing` when yt-dlp is absent. Default quality ceiling is **1080p** (`youtubeLanguageProfile.quality`); change under `/settings` → Language → YouTube quality.
 - **Playback:** canonical `https://www.youtube.com/watch?v=ID` with mpv `--ytdl-format` (DASH `bestvideo+bestaudio` capped to the profile) and `--ytdl-raw-options` (SponsorBlock, live-from-start). Kunai disables mpv-ytdlautoformat overrides via `--script-opts=ytdlautoformat-domains=` so a user-level `ytdlautoformat` script cannot force 720p. **No full video file is written for play** — mpv streams via yt-dlp; only JSON metadata is cached in SQLite.
 - **Downloads:** explicit queue via `d` / download flows; yt-dlp writes `.mp4` to `downloadPath` (or OS default) with `-f` from the same format selector, `--merge-output-format mp4`, cookies/extractor args, and optional `--sponsorblock-remove`; live streams rejected at enqueue.
-- **Process output is bounded:** metadata mode caps complete stdout/stderr payloads, while download progress mode caps stderr and any incomplete stdout line. A malformed or stalled yt-dlp process is terminated instead of growing an unbounded in-memory progress buffer.
+- **Process output is bounded:** metadata mode caps complete stdout/stderr payloads, while download progress mode caps each incomplete output line and retains only a bounded stderr tail. A malformed or stalled yt-dlp process is terminated instead of growing an unbounded in-memory progress buffer.
 - **History:** persisted as `mediaKind: "video"`; resume/continue restores youtube shell mode; playlist rows label `#N`.
 - **Share:** `kunai://` links use `cat=youtube:VIDEO_ID` and `kind=video`.
 - **Settings:** `/settings` → YouTube section for Invidious instance, Piped URL, cookies, extractor args, SponsorBlock categories (`config.youtubeMetadata.*`). Rebinds provider without restart.
@@ -928,7 +928,7 @@ Miruro resolves entirely through `GET /api/secure/pipe?e=…` on `www.miruro.bz`
   at most three redirects itself, reapplying the exact uwucdn/owocdn allowlist before
   each request and rejecting HTTPS-to-HTTP downgrades. Curl never receives `-L`, so
   an allowlisted CDN response cannot redirect the local relay into another host or a
-  plaintext request.
+  plaintext request. Relative playlist entries resolve from the final redirected URL.
 - **Pipe decoding is endpoint-aware and every stage has its own code.**
   `decodeMiruroPipePayload({ body, obfuscationVersion, expectedKind, keyHex })` raises
   `MiruroPipeDecodeError` with one of `pipe-key-missing`, `pipe-version-mismatch`,

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -351,6 +351,7 @@ Third lane provider for standalone videos, playlists, and channels.
 - **Detail/quality:** `yt-dlp -J` on cache miss (SQLite `youtube_metadata_cache`, 15-minute TTL). Resolve fails with `yt-dlp-missing` when yt-dlp is absent. Default quality ceiling is **1080p** (`youtubeLanguageProfile.quality`); change under `/settings` → Language → YouTube quality.
 - **Playback:** canonical `https://www.youtube.com/watch?v=ID` with mpv `--ytdl-format` (DASH `bestvideo+bestaudio` capped to the profile) and `--ytdl-raw-options` (SponsorBlock, live-from-start). Kunai disables mpv-ytdlautoformat overrides via `--script-opts=ytdlautoformat-domains=` so a user-level `ytdlautoformat` script cannot force 720p. **No full video file is written for play** — mpv streams via yt-dlp; only JSON metadata is cached in SQLite.
 - **Downloads:** explicit queue via `d` / download flows; yt-dlp writes `.mp4` to `downloadPath` (or OS default) with `-f` from the same format selector, `--merge-output-format mp4`, cookies/extractor args, and optional `--sponsorblock-remove`; live streams rejected at enqueue.
+- **Process output is bounded:** metadata mode caps complete stdout/stderr payloads, while download progress mode caps stderr and any incomplete stdout line. A malformed or stalled yt-dlp process is terminated instead of growing an unbounded in-memory progress buffer.
 - **History:** persisted as `mediaKind: "video"`; resume/continue restores youtube shell mode; playlist rows label `#N`.
 - **Share:** `kunai://` links use `cat=youtube:VIDEO_ID` and `kind=video`.
 - **Settings:** `/settings` → YouTube section for Invidious instance, Piped URL, cookies, extractor args, SponsorBlock categories (`config.youtubeMetadata.*`). Rebinds provider without restart.
@@ -923,6 +924,11 @@ Miruro resolves entirely through `GET /api/secure/pipe?e=…` on `www.miruro.bz`
   path performs no such probe, so it emits no attestation and the CLI's own
   stream-health gate probes normally. A raw URL, a decoded playlist, or a non-empty
   candidate list is not reachability evidence.
+- **The fingerprint relay validates every redirect.** The loopback HLS relay follows
+  at most three redirects itself, reapplying the exact uwucdn/owocdn allowlist before
+  each request and rejecting HTTPS-to-HTTP downgrades. Curl never receives `-L`, so
+  an allowlisted CDN response cannot redirect the local relay into another host or a
+  plaintext request.
 - **Pipe decoding is endpoint-aware and every stage has its own code.**
   `decodeMiruroPipePayload({ body, obfuscationVersion, expectedKind, keyHex })` raises
   `MiruroPipeDecodeError` with one of `pipe-key-missing`, `pipe-version-mismatch`,

--- a/apps/cli/src/infra/player/hls-relay.ts
+++ b/apps/cli/src/infra/player/hls-relay.ts
@@ -93,25 +93,29 @@ export type HlsRelayCurlResponse = {
 
 export type HlsRelayCurlRequest = (url: string) => Promise<HlsRelayCurlResponse>;
 
+export type HlsRelayUpstreamResponse = HlsRelayCurlResponse & {
+  readonly effectiveUrl: string;
+};
+
 export async function fetchHlsRelayUpstream(
   url: string,
   request: HlsRelayCurlRequest,
-): Promise<HlsRelayCurlResponse> {
+): Promise<HlsRelayUpstreamResponse> {
   let currentUrl = url;
   for (let redirectCount = 0; redirectCount <= 3; redirectCount++) {
     const current = assertRelayUpstreamUrl(currentUrl);
-    const response = await request(currentUrl);
+    const response = await request(current.href);
     if (response.status < 300 || response.status >= 400 || !response.redirectUrl) {
-      return response;
+      return { ...response, effectiveUrl: current.href };
     }
     if (redirectCount === 3) {
       throw new Error("upstream redirected too many times");
     }
-    const redirect = assertRelayUpstreamUrl(response.redirectUrl);
+    const redirect = assertRelayUpstreamUrl(new URL(response.redirectUrl, current).href);
     if (current.protocol === "https:" && redirect.protocol === "http:") {
       throw new Error("HTTPS upstream cannot redirect to HTTP");
     }
-    currentUrl = response.redirectUrl;
+    currentUrl = redirect.href;
   }
   throw new Error("upstream redirected too many times");
 }
@@ -227,7 +231,11 @@ function curlFetchOnce(
   });
 }
 
-function curlFetch(url: string, referer: string, origin: string): Promise<HlsRelayCurlResponse> {
+function curlFetch(
+  url: string,
+  referer: string,
+  origin: string,
+): Promise<HlsRelayUpstreamResponse> {
   return fetchHlsRelayUpstream(url, (currentUrl) => curlFetchOnce(currentUrl, referer, origin));
 }
 
@@ -360,7 +368,7 @@ export function startHlsRelay(
           if (looksLikeHlsPlaylist(r.body)) {
             const rewritten = rewriteHlsPlaylistForRelay(
               r.body.toString("utf-8"),
-              srcUrl,
+              r.effectiveUrl,
               relayOrigin,
             );
             return new Response(rewritten, {
@@ -403,7 +411,7 @@ export function startHlsRelay(
           if (r.status === 200 && looksLikeHlsPlaylist(r.body)) {
             const rewritten = rewriteHlsPlaylistForRelay(
               r.body.toString("utf-8"),
-              srcUrl,
+              r.effectiveUrl,
               relayOrigin,
             );
             return new Response(rewritten, {

--- a/apps/cli/src/infra/player/hls-relay.ts
+++ b/apps/cli/src/infra/player/hls-relay.ts
@@ -121,7 +121,9 @@ export async function fetchHlsRelayUpstream(
   request: HlsRelayCurlRequest,
   options: HlsRelayFetchOptions = {},
 ): Promise<HlsRelayUpstreamResponse> {
-  const now = options.now ?? Date.now;
+  // Redirect-chain budgets are elapsed-time limits. A wall-clock correction
+  // must not restore time to later hops, so production uses a monotonic clock.
+  const now = options.now ?? (() => performance.now());
   const startedAt = now();
   const bodyLimitBytes = options.maxResponseBytes ?? MAX_UPSTREAM_BODY_BYTES;
   const curlTimeoutMs = options.curlTimeoutMs ?? 25_000;
@@ -169,6 +171,37 @@ export async function fetchHlsRelayUpstream(
   throw new Error("upstream redirected too many times");
 }
 
+export function buildHlsRelayCurlArgs(
+  url: string,
+  referer: string,
+  origin: string,
+  budget: HlsRelayCurlBudget,
+): string[] {
+  return [
+    // curl only honors --disable/-q as a config-file guard when it is the first
+    // argument. Without it, a user's `location` setting can follow a redirect
+    // before Kunai validates the next hop.
+    "-q",
+    "-sS",
+    "--no-location",
+    "--http2",
+    "-A",
+    AGENT,
+    "-H",
+    `Referer: ${referer}`,
+    "-H",
+    `Origin: ${origin}`,
+    "-H",
+    "Accept: */*",
+    "--max-time",
+    (Math.max(1, budget.curlTimeoutMs) / 1_000).toFixed(3),
+    "-w",
+    `\n${CURL_META_MARKER}%{http_code}\n%{content_type}\n%{redirect_url}`,
+    "--",
+    url,
+  ];
+}
+
 function curlFetchOnce(
   url: string,
   referer: string,
@@ -177,24 +210,7 @@ function curlFetchOnce(
 ): Promise<HlsRelayCurlResponse> {
   assertRelayUpstreamUrl(url);
   return new Promise((resolve, reject) => {
-    const proc = spawn("curl", [
-      "-sS",
-      "--http2",
-      "-A",
-      AGENT,
-      "-H",
-      `Referer: ${referer}`,
-      "-H",
-      `Origin: ${origin}`,
-      "-H",
-      "Accept: */*",
-      "--max-time",
-      (Math.max(1, budget.curlTimeoutMs) / 1_000).toFixed(3),
-      "-w",
-      `\n${CURL_META_MARKER}%{http_code}\n%{content_type}\n%{redirect_url}`,
-      "--",
-      url,
-    ]);
+    const proc = spawn("curl", buildHlsRelayCurlArgs(url, referer, origin, budget));
     let chunks: Buffer[] = [];
     let totalBytes = 0;
     let stderr = "";
@@ -415,7 +431,7 @@ export function startHlsRelay(
           if (r.status !== 200) {
             options.onUpstreamError?.({
               status: r.status,
-              host: new URL(srcUrl).hostname,
+              host: new URL(r.effectiveUrl).hostname,
               message: `upstream ${r.status}`,
             });
             return new Response(`upstream ${r.status}`, { status: r.status });
@@ -457,7 +473,7 @@ export function startHlsRelay(
           if (r.status !== 200) {
             options.onUpstreamError?.({
               status: r.status,
-              host: new URL(srcUrl).hostname,
+              host: new URL(r.effectiveUrl).hostname,
               message: `upstream ${r.status}`,
             });
           }

--- a/apps/cli/src/infra/player/hls-relay.ts
+++ b/apps/cli/src/infra/player/hls-relay.ts
@@ -84,19 +84,48 @@ function assertRelayUpstreamUrl(url: string): URL {
   return parsed;
 }
 
-function curlFetch(
+export type HlsRelayCurlResponse = {
+  readonly status: number;
+  readonly contentType: string;
+  readonly body: Buffer;
+  readonly redirectUrl: string | null;
+};
+
+export type HlsRelayCurlRequest = (url: string) => Promise<HlsRelayCurlResponse>;
+
+export async function fetchHlsRelayUpstream(
+  url: string,
+  request: HlsRelayCurlRequest,
+): Promise<HlsRelayCurlResponse> {
+  let currentUrl = url;
+  for (let redirectCount = 0; redirectCount <= 3; redirectCount++) {
+    const current = assertRelayUpstreamUrl(currentUrl);
+    const response = await request(currentUrl);
+    if (response.status < 300 || response.status >= 400 || !response.redirectUrl) {
+      return response;
+    }
+    if (redirectCount === 3) {
+      throw new Error("upstream redirected too many times");
+    }
+    const redirect = assertRelayUpstreamUrl(response.redirectUrl);
+    if (current.protocol === "https:" && redirect.protocol === "http:") {
+      throw new Error("HTTPS upstream cannot redirect to HTTP");
+    }
+    currentUrl = response.redirectUrl;
+  }
+  throw new Error("upstream redirected too many times");
+}
+
+function curlFetchOnce(
   url: string,
   referer: string,
   origin: string,
-): Promise<{ status: number; contentType: string; body: Buffer }> {
+): Promise<HlsRelayCurlResponse> {
   assertRelayUpstreamUrl(url);
   return new Promise((resolve, reject) => {
     const proc = spawn("curl", [
       "-sS",
       "--http2",
-      "-L",
-      "--max-redirs",
-      "3",
       "-A",
       AGENT,
       "-H",
@@ -108,7 +137,7 @@ function curlFetch(
       "--max-time",
       "25",
       "-w",
-      `\n${CURL_META_MARKER}%{http_code}\n%{content_type}`,
+      `\n${CURL_META_MARKER}%{http_code}\n%{content_type}\n%{redirect_url}`,
       "--",
       url,
     ]);
@@ -186,15 +215,20 @@ function curlFetch(
       const contentType =
         (metaLines[1] ?? "application/octet-stream").split(";")[0]?.trim() ||
         "application/octet-stream";
+      const redirectUrl = metaLines[2]?.trim() || null;
       if (!Number.isFinite(status) || status <= 0) {
         reject(new Error(`curl invalid status trailer: ${metaLines[0] ?? ""}`));
         return;
       }
-      resolve({ status, contentType, body });
+      resolve({ status, contentType, body, redirectUrl });
     });
     // Spawn failure (curl missing, ENOMEM): there is no process to kill.
     proc.on("error", (err: Error) => fail(err, false));
   });
+}
+
+function curlFetch(url: string, referer: string, origin: string): Promise<HlsRelayCurlResponse> {
+  return fetchHlsRelayUpstream(url, (currentUrl) => curlFetchOnce(currentUrl, referer, origin));
 }
 
 export function toB64Url(buf: Buffer): string {

--- a/apps/cli/src/infra/player/hls-relay.ts
+++ b/apps/cli/src/infra/player/hls-relay.ts
@@ -89,9 +89,28 @@ export type HlsRelayCurlResponse = {
   readonly contentType: string;
   readonly body: Buffer;
   readonly redirectUrl: string | null;
+  /** Complete curl stdout, including the fixed metadata trailer. */
+  readonly receivedBytes?: number;
 };
 
-export type HlsRelayCurlRequest = (url: string) => Promise<HlsRelayCurlResponse>;
+export type HlsRelayCurlBudget = {
+  readonly maxResponseBytes: number;
+  readonly bodyLimitBytes: number;
+  readonly curlTimeoutMs: number;
+  readonly watchdogTimeoutMs: number;
+};
+
+export type HlsRelayCurlRequest = (
+  url: string,
+  budget: HlsRelayCurlBudget,
+) => Promise<HlsRelayCurlResponse>;
+
+export type HlsRelayFetchOptions = {
+  readonly now?: () => number;
+  readonly maxResponseBytes?: number;
+  readonly curlTimeoutMs?: number;
+  readonly watchdogTimeoutMs?: number;
+};
 
 export type HlsRelayUpstreamResponse = HlsRelayCurlResponse & {
   readonly effectiveUrl: string;
@@ -100,11 +119,41 @@ export type HlsRelayUpstreamResponse = HlsRelayCurlResponse & {
 export async function fetchHlsRelayUpstream(
   url: string,
   request: HlsRelayCurlRequest,
+  options: HlsRelayFetchOptions = {},
 ): Promise<HlsRelayUpstreamResponse> {
+  const now = options.now ?? Date.now;
+  const startedAt = now();
+  const bodyLimitBytes = options.maxResponseBytes ?? MAX_UPSTREAM_BODY_BYTES;
+  const curlTimeoutMs = options.curlTimeoutMs ?? 25_000;
+  const watchdogTimeoutMs = options.watchdogTimeoutMs ?? CURL_WATCHDOG_MS;
+  let remainingResponseBytes = bodyLimitBytes;
+
+  const remainingMs = (limitMs: number) => Math.max(0, limitMs - Math.max(0, now() - startedAt));
+  const assertWithinDeadline = () => {
+    if (remainingMs(curlTimeoutMs) <= 0) {
+      throw new Error(`upstream redirect chain exceeded ${curlTimeoutMs}ms`);
+    }
+  };
+
   let currentUrl = url;
   for (let redirectCount = 0; redirectCount <= 3; redirectCount++) {
+    assertWithinDeadline();
     const current = assertRelayUpstreamUrl(currentUrl);
-    const response = await request(current.href);
+    const response = await request(current.href, {
+      maxResponseBytes: remainingResponseBytes,
+      bodyLimitBytes,
+      curlTimeoutMs: remainingMs(curlTimeoutMs),
+      watchdogTimeoutMs: remainingMs(watchdogTimeoutMs),
+    });
+    const receivedBytes = response.receivedBytes ?? response.body.length;
+    if (!Number.isSafeInteger(receivedBytes) || receivedBytes < 0) {
+      throw new Error("upstream response reported an invalid byte count");
+    }
+    if (receivedBytes > remainingResponseBytes) {
+      throw new Error(`upstream body exceeded ${bodyLimitBytes} bytes`);
+    }
+    remainingResponseBytes -= receivedBytes;
+    assertWithinDeadline();
     if (response.status < 300 || response.status >= 400 || !response.redirectUrl) {
       return { ...response, effectiveUrl: current.href };
     }
@@ -124,6 +173,7 @@ function curlFetchOnce(
   url: string,
   referer: string,
   origin: string,
+  budget: HlsRelayCurlBudget,
 ): Promise<HlsRelayCurlResponse> {
   assertRelayUpstreamUrl(url);
   return new Promise((resolve, reject) => {
@@ -139,7 +189,7 @@ function curlFetchOnce(
       "-H",
       "Accept: */*",
       "--max-time",
-      "25",
+      (Math.max(1, budget.curlTimeoutMs) / 1_000).toFixed(3),
       "-w",
       `\n${CURL_META_MARKER}%{http_code}\n%{content_type}\n%{redirect_url}`,
       "--",
@@ -164,18 +214,21 @@ function curlFetchOnce(
     // is running: a stopped process, or a shim that never execs curl, leaves
     // this promise pending forever and the request handler awaiting it. This is
     // the backstop, deliberately above curl's own limit so curl reports first.
-    const watchdog = setTimeout(() => {
-      fail(new Error(`curl did not exit within ${CURL_WATCHDOG_MS}ms`));
-    }, CURL_WATCHDOG_MS);
+    const watchdog = setTimeout(
+      () => {
+        fail(new Error(`curl did not exit within ${budget.watchdogTimeoutMs}ms`));
+      },
+      Math.max(1, budget.watchdogTimeoutMs),
+    );
 
     proc.stdout.on("data", (d: Buffer) => {
       if (settled) return;
       totalBytes += d.length;
-      if (totalBytes > MAX_UPSTREAM_BODY_BYTES) {
+      if (totalBytes > budget.maxResponseBytes) {
         // Drop the buffered body before rejecting; holding 64 MiB until the
         // rejection unwinds is the opposite of what the cap is for.
         chunks = [];
-        fail(new Error(`upstream body exceeded ${MAX_UPSTREAM_BODY_BYTES} bytes`));
+        fail(new Error(`upstream body exceeded ${budget.bodyLimitBytes} bytes`));
         return;
       }
       chunks.push(d);
@@ -224,7 +277,7 @@ function curlFetchOnce(
         reject(new Error(`curl invalid status trailer: ${metaLines[0] ?? ""}`));
         return;
       }
-      resolve({ status, contentType, body, redirectUrl });
+      resolve({ status, contentType, body, redirectUrl, receivedBytes: buf.length });
     });
     // Spawn failure (curl missing, ENOMEM): there is no process to kill.
     proc.on("error", (err: Error) => fail(err, false));
@@ -236,7 +289,9 @@ function curlFetch(
   referer: string,
   origin: string,
 ): Promise<HlsRelayUpstreamResponse> {
-  return fetchHlsRelayUpstream(url, (currentUrl) => curlFetchOnce(currentUrl, referer, origin));
+  return fetchHlsRelayUpstream(url, (currentUrl, budget) =>
+    curlFetchOnce(currentUrl, referer, origin, budget),
+  );
 }
 
 export function toB64Url(buf: Buffer): string {

--- a/apps/cli/test/unit/infra/player/hls-relay.test.ts
+++ b/apps/cli/test/unit/infra/player/hls-relay.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildHlsRelayCurlArgs,
   fetchHlsRelayUpstream,
   fromB64Url,
   looksLikeHlsPlaylist,
@@ -14,6 +15,26 @@ const RELAY = "http://127.0.0.1:9";
 const BASE = "https://vault-06.uwucdn.top/path/to/index.m3u8?token=abc%2B%2F%3D";
 
 describe("hls-relay gating", () => {
+  test("disables curl config and redirect following before every other argument", () => {
+    const args = buildHlsRelayCurlArgs(
+      "https://vault-06.uwucdn.top/start.m3u8",
+      "https://kwik.cx/",
+      "https://kwik.cx",
+      {
+        maxResponseBytes: 1024,
+        bodyLimitBytes: 1024,
+        curlTimeoutMs: 25_000,
+        watchdogTimeoutMs: 30_000,
+      },
+    );
+
+    expect(args[0]).toBe("-q");
+    expect(args).toContain("--no-location");
+    expect(args).not.toContain("-L");
+    expect(args).not.toContain("--location");
+    expect(args.at(-1)).toBe("https://vault-06.uwucdn.top/start.m3u8");
+  });
+
   test("rejects a redirect before requesting a non-allowlisted target", async () => {
     const requested: string[] = [];
 

--- a/apps/cli/test/unit/infra/player/hls-relay.test.ts
+++ b/apps/cli/test/unit/infra/player/hls-relay.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  fetchHlsRelayUpstream,
   fromB64Url,
   looksLikeHlsPlaylist,
   rewriteHlsPlaylistForRelay,
@@ -13,6 +14,49 @@ const RELAY = "http://127.0.0.1:9";
 const BASE = "https://vault-06.uwucdn.top/path/to/index.m3u8?token=abc%2B%2F%3D";
 
 describe("hls-relay gating", () => {
+  test("rejects a redirect before requesting a non-allowlisted target", async () => {
+    const requested: string[] = [];
+
+    await expect(
+      fetchHlsRelayUpstream("https://vault-06.uwucdn.top/start.m3u8", async (url) => {
+        requested.push(url);
+        return url.endsWith("start.m3u8")
+          ? {
+              status: 302,
+              contentType: "text/plain",
+              body: Buffer.alloc(0),
+              redirectUrl: "http://169.254.169.254/latest/meta-data/",
+            }
+          : {
+              status: 200,
+              contentType: "text/plain",
+              body: Buffer.from("secret"),
+              redirectUrl: null,
+            };
+      }),
+    ).rejects.toThrow("upstream host not allowlisted");
+
+    expect(requested).toEqual(["https://vault-06.uwucdn.top/start.m3u8"]);
+  });
+
+  test("rejects an HTTPS redirect downgrade before the second request", async () => {
+    const requested: string[] = [];
+
+    await expect(
+      fetchHlsRelayUpstream("https://vault-06.uwucdn.top/start.m3u8", async (url) => {
+        requested.push(url);
+        return {
+          status: 302,
+          contentType: "text/plain",
+          body: Buffer.alloc(0),
+          redirectUrl: "http://vault-06.uwucdn.top/plaintext.m3u8",
+        };
+      }),
+    ).rejects.toThrow("HTTPS upstream cannot redirect to HTTP");
+
+    expect(requested).toEqual(["https://vault-06.uwucdn.top/start.m3u8"]);
+  });
+
   test("streamNeedsHlsRelay matches only uwucdn/owocdn hosts", () => {
     expect(streamNeedsHlsRelay("https://vault-06.uwucdn.top/x/index.m3u8")).toBe(true);
     expect(streamNeedsHlsRelay("https://vault-15.owocdn.top/x/index.m3u8")).toBe(true);

--- a/apps/cli/test/unit/infra/player/hls-relay.test.ts
+++ b/apps/cli/test/unit/infra/player/hls-relay.test.ts
@@ -122,6 +122,103 @@ describe("hls-relay gating", () => {
     ).rejects.toThrow("upstream redirected too many times");
   });
 
+  test("shares response bytes and deadlines across every redirect hop", async () => {
+    let now = 1_000;
+    const observed: Array<{
+      readonly maxResponseBytes: number;
+      readonly curlTimeoutMs: number;
+      readonly watchdogTimeoutMs: number;
+    }> = [];
+
+    const response = await fetchHlsRelayUpstream(
+      "https://vault-06.uwucdn.top/start.m3u8?step=0",
+      async (url, budget) => {
+        observed.push({
+          maxResponseBytes: budget.maxResponseBytes,
+          curlTimeoutMs: budget.curlTimeoutMs,
+          watchdogTimeoutMs: budget.watchdogTimeoutMs,
+        });
+        now += 5_000;
+        const step = Number(new URL(url).searchParams.get("step") ?? "0");
+        return step < 2
+          ? {
+              status: 302,
+              contentType: "text/plain",
+              body: Buffer.alloc(20),
+              redirectUrl: `https://vault-06.uwucdn.top/next.m3u8?step=${step + 1}`,
+              receivedBytes: 30,
+            }
+          : {
+              status: 200,
+              contentType: "application/vnd.apple.mpegurl",
+              body: Buffer.from("#EXTM3U\n"),
+              redirectUrl: null,
+              receivedBytes: 10,
+            };
+      },
+      {
+        now: () => now,
+        maxResponseBytes: 100,
+        curlTimeoutMs: 25_000,
+        watchdogTimeoutMs: 30_000,
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(observed).toEqual([
+      { maxResponseBytes: 100, curlTimeoutMs: 25_000, watchdogTimeoutMs: 30_000 },
+      { maxResponseBytes: 70, curlTimeoutMs: 20_000, watchdogTimeoutMs: 25_000 },
+      { maxResponseBytes: 40, curlTimeoutMs: 15_000, watchdogTimeoutMs: 20_000 },
+    ]);
+  });
+
+  test("rejects redirect bodies that exceed the shared response budget", async () => {
+    let requests = 0;
+
+    await expect(
+      fetchHlsRelayUpstream(
+        "https://vault-06.uwucdn.top/start.m3u8",
+        async () => {
+          requests += 1;
+          return {
+            status: 302,
+            contentType: "text/plain",
+            body: Buffer.alloc(60),
+            redirectUrl: "https://vault-06.uwucdn.top/next.m3u8",
+            receivedBytes: 60,
+          };
+        },
+        { maxResponseBytes: 100 },
+      ),
+    ).rejects.toThrow("upstream body exceeded 100 bytes");
+
+    expect(requests).toBe(2);
+  });
+
+  test("rejects a redirect chain after one shared curl deadline", async () => {
+    let now = 10_000;
+    let requests = 0;
+
+    await expect(
+      fetchHlsRelayUpstream(
+        "https://vault-06.uwucdn.top/start.m3u8",
+        async () => {
+          requests += 1;
+          now += 13_000;
+          return {
+            status: 302,
+            contentType: "text/plain",
+            body: Buffer.alloc(0),
+            redirectUrl: "https://vault-06.uwucdn.top/next.m3u8",
+          };
+        },
+        { now: () => now, curlTimeoutMs: 25_000, watchdogTimeoutMs: 30_000 },
+      ),
+    ).rejects.toThrow("upstream redirect chain exceeded 25000ms");
+
+    expect(requests).toBe(2);
+  });
+
   test("streamNeedsHlsRelay matches only uwucdn/owocdn hosts", () => {
     expect(streamNeedsHlsRelay("https://vault-06.uwucdn.top/x/index.m3u8")).toBe(true);
     expect(streamNeedsHlsRelay("https://vault-15.owocdn.top/x/index.m3u8")).toBe(true);

--- a/apps/cli/test/unit/infra/player/hls-relay.test.ts
+++ b/apps/cli/test/unit/infra/player/hls-relay.test.ts
@@ -57,6 +57,71 @@ describe("hls-relay gating", () => {
     expect(requested).toEqual(["https://vault-06.uwucdn.top/start.m3u8"]);
   });
 
+  test("returns the final URL so relative playlist entries use the redirected base", async () => {
+    const response = await fetchHlsRelayUpstream(
+      "https://vault-06.uwucdn.top/old/master.m3u8",
+      async (url) =>
+        url.includes("/old/")
+          ? {
+              status: 302,
+              contentType: "text/plain",
+              body: Buffer.alloc(0),
+              redirectUrl: "https://vault-06.uwucdn.top/new/master.m3u8",
+            }
+          : {
+              status: 200,
+              contentType: "application/vnd.apple.mpegurl",
+              body: Buffer.from("#EXTM3U\nsegment.ts\n"),
+              redirectUrl: null,
+            },
+    );
+
+    expect(response.effectiveUrl).toBe("https://vault-06.uwucdn.top/new/master.m3u8");
+    const rewritten = rewriteHlsPlaylistForRelay(
+      response.body.toString("utf-8"),
+      response.effectiveUrl,
+      RELAY,
+    );
+    expect(rewritten).toContain(
+      `/s/${toB64Url(Buffer.from("https://vault-06.uwucdn.top/new/segment.ts"))}`,
+    );
+  });
+
+  test("allows three redirects but refuses a fourth", async () => {
+    const request = async (url: string) => {
+      const step = Number(new URL(url).searchParams.get("step") ?? "0");
+      return step < 3
+        ? {
+            status: 302,
+            contentType: "text/plain",
+            body: Buffer.alloc(0),
+            redirectUrl: `https://vault-06.uwucdn.top/next.m3u8?step=${step + 1}`,
+          }
+        : {
+            status: 200,
+            contentType: "application/vnd.apple.mpegurl",
+            body: Buffer.from("#EXTM3U\n"),
+            redirectUrl: null,
+          };
+    };
+
+    await expect(
+      fetchHlsRelayUpstream("https://vault-06.uwucdn.top/start.m3u8", request),
+    ).resolves.toMatchObject({ status: 200 });
+
+    await expect(
+      fetchHlsRelayUpstream("https://vault-06.uwucdn.top/start.m3u8", async (url) => {
+        const step = Number(new URL(url).searchParams.get("step") ?? "0");
+        return {
+          status: 302,
+          contentType: "text/plain",
+          body: Buffer.alloc(0),
+          redirectUrl: `https://vault-06.uwucdn.top/next.m3u8?step=${step + 1}`,
+        };
+      }),
+    ).rejects.toThrow("upstream redirected too many times");
+  });
+
   test("streamNeedsHlsRelay matches only uwucdn/owocdn hosts", () => {
     expect(streamNeedsHlsRelay("https://vault-06.uwucdn.top/x/index.m3u8")).toBe(true);
     expect(streamNeedsHlsRelay("https://vault-15.owocdn.top/x/index.m3u8")).toBe(true);

--- a/packages/providers/src/youtube/spawn-ytdlp.ts
+++ b/packages/providers/src/youtube/spawn-ytdlp.ts
@@ -2,7 +2,7 @@ const DEFAULT_YTDLP_TIMEOUT_MS = 45_000;
 const DEFAULT_YTDLP_STDOUT_LIMIT_BYTES = 16 * 1024 * 1024;
 const DEFAULT_YTDLP_STDERR_LIMIT_BYTES = 1024 * 1024;
 const DEFAULT_YTDLP_EXIT_GRACE_MS = 2_500;
-const DEFAULT_STREAMING_STDERR_LIMIT_BYTES = 64 * 1024;
+const DEFAULT_STREAMING_OUTPUT_LIMIT_BYTES = 64 * 1024;
 
 export type YtDlpProcess = {
   readonly stdout: ReadableStream<Uint8Array>;
@@ -64,7 +64,7 @@ export function runYtDlpProcess(options: RunYtDlpProcessOptions): RunYtDlpProces
   let terminated = false;
   let forceKillId: ReturnType<typeof setTimeout> | undefined;
   const exitGraceMs = options.exitGraceMs ?? DEFAULT_YTDLP_EXIT_GRACE_MS;
-  const maxStderrBytes = options.maxStderrBytes ?? DEFAULT_STREAMING_STDERR_LIMIT_BYTES;
+  const maxStderrBytes = options.maxStderrBytes ?? DEFAULT_STREAMING_OUTPUT_LIMIT_BYTES;
 
   const terminate = () => {
     if (terminated) return;
@@ -84,6 +84,8 @@ export function runYtDlpProcess(options: RunYtDlpProcessOptions): RunYtDlpProces
   const stdoutPromise = readStreamLines({
     stream: proc.stdout,
     signal: ioController.signal,
+    maxBytes: DEFAULT_STREAMING_OUTPUT_LIMIT_BYTES,
+    label: "yt-dlp stdout",
     onLine: (line) => options.onStdoutLine?.(line),
   });
   const stderrPromise = readStreamLines({

--- a/packages/providers/src/youtube/spawn-ytdlp.ts
+++ b/packages/providers/src/youtube/spawn-ytdlp.ts
@@ -46,6 +46,8 @@ export type RunYtDlpProcessHandle = {
 };
 
 const defaultYtDlpSpawn: YtDlpSpawn = (command) =>
+  // SAFETY: pipe/ignore stdio makes Bun.spawn expose the stdout, stderr,
+  // exited, and kill members consumed by YtDlpProcess.
   Bun.spawn([...command], {
     stdout: "pipe",
     stderr: "pipe",
@@ -266,7 +268,7 @@ async function readStreamLines(options: {
   const reader = options.stream.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
-  let bytes = 0;
+  let pendingLineBytes = 0;
   const cancelReader = () => {
     void reader.cancel(options.signal.reason).catch(() => undefined);
   };
@@ -278,9 +280,17 @@ async function readStreamLines(options: {
       const { done, value } = await reader.read();
       if (done) break;
       if (options.maxBytes !== undefined) {
-        bytes += value.byteLength;
-        if (bytes > options.maxBytes) {
-          throw new Error(`${options.label ?? "yt-dlp stream"} exceeded ${options.maxBytes} bytes`);
+        for (const byte of value) {
+          if (byte === 0x0a) {
+            pendingLineBytes = 0;
+            continue;
+          }
+          pendingLineBytes += 1;
+          if (pendingLineBytes > options.maxBytes) {
+            throw new Error(
+              `${options.label ?? "yt-dlp stream"} exceeded ${options.maxBytes} bytes`,
+            );
+          }
         }
       }
       buffer += decoder.decode(value, { stream: true });

--- a/packages/providers/test/youtube/spawn-ytdlp.test.ts
+++ b/packages/providers/test/youtube/spawn-ytdlp.test.ts
@@ -52,6 +52,24 @@ describe("spawnYtDlpWithTimeout", () => {
 });
 
 describe("runYtDlpProcess", () => {
+  test("rejects and kills yt-dlp when a stdout line exceeds the streaming cap", async () => {
+    const killSignals: (string | number | undefined)[] = [];
+    const proc = createFakeProcess({
+      stdout: streamFromText("x".repeat(64 * 1024 + 1)),
+      stderr: streamFromText(""),
+      onKill: (signal) => killSignals.push(signal),
+    });
+
+    const handle = runYtDlpProcess({
+      args: ["--newline"],
+      exitGraceMs: 5,
+      spawn: () => proc,
+    });
+
+    await expect(handle.completed).rejects.toThrow("yt-dlp stdout exceeded 65536 bytes");
+    expect(killSignals.length).toBeGreaterThan(0);
+  });
+
   test("invokes stdout line callbacks and returns exit metadata", async () => {
     const lines: string[] = [];
     const proc = createFakeProcess({

--- a/packages/providers/test/youtube/spawn-ytdlp.test.ts
+++ b/packages/providers/test/youtube/spawn-ytdlp.test.ts
@@ -70,6 +70,24 @@ describe("runYtDlpProcess", () => {
     expect(killSignals.length).toBeGreaterThan(0);
   });
 
+  test("accepts more than the streaming cap when each stdout line stays bounded", async () => {
+    const lines: string[] = [];
+    const proc = createFakeProcess({
+      stdout: streamFromText("x\n".repeat(32 * 1024 + 1)),
+      stderr: streamFromText(""),
+      onKill: () => undefined,
+    });
+
+    const handle = runYtDlpProcess({
+      args: ["--newline"],
+      spawn: () => proc,
+      onStdoutLine: (line) => lines.push(line),
+    });
+
+    await expect(handle.completed).resolves.toEqual({ exitCode: 0, stderr: "" });
+    expect(lines).toHaveLength(32 * 1024 + 1);
+  });
+
   test("invokes stdout line callbacks and returns exit metadata", async () => {
     const lines: string[] = [];
     const proc = createFakeProcess({


### PR DESCRIPTION
## What changed

Bounds provider-controlled relay and yt-dlp process input so malformed upstreams cannot bypass redirect policy, grow memory without limit, or leave child processes running indefinitely.

- validates every HLS redirect against the exact uwucdn/owocdn allowlist and rejects HTTPS-to-HTTP downgrade
- disables `.curlrc` and curl redirect following, then applies one monotonic 25-second deadline and 64 MiB byte budget across the full redirect chain
- resolves relative playlist entries from the final effective URL and reports redirected HTTP failures against the effective host
- bounds yt-dlp streaming lines and retained stderr while preserving long downloads with many valid short progress lines
- documents the relay contract and adds a patch changeset

## Verification

- `bun run test -- --force` — 23/23 tasks, 0 cached; CLI unit 5,123 pass / 1 intentional Windows skip; CLI integration 238 pass / 25 gated skips
- `bun run build -- --force` — 10/10 tasks, 0 cached; linux-x64 host binary built at 81.9 MiB
- `bun run typecheck -- --force` — 14/14 tasks, 0 cached
- `bun run lint -- --force` — 12/12 tasks, 0 cached
- `bun run fmt:check -- --force` — 26/26 tasks, 0 cached
- `bun run verify:doc-paths`
- `bun run guard`
- `bun run lint:anti-slop:changed origin/main` — 0 findings
- independent review completed; all security/correctness findings addressed

## Checklist

- [x] Changeset added for user-visible behavior
- [x] `bun run guard`
- [x] Format, lint, test, and typecheck gates run uncached
- [x] Build run uncached
- [ ] Live provider smoke skipped: this change is covered deterministically; external provider health is tracked as a separate release gate
- [ ] Docker, hermetic npm candidate, preserved-native, and cross-platform compiled smoke cells remain gated release evidence


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Improved HLS relay redirect handling, including redirect allowlisting and HTTPS downgrade protection.
  * Added cumulative response-size and timeout limits to prevent oversized or stalled relay requests.
  * Improved playlist and error handling after redirects.

* **Bug Fixes**
  * Prevented unbounded yt-dlp output while allowing larger output when split across valid lines.
  * Malformed or stalled yt-dlp processes are now terminated safely.

* **Documentation**
  * Updated provider guidance for relay redirects and yt-dlp output limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->