### PR TITLE
refactor: clear anti-slop chained assertions from src and make the rule blocking [hold until after 0.3.0]

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,8 +7,12 @@
     "es2026": true
   },
   "plugins": ["eslint", "typescript", "import", "unicorn", "promise", "node", "react", "jsx-a11y"],
-
-  "jsPlugins": [{ "name": "anti-slop", "specifier": "./tools/oxlint/anti-slop/index.ts" }],
+  "jsPlugins": [
+    {
+      "name": "anti-slop",
+      "specifier": "./tools/oxlint/anti-slop/index.ts"
+    }
+  ],
   "categories": {
     "correctness": "error",
     "suspicious": "warn",
@@ -19,25 +23,18 @@
     "anti-slop/no-object-parameters": "error",
     "anti-slop/no-reflect-apply": "error",
     "anti-slop/no-reflect-get": "error",
-
     "no-debugger": "error",
     "no-console": "off",
-
     "curly": "off",
     "eqeqeq": "warn",
-
     "no-await-in-loop": "off",
     "no-underscore-dangle": "off",
-
     "eslint/no-unused-vars": "off",
     "typescript/no-unused-vars": "warn",
-
     "typescript/no-explicit-any": "warn",
     "typescript/no-non-null-assertion": "warn",
-
     "import/no-cycle": "warn",
     "promise/no-return-wrap": "warn",
-
     "react/react-in-jsx-scope": "off",
     "unicorn/prefer-node-protocol": "warn",
     "unicorn/no-array-for-each": "off",
@@ -47,18 +44,23 @@
   },
   "overrides": [
     {
-      "files": ["**/*.test.ts", "**/*.spec.ts", "**/*.test.tsx", "**/*.spec.tsx", "**/test/**", "**/__mocks__/**"],
+      "files": ["**/*.test.ts", "**/*.spec.ts", "**/*.test.tsx", "**/*.spec.tsx"],
       "env": {
         "vitest": true
       },
       "rules": {
-        "anti-slop/no-chained-type-assertions": "off",
-        "anti-slop/no-object-parameters": "off",
-        "anti-slop/no-reflect-apply": "off",
-        "anti-slop/no-reflect-get": "off",
         "typescript/no-explicit-any": "off",
         "typescript/no-non-null-assertion": "off",
         "unicorn/consistent-function-scoping": "off"
+      }
+    },
+    {
+      "files": ["**/*.test.ts", "**/*.spec.ts", "**/*.test.tsx", "**/*.spec.tsx", "**/test/**", "**/__mocks__/**"],
+      "rules": {
+        "anti-slop/no-chained-type-assertions": "off",
+        "anti-slop/no-object-parameters": "off",
+        "anti-slop/no-reflect-apply": "off",
+        "anti-slop/no-reflect-get": "off"
       }
     },
     {
@@ -88,7 +90,6 @@
     "apps/cli/dist/**",
     "dist/**",
     "node_modules/**",
-
     ".agent/**",
     ".agents/**",
     ".claude/**",
@@ -100,18 +101,15 @@
     ".pi/**",
     ".roo/**",
     ".windsurf/**",
-
     ".git/**",
     ".turbo/**",
     ".next/**",
     ".cache/**",
     "coverage/**",
-
     "bun.lock",
     "pnpm-lock.yaml",
     "package-lock.json",
     "yarn.lock",
-
     "**/*.min.js",
     "**/*.d.ts"
   ]

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,12 +7,19 @@
     "es2026": true
   },
   "plugins": ["eslint", "typescript", "import", "unicorn", "promise", "node", "react", "jsx-a11y"],
+
+  "jsPlugins": [{ "name": "anti-slop", "specifier": "./tools/oxlint/anti-slop/index.ts" }],
   "categories": {
     "correctness": "error",
     "suspicious": "warn",
     "perf": "warn"
   },
   "rules": {
+    "anti-slop/no-chained-type-assertions": "error",
+    "anti-slop/no-object-parameters": "error",
+    "anti-slop/no-reflect-apply": "error",
+    "anti-slop/no-reflect-get": "error",
+
     "no-debugger": "error",
     "no-console": "off",
 
@@ -40,11 +47,15 @@
   },
   "overrides": [
     {
-      "files": ["**/*.test.ts", "**/*.spec.ts", "**/*.test.tsx", "**/*.spec.tsx"],
+      "files": ["**/*.test.ts", "**/*.spec.ts", "**/*.test.tsx", "**/*.spec.tsx", "**/test/**", "**/__mocks__/**"],
       "env": {
         "vitest": true
       },
       "rules": {
+        "anti-slop/no-chained-type-assertions": "off",
+        "anti-slop/no-object-parameters": "off",
+        "anti-slop/no-reflect-apply": "off",
+        "anti-slop/no-reflect-get": "off",
         "typescript/no-explicit-any": "off",
         "typescript/no-non-null-assertion": "off",
         "unicorn/consistent-function-scoping": "off"

--- a/apps/cli/src/app-shell/browse-shell-view.ts
+++ b/apps/cli/src/app-shell/browse-shell-view.ts
@@ -26,8 +26,19 @@ export function formatBrowseShellError(error: unknown): string {
  * (the SearchResult): header + synopsis render with no network; the detail fetch
  * only gap-fills cast/seasons/trailer/links.
  */
+/**
+ * Read the `SearchResult`-shaped fields a browse option may carry.
+ *
+ * `BrowseShellOption<T>` is generic over its value, so a row's payload is only
+ * a search result by convention. Narrowing here keeps that assumption in one
+ * checked place instead of asserting it at each reader.
+ */
+export function browseOptionFacts(value: unknown): Partial<SearchResult> {
+  return typeof value === "object" && value !== null ? (value as Partial<SearchResult>) : {};
+}
+
 export function buildBrowseDetailsSheetSeed<T>(option: BrowseShellOption<T>): DetailsSheetSeed {
-  const value = option.value as unknown as Partial<SearchResult> | undefined;
+  const value = browseOptionFacts(option.value);
   return {
     title: option.previewTitle ?? option.label,
     type: value?.type === "movie" ? "movie" : "series",

--- a/apps/cli/src/app-shell/browse-shell.tsx
+++ b/apps/cli/src/app-shell/browse-shell.tsx
@@ -63,6 +63,7 @@ import {
   resolveDetailsOverlaySubmitValue,
 } from "./browse-search-state";
 import {
+  browseOptionFacts,
   buildBrowseDetailsSheetSeed,
   formatBrowseShellError,
   MIN_RESULTS_FOR_LOCAL_FILTER,
@@ -815,7 +816,7 @@ export function BrowseShell<T>({
       // not a forced dump into the search field.
 
       const seed = buildBrowseDetailsSheetSeed(resolved);
-      const value = resolved.value as unknown as Partial<SearchResult>;
+      const value = browseOptionFacts(resolved.value);
       const titleId = typeof value?.id === "string" ? value.id : undefined;
       const cached = titleId ? (peekTitleDetail(titleId, seed.type) ?? null) : null;
 

--- a/apps/cli/src/app-shell/diagnostics-bundle-input.ts
+++ b/apps/cli/src/app-shell/diagnostics-bundle-input.ts
@@ -21,7 +21,7 @@ export function buildSupportBundleInputFromContainer(
 ): SupportBundleInputFromContainer {
   const state = panelInput.state;
   return {
-    capabilities: container.capabilitySnapshot as unknown as Record<string, unknown> | null,
+    capabilities: container.capabilitySnapshot as Record<string, unknown> | null,
     playbackSourceInventory: state.stream?.providerResolveResult
       ? buildPlaybackSourceInventoryDiagnosticsSummary(state.stream.providerResolveResult, {
           selectedSubtitleUrl: state.stream.subtitle,

--- a/apps/cli/src/app/playback/PlaybackPhase.ts
+++ b/apps/cli/src/app/playback/PlaybackPhase.ts
@@ -4285,11 +4285,8 @@ export class PlaybackPhase implements Phase<TitleInfo, PlaybackOutcome> {
           return;
         }
 
-        const mergedSubtitleList = mergeSubtitleTracks(
-          stream.subtitleList,
-          result.list as unknown as SubtitleTrack[],
-        );
-        const selected = selectAutomaticSubtitle(mergedSubtitleList as never, requestedSubLang);
+        const mergedSubtitleList = mergeSubtitleTracks(stream.subtitleList, result.list);
+        const selected = selectAutomaticSubtitle(mergedSubtitleList, requestedSubLang);
         const selectedUrl = selected?.url ?? result.selected ?? null;
         if (!selectedUrl) {
           diagnosticsService.record(

--- a/apps/cli/src/app/playback/subtitle-selection.ts
+++ b/apps/cli/src/app/playback/subtitle-selection.ts
@@ -2,7 +2,6 @@ import { isSubtitlePreferenceDisabled } from "@/domain/media/media-preferences";
 import { hardSubSatisfiesSubtitlePreference } from "@/domain/subtitle-policy";
 import type { StreamInfo, SubtitleTrack } from "@/domain/types";
 import { langMatches, selectAutomaticSubtitle } from "@/subtitle";
-import type { SubtitleEntry } from "@/subtitle";
 
 export type SubtitleDecision = {
   subtitle: string | null;
@@ -111,8 +110,7 @@ export async function choosePlaybackSubtitle({
   }
 
   if (stream.subtitleList?.length) {
-    const tracks = stream.subtitleList as unknown as SubtitleEntry[];
-    const pick = selectAutomaticSubtitle(tracks, subLang);
+    const pick = selectAutomaticSubtitle(stream.subtitleList, subLang);
     return {
       subtitle: pick?.url ?? null,
       reason:

--- a/apps/cli/src/image/native-image.ts
+++ b/apps/cli/src/image/native-image.ts
@@ -67,7 +67,7 @@ type NativeImage = {
 type NativeImageCtor = new (input: Uint8Array, options: NativeImageOptions) => NativeImage;
 
 function nativeImageCtor(): NativeImageCtor | null {
-  const candidate = (Bun as unknown as { Image?: unknown }).Image;
+  const candidate = (Bun as { Image?: unknown }).Image;
   return typeof candidate === "function" ? (candidate as NativeImageCtor) : null;
 }
 

--- a/apps/cli/src/infra/clipboard.ts
+++ b/apps/cli/src/infra/clipboard.ts
@@ -31,7 +31,12 @@ export type ClipboardRuntime = {
 export const defaultClipboardRuntime: ClipboardRuntime = {
   platform: process.platform,
   env: process.env,
-  spawn: (command, options) => Bun.spawn([...command], options) as unknown as ClipboardProcess,
+  spawn: (command, options) => {
+    // Mapped field by field rather than asserted: `ClipboardProcess` is the
+    // port this module actually uses, and Bun's `Subprocess` is wider than it.
+    const child = Bun.spawn([...command], options);
+    return { exited: child.exited, stdin: child.stdin, stdout: child.stdout };
+  },
 };
 
 function copyCommand(runtime: ClipboardRuntime): string[] {

--- a/apps/cli/src/infra/diagnostics/event-loop-monitor.ts
+++ b/apps/cli/src/infra/diagnostics/event-loop-monitor.ts
@@ -94,12 +94,14 @@ export function installEventLoopMonitor(
     }
     lastCpu = process.cpuUsage();
     scheduledAt = Date.now();
-    timer = setTimeout(tick, intervalMs);
-    (timer as unknown as { unref?: () => void }).unref?.();
+    const handle = setTimeout(tick, intervalMs);
+    timer = handle;
+    handle.unref?.();
   };
 
-  timer = setTimeout(tick, intervalMs);
-  (timer as unknown as { unref?: () => void }).unref?.();
+  const initialHandle = setTimeout(tick, intervalMs);
+  timer = initialHandle;
+  initialHandle.unref?.();
 
   return () => {
     stopped = true;

--- a/apps/cli/src/infra/diagnostics/heap-profiler.ts
+++ b/apps/cli/src/infra/diagnostics/heap-profiler.ts
@@ -19,6 +19,23 @@ export type HeapSnapshotLike = {
   readonly nodeClassNames: readonly string[];
 };
 
+/**
+ * Narrow a Bun heap snapshot to the raw node table this profiler walks.
+ *
+ * Bun's own `HeapSnapshot` type does not describe the parallel `nodes` /
+ * `nodeClassNames` arrays, so the shape has to be checked rather than claimed.
+ * A Bun release that changes the table fails here with a clear message instead
+ * of silently producing an empty histogram.
+ */
+function toHeapSnapshotLike(snapshot: unknown): HeapSnapshotLike {
+  const record = snapshot as Readonly<Record<string, unknown>>;
+  const { nodes, nodeClassNames } = record;
+  if (!Array.isArray(nodes) || !Array.isArray(nodeClassNames)) {
+    throw new Error("Bun.generateHeapSnapshot() did not return the expected node table");
+  }
+  return { nodes, nodeClassNames };
+}
+
 /** Count live heap nodes per class name. */
 export function classNameHistogram(snapshot: HeapSnapshotLike): Map<string, number> {
   const counts = new Map<string, number>();
@@ -63,11 +80,11 @@ export function installHeapProfiler(): void {
   const startedAt = Date.now();
   writeFileSync(rssCsv, "elapsed_s,rss_mb,heap_used_mb\n");
 
-  const baseline = classNameHistogram(Bun.generateHeapSnapshot() as unknown as HeapSnapshotLike);
+  const baseline = classNameHistogram(toHeapSnapshotLike(Bun.generateHeapSnapshot()));
 
   const report = (reason: string): void => {
     const snap = Bun.generateHeapSnapshot();
-    const growth = topGrowth(baseline, classNameHistogram(snap as unknown as HeapSnapshotLike));
+    const growth = topGrowth(baseline, classNameHistogram(toHeapSnapshotLike(snap)));
     const summary = formatGrowthReport(reason, growth);
     process.stderr.write(summary);
     const ts = new Date().toISOString().replace(/[:.]/g, "-");

--- a/apps/cli/src/infra/diagnostics/memory-watchdog.ts
+++ b/apps/cli/src/infra/diagnostics/memory-watchdog.ts
@@ -99,9 +99,11 @@ export function installMemoryWatchdog(): void {
     const url = URL.createObjectURL(
       new Blob([WATCHDOG_WORKER_SOURCE], { type: "text/javascript" }),
     );
-    const worker = new Worker(url);
-    // Never let the watchdog keep the process alive on its own.
-    (worker as unknown as { unref?: () => void }).unref?.();
+    const worker: { unref?: () => void } = new Worker(url);
+    // Never let the watchdog keep the process alive on its own. `unref` is a
+    // Bun/Node extension that the DOM `Worker` lib type does not declare, so
+    // the handle is held at the shape this function actually uses.
+    worker.unref?.();
   } catch {
     // Workers / Blob URLs unavailable in this runtime — skip silently.
   }

--- a/packages/providers/src/videasy/direct.ts
+++ b/packages/providers/src/videasy/direct.ts
@@ -278,6 +278,35 @@ type WasmExports = {
   decrypt(payloadPointer: number, tmdbId: number): number;
 };
 
+/**
+ * Narrow an instantiated module's exports to the three functions this provider
+ * calls.
+ *
+ * The WASM boundary is genuinely untyped — `ASUtil & Record<string, unknown>`
+ * shares no structure with `WasmExports`, so no assertion can be honest here.
+ * Checking the three callables is what earns the type, and a module missing one
+ * fails loudly at load rather than as `undefined is not a function` mid-decode.
+ */
+function requireWasmFunction<K extends keyof WasmExports>(
+  exports: Readonly<Record<string, unknown>>,
+  name: K,
+): WasmExports[K] {
+  const value = exports[name];
+  if (typeof value !== "function") {
+    throw new Error(`videasy wasm module is missing ${String(name)}()`);
+  }
+  // `value` is `unknown` until checked, so this narrows rather than reinterprets.
+  return value as WasmExports[K];
+}
+
+function toWasmExports(exports: Readonly<Record<string, unknown>>): WasmExports {
+  return {
+    __newString: requireWasmFunction(exports, "__newString"),
+    __getString: requireWasmFunction(exports, "__getString"),
+    decrypt: requireWasmFunction(exports, "decrypt"),
+  };
+}
+
 let wasmExportsPromise: Promise<WasmExports> | null = null;
 let wasmDecodeQueue: Promise<void> = Promise.resolve();
 
@@ -2011,7 +2040,7 @@ async function loadWasmExports(): Promise<WasmExports> {
         abort: () => {},
       },
     });
-    return module.exports as unknown as WasmExports;
+    return toWasmExports(module.exports);
   })();
 
   wasmExportsPromise = attempt;

--- a/packages/storage/src/repositories/notifications.ts
+++ b/packages/storage/src/repositories/notifications.ts
@@ -33,6 +33,12 @@ interface NotificationRow {
   readonly title: string;
   readonly body: string;
   readonly item_json: string | null;
+  /**
+   * A create-time snapshot of the actions a notification offered. It is NOT the
+   * authority: actions are derived from `kind` at render time, because a stored
+   * snapshot goes stale as soon as the action set for that kind changes. Read it
+   * for history, never to decide what to show.
+   */
   readonly action_json: string | null;
   readonly created_at: string;
   readonly updated_at: string;

--- a/scripts/publish-npm-release.ts
+++ b/scripts/publish-npm-release.ts
@@ -135,18 +135,33 @@ function parseJson(stdout: string, context: string): unknown {
   }
 }
 
+/** Read one required non-empty string field, or fail with the field named. */
+function requireStringField(
+  record: Readonly<Record<string, unknown>>,
+  field: string,
+  context: string,
+): string {
+  const value = record[field];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`[publish] ${context} npm pack metadata has no ${field}.`);
+  }
+  return value;
+}
+
 function parseNpmPackMetadata(stdout: string, context: string): NpmPackMetadata {
   const parsed = parseJson(stdout, `${context} npm pack`);
   if (!Array.isArray(parsed) || parsed.length !== 1 || !isJsonObject(parsed[0])) {
     throw new Error(`[publish] ${context} npm pack must return exactly one metadata record.`);
   }
   const record = parsed[0];
-  for (const field of ["name", "version", "integrity", "filename"] as const) {
-    if (typeof record[field] !== "string" || record[field].length === 0) {
-      throw new Error(`[publish] ${context} npm pack metadata has no ${field}.`);
-    }
-  }
-  return record as unknown as NpmPackMetadata;
+  // Built field by field rather than asserted: the reads are what prove the
+  // shape, so the return type is earned instead of claimed.
+  return {
+    name: requireStringField(record, "name", context),
+    version: requireStringField(record, "version", context),
+    integrity: requireStringField(record, "integrity", context),
+    filename: requireStringField(record, "filename", context),
+  };
 }
 
 function isSha512Integrity(value: string): boolean {

--- a/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
+++ b/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
@@ -14,7 +14,7 @@ function collectInferTypeParameterNames(
   names: Set<string>,
 ): void {
   if (node.type === "TSInferType") names.add(node.typeParameter.name.name);
-  const record = node as unknown as Readonly<Record<string, unknown>>;
+  const record = node as Readonly<Record<string, unknown>>;
   for (const key of visitorKeys[node.type] ?? []) {
     const value = record[key];
     if (isNode(value)) {


### PR DESCRIPTION
Rebased onto `main` (was 47 commits behind, branched before #261/#285/#311). Base is `main`; the old "Stack 4 of 4 / base `stack/3-analytics-series`" line is gone — that branch merged as #261 and no longer exists.


All 15 src findings of `no-chained-type-assertions` cleared; the rule now blocks in `.oxlintrc.json` with test paths exempted (~300 baseline there).

Most were not load-bearing — both subtitle casts were unnecessary, including a `selectAutomaticSubtitle(mergedSubtitleList as never, ...)`. `SubtitleEntry` already contains every field of `SubtitleTrack`, so removing them typechecks unchanged. Where the boundary is genuinely untyped (videasy WASM, `Bun.generateHeapSnapshot()`, npm pack metadata) the assertion is now *earned* by a check rather than moved.

Verified the gate bites: reintroducing a chained assertion fails oxlint, removing it passes.

Gates standing alone: typecheck 14/14, lint 12/12, doc gates clean. Full suite 23/23 on the combined tip.


---
**Follow-up commit — `fix(lint): keep the wider test glob to the anti-slop rules only`**

The new rules were added to the override block that already turns off `typescript/no-explicit-any`, `typescript/no-non-null-assertion` and `unicorn/consistent-function-scoping`. Widening that block's glob to `**/test/**` + `**/__mocks__/**` therefore also stopped warning about `any` and non-null assertions in **48** non-test-file `.ts` files under `test/` (helpers, harness, templates, preload). They are warnings, so CI stayed green either way — which is why it would never have been noticed. The wider glob is right for the anti-slop rules; it just should not have dragged the other three along. Now its own override block.

**Gates on the rebased tip** — `lint` 12/12, `typecheck` 14/14, `fmt:check` 26/26, all `0 cached`. Full suite: 5350 pass / 1 fail on one run (`DownloadService youtube argv contract > abort calls runYtDlpProcess cancel handle`), then 3 clean full runs and 3 clean targeted runs — intermittent under the parallel suite, same class as the `buildDiagnosticsInsight` flake, not from this change.

https://claude.ai/code/session_01EfworT7Px6Ky5QkuikrWqG
