### PR TITLE
fix(presence): give the Discord card a play button distinct from the catalog link

### DIFF
--- a/.changeset/brave-pandas-point.md
+++ b/.changeset/brave-pandas-point.md
@@ -1,0 +1,28 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Give the Discord presence card a play button that is distinct from the catalog link.
+
+### Fixes
+
+- The presence card exposed four clickable surfaces resolving to at most two
+  destinations, and the play target was not one of them. For a movie, or an
+  anime known only by an AniList id, the poster, title, state row, and the
+  single button all collapsed onto one identical URL, because neither has a
+  distinct episode page for `state_url` to point at.
+- `state_url` is now set only when the episode page is a different destination
+  from the title page, so the title and state rows stop repeating one link.
+
+### Behavior
+
+- Presence now fills both button slots Discord allows: **Play on Kunai**,
+  carrying the https web-share URL for the live playback target, followed by the
+  catalog button. The catalog button is dropped when it would resolve to the
+  play target.
+- The play button uses the web-share route rather than the `kunai://` ref
+  because Discord rejects any button URL that is not http(s); the web route
+  hands off to `kunai://` on open. A title with no catalog ids still gets the
+  play button, where it previously got no buttons at all.
+- The `kunai://` ref stays in the presence state line and in `playable_ref`, so
+  copy-paste is unchanged. Private-privacy playback still emits no buttons.

--- a/.docs/presence-integrations.md
+++ b/.docs/presence-integrations.md
@@ -36,7 +36,7 @@ Discord presence is optional and local-only:
    `position / duration` label in `state` for clients that render time remaining differently.
 5. Paused playback sends `timestamps: null` with static `Paused at …` text so Discord does not
    keep advancing the old timer. After three minutes paused (tunable), Kunai clears the activity.
-6. Full privacy adds safe poster artwork and catalog links when ids are known.
+6. Full privacy adds safe poster artwork, a **Play on Kunai** button, and catalog links when ids are known.
 
 If any requirement is missing, Kunai records a diagnostics event and disables automatic retry until
 the user reconnects from Settings or changes the presence configuration. Duplicate activity payloads
@@ -129,22 +129,27 @@ Presence integrations must never receive:
 `presencePrivacy: "full"` may include title, episode, catalog ids, playback timestamps, and safe
 poster artwork.
 
-Discord activity buttons are URL-only (max two). During full privacy playback Kunai adds a single
-catalog button when ids are known:
+Discord activity buttons are URL-only (max two). During full privacy playback Kunai fills both:
 
-- **View episode on TMDB** for TV with a TMDB id
-- otherwise **View on AniList**, **View on IMDb**, or **View on TMDB** for the series/movie
+1. **Play on Kunai** — the https web-share route for the live playback target
+2. a catalog button when ids are known — **View episode on TMDB** for TV with a TMDB id,
+   otherwise **View on AniList**, **View on IMDb**, or **View on TMDB** for the series/movie
+
+The play button carries the https web-share URL, not the `kunai://` ref, because Discord rejects
+any button URL that is not http(s); the web route hands off to `kunai://` on open. A title with no
+catalog ids still gets the play button, and a catalog link that resolves to the play target is
+dropped rather than shown as a second button to the same place.
 
 Recent Discord clients also support clickable text/image via `details_url`, `state_url`, and
-`assets.large_url` when catalog ids are known. Under full privacy, the encoded playable
-`kunai://` ref is also appended to the presence `state` line (and exposed as `playable_ref` in
-url-fields); Discord buttons remain https catalog links only because Discord only allows http(s)
-button URLs.
+`assets.large_url` when catalog ids are known. `state_url` is set only when the episode page is a
+different destination from the title page — a movie has no episode page, and an AniList-only title
+resolves both to the same series page, so linking it would point the title and state rows at one
+identical URL. The encoded playable `kunai://` ref stays appended to the presence `state` line and
+exposed as `playable_ref` in url-fields.
 
-Play-in-Kunai handoffs use the shared `PlaybackTargetRef` codec (see `.docs/share-links.md`). The
-playable ref is derived from the live activity via `buildShareRefForActivity` in
-`discord-activity-links.ts`, so the `kunai://` text ref stays episode-accurate alongside the https
-catalog buttons.
+Play-in-Kunai handoffs use the shared `PlaybackTargetRef` codec (see `.docs/share-links.md`). Both
+the `kunai://` text ref and the https play button are derived from the live activity via
+`buildShareRefForActivity` in `discord-activity-links.ts`, so they stay episode-accurate.
 `presenceDiscordOpenUrl` remains in settings for future use but is not wired into the default
 activity payload.
 
@@ -179,7 +184,8 @@ Discord Rich Presence here is local IPC, not OAuth:
 4. Set `presenceProvider: "discord"` and preferred `presencePrivacy`.
 5. Start playback in Kunai.
 6. Confirm Discord activity shows poster (or uploaded `kunai` fallback), `S# E# · episode`,
-   progress bar after duration is known, clickable catalog URLs, and a catalog button when ids exist.
+   progress bar after duration is known, clickable catalog URLs, a **Play on Kunai** button, and a
+   catalog button when ids exist.
 7. Pause → static card, no advancing timer; after ~3 minutes → presence clears.
 8. Autoplay next episode → card updates without clearing binge session suffix (after 15+ minutes).
 9. Return to search / quit → presence clears.

--- a/.docs/share-links.md
+++ b/.docs/share-links.md
@@ -64,7 +64,7 @@ Parser returns `null` when neither `cat` nor `q` is present, or when the catalog
 - `kunai --handoff-url <url>` — OS protocol handler path (confirmation required)
 - Post-play **Share link** action and history **Copy share link**
 - mpv `Ctrl+Shift+S` — copy the HTTPS link at live `time-pos`
-- Discord Rich Presence — https catalog button; playable `kunai://` ref in presence text (not a button; Discord only allows http(s) buttons)
+- Discord Rich Presence — **Play on Kunai** button carrying the https web-share URL, plus an https catalog button; the `kunai://` ref also stays in presence text (Discord only allows http(s) button URLs, so the play button uses the web route)
 
 ## Timestamp resume
 

--- a/apps/cli/src/services/presence/discord-activity-links.ts
+++ b/apps/cli/src/services/presence/discord-activity-links.ts
@@ -1,6 +1,7 @@
 import { resolveCatalogPosterUrl } from "@/domain/catalog/resolve-catalog-poster-url";
 import {
   encodePlaybackTargetRef,
+  encodePlaybackTargetWebUrl,
   type PlaybackTargetRef,
 } from "@/domain/share/playback-target-ref";
 import { buildShareRefFromTitleContext } from "@/domain/share/share-ref-from-title-context";
@@ -31,6 +32,25 @@ export function buildPlayableShareUrlForActivity(
   if (privacy === "private") return null;
   const ref = buildShareRefForActivity(activity);
   return ref ? encodePlaybackTargetRef(ref) : null;
+}
+
+/**
+ * The same playback target as {@link buildPlayableShareUrlForActivity}, but over
+ * https so Discord will accept it as a button.
+ *
+ * Discord rejects any button URL that is not http(s), which is why the
+ * `kunai://` ref rode along as presence *text* and the only button repeated the
+ * catalog link — the play target and the catalog target rendered as the same
+ * destination. The web share route is an ordinary https URL that hands off to
+ * `kunai://`, so the play action can finally be its own button.
+ */
+export function buildPlayableWebUrlForActivity(
+  activity: PresencePlaybackActivity,
+  privacy: "full" | "private",
+): string | null {
+  if (privacy === "private") return null;
+  const ref = buildShareRefForActivity(activity);
+  return ref ? encodePlaybackTargetWebUrl(ref) : null;
 }
 
 export function buildCatalogViewLink(input: {
@@ -96,14 +116,26 @@ export function buildBestCatalogLink(
   return buildCatalogEpisodeLink(activity) ?? buildCatalogViewLink(activity);
 }
 
+/** Discord renders at most two presence buttons; extras are dropped silently. */
+export const DISCORD_MAX_PRESENCE_BUTTONS = 2;
+
 export function buildDiscordPresenceButtons(
   activity: PresencePlaybackActivity,
   privacy: "full" | "private",
 ): readonly { label: string; url: string }[] {
   if (privacy === "private") return [];
 
+  const buttons: { label: string; url: string }[] = [];
+  const playUrl = buildPlayableWebUrlForActivity(activity, privacy);
+  if (playUrl) buttons.push({ label: "Play on Kunai", url: playUrl });
+
+  // A catalog button that resolves to the play target would give the card two
+  // buttons and one destination, which is the duplication this list exists to
+  // avoid.
   const catalog = buildBestCatalogLink(activity);
-  return catalog ? [catalog] : [];
+  if (catalog && catalog.url !== playUrl) buttons.push(catalog);
+
+  return buttons.slice(0, DISCORD_MAX_PRESENCE_BUTTONS);
 }
 
 export function buildDiscordActivityUrlFields(
@@ -112,10 +144,13 @@ export function buildDiscordActivityUrlFields(
 ): Record<string, string> {
   const viewLink = buildCatalogViewLink({ mode: activity.mode, title: activity.title });
   const episodeLink = buildCatalogEpisodeLink(activity);
-  const stateLink = episodeLink ?? viewLink;
   const fields: Record<string, string> = {};
   if (viewLink) fields.details_url = viewLink.url;
-  if (stateLink) fields.state_url = stateLink.url;
+  // The state line is only worth linking when it goes somewhere the title does
+  // not. A movie has no episode page, and an AniList-only title resolves both
+  // links to the same series page — in both cases the old `episodeLink ??
+  // viewLink` made the title and state rows point at one identical URL.
+  if (episodeLink && episodeLink.url !== viewLink?.url) fields.state_url = episodeLink.url;
   const playable = buildPlayableShareUrlForActivity(activity, privacy);
   if (playable) fields.playable_ref = playable;
   return fields;

--- a/apps/cli/test/unit/services/presence/PresenceServiceImpl.test.ts
+++ b/apps/cli/test/unit/services/presence/PresenceServiceImpl.test.ts
@@ -4,6 +4,7 @@ import type { DiagnosticsStore } from "@/services/diagnostics/DiagnosticsStore";
 import type { ConfigService, KitsuneConfig } from "@/services/persistence/ConfigService";
 import { DEFAULT_CONFIG } from "@/services/persistence/ConfigStore";
 import { resolveTuning } from "@/services/persistence/tuning";
+import { buildPlayableWebUrlForActivity } from "@/services/presence/discord-activity-links";
 import {
   __testing as presenceTesting,
   buildDiscordActivity,
@@ -103,7 +104,11 @@ describe("PresenceServiceImpl", () => {
     });
     expect(String(buildDiscordActivity(activity, "full").state)).toContain("S4 E9");
     expect(buildDiscordActivity(activity, "full").playable_ref).toContain("kunai://play?");
-    expect(buildDiscordActivity(activity, "full").buttons).toBeUndefined();
+    // No catalog ids, so there is no catalog button — but the play target is
+    // still known, and it is the one button worth showing.
+    expect(buildDiscordActivity(activity, "full").buttons).toEqual([
+      { label: "Play on Kunai", url: buildPlayableWebUrlForActivity(activity, "full") as string },
+    ]);
     expect(buildDiscordActivity(activity, "private")).toMatchObject({
       details: "Watching with Kunai",
       state: "Playing",
@@ -242,14 +247,18 @@ describe("PresenceServiceImpl", () => {
     expect(payload).toMatchObject({
       details: "Frieren: Beyond Journey's End",
       details_url: "https://anilist.co/anime/154587",
-      state_url: "https://anilist.co/anime/154587",
-      buttons: [{ label: "View on AniList", url: "https://anilist.co/anime/154587" }],
+      buttons: [
+        { label: "Play on Kunai", url: buildPlayableWebUrlForActivity(activity, "full") as string },
+        { label: "View on AniList", url: "https://anilist.co/anime/154587" },
+      ],
       assets: {
         large_image: "https://image.example/frieren.jpg",
         large_text: "Frieren: Beyond Journey's End",
         large_url: "https://anilist.co/anime/154587",
       },
     });
+    // AniList has no per-episode page, so linking the state row would repeat the title link.
+    expect(payload).not.toHaveProperty("state_url");
     expect(String(payload.state)).toContain("S1 E14 · Smells Like Trouble");
     expect(payload).not.toHaveProperty("largeImageKey");
     expect(payload).not.toHaveProperty("smallImageKey");
@@ -271,6 +280,7 @@ describe("PresenceServiceImpl", () => {
     };
 
     expect(buildDiscordActivity(activity, "full").buttons).toEqual([
+      { label: "Play on Kunai", url: buildPlayableWebUrlForActivity(activity, "full") as string },
       {
         label: "View episode on TMDB",
         url: "https://www.themoviedb.org/tv/1396/season/4/episode/9",

--- a/apps/cli/test/unit/services/presence/discord-activity-links.test.ts
+++ b/apps/cli/test/unit/services/presence/discord-activity-links.test.ts
@@ -8,6 +8,7 @@ import {
   buildDiscordPosterAsset,
   buildDiscordPresenceButtons,
   buildPlayableShareUrlForActivity,
+  buildPlayableWebUrlForActivity,
   buildShareRefForActivity,
 } from "@/services/presence/discord-activity-links";
 
@@ -51,11 +52,32 @@ test("buildCatalogEpisodeLink returns TMDB episode pages when possible", () => {
   });
 });
 
-test("buildDiscordPresenceButtons only exposes catalog links", () => {
-  expect(buildDiscordPresenceButtons(baseActivity, "full")).toEqual([
+/**
+ * The play target used to reach Discord only as presence *text*, so the single
+ * button repeated the catalog link and the card offered one destination under
+ * two affordances. Discord refuses non-http(s) button URLs, so the play button
+ * must carry the https web-share route rather than the `kunai://` ref.
+ */
+test("buildDiscordPresenceButtons leads with a play button distinct from the catalog link", () => {
+  const buttons = buildDiscordPresenceButtons(baseActivity, "full");
+  const playUrl = buildPlayableWebUrlForActivity(baseActivity, "full");
+
+  expect(buttons).toEqual([
+    { label: "Play on Kunai", url: playUrl as string },
     { label: "View on AniList", url: "https://anilist.co/anime/21" },
   ]);
+  expect(buttons[0]?.url.startsWith("https://")).toBe(true);
+  expect(buttons[0]?.url).not.toBe(buttons[1]?.url);
+  expect(buttons.length).toBeLessThanOrEqual(2);
   expect(buildDiscordPresenceButtons(baseActivity, "private")).toEqual([]);
+});
+
+test("buildPlayableWebUrlForActivity yields an https handoff and stays private-safe", () => {
+  const webUrl = buildPlayableWebUrlForActivity(baseActivity, "full");
+  expect(webUrl?.startsWith("https://")).toBe(true);
+  // Same playback target as the kunai:// ref, carried over a scheme Discord accepts.
+  expect(buildPlayableShareUrlForActivity(baseActivity, "full")?.startsWith("kunai://")).toBe(true);
+  expect(buildPlayableWebUrlForActivity(baseActivity, "private")).toBeNull();
 });
 
 test("buildDiscordPosterAsset uses HTTPS poster URLs for Discord large_image", () => {
@@ -115,14 +137,14 @@ test("buildDiscordPosterAsset accepts title thumbnail artwork", () => {
 });
 
 test("buildDiscordActivityUrlFields exposes clickable catalog links", () => {
+  // An AniList-only title has no distinct episode page, so linking the state row
+  // would point it at the same URL as the title row.
   expect(buildDiscordActivityUrlFields(baseActivity)).toEqual({
     details_url: "https://anilist.co/anime/21",
-    state_url: "https://anilist.co/anime/21",
     playable_ref: "kunai://play?cat=anilist%3A21&kind=anime&s=1&e=1&src=allanime&n=One%20Piece",
   });
   expect(buildDiscordActivityUrlFields(baseActivity, "private")).toEqual({
     details_url: "https://anilist.co/anime/21",
-    state_url: "https://anilist.co/anime/21",
   });
   expect(
     buildDiscordActivityUrlFields({


### PR DESCRIPTION
## The bug

The Discord presence card offered **four clickable surfaces resolving to at most two destinations**, and the play target was not one of them.

Measured against the live builders, before this change:

| Surface | Series + TMDB | Movie + TMDB | Anime + AniList only |
| --- | --- | --- | --- |
| `assets.large_url` (poster) | `tv/24428` | `movie/438631` | `anime/21` |
| `details_url` (title) | `tv/24428` | `movie/438631` | `anime/21` |
| `state_url` (state row) | `…/season/1/episode/1` | `movie/438631` | `anime/21` |
| button | `…/season/1/episode/1` | `movie/438631` | `anime/21` |
| play target | `kunai://play?…` — **text only, not clickable** | | |

For a movie, or an anime known only by an AniList id, **all four collapse onto one identical URL**: neither has a distinct episode page, so `state_url`'s `episodeLink ?? viewLink` fell back to the title link.

The play target reached Discord only as text appended to the state line. `.docs/share-links.md` recorded why — Discord rejects any button URL that is not http(s), and the ref is `kunai://`.

## The fix

`encodePlaybackTargetWebUrl()` already produces `https://kunai.kitsunekode.in/w/<code>`, an ordinary https URL that hands off to `kunai://` on open. That is a legal Discord button URL, so the play action can finally be its own button.

Buttons now fill both slots Discord allows:

1. **Play on Kunai** — the https web-share URL for the live playback target
2. the catalog button — dropped when it resolves to the play target, so the card never shows two buttons to one place

A title with **no catalog ids** still gets the play button. That case previously produced no buttons at all.

`state_url` is now set only when the episode page is a genuinely different destination from the title page. The `kunai://` ref stays in the state line and in `playable_ref`, so copy-paste is unchanged.

After:

| Surface | Series + TMDB | Movie + TMDB | Anime + AniList only |
| --- | --- | --- | --- |
| `details_url` | `tv/24428` | `movie/438631` | `anime/21` |
| `state_url` | `…/season/1/episode/1` | *omitted* | *omitted* |
| button 1 | **Play on Kunai** → https web share | same | same |
| button 2 | `…/season/1/episode/1` | `movie/438631` | `anime/21` |

## Tests

Three existing tests encoded the old behaviour and are updated rather than deleted:

- `buildDiscordPresenceButtons only exposes catalog links` → now asserts the play button leads, is https, and differs from the catalog button
- the AniList payload test asserted the duplicated `state_url` → now asserts `state_url` is absent, because linking it would repeat the title link
- the privacy-safe test asserted `buttons` was `undefined` for an id-less title → now asserts the play button

New coverage: `buildPlayableWebUrlForActivity` yields an https handoff and returns `null` under `presencePrivacy: "private"`, matching the existing `kunai://` ref behaviour. Private playback still emits no buttons at all.

## Verification

Run on this branch standing alone off `main`, all `--force` so no turbo cache replay:

| Gate | Result |
| --- | --- |
| `typecheck --force` | 14/14, 0 cached |
| `test --force` | 23/23, **0 fail**, 0 cached |
| `lint` | 0 warnings, 0 errors |
| `fmt:check` | clean |
| `verify:doc-paths` | all paths resolve |

Docs updated in the same change set: `.docs/presence-integrations.md` (button list, the http(s) constraint, and the `state_url` rule) and `.docs/share-links.md`.

## Not in this PR

`presenceDiscordOpenUrl` is stored, validated, and surfaced in `/presence` and `/settings`, but nothing reads it when building the activity payload — a declaration with no reader. The settings detail already calls it "reserved for future handoffs", so it is left as-is here rather than quietly repurposed for the play button.
