### PR TITLE
feat(diagnostics): make `diagnostics recent` readable in a terminal

### DIFF
--- a/.changeset/lucky-moons-report.md
+++ b/.changeset/lucky-moons-report.md
@@ -1,0 +1,26 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Make `kunai diagnostics recent` readable in a terminal.
+
+### Features
+
+- Add a `pretty` format that lays each event out as a timestamped header, its
+  message, and its context as `key=value` pairs. Events group under a date
+  heading and a session id heads its run rather than repeating on every line.
+- `pretty` is the default only when stdout is a terminal. A pipe or redirect
+  still receives `jsonl`, so `kunai diagnostics recent > report.jsonl` and
+  `| jq` are unchanged. `--format` always overrides.
+- Colour follows the same terminal signal and is disabled by `NO_COLOR` or
+  `--no-color`; `--color` forces it on for a pipe that wants escapes. Only
+  16-colour SGR is used, which terminals reporting no `COLORTERM` still render.
+
+### Behavior
+
+- Every context key is printed, but the ones that repeat with the same value on
+  nearly every event (`status`, `severity`, `recommendedAction`, `spanFamily`)
+  sort last so the fields that differ lead the line.
+- Oversized values are sampled with an explicit count — one real
+  `skippedReasons` array runs to 82 entries and roughly two thousand characters.
+  `jsonl` and `markdown` remain lossless.

--- a/.docs/diagnostics-guide.md
+++ b/.docs/diagnostics-guide.md
@@ -56,9 +56,28 @@ Export a redacted support bundle with `/export-diagnostics`. The exported JSON i
 For agent-friendly local inspection without launching the shell:
 
 ```sh
+kunai diagnostics recent                            # pretty in a terminal, jsonl when piped
 kunai diagnostics recent --format jsonl --limit 200
 kunai diagnostics recent --format markdown --limit 50
+kunai diagnostics recent --no-color                 # pretty without ANSI
 ```
+
+`--format` accepts `pretty`, `jsonl`, or `markdown`. With no `--format`, the
+command prints `pretty` to a terminal and `jsonl` everywhere else, so a redirect
+or a pipe into `jq` keeps the machine format it has always produced.
+
+`pretty` groups events under a date heading, prints each session id once per run
+rather than on every line, and renders context as `key=value`. It keeps every
+context key — a diagnostics reader that drops fields is worse than a noisy one —
+but sorts the ones that repeat on nearly every event (`status`, `severity`,
+`recommendedAction`, `spanFamily`) last. Colour follows the terminal and is
+disabled by `NO_COLOR` or `--no-color`; `--color` forces it back on for a pipe
+that wants escapes.
+
+`pretty` also samples oversized context values — arrays past three entries and
+strings past 160 characters — and states how much it left out, because a single
+`skippedReasons` array can otherwise run to two thousand characters on one line.
+`jsonl` and `markdown` stay lossless, so use them when the full value matters.
 
 The command reads the same redacted cache-DB events used by `/diagnostics` and
 support bundles. JSONL is an export/readout format, not the canonical store.

--- a/apps/cli/src/cli-args.ts
+++ b/apps/cli/src/cli-args.ts
@@ -98,6 +98,7 @@ MAINTENANCE
   kunai doctor --json          Print the same report as JSON
   kunai uninstall              Remove kunai (add --purge to also delete user data)
   kunai diagnostics recent     Print recent redacted diagnostics from the local cache DB
+                               (--format pretty|jsonl|markdown, --limit N, --no-color)
   kunai completion <shell>     Print a shell completion script (bash|zsh|fish|powershell)
 
 Inside the app, press / for the command palette and ? for keyboard help.

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -625,7 +625,12 @@ export async function runCli(argv = process.argv.slice(2)): Promise<void> {
   if (argv[0] === "diagnostics") {
     const { runDiagnosticsRecentCommand } =
       await import("./services/diagnostics/diagnostics-export");
-    process.exit(await runDiagnosticsRecentCommand(argv.slice(1)));
+    process.exit(
+      await runDiagnosticsRecentCommand(argv.slice(1), {
+        isTty: Boolean(process.stdout.isTTY),
+        noColor: Boolean(process.env.NO_COLOR),
+      }),
+    );
   }
 
   // Best-effort: clear any stale `*.old` left by a prior Windows self-replace.

--- a/apps/cli/src/services/diagnostics/diagnostics-export.ts
+++ b/apps/cli/src/services/diagnostics/diagnostics-export.ts
@@ -7,12 +7,19 @@ import {
 
 import type { DiagnosticEvent } from "./diagnostic-event";
 
-export type DiagnosticsExportFormat = "jsonl" | "markdown";
+export type DiagnosticsExportFormat = "jsonl" | "markdown" | "pretty";
 
 export interface DiagnosticsRecentCommandOptions {
   readonly format?: DiagnosticsExportFormat;
   readonly limit?: number;
   readonly stdout?: Pick<typeof process.stdout, "write">;
+  /**
+   * Whether the destination is an interactive terminal. Drives both the default
+   * format and whether colour is emitted, so a pipe keeps getting the machine
+   * format it has always got.
+   */
+  readonly isTty?: boolean;
+  readonly noColor?: boolean;
 }
 
 export async function runDiagnosticsRecentCommand(
@@ -20,7 +27,10 @@ export async function runDiagnosticsRecentCommand(
   options: DiagnosticsRecentCommandOptions = {},
 ): Promise<number> {
   if (argv[0] !== "recent") {
-    process.stderr.write("Usage: kunai diagnostics recent [--format jsonl|markdown] [--limit N]\n");
+    process.stderr.write(
+      "Usage: kunai diagnostics recent [--format pretty|jsonl|markdown] [--limit N] [--no-color]\n" +
+        "       Defaults to pretty in a terminal and jsonl when piped or redirected.\n",
+    );
     return 1;
   }
 
@@ -31,10 +41,9 @@ export async function runDiagnosticsRecentCommand(
     runMigrations(db, "cache");
     const repository = new DiagnosticEventsRepository(db);
     const events = repository.listRecent(parsed.limit) as readonly DiagnosticEvent[];
-    const output =
-      parsed.format === "markdown"
-        ? formatDiagnosticEventsAsMarkdown(events)
-        : formatDiagnosticEventsAsJsonl(events);
+    const output = renderDiagnosticEvents(events, parsed.format, {
+      color: parsed.format === "pretty" && parsed.color,
+    });
     (options.stdout ?? process.stdout).write(output);
     return 0;
   } finally {
@@ -42,8 +51,183 @@ export async function runDiagnosticsRecentCommand(
   }
 }
 
+function renderDiagnosticEvents(
+  events: readonly DiagnosticEvent[],
+  format: DiagnosticsExportFormat,
+  options: PrettyDiagnosticsOptions,
+): string {
+  if (format === "markdown") return formatDiagnosticEventsAsMarkdown(events);
+  if (format === "pretty") return formatDiagnosticEventsAsPretty(events, options);
+  return formatDiagnosticEventsAsJsonl(events);
+}
+
 export function formatDiagnosticEventsAsJsonl(events: readonly DiagnosticEvent[]): string {
   return events.map((event) => JSON.stringify(event)).join("\n") + (events.length > 0 ? "\n" : "");
+}
+
+export type PrettyDiagnosticsOptions = {
+  /** ANSI colour is opt-in: diagnostics output is pasted into bug reports. */
+  readonly color?: boolean;
+};
+
+/**
+ * Context keys nearly every event repeats with the same value. They are still
+ * printed — a diagnostics reader must not hide data — but they sort last so the
+ * fields that actually differ between events lead the line.
+ */
+const LOW_SIGNAL_CONTEXT_KEYS = new Set(["status", "severity", "recommendedAction", "spanFamily"]);
+
+/**
+ * Basic 16-colour SGR only. Terminals that report no `COLORTERM`/`TERM` still
+ * render these, which 256-colour and truecolour escapes cannot promise.
+ */
+const ANSI = {
+  reset: "\u001b[0m",
+  dim: "\u001b[2m",
+  bold: "\u001b[1m",
+  red: "\u001b[31m",
+  green: "\u001b[32m",
+  yellow: "\u001b[33m",
+  blue: "\u001b[34m",
+  magenta: "\u001b[35m",
+  cyan: "\u001b[36m",
+} as const;
+
+const LEVEL_COLOR: Record<DiagnosticEvent["level"], string> = {
+  debug: ANSI.dim,
+  info: ANSI.cyan,
+  warn: ANSI.yellow,
+  error: `${ANSI.bold}${ANSI.red}`,
+};
+
+/**
+ * Human-readable rendering of recent diagnostics.
+ *
+ * The stored form is one JSON object per line, which is right for machines and
+ * unreadable in a terminal: a single event wraps over several lines and buries
+ * its message among correlation ids. This lays each event out as a timestamped
+ * header, its message, and its context as `key=value` pairs, grouped under a
+ * date heading so a multi-day tail stays legible.
+ */
+export function formatDiagnosticEventsAsPretty(
+  events: readonly DiagnosticEvent[],
+  options: PrettyDiagnosticsOptions = {},
+): string {
+  if (events.length === 0) return "No diagnostic events recorded.\n";
+
+  const paint = (value: string, code: string): string =>
+    options.color ? `${code}${value}${ANSI.reset}` : value;
+  const levelWidth = Math.max(...events.map((event) => event.level.length));
+  const categoryWidth = Math.max(...events.map((event) => event.category.length));
+  // Continuation lines align under the header rather than restating the time.
+  const indent = " ".repeat("HH:MM:SS.mmm".length + 2);
+
+  const lines: string[] = [];
+  let currentDay: string | null = null;
+  let currentSessionId: string | undefined;
+
+  for (const event of events) {
+    const date = new Date(event.timestamp);
+    const day = formatLocalDay(date);
+    if (day !== currentDay) {
+      if (lines.length > 0) lines.push("");
+      lines.push(paint(day, ANSI.bold));
+      currentDay = day;
+      // A day heading is a visual break, so reprint the session under it even
+      // when the run spans midnight.
+      currentSessionId = undefined;
+    }
+    // A session id is long and usually identical for every event in a tail.
+    // Printing it per line buries the fields that differ, so it heads its run
+    // instead — the same treatment the date gets.
+    if (event.sessionId && event.sessionId !== currentSessionId) {
+      lines.push(paint(`${indent}${event.sessionId}`, ANSI.dim));
+      currentSessionId = event.sessionId;
+    }
+
+    lines.push(
+      [
+        paint(formatLocalTimeOfDay(date), ANSI.dim),
+        paint(event.level.toUpperCase().padEnd(levelWidth), LEVEL_COLOR[event.level]),
+        paint(event.category.padEnd(categoryWidth), ANSI.magenta),
+        paint(event.operation, ANSI.bold),
+      ].join("  "),
+    );
+    if (event.message) lines.push(`${indent}${event.message}`);
+
+    const details = [
+      formatCorrelation(event, { omitSessionId: true }),
+      formatPrettyContext(event.context),
+    ]
+      .filter((part) => part.length > 0)
+      .join("  ");
+    if (details) lines.push(`${indent}${paint(details, ANSI.dim)}`);
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+/** Local time, not UTC: `recent` is read against the clock on the wall. */
+function formatLocalDay(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function formatLocalTimeOfDay(date: Date): string {
+  const hours = `${date.getHours()}`.padStart(2, "0");
+  const minutes = `${date.getMinutes()}`.padStart(2, "0");
+  const seconds = `${date.getSeconds()}`.padStart(2, "0");
+  const millis = `${date.getMilliseconds()}`.padStart(3, "0");
+  return `${hours}:${minutes}:${seconds}.${millis}`;
+}
+
+function formatPrettyContext(context: Record<string, unknown> | undefined): string {
+  if (!context) return "";
+  const entries = Object.entries(context).filter(([, value]) => value !== undefined);
+  if (entries.length === 0) return "";
+  entries.sort(([left], [right]) => {
+    const leftLow = LOW_SIGNAL_CONTEXT_KEYS.has(left) ? 1 : 0;
+    const rightLow = LOW_SIGNAL_CONTEXT_KEYS.has(right) ? 1 : 0;
+    return leftLow - rightLow;
+  });
+  return entries.map(([key, value]) => `${key}=${formatContextValue(value)}`).join("  ");
+}
+
+/**
+ * Elision bounds for the readable format only.
+ *
+ * A single context value can be enormous — one real `skippedReasons` array runs
+ * to 82 entries and roughly two thousand characters, which turns the whole tail
+ * into one unreadable line. `pretty` samples such a value and says how much it
+ * left out; `jsonl` and `markdown` stay lossless, so nothing is unrecoverable.
+ */
+const PRETTY_ARRAY_SAMPLE = 3;
+const PRETTY_STRING_MAX = 160;
+
+function formatContextValue(value: unknown): string {
+  if (typeof value === "string") {
+    const truncated =
+      value.length > PRETTY_STRING_MAX
+        ? `${value.slice(0, PRETTY_STRING_MAX)}… +${value.length - PRETTY_STRING_MAX} chars`
+        : value;
+    // Quote only when the value would otherwise blur into the next pair.
+    return /[\s=]/.test(truncated) ? JSON.stringify(truncated) : truncated;
+  }
+  if (Array.isArray(value)) return formatContextArray(value);
+  if (value === null || typeof value !== "object") return String(value);
+  return JSON.stringify(value);
+}
+
+function formatContextArray(value: readonly unknown[]): string {
+  if (value.length <= PRETTY_ARRAY_SAMPLE) return JSON.stringify(value);
+  const sample = value
+    .slice(0, PRETTY_ARRAY_SAMPLE)
+    .map((entry) => JSON.stringify(entry))
+    .join(",");
+  return `[${sample},… +${value.length - PRETTY_ARRAY_SAMPLE} more]`;
 }
 
 export function formatDiagnosticEventsAsMarkdown(events: readonly DiagnosticEvent[]): string {
@@ -68,21 +252,42 @@ export function formatDiagnosticEventsAsMarkdown(events: readonly DiagnosticEven
   return lines.join("\n");
 }
 
-function parseDiagnosticsRecentArgs(
+/**
+ * Exported so the format-default rule is testable without touching the real
+ * profile: `runDiagnosticsRecentCommand` resolves `getKunaiPaths()` and opens
+ * the live cache database, which a unit test must never do.
+ */
+export function parseDiagnosticsRecentArgs(
   argv: readonly string[],
   defaults: DiagnosticsRecentCommandOptions,
-): { readonly format: DiagnosticsExportFormat; readonly limit: number } {
-  let format = defaults.format ?? "jsonl";
+): {
+  readonly format: DiagnosticsExportFormat;
+  readonly limit: number;
+  readonly color: boolean;
+} {
+  // A terminal gets the readable format; a pipe or redirect keeps the machine
+  // format it has always received, so `> file` and `| jq` are unaffected.
+  const isTty = defaults.isTty ?? false;
+  let format: DiagnosticsExportFormat = defaults.format ?? (isTty ? "pretty" : "jsonl");
   let limit = defaults.limit ?? 100;
+  let color = isTty && !defaults.noColor;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--format") {
       const value = argv[index + 1];
-      if (value === "jsonl" || value === "markdown") {
+      if (value === "jsonl" || value === "markdown" || value === "pretty") {
         format = value;
         index += 1;
       }
+      continue;
+    }
+    if (arg === "--no-color") {
+      color = false;
+      continue;
+    }
+    if (arg === "--color") {
+      color = true;
       continue;
     }
     if (arg === "--limit") {
@@ -94,12 +299,15 @@ function parseDiagnosticsRecentArgs(
     }
   }
 
-  return { format, limit };
+  return { format, limit, color };
 }
 
-function formatCorrelation(event: DiagnosticEvent): string {
+function formatCorrelation(
+  event: DiagnosticEvent,
+  options: { readonly omitSessionId?: boolean } = {},
+): string {
   return [
-    event.sessionId ? `session=${event.sessionId}` : null,
+    event.sessionId && !options.omitSessionId ? `session=${event.sessionId}` : null,
     event.playbackCycleId ? `playbackCycle=${event.playbackCycleId}` : null,
     event.providerAttemptId ? `providerAttempt=${event.providerAttemptId}` : null,
     event.traceId ? `trace=${event.traceId}` : null,

--- a/apps/cli/test/unit/services/diagnostics/diagnostics-export.test.ts
+++ b/apps/cli/test/unit/services/diagnostics/diagnostics-export.test.ts
@@ -4,6 +4,8 @@ import type { DiagnosticEvent } from "@/services/diagnostics/diagnostic-event";
 import {
   formatDiagnosticEventsAsJsonl,
   formatDiagnosticEventsAsMarkdown,
+  formatDiagnosticEventsAsPretty,
+  parseDiagnosticsRecentArgs,
 } from "@/services/diagnostics/diagnostics-export";
 
 const event: DiagnosticEvent = {
@@ -33,4 +35,132 @@ test("formats diagnostic events as copy-friendly markdown", () => {
   expect(formatDiagnosticEventsAsMarkdown([event])).toContain(
     '"url": "https://cdn.example/stream.m3u8?token=[redacted]"',
   );
+});
+
+/**
+ * Diagnostics output is pasted into bug reports, so the readable format must be
+ * plain text unless colour is explicitly asked for.
+ */
+test("pretty format stays free of ANSI unless colour is requested", () => {
+  const plain = formatDiagnosticEventsAsPretty([event]);
+  expect(plain).not.toContain("\u001b[");
+  expect(plain).toContain("provider.resolve.timeline");
+  expect(plain).toContain("Provider resolve failed");
+  expect(plain).toContain("ERROR");
+
+  expect(formatDiagnosticEventsAsPretty([event], { color: true })).toContain("\u001b[");
+});
+
+test("pretty format groups the date and prints a session id once per run", () => {
+  const second: DiagnosticEvent = {
+    ...event,
+    timestamp: event.timestamp + 1_000,
+    level: "info",
+    message: "Provider resolve retried",
+  };
+  const rendered = formatDiagnosticEventsAsPretty([event, second]);
+  const lines = rendered.split("\n");
+
+  expect(lines[0]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  // Local time, not UTC: `recent` is read against the clock on the wall.
+  expect(lines.filter((line) => /^\d{2}:\d{2}:\d{2}\.\d{3}\s{2}/.test(line))).toHaveLength(2);
+  // The id heads its run rather than repeating on every event.
+  expect(lines.filter((line) => line.trim() === "session-1")).toHaveLength(1);
+  expect(rendered).not.toContain("session=session-1");
+});
+
+test("pretty format keeps every context key and sorts the repetitive ones last", () => {
+  const noisy: DiagnosticEvent = {
+    ...event,
+    context: { status: "failed", failureCode: "need-captcha", severity: "unhealthy", attempts: 3 },
+  };
+  const details = formatDiagnosticEventsAsPretty([noisy])
+    .split("\n")
+    .find((line) => line.includes("failureCode="));
+
+  expect(details).toBeDefined();
+  // Nothing is hidden — a diagnostics reader that drops fields is worse than a
+  // noisy one — but the fields that differ between events lead.
+  expect(details).toContain("status=failed");
+  expect(details).toContain("severity=unhealthy");
+  expect(details?.indexOf("failureCode=")).toBeLessThan(details?.indexOf("status=") ?? -1);
+  expect(details?.indexOf("attempts=")).toBeLessThan(details?.indexOf("severity=") ?? -1);
+});
+
+test("pretty format quotes only values that would blur into the next pair", () => {
+  const spaced: DiagnosticEvent = {
+    ...event,
+    context: { label: "The Avengers S01E01", reason: "shutdown", count: 2 },
+  };
+  const rendered = formatDiagnosticEventsAsPretty([spaced]);
+
+  expect(rendered).toContain('label="The Avengers S01E01"');
+  expect(rendered).toContain("reason=shutdown");
+  expect(rendered).toContain("count=2");
+});
+
+test("pretty format reports an empty tail instead of rendering nothing", () => {
+  expect(formatDiagnosticEventsAsPretty([])).toBe("No diagnostic events recorded.\n");
+});
+
+/**
+ * A pipe or redirect must keep the machine format it has always produced, or
+ * `kunai diagnostics recent > report.jsonl` and `| jq` silently change shape.
+ */
+test("format defaults to pretty on a terminal and jsonl when piped", () => {
+  expect(parseDiagnosticsRecentArgs([], { isTty: true }).format).toBe("pretty");
+  expect(parseDiagnosticsRecentArgs([], { isTty: false }).format).toBe("jsonl");
+  expect(parseDiagnosticsRecentArgs([], {}).format).toBe("jsonl");
+
+  // An explicit --format always wins over the terminal default.
+  expect(parseDiagnosticsRecentArgs(["--format", "jsonl"], { isTty: true }).format).toBe("jsonl");
+  expect(parseDiagnosticsRecentArgs(["--format", "pretty"], { isTty: false }).format).toBe(
+    "pretty",
+  );
+  expect(parseDiagnosticsRecentArgs(["--format", "markdown"], { isTty: true }).format).toBe(
+    "markdown",
+  );
+});
+
+test("colour follows the terminal, and both NO_COLOR and --no-color turn it off", () => {
+  expect(parseDiagnosticsRecentArgs([], { isTty: true }).color).toBe(true);
+  expect(parseDiagnosticsRecentArgs([], { isTty: false }).color).toBe(false);
+  expect(parseDiagnosticsRecentArgs([], { isTty: true, noColor: true }).color).toBe(false);
+  expect(parseDiagnosticsRecentArgs(["--no-color"], { isTty: true }).color).toBe(false);
+  // --color is the way back on for a pipe that does want escapes.
+  expect(parseDiagnosticsRecentArgs(["--color"], { isTty: false }).color).toBe(true);
+});
+
+test("limit stays bounded and ignores junk", () => {
+  expect(parseDiagnosticsRecentArgs([], {}).limit).toBe(100);
+  expect(parseDiagnosticsRecentArgs(["--limit", "5"], {}).limit).toBe(5);
+  expect(parseDiagnosticsRecentArgs(["--limit", "999999"], {}).limit).toBe(10_000);
+  expect(parseDiagnosticsRecentArgs(["--limit", "nope"], {}).limit).toBe(100);
+});
+
+/**
+ * One real `skippedReasons` array ran to 82 entries and about two thousand
+ * characters, which turned the whole tail into a single unreadable line. The
+ * readable format samples it and says how much it dropped; `jsonl` stays
+ * lossless so nothing is unrecoverable.
+ */
+test("pretty format samples oversized values and says what it elided", () => {
+  const bulky: DiagnosticEvent = {
+    ...event,
+    context: {
+      skippedReasons: Array.from({ length: 82 }, () => "movie"),
+      shortList: ["a", "b"],
+      note: "x".repeat(400),
+    },
+  };
+  const rendered = formatDiagnosticEventsAsPretty([bulky]);
+
+  expect(rendered).toContain('skippedReasons=["movie","movie","movie",… +79 more]');
+  // A short array is still shown in full.
+  expect(rendered).toContain('shortList=["a","b"]');
+  expect(rendered).toContain("… +240 chars");
+  expect(rendered.split("\n").every((line) => line.length < 400)).toBe(true);
+
+  // The lossless formats keep every entry.
+  expect(formatDiagnosticEventsAsJsonl([bulky])).toContain(JSON.stringify(bulky.context));
 });

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceFingerprint": "56899b74f64c872a90d7365341ba537895b645f6073e3b22779a5fe7654f0806",
-  "docsContentFingerprint": "764b92ca7c260171b5af6e3ff263e19ff60d758ecdaa0c1be0c9a7d804002b7d",
+  "cliSourceFingerprint": "e30a318b4b8394a24d7bb6ee694c11aebb9fa34b5a80700d782b7ea6d36ba5af",
+  "docsContentFingerprint": "eb26670b24929b646c9e09f53ca18273e48342bdc68aef093ba071a86ae90b82",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/docs/users/cli-reference.mdx
+++ b/docs/users/cli-reference.mdx
@@ -50,13 +50,24 @@ redacted, without launching the shell. Useful when attaching evidence to an
 issue.
 
 ```bash
-kunai diagnostics recent                        # JSONL, most recent first
+kunai diagnostics recent                        # readable output, most recent first
+kunai diagnostics recent --format jsonl         # one JSON object per line
 kunai diagnostics recent --format markdown      # human-readable table
 kunai diagnostics recent --limit 50             # cap how many events print
+kunai diagnostics recent --no-color             # readable output without colour
 ```
 
-`--format` accepts `jsonl` (default) or `markdown`. Events come from the local
-cache database; nothing is uploaded.
+`--format` accepts `pretty`, `jsonl`, or `markdown`. Without `--format`, Kunai
+prints the readable `pretty` output to a terminal and `jsonl` when the output is
+piped or redirected, so `kunai diagnostics recent > report.jsonl` and
+`kunai diagnostics recent | jq` behave exactly as before.
+
+Colour follows the terminal and turns off under `NO_COLOR` or `--no-color`. Use
+`--color` to keep it through a pipe.
+
+To stay readable, `pretty` shortens very long context values and says how much it
+left out. `--format jsonl` and `--format markdown` always print them in full.
+Events come from the local cache database; nothing is uploaded.
 
 ## Shell completions
 


### PR DESCRIPTION
## Why

`kunai diagnostics recent` printed one JSON object per line. That is right for a pipe and unreadable at a prompt — a single event wraps over several terminal lines and buries its message among correlation ids:

```
{"timestamp":1787762774889,"level":"info","category":"presence","operation":"presence.clear.succeeded","message":"Presence clear skipped — client already closed during shutdown","sessionId":"session:0122cd74-f190-4efb-a988-8618fe1cbcf7","context":{"status":"succeeded","severity":"healthy","recommendedAction":"none","spanFamily":"presence.session","provider":"discord","reason":"playback-exited","error":"Discord IPC client was destroyed"}}
```

Now:

```
2026-08-26
              session:0122cd74-f190-4efb-a988-8618fe1cbcf7
22:16:14.889  INFO   presence  presence.clear.succeeded
              Presence clear skipped — client already closed during shutdown
              provider=discord  reason=playback-exited  error="Discord IPC client was destroyed"  status=succeeded  severity=healthy  recommendedAction=none  spanFamily=presence.session
22:16:14.860  INFO   session   session.event
              Cancelling active work
              id=playback-resolve:tmdb:24428:1:1  label="The Avengers S01E01"  reason=shutdown
22:16:14.034  DEBUG  runtime   background.work.drain
              Background lane drained: attention-refresh
              lane=attention-refresh  completed=1  failed=0  skipped=0
```

## Design decisions

**A pipe keeps the format it always had.** `pretty` is the default *only* when stdout is a TTY; a pipe or redirect still gets `jsonl`, so `kunai diagnostics recent > report.jsonl` and `| jq` are unaffected. `--format` always overrides. This is the one behaviour a test pins hardest.

**The session id heads its run.** It is 45 characters and usually identical for every event in a tail, so printing it per line buries the fields that differ. It gets the same treatment as the date, and reprints after a day break.

**Nothing is hidden, but the repetitive keys move out of the way.** `status`, `severity`, `recommendedAction`, and `spanFamily` carry the same value on nearly every event. They are still printed — a diagnostics reader that drops fields is worse than a noisy one — but they sort last so the distinguishing fields lead.

**Oversized values are sampled with a count.** One real `skippedReasons` array runs to 82 entries and about 2000 characters, which turns the tail into a single unreadable line. Arrays past three entries and strings past 160 characters are elided with an explicit marker:

```
skippedReasons=["movie","movie","movie",… +79 more]
```

`jsonl` and `markdown` stay lossless, so nothing is unrecoverable.

**Colour**: follows the TTY signal, off under `NO_COLOR` or `--no-color`, forced on with `--color`. Only 16-colour SGR is used — terminals that report no `COLORTERM`/`TERM` still render those, which 256-colour and truecolour escapes cannot promise.

## Testing note

`parseDiagnosticsRecentArgs` is exported so the format-default rule is testable. `runDiagnosticsRecentCommand` resolves `getKunaiPaths()` and opens the **live** cache database, which a unit test must never touch — so the rule is tested through the pure parser instead.

Nine new tests cover: no ANSI unless requested, date grouping, session printed once, key ordering with nothing dropped, selective quoting, empty tail, the TTY/pipe default matrix, the colour matrix, limit bounds, and the elision (including that `jsonl` still contains the full value).

## Verification

Deterministic gates on this branch standing alone off `main`, all `--force` (no turbo replay):

| Gate | Result |
| --- | --- |
| `typecheck --force` | 14/14, 0 cached |
| `test --force` | 23/23, **0 fail**, 0 cached (5137 unit) |
| `lint` | 0 warnings, 0 errors |
| `fmt:check` | clean |
| `verify:doc-paths` | all paths resolve |
| `build` | 10/10 |

End-to-end against the **compiled binary**, reading a *copy* of a real cache database under an isolated `HOME`/`XDG_*` profile (never the live profile):

- PTY → readable form with colour, and the 82-entry array elided
- piped → byte-for-byte `jsonl` as before

Docs updated in the same change set: `.docs/diagnostics-guide.md`, `docs/users/cli-reference.mdx`, and the `--help` line in `cli-args.ts`. `apps/docs/lib/generated-metadata.json` carries the regenerated fingerprints for those edits.
