### PR TITLE
fix(update): bound release metadata requests

### DIFF
--- a/.changeset/quick-owls-timeout.md
+++ b/.changeset/quick-owls-timeout.md
@@ -1,0 +1,6 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Bound GitHub and npm update-metadata requests to 15 seconds, use the injected
+request path for every install channel, and reject malformed registry versions.

--- a/apps/cli/src/services/update/UpdateService.ts
+++ b/apps/cli/src/services/update/UpdateService.ts
@@ -1,8 +1,11 @@
+import { withTimeoutSignal } from "@/infra/abort/timeout-signal";
 import type { ConfigService, KitsuneConfig } from "@/services/persistence/ConfigService";
 
 import type { InstallMethod } from "./install-method";
 import { updateGuidanceForInstallMethod } from "./install-method";
+import { type MetadataFetch, UPDATE_METADATA_TIMEOUT_MS } from "./latest-version";
 import { shouldRunUpdateCheck, updateCheckCachePatch } from "./update-check-cache";
+import { parseCanonicalVersion } from "./version";
 
 export type UpdateCheckStatus =
   | "disabled"
@@ -150,16 +153,25 @@ export class UpdateService {
   }
 }
 
-export async function fetchLatestKunaiVersion(): Promise<string> {
-  const response = await fetch("https://registry.npmjs.org/@kitsunekode%2fkunai/latest");
+export async function fetchLatestKunaiVersion(
+  fetchImpl: MetadataFetch = fetch,
+  signal: AbortSignal = withTimeoutSignal(undefined, UPDATE_METADATA_TIMEOUT_MS),
+): Promise<string> {
+  const response = await fetchImpl("https://registry.npmjs.org/@kitsunekode%2fkunai/latest", {
+    headers: { "user-agent": "kunai-cli" },
+    signal,
+  });
   if (!response.ok) {
     throw new Error(`npm registry returned ${response.status}`);
   }
+  // SAFETY: JSON stays untrusted; the version is type-checked and parsed canonically below.
   const payload = (await response.json()) as { version?: unknown };
-  if (typeof payload.version !== "string" || !payload.version.trim()) {
-    throw new Error("npm registry response did not include a version");
+  const version =
+    typeof payload.version === "string" ? parseCanonicalVersion(payload.version.trim()) : null;
+  if (!version) {
+    throw new Error("npm registry response did not include a stable canonical version");
   }
-  return payload.version;
+  return version;
 }
 
 function normalizeVersion(version: string): string {

--- a/apps/cli/src/services/update/latest-version.ts
+++ b/apps/cli/src/services/update/latest-version.ts
@@ -1,6 +1,14 @@
+import { withTimeoutSignal } from "@/infra/abort/timeout-signal";
+
 import { parsePublishedVersionTag } from "./version";
 
 const DEFAULT_RELEASES_API = "https://api.github.com/repos/KitsuneKode/kunai/releases/latest";
+export const UPDATE_METADATA_TIMEOUT_MS = 15_000;
+
+export type MetadataFetch = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
 
 export function resolveReleasesApiUrl(): string {
   return process.env.KUNAI_RELEASES_API?.trim() || DEFAULT_RELEASES_API;
@@ -21,12 +29,17 @@ export function parseVersionFromTag(tag: string | undefined): string | null {
  * injectable for tests.
  */
 export async function fetchLatestVersion(
-  fetchImpl: typeof fetch = fetch,
+  fetchImpl: MetadataFetch = fetch,
   url: string = resolveReleasesApiUrl(),
+  signal: AbortSignal = withTimeoutSignal(undefined, UPDATE_METADATA_TIMEOUT_MS),
 ): Promise<string | null> {
   try {
-    const res = await fetchImpl(url, { headers: { "user-agent": "kunai-cli" } });
+    const res = await fetchImpl(url, {
+      headers: { "user-agent": "kunai-cli" },
+      signal,
+    });
     if (!res.ok) return null;
+    // SAFETY: JSON stays untrusted; parseVersionFromTag strictly validates the only field consumed.
     const body = (await res.json()) as { tag_name?: string };
     return parseVersionFromTag(body.tag_name);
   } catch {

--- a/apps/cli/src/services/update/native-installer/install-latest.ts
+++ b/apps/cli/src/services/update/native-installer/install-latest.ts
@@ -86,7 +86,7 @@ async function installLatestImpl(options: InstallLatestOptions): Promise<Install
   const resolved =
     options.version && options.version !== "latest"
       ? normalizeRequestedVersion(options.version)
-      : parseCanonicalVersion((await fetchLatestVersion(fetchImpl as typeof fetch)) ?? "");
+      : parseCanonicalVersion((await fetchLatestVersion(fetchImpl)) ?? "");
   if (!resolved) {
     return { status: "failed", error: "Could not resolve target version." };
   }

--- a/apps/cli/src/services/update/resolve-latest-version.ts
+++ b/apps/cli/src/services/update/resolve-latest-version.ts
@@ -1,5 +1,11 @@
+import { withTimeoutSignal } from "@/infra/abort/timeout-signal";
+
 import type { InstallMethodKind } from "./install-method";
-import { fetchLatestVersion } from "./latest-version";
+import {
+  fetchLatestVersion,
+  type MetadataFetch,
+  UPDATE_METADATA_TIMEOUT_MS,
+} from "./latest-version";
 import { fetchLatestKunaiVersion } from "./UpdateService";
 
 /**
@@ -8,19 +14,20 @@ import { fetchLatestKunaiVersion } from "./UpdateService";
  */
 export async function resolveLatestVersion(
   channel: InstallMethodKind,
-  fetchImpl: typeof fetch = fetch,
+  fetchImpl: MetadataFetch = fetch,
+  signal: AbortSignal = withTimeoutSignal(undefined, UPDATE_METADATA_TIMEOUT_MS),
 ): Promise<string | null> {
   switch (channel) {
     case "binary":
-      return fetchLatestVersion(fetchImpl);
+      return fetchLatestVersion(fetchImpl, undefined, signal);
     case "npm-global":
     case "bun-global":
       try {
-        return await fetchLatestKunaiVersion();
+        return await fetchLatestKunaiVersion(fetchImpl, signal);
       } catch {
         return null;
       }
     default:
-      return fetchLatestVersion(fetchImpl);
+      return fetchLatestVersion(fetchImpl, undefined, signal);
   }
 }

--- a/apps/cli/test/unit/latest-version.test.ts
+++ b/apps/cli/test/unit/latest-version.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 
 import {
   fetchLatestVersion,
+  type MetadataFetch,
   parseVersionFromTag,
   resolveReleasesApiUrl,
 } from "@/services/update/latest-version";
@@ -20,8 +21,8 @@ test("parseVersionFromTag rejects leading zeros and prerelease tags", () => {
   expect(parseVersionFromTag("1.2.3+build")).toBeNull();
 });
 
-function fakeFetch(status: number, body: unknown): typeof fetch {
-  return (async () => new Response(JSON.stringify(body), { status })) as unknown as typeof fetch;
+function fakeFetch(status: number, body: object): MetadataFetch {
+  return async () => new Response(JSON.stringify(body), { status });
 }
 
 test("strips the leading v from the tag", async () => {
@@ -44,8 +45,32 @@ test("resolveReleasesApiUrl honors KUNAI_RELEASES_API override", () => {
 });
 
 test("returns null when fetch throws", async () => {
-  const throwing = (async () => {
+  const throwing: MetadataFetch = async () => {
     throw new Error("network down");
-  }) as unknown as typeof fetch;
+  };
   expect(await fetchLatestVersion(throwing)).toBeNull();
+});
+
+test("applies a metadata request deadline by default", async () => {
+  let requestSignal: AbortSignal | null | undefined;
+  const inspectingFetch: MetadataFetch = async (_input, init) => {
+    requestSignal = init?.signal;
+    return new Response(JSON.stringify({ tag_name: "v1.4.2" }), { status: 200 });
+  };
+
+  expect(await fetchLatestVersion(inspectingFetch)).toBe("1.4.2");
+  expect(requestSignal).toBeInstanceOf(AbortSignal);
+});
+
+test("forwards an injected abort signal", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  let requestSignal: AbortSignal | null | undefined;
+  const inspectingFetch: MetadataFetch = async (_input, init) => {
+    requestSignal = init?.signal;
+    throw new Error("aborted");
+  };
+
+  expect(await fetchLatestVersion(inspectingFetch, undefined, controller.signal)).toBeNull();
+  expect(requestSignal).toBe(controller.signal);
 });

--- a/apps/cli/test/unit/services/update/resolve-latest-version.test.ts
+++ b/apps/cli/test/unit/services/update/resolve-latest-version.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import type { MetadataFetch } from "@/services/update/latest-version";
+import { resolveLatestVersion } from "@/services/update/resolve-latest-version";
+
+describe("resolveLatestVersion", () => {
+  test("uses the injected fetch and deadline for package-manager channels", async () => {
+    const controller = new AbortController();
+    let requestUrl = "";
+    let requestSignal: AbortSignal | null | undefined;
+    const fetchImpl: MetadataFetch = async (input, init) => {
+      requestUrl = String(input);
+      requestSignal = init?.signal;
+      return new Response(JSON.stringify({ version: "0.3.0" }), { status: 200 });
+    };
+
+    expect(await resolveLatestVersion("npm-global", fetchImpl, controller.signal)).toBe("0.3.0");
+    expect(requestUrl).toBe("https://registry.npmjs.org/@kitsunekode%2fkunai/latest");
+    expect(requestSignal).toBe(controller.signal);
+  });
+
+  test("rejects malformed versions from the npm registry", async () => {
+    const fetchImpl: MetadataFetch = async () =>
+      new Response(JSON.stringify({ version: "0.3.0-beta.1" }), {
+        status: 200,
+      });
+
+    expect(await resolveLatestVersion("bun-global", fetchImpl)).toBeNull();
+  });
+
+  test("returns null when package metadata lookup fails", async () => {
+    const fetchImpl: MetadataFetch = async () => {
+      throw new Error("network down");
+    };
+
+    expect(await resolveLatestVersion("npm-global", fetchImpl)).toBeNull();
+  });
+});

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "714d222971b43c2eec825c81d973aa8d0def23f78625e159e5925f4c4daa1b8a",
-  "docsContentFingerprint": "b507955a74b2c3e670420ec4dcb696390433881dd09102b68030c3a69d5c1e10",
+  "docsContentFingerprint": "764b92ca7c260171b5af6e3ff263e19ff60d758ecdaa0c1be0c9a7d804002b7d",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/docs/users/install-and-update.mdx
+++ b/docs/users/install-and-update.mdx
@@ -194,6 +194,8 @@ Install scripts (`install.sh`, `install.ps1`) only install. They do not upgrade 
 ## Update checks
 
 Kunai runs a **cached, non-blocking** background update check at startup.
+Release-metadata requests stop after 15 seconds, so an unavailable GitHub or npm
+endpoint cannot leave startup checks or `kunai upgrade` waiting indefinitely.
 
 - **Binary installs:** when `autoApplyBinaryUpdates` is enabled (default), Kunai downloads and stages the new version under `versions/` automatically. Restart Kunai to run the new binary. Toggle this from `/update`.
 - **npm/bun/source:** notify-only — run `kunai upgrade` or your package manager manually.


### PR DESCRIPTION
Summary:
- cap GitHub and npm release-metadata requests at 15 seconds
- route npm and Bun channels through the injected fetch and abort seam
- reject malformed registry versions before upgrade planning
- document the deadline and add a 0.3.0 patch changeset

Verification:
- `bun run test -- --force` (23/23 tasks, 0 cached; 5,120 CLI unit tests and 238 integration tests passed)
- `bun run typecheck -- --force`
- `bun run lint -- --force`
- `bun run fmt`
- `bun run build -- --force`
- `bun run verify:doc-paths`
- `bun run guard`
- targeted update and native-installer tests (26 passed)