### PR TITLE
fix(providers): cover every production provider in the matrix, drop the dead Wings mirror

### DIFF
--- a/.changeset/olive-otters-race.md
+++ b/.changeset/olive-otters-race.md
@@ -1,0 +1,25 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Retire the dead Videasy seed mirror and cover every production provider in the live matrix.
+
+### Fixes
+
+- Remove `api.wingsdatabase.com` from the Videasy seed rotation. The name is
+  NXDOMAIN on both Cloudflare and Google resolvers and the surviving apex does
+  not serve `/seed`, so it could never win the seed race — it only spent a
+  request slot and then occupied the five-minute host penalty box after every
+  cold resolve, which read as a redundant pair while offering no redundancy.
+  `api.speedracelight.com` remains the live host and is unaffected.
+
+### Behavior
+
+- The seed transport still races N hosts and now takes an injected host list, so
+  a live mirror can be added back to `WINGS_API_BASES` without reintroducing a
+  second constant. A preferred-host cache entry can no longer resurrect a host
+  that is no longer configured.
+- `bun run test:live:matrix` now covers all seven providers that
+  `loadProductionProviderModules()` registers. It previously skipped `vidlink`
+  and `anidb` — and `anidb` is the default anime lane the release signoff
+  depends on, so an outage there would have reported a green matrix.

--- a/.docs/provider-dossiers/videasy.md
+++ b/.docs/provider-dossiers/videasy.md
@@ -49,7 +49,7 @@ Deliberately **not** done, and why:
 ## Production status (2026-07-16)
 
 - **Module:** `packages/providers/src/videasy/direct.ts` + `flavors.ts` + `crypto.ts`
-- **Active stream API:** `api.speedracelight.com` (primary; used by player.videasy.to / cineby.at / cineplay.to). Mirror: `api.wingsdatabase.com`.
+- **Active stream API:** `api.speedracelight.com` (sole seed host; used by player.videasy.to / cineby.at / cineplay.to). The `api.wingsdatabase.com` mirror was removed on 2026-08-26 — the name is NXDOMAIN on Cloudflare and Google resolvers and the surviving apex does not serve `/seed`, so it could only lose the race and then occupy the penalty box. The transport still races N hosts via `WINGS_API_BASES`; add a mirror there when a live one exists.
 - **Decrypt:** seed + `enc=2` + mvm1 PRNG XOR. **Must use sparse `Array(61)`** for PRNG state (`n in state` mask). Dense arrays break every payload.
 - **Cineby UI catalog** (https://www.cineby.at/tv/299167 “Dutton Ranch” example):
   | UI             | API route                  | Live note (S1E1)         |

--- a/apps/cli/test/live/README.md
+++ b/apps/cli/test/live/README.md
@@ -11,6 +11,8 @@ bun run test:live:videasy
 bun run test:live:videasy -- --fixture=bloodhounds
 bun run test:live:videasy -- --suite
 bun run test:live:rivestream
+bun run test:live:vidlink
+bun run test:live:anidb
 bun run test:live:allanime "Kimetsu no Yaiba" SJms742bSTrcyJZay
 bun run test:live:miruro 1159 21 "One Piece"
 bun run test:live:youtube
@@ -94,8 +96,10 @@ For each run, the JSON payload should include:
 - redacted diagnostics export path when a failure needs reporting
 
 `bun run test:live:matrix` runs the focused provider smokes as one serial pass and emits a single
-JSON report. Pass a provider id (`videasy`, `rivestream`, `allanime`, `miruro`, `youtube`) or
-media bucket (`series`, `anime`, `youtube`) to narrow the matrix while debugging. Each smoke has
+JSON report. It covers every provider `loadProductionProviderModules()` registers, so a default
+lane cannot go dark without a red row. Pass a provider id (`videasy`, `rivestream`, `vidlink`,
+`anidb`, `allanime`, `miruro`, `youtube`) or media bucket (`movie`, `series`, `anime`, `youtube`)
+to narrow the matrix while debugging. Each smoke has
 a 45-second deadline so a provider outage returns a diagnostic report instead of hanging the pass.
 
 Each matrix row includes a `healthClass`:

--- a/apps/cli/test/live/provider-matrix.smoke.mjs
+++ b/apps/cli/test/live/provider-matrix.smoke.mjs
@@ -17,6 +17,18 @@ const MATRIX = [
     fixture: "Breaking Bad S01E01",
   },
   {
+    provider: "vidlink",
+    command: ["bun", "test/live/vidlink-inception.smoke.ts"],
+    media: "movie",
+    fixture: "Inception (DASH + playlist cookie)",
+  },
+  {
+    provider: "anidb",
+    command: ["bun", "-e", "await import('./test/live/anidb-onigiri.smoke.ts')"],
+    media: "anime",
+    fixture: "Onigiri S01E01",
+  },
+  {
     provider: "allanime",
     command: ["bun", "-e", "await import('./test/live/allanime-demonslayer.smoke.ts')"],
     media: "anime",

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,7 +1,7 @@
 {
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceFingerprint": "714d222971b43c2eec825c81d973aa8d0def23f78625e159e5925f4c4daa1b8a",
+  "cliSourceFingerprint": "56899b74f64c872a90d7365341ba537895b645f6073e3b22779a5fe7654f0806",
   "docsContentFingerprint": "764b92ca7c260171b5af6e3ff263e19ff60d758ecdaa0c1be0c9a7d804002b7d",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
@@ -17,7 +17,8 @@
       "capabilities": ["source-resolve", "subtitle-resolve", "multi-source", "quality-ranked"],
       "status": "active",
       "notes": [
-        "2026-07-16: active stream API is api.speedracelight.com (player.videasy.to / cineby.at); api.wingsdatabase.com is a mirror.",
+        "2026-07-16: active stream API is api.speedracelight.com (player.videasy.to / cineby.at).",
+        "2026-08-26: the api.wingsdatabase.com seed mirror was removed — NXDOMAIN on public resolvers; the surviving apex does not serve /seed. db.wingsdatabase.com still resolves and stays listed.",
         "2026-07-16: Cineby server catalog labels (Yoru/Neon/Sage/Jett/…) map to /cdn /neon2 /ym /jett /… routes.",
         "2026-07-18: Inventory UI order matches cineby Servers (Yoru first). Resolve Phase A is Yoru → Cypher → Neon → Sage → Jett → Breach → Vyse; localized servers stay Phase B.",
         "2026-07-18: Resolve-gate always segment-probes HLS before attesting streamReachabilityVerified; dead CDNs fail over instead of hanging.",

--- a/packages/providers/src/videasy/crypto.ts
+++ b/packages/providers/src/videasy/crypto.ts
@@ -3,7 +3,7 @@
  *
  * Extracted from player.videasy.to (chunk decrypt path used by cineby.at /
  * cineplay.to). The old Videasy API used WASM + AES; the current
- * `api.speedracelight.com` / `api.wingsdatabase.com` path uses seed + enc=2
+ * `api.speedracelight.com` path uses seed + enc=2
  * with a custom PRNG XOR cipher and "mvm1" magic-byte validation.
  *
  * Flow:

--- a/packages/providers/src/videasy/direct.ts
+++ b/packages/providers/src/videasy/direct.ts
@@ -95,8 +95,18 @@ export const VIDKING_API_BASE = "https://api.videasy.to";
  * Hosts are interchangeable; seed must be fetched from the same host used for sources.
  */
 export const WINGS_API_BASE = "https://api.speedracelight.com";
-/** Mirror host still serving the same seed + enc=2 contract. */
-export const WINGS_API_FALLBACK_BASE = "https://api.wingsdatabase.com";
+/**
+ * Every host serving the seed + enc=2 contract, in preference order.
+ *
+ * The old `api.wingsdatabase.com` mirror was removed on 2026-08-26. The name is
+ * NXDOMAIN on public resolvers (Cloudflare and Google both answer Status 3) and
+ * the surviving apex does not serve `/seed`, so it could never win the race — it
+ * only spent a request slot and then sat in the five-minute penalty box after
+ * every cold resolve, which reads as a healthy pair while offering no
+ * redundancy at all. The transport still races N hosts: add a mirror back to
+ * this list when one exists rather than reintroducing a second constant.
+ */
+export const WINGS_API_BASES: readonly string[] = [WINGS_API_BASE];
 /** TMDB proxy on the old domain (redirects to api.videasy.to/3). */
 export const VIDEASY_DB_BASE = "https://api.videasy.to/3";
 
@@ -1399,21 +1409,22 @@ export function fetchWingsdatabaseSeedForTest(
   mediaId: number,
   context: ProviderRuntimeContext,
   signal?: AbortSignal,
+  hosts: readonly string[] = WINGS_API_BASES,
 ): Promise<WingsSeedTransport | undefined> {
-  return fetchWingsdatabaseSeed(mediaId, context, signal);
+  return fetchWingsdatabaseSeed(mediaId, context, signal, hosts);
 }
 
 /**
  * Test seam: which hosts currently carry a failure penalty.
  *
  * Request order alone cannot prove this — when every host is penalized the
- * transport deliberately races them all rather than giving up, so "both hosts
- * were contacted" is true both when nothing was blamed and when everything was.
+ * transport deliberately races them all rather than giving up, so "every host
+ * was contacted" is true both when nothing was blamed and when everything was.
  */
-export function wingsPenalizedHostsForTest(): readonly string[] {
-  return [WINGS_API_BASE, WINGS_API_FALLBACK_BASE].filter((base) =>
-    Boolean(wingsHostFailureCache.get(base)),
-  );
+export function wingsPenalizedHostsForTest(
+  hosts: readonly string[] = WINGS_API_BASES,
+): readonly string[] {
+  return hosts.filter((base) => Boolean(wingsHostFailureCache.get(base)));
 }
 
 /** Test seam: module-scoped transport state must not leak between test cases. */
@@ -1431,6 +1442,7 @@ async function fetchWingsdatabaseSeed(
   mediaId: number,
   context: ProviderRuntimeContext,
   signal?: AbortSignal,
+  hosts: readonly string[] = WINGS_API_BASES,
 ): Promise<WingsSeedTransport | undefined> {
   const requester = context.fetch?.fetch.bind(context.fetch) ?? fetch;
   const effectiveSignal = signal ?? context.signal;
@@ -1441,16 +1453,16 @@ async function fetchWingsdatabaseSeed(
     referer: "https://www.cineby.at/",
   } as const;
 
+  // A preferred host only leads when it is still one of the configured hosts —
+  // a retired mirror must not be resurrected by a cache entry that outlived it.
   const preferredBase = wingsPreferredHostCache.get(mediaId);
-  const bases = preferredBase
-    ? [
-        preferredBase,
-        ...[WINGS_API_BASE, WINGS_API_FALLBACK_BASE].filter((base) => base !== preferredBase),
-      ]
-    : [WINGS_API_BASE, WINGS_API_FALLBACK_BASE];
+  const bases =
+    preferredBase && hosts.includes(preferredBase)
+      ? [preferredBase, ...hosts.filter((base) => base !== preferredBase)]
+      : [...hosts];
 
-  // Prefer cached seeds (order: last working host, primary, fallback); every
-  // fallback stays an indivisible host+seed pair.
+  // Prefer cached seeds (order: last working host, then the configured hosts);
+  // every fallback stays an indivisible host+seed pair.
   const uncached: string[] = [];
   for (const apiBase of bases) {
     const cachedSeed = wingsSeedCache.get(wingsSeedCacheKey(apiBase, mediaId));

--- a/packages/providers/src/videasy/flavors.ts
+++ b/packages/providers/src/videasy/flavors.ts
@@ -82,7 +82,7 @@ export type VidkingFlavorDefinition = {
  * Cypher is Kunai-only (explicit quality ladder; not on the website).
  */
 const FLAVORS: readonly VidkingFlavorDefinition[] = [
-  /* ── Active Cineby catalog (api.speedracelight.com / api.wingsdatabase.com) ── */
+  /* ── Active Cineby catalog (api.speedracelight.com) ── */
   {
     id: "cineby-yoru",
     themeLabel: "Yoru",

--- a/packages/providers/src/videasy/manifest.ts
+++ b/packages/providers/src/videasy/manifest.ts
@@ -49,7 +49,6 @@ export const videasyManifest = defineProviderManifest({
     upstreamHosts: [
       "api.videasy.to",
       "api.speedracelight.com",
-      "api.wingsdatabase.com",
       "db.videasy.to",
       "db.speedracelight.com",
       "db.wingsdatabase.com",
@@ -62,7 +61,8 @@ export const videasyManifest = defineProviderManifest({
     ],
   },
   notes: [
-    "2026-07-16: active stream API is api.speedracelight.com (player.videasy.to / cineby.at); api.wingsdatabase.com is a mirror.",
+    "2026-07-16: active stream API is api.speedracelight.com (player.videasy.to / cineby.at).",
+    "2026-08-26: the api.wingsdatabase.com seed mirror was removed — NXDOMAIN on public resolvers; the surviving apex does not serve /seed. db.wingsdatabase.com still resolves and stays listed.",
     "2026-07-16: Cineby server catalog labels (Yoru/Neon/Sage/Jett/…) map to /cdn /neon2 /ym /jett /… routes.",
     "2026-07-18: Inventory UI order matches cineby Servers (Yoru first). Resolve Phase A is Yoru → Cypher → Neon → Sage → Jett → Breach → Vyse; localized servers stay Phase B.",
     "2026-07-18: Resolve-gate always segment-probes HLS before attesting streamReachabilityVerified; dead CDNs fail over instead of hanging.",

--- a/packages/providers/test/videasy-preferred-fallback.test.ts
+++ b/packages/providers/test/videasy-preferred-fallback.test.ts
@@ -35,7 +35,14 @@ const passthroughEndpointHealth: EndpointHealthPort = {
 };
 
 describe("videasy preferred source fallback", () => {
-  test("keeps a Wings fallback seed and encrypted source request on the same host", async () => {
+  /**
+   * A seed is only valid for the host that issued it, so the encrypted source
+   * request must follow the seed's host. This pins the pairing on the single
+   * configured host; multi-host failover — who wins, who is blamed, and who must
+   * not be — is covered with injected hosts in `videasy-wings-seed-race.test.ts`,
+   * which is what keeps this assertion from depending on a live mirror.
+   */
+  test("keeps the Wings seed and encrypted source request on the same host", async () => {
     const requestedUrls: string[] = [];
     const context = {
       now: () => "2026-07-16T00:00:00.000Z",
@@ -48,9 +55,6 @@ describe("videasy preferred source fallback", () => {
           const url = String(input);
           requestedUrls.push(url);
           if (url === "https://api.speedracelight.com/seed?mediaId=987654") {
-            return new Response("", { status: 503 });
-          }
-          if (url === "https://api.wingsdatabase.com/seed?mediaId=987654") {
             return new Response(
               JSON.stringify({ seed: "test-seed.vAlIdS33dString", ttlMs: 30_000 }),
             );
@@ -77,7 +81,9 @@ describe("videasy preferred source fallback", () => {
       new URL(url).pathname.startsWith("/neon2/"),
     );
     expect(sourceRequests.length).toBeGreaterThan(0);
-    expect(sourceRequests.every((url) => new URL(url).host === "api.wingsdatabase.com")).toBe(true);
+    expect(sourceRequests.every((url) => new URL(url).host === "api.speedracelight.com")).toBe(
+      true,
+    );
   });
 
   test("deprecated Helium/1movies source id is recognized; legacy Videasy endpoints also deprecated", () => {

--- a/packages/providers/test/videasy-wings-seed-race.test.ts
+++ b/packages/providers/test/videasy-wings-seed-race.test.ts
@@ -6,9 +6,21 @@ import {
   clearWingsTransportCachesForTest,
   fetchWingsdatabaseSeedForTest,
   WINGS_API_BASE,
-  WINGS_API_FALLBACK_BASE,
+  WINGS_API_BASES,
   wingsPenalizedHostsForTest,
 } from "../src/videasy/direct";
+
+/**
+ * Production runs a single Wings host today, but the transport still races N of
+ * them, and the behaviours worth pinning here — who gets blamed for a failure,
+ * and who must not be — only exist with more than one. These two synthetic
+ * hosts exercise that machinery without asserting that any particular mirror is
+ * alive, which is exactly the coupling that let a dead `api.wingsdatabase.com`
+ * sit in the rotation looking like redundancy.
+ */
+const TEST_PRIMARY = "https://primary.wings.test";
+const TEST_MIRROR = "https://mirror.wings.test";
+const TEST_HOSTS = [TEST_PRIMARY, TEST_MIRROR] as const;
 
 /**
  * A deferred request: the test decides exactly when each host answers, so the
@@ -20,13 +32,14 @@ type Deferred = {
   readonly aborted: () => boolean;
 };
 
-function createRequester() {
+function createRequester(hosts: readonly string[] = WINGS_API_BASES) {
   const pending = new Map<string, Deferred>();
   const calls: string[] = [];
 
   const requester = (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const url = String(input);
-    const host = url.startsWith(WINGS_API_BASE) ? WINGS_API_BASE : WINGS_API_FALLBACK_BASE;
+    const host = hosts.find((candidate) => url.startsWith(candidate));
+    if (!host) throw new Error(`unexpected seed host in request: ${url}`);
     calls.push(host);
     return new Promise<Response>((resolve, reject) => {
       let wasAborted = false;
@@ -79,8 +92,25 @@ beforeEach(() => {
   clearWingsTransportCachesForTest();
 });
 
+describe("Wings host configuration", () => {
+  /**
+   * `api.wingsdatabase.com` was removed on 2026-08-26 as NXDOMAIN. A host that
+   * can never answer is not redundancy — it costs a request slot and a penalty
+   * entry per cold resolve — so the rotation must not quietly regrow one.
+   */
+  test("every configured host is a live-looking absolute origin", () => {
+    expect(WINGS_API_BASES.length).toBeGreaterThan(0);
+    expect(WINGS_API_BASES).toContain(WINGS_API_BASE);
+    expect(WINGS_API_BASES).not.toContain("https://api.wingsdatabase.com");
+    for (const base of WINGS_API_BASES) {
+      expect(base.startsWith("https://")).toBe(true);
+      expect(base.endsWith("/")).toBe(false);
+    }
+  });
+});
+
 describe("Wings seed race outcomes", () => {
-  test("primary wins and its seed is paired with its own host", async () => {
+  test("the configured production host wins and pairs its seed with itself", async () => {
     const harness = createRequester();
     const pendingResult = fetchWingsdatabaseSeedForTest(1, createContext(harness.requester));
 
@@ -89,68 +119,100 @@ describe("Wings seed race outcomes", () => {
     expect(await pendingResult).toEqual({ apiBase: WINGS_API_BASE, seed: "seed-value" });
   });
 
-  test("fallback wins and its seed is paired with the fallback host", async () => {
-    const harness = createRequester();
-    const pendingResult = fetchWingsdatabaseSeedForTest(2, createContext(harness.requester));
+  test("a mirror wins and its seed is paired with the mirror host", async () => {
+    const harness = createRequester(TEST_HOSTS);
+    const pendingResult = fetchWingsdatabaseSeedForTest(
+      2,
+      createContext(harness.requester),
+      undefined,
+      TEST_HOSTS,
+    );
 
-    await harness.settle(WINGS_API_FALLBACK_BASE, SEED_BODY);
+    await harness.settle(TEST_MIRROR, SEED_BODY);
 
-    expect(await pendingResult).toEqual({
-      apiBase: WINGS_API_FALLBACK_BASE,
-      seed: "seed-value",
-    });
+    expect(await pendingResult).toEqual({ apiBase: TEST_MIRROR, seed: "seed-value" });
   });
 
   test("a loser aborted after the winner is not penalized", async () => {
-    const first = createRequester();
-    const firstResult = fetchWingsdatabaseSeedForTest(3, createContext(first.requester));
-    await first.settle(WINGS_API_BASE, SEED_BODY);
+    const first = createRequester(TEST_HOSTS);
+    const firstResult = fetchWingsdatabaseSeedForTest(
+      3,
+      createContext(first.requester),
+      undefined,
+      TEST_HOSTS,
+    );
+    await first.settle(TEST_PRIMARY, SEED_BODY);
     await firstResult;
 
-    // The fallback lost and was aborted. That is not evidence about the host.
-    expect(wingsPenalizedHostsForTest()).toEqual([]);
+    // The mirror lost and was aborted. That is not evidence about the host.
+    expect(wingsPenalizedHostsForTest(TEST_HOSTS)).toEqual([]);
   });
 
   test("a genuine pre-winner failure penalizes only that host", async () => {
-    const first = createRequester();
-    const firstResult = fetchWingsdatabaseSeedForTest(5, createContext(first.requester));
-    await first.fail(WINGS_API_BASE, "seed HTTP 500");
-    await first.settle(WINGS_API_FALLBACK_BASE, SEED_BODY);
-    expect(await firstResult).toEqual({ apiBase: WINGS_API_FALLBACK_BASE, seed: "seed-value" });
+    const first = createRequester(TEST_HOSTS);
+    const firstResult = fetchWingsdatabaseSeedForTest(
+      5,
+      createContext(first.requester),
+      undefined,
+      TEST_HOSTS,
+    );
+    await first.fail(TEST_PRIMARY, "seed HTTP 500");
+    await first.settle(TEST_MIRROR, SEED_BODY);
+    expect(await firstResult).toEqual({ apiBase: TEST_MIRROR, seed: "seed-value" });
 
     // The primary is in the penalty box, so the next request skips it entirely.
-    const second = createRequester();
-    const secondResult = fetchWingsdatabaseSeedForTest(6, createContext(second.requester));
-    await second.settle(WINGS_API_FALLBACK_BASE, SEED_BODY);
+    const second = createRequester(TEST_HOSTS);
+    const secondResult = fetchWingsdatabaseSeedForTest(
+      6,
+      createContext(second.requester),
+      undefined,
+      TEST_HOSTS,
+    );
+    await second.settle(TEST_MIRROR, SEED_BODY);
     await secondResult;
 
-    expect(second.calls).toEqual([WINGS_API_FALLBACK_BASE]);
-    expect(wingsPenalizedHostsForTest()).toEqual([WINGS_API_BASE]);
+    expect(second.calls).toEqual([TEST_MIRROR]);
+    expect(wingsPenalizedHostsForTest(TEST_HOSTS)).toEqual([TEST_PRIMARY]);
   });
 
   test("when every host fails the result is undefined", async () => {
-    const harness = createRequester();
-    const pendingResult = fetchWingsdatabaseSeedForTest(7, createContext(harness.requester));
+    const harness = createRequester(TEST_HOSTS);
+    const pendingResult = fetchWingsdatabaseSeedForTest(
+      7,
+      createContext(harness.requester),
+      undefined,
+      TEST_HOSTS,
+    );
 
-    await harness.fail(WINGS_API_BASE, "seed HTTP 500");
-    await harness.fail(WINGS_API_FALLBACK_BASE, "seed HTTP 500");
+    await harness.fail(TEST_PRIMARY, "seed HTTP 500");
+    await harness.fail(TEST_MIRROR, "seed HTTP 500");
 
     expect(await pendingResult).toBeUndefined();
-    expect(wingsPenalizedHostsForTest()).toEqual([WINGS_API_BASE, WINGS_API_FALLBACK_BASE]);
+    expect(wingsPenalizedHostsForTest(TEST_HOSTS)).toEqual([TEST_PRIMARY, TEST_MIRROR]);
   });
 
   test("all hosts penalized still races them rather than giving up forever", async () => {
-    const first = createRequester();
-    const firstResult = fetchWingsdatabaseSeedForTest(8, createContext(first.requester));
-    await first.fail(WINGS_API_BASE, "seed HTTP 500");
-    await first.fail(WINGS_API_FALLBACK_BASE, "seed HTTP 500");
+    const first = createRequester(TEST_HOSTS);
+    const firstResult = fetchWingsdatabaseSeedForTest(
+      8,
+      createContext(first.requester),
+      undefined,
+      TEST_HOSTS,
+    );
+    await first.fail(TEST_PRIMARY, "seed HTTP 500");
+    await first.fail(TEST_MIRROR, "seed HTTP 500");
     await firstResult;
 
-    const second = createRequester();
-    const secondResult = fetchWingsdatabaseSeedForTest(9, createContext(second.requester));
-    await second.settle(WINGS_API_BASE, SEED_BODY);
+    const second = createRequester(TEST_HOSTS);
+    const secondResult = fetchWingsdatabaseSeedForTest(
+      9,
+      createContext(second.requester),
+      undefined,
+      TEST_HOSTS,
+    );
+    await second.settle(TEST_PRIMARY, SEED_BODY);
 
-    expect(await secondResult).toEqual({ apiBase: WINGS_API_BASE, seed: "seed-value" });
+    expect(await secondResult).toEqual({ apiBase: TEST_PRIMARY, seed: "seed-value" });
   });
 
   /**
@@ -160,17 +222,19 @@ describe("Wings seed race outcomes", () => {
    */
   test("caller abort penalizes neither host", async () => {
     const controller = new AbortController();
-    const first = createRequester();
+    const first = createRequester(TEST_HOSTS);
     const firstResult = fetchWingsdatabaseSeedForTest(
       10,
       createContext(first.requester, controller.signal),
+      undefined,
+      TEST_HOSTS,
     );
 
     await Promise.resolve();
     controller.abort();
 
     expect(await firstResult).toBeUndefined();
-    expect(wingsPenalizedHostsForTest()).toEqual([]);
+    expect(wingsPenalizedHostsForTest(TEST_HOSTS)).toEqual([]);
   });
 
   test("a cached seed short-circuits the race for the same media id", async () => {
@@ -186,5 +250,34 @@ describe("Wings seed race outcomes", () => {
       seed: "seed-value",
     });
     expect(second.calls).toEqual([]);
+  });
+
+  /**
+   * A preferred-host entry can outlive the host it names when a mirror is
+   * retired. It must not put that dead host back at the front of the race.
+   */
+  test("a preferred host that is no longer configured is not resurrected", async () => {
+    const first = createRequester(TEST_HOSTS);
+    const firstResult = fetchWingsdatabaseSeedForTest(
+      13,
+      createContext(first.requester),
+      undefined,
+      TEST_HOSTS,
+    );
+    await first.settle(TEST_MIRROR, SEED_BODY);
+    await firstResult;
+
+    // The mirror is retired: only the primary remains configured.
+    const second = createRequester([TEST_PRIMARY]);
+    const secondResult = fetchWingsdatabaseSeedForTest(
+      13,
+      createContext(second.requester),
+      undefined,
+      [TEST_PRIMARY],
+    );
+    await second.settle(TEST_PRIMARY, SEED_BODY);
+
+    expect(await secondResult).toEqual({ apiBase: TEST_PRIMARY, seed: "seed-value" });
+    expect(second.calls).toEqual([TEST_PRIMARY]);
   });
 });


### PR DESCRIPTION
## Why

Two gaps found while auditing provider health against `main` ahead of 0.3.0. Neither is a provider outage — one is missing evidence, the other is a host that has been dead long enough to stop being redundancy.

### The matrix was blind to the default anime lane

`bun run test:live:matrix` ran 5 of the 7 providers `loadProductionProviderModules()` registers. The two it skipped:

- **`anidb`** — the **default** anime provider (`DEFAULT_CONFIG.animeProvider`), and the lane `ReleaseProviderSignoff` signs off on. A total outage here would have left the matrix green.
- **`vidlink`** — which has already had one outage stay invisible for exactly this reason.

Both are now rows, so the matrix covers every registered production provider.

### `api.wingsdatabase.com` is NXDOMAIN

The Videasy seed mirror does not resolve:

| Resolver | `api.wingsdatabase.com` |
| --- | --- |
| Cloudflare (1.1.1.1) | `Status: 3` (NXDOMAIN) |
| Google (dns.google) | `Status: 3` (NXDOMAIN) |

The surviving apex `wingsdatabase.com` does not serve `/seed` either (curl exit 6). Meanwhile `api.speedracelight.com/seed` returns **200**.

So the mirror could never win the seed race. It only spent a request slot and then sat in the five-minute penalty box after every cold resolve — Videasy read as a redundant pair while having no redundancy at all. `manifest.ts` and the dossier both still called it a live mirror.

`db.wingsdatabase.com` **does** still resolve, so it stays in the relay allowlist. Only the `api.` host is removed.

## What changed

- `WINGS_API_FALLBACK_BASE` is replaced by `WINGS_API_BASES`, a list the transport still races N-wide. A live mirror can be added back without reintroducing a second constant.
- The removal is documented where the host used to be declared, plus in `manifest.ts` notes and `.docs/provider-dossiers/videasy.md`.
- `api.wingsdatabase.com` removed from the Videasy relay `upstreamHosts` allowlist.

### Keeping the test coverage the mirror was carrying

The seed-race suite pins who gets blamed for a failure and who must not be — including the fix for caller-aborts poisoning both hosts for five minutes. **Those behaviours only exist with more than one host**, so deleting the mirror would have silently deleted that coverage.

Instead the race takes an injected host list. Tests exercise the machinery with synthetic hosts rather than asserting a real mirror is alive — which is the coupling that let a dead host sit in the rotation looking like redundancy in the first place.

Two previously unenforced invariants are now pinned:
- a retired host cannot be resurrected by a preferred-host cache entry that outlived it
- `api.wingsdatabase.com` cannot reappear in the rotation

`videasy-preferred-fallback.test.ts` expressed "seed and source stay on one host" via the second host; it now pins the same invariant on the single configured host, with failover covered in the race suite.

## Verification

Deterministic gates, all `--force` (no turbo replay), on this branch standing alone off `main`:

| Gate | Result |
| --- | --- |
| `typecheck --force` | 14/14, 0 cached |
| `test --force` | 23/23, **0 fail** (5128 unit + 238 integration + 172 storage + 88 docs) |
| `lint` | 0 warnings, 0 errors |
| `fmt:check` | clean |
| `verify:doc-paths` | all paths resolve |

Live, after the change:

- **Release signoff green on all three default lanes** — movie/series via `videasy`, anime via `anidb`, each with `configuredProvider === successfulProvider` (no silent fallback) and `streamReachable: true`.
- **Matrix 6/7 healthy** across all seven providers. The one red is AllAnime's captcha gate, which is environmental (its search and episode catalog load fine through the same host; only the source query is gated) and already classified `environment-network` with the relay remedy in the error text.

Provider behaviour is unchanged — Videasy resolves through the live host exactly as before.

## Note for a follow-up (not in this PR)

`apps/docs/scripts/sync-code-metadata.ts:99` — `extractArray` splits manifest notes on `,`, so **any comma in a provider note silently becomes two bullets on the public docs site**. Every existing note happens to avoid commas, so it has never surfaced; the convention is load-bearing and undocumented. Worked around here with a semicolon. Worth its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Provider Updates**
  - Updated Videasy to use `api.speedracelight.com` as its active stream API.
  - Removed references to the defunct WingsDatabase stream mirror while retaining relevant database documentation.
  - Preserved support for dynamically added live mirrors.

- **Documentation**
  - Expanded live smoke-check examples and provider coverage to include Vidlink, AniDB, and movie content.

- **Testing**
  - Expanded coverage for host selection, fallback behavior, retries, cancellation, and retired hosts across supported providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->