### PR TITLE
fix(docs): stop the manifest parser from shredding provider notes

### DIFF
--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -36,8 +36,7 @@
       "capabilities": ["source-resolve", "subtitle-resolve", "quality-ranked"],
       "status": "active",
       "notes": [
-        "Browserless: TMDB id is encrypted via enc-dec.app",
-        "then sources are fetched from vidlink.pro/api/b.",
+        "Browserless: TMDB id is encrypted via enc-dec.app, then sources are fetched from vidlink.pro/api/b.",
         "Returns a multi-quality HLS playlist (mpv selects the rendition) plus provider subtitles.",
         "External dependency: relies on enc-dec.app for the id-encryption step; falls back to other providers if it is unavailable."
       ]
@@ -63,11 +62,8 @@
       "capabilities": ["search", "episode-list", "source-resolve", "quality-ranked"],
       "status": "active",
       "notes": [
-        "Parity with ani-cli v5.0 (2026-08-01): browse search",
-        "/api/frontend anime episodes + episode languages",
-        "embed → HLS master.",
-        "Episode metadata follows the explicit anidb.app → official anidb.net AID cross-link",
-        "then reads official XML; AniList/Jikan fill missing fields and still artwork.",
+        "Parity with ani-cli v5.0 (2026-08-01): browse search, /api/frontend anime episodes + episode languages, embed → HLS master.",
+        "Episode metadata follows the explicit anidb.app → official anidb.net AID cross-link, then reads official XML; AniList/Jikan fill missing fields and still artwork.",
         "Bun/fetch often gets Cloudflare 403 on anidb.app HTML/API; production path uses curl with a Chrome UA (dossier-proven).",
         "HLS media on hls.anidb.app usually works with native fetch after the embed URL is obtained. Ladder expansion uses the same curl fallback as metadata so a relay miss does not collapse to one auto row.",
         "Sub = Japanese audio (jpn embed); dub = English audio (eng embed) when the languages API exposes it. No independently addressable subtitle track has been observed — do not advertise hardsub.",
@@ -84,18 +80,10 @@
       "capabilities": ["search", "episode-list", "source-resolve", "subtitle-resolve", "multi-source"],
       "status": "active",
       "notes": [
-        "AllManga-compatible client uses local fetch/decode logic for search",
-        "catalog",
-        "and source resolution.",
+        "AllManga-compatible client uses local fetch/decode logic for search, catalog, and source resolution.",
         "The active CLI path is browserless; unsupported extracted embeds should return deterministic failure.",
-        "Source inventory: Default",
-        "Yt-mp4",
-        "S-mp4",
-        "Mp4 (mp4upload scrape)",
-        "Luf-Mp4",
-        "Ak. Filemoon is gone.",
-        "2026-08: mkissa crypto rotates buildId + derivation constants (81 → 119 → 140; 140 added bootPrefix HMAC and group.host.lane.buildId.epoch payload) with /client-crypto/v1/bootstrap (x-aa-boot)",
-        "7-day epochs. ani-cli v5 moved primary to anidb.app."
+        "Source inventory: Default, Yt-mp4, S-mp4, Mp4 (mp4upload scrape), Luf-Mp4, Ak. Filemoon is gone.",
+        "2026-08: mkissa crypto rotates buildId + derivation constants (81 → 119 → 140; 140 added bootPrefix HMAC and group.host.lane.buildId.epoch payload) with /client-crypto/v1/bootstrap (x-aa-boot), 7-day epochs. ani-cli v5 moved primary to anidb.app."
       ]
     },
     {
@@ -110,12 +98,9 @@
       "notes": [
         "2026-07-16: Browser network on www.miruro.bz/watch/{anilistId}/... uses GET /api/secure/pipe?e=… (200 plain + x-obfuscated). HLS on vault*.ultracloud / owocdn with stream.referer https://kwik.cx/.",
         "Bun fetch often gets CF 403 HTML on pipe; production path falls back to curl --http2 with browser headers (dossier-proven on this machine).",
-        "Primary hosts: www.miruro.bz",
-        "www.miruro.ru. Bare miruro.bz/.ru are 301 redirects to www. and still CF-block at the pipe path; miruro.com serves a different app shell with no /api/secure/pipe; miruro.tv/.to are TLS-dead — all stay off the resolve list.",
+        "Primary hosts: www.miruro.bz, www.miruro.ru. Bare miruro.bz/.ru are 301 redirects to www. and still CF-block at the pipe path; miruro.com serves a different app shell with no /api/secure/pipe; miruro.tv/.to are TLS-dead — all stay off the resolve list.",
         "Uses Miruro pipe API with XOR/gzip decryption key 71951034f8fbcf53d89db52ceb3dc22c.",
-        "The default anime priority names AniDB first; that list is ordering",
-        "not an allowlist",
-        "so Miruro remains a registered fallback and manually selectable when the curl/http2 path works.",
+        "The default anime priority names AniDB first; that list is ordering, not an allowlist, so Miruro remains a registered fallback and manually selectable when the curl/http2 path works.",
         "May hit Cloudflare rate limits if called too frequently.",
         "2026-08-17: curl --http2 with browser headers also receives CF 403 HTML from some networks; the WAF block message now carries a relay hint."
       ]

--- a/apps/docs/lib/manifest-parsing.ts
+++ b/apps/docs/lib/manifest-parsing.ts
@@ -1,0 +1,109 @@
+/**
+ * Manifest value parsing for the docs codegen.
+ *
+ * Lives beside the generated output rather than inside `sync-code-metadata.ts`
+ * so it can be tested without pulling the CLI source (and its `@/` path
+ * aliases) into the docs TypeScript program. These are pure string functions.
+ */
+
+/** Read a single quoted manifest value, honouring apostrophes inside it. */
+export function extractString(content: string, prop: string): string | null {
+  const start = findPropertyValueStart(content, prop);
+  if (start < 0) return null;
+  const literal = readStringLiteral(content, start);
+  return literal ? literal.value : null;
+}
+
+export function extractBoolean(content: string, prop: string): boolean {
+  const regex = new RegExp(`${prop}:\\s*(true|false)`);
+  const match = content.match(regex);
+  return match ? match[1] === "true" : false;
+}
+
+/**
+ * Reads a manifest array as a list of string literals.
+ *
+ * Splitting the array body on `,` and stripping every quote — which is what
+ * this did — corrupts ordinary prose silently: a comma inside a note split it
+ * into two docs bullets, an apostrophe was deleted from the middle of a word,
+ * and a `]` inside a note truncated it and dropped every entry after it. None
+ * of that failed loudly; it just shipped to the public docs site. So the body
+ * is scanned for string literals instead, and everything between them —
+ * commas, whitespace, a trailing comma — is separator that never reaches the
+ * value.
+ */
+export function extractArray(content: string, prop: string): string[] {
+  const start = findPropertyValueStart(content, prop);
+  if (start < 0 || content[start] !== "[") return [];
+
+  const values: string[] = [];
+  let index = start + 1;
+  let depth = 1;
+  while (index < content.length && depth > 0) {
+    const char = content[index];
+    if (char === undefined) break;
+    if (QUOTES.has(char)) {
+      const literal = readStringLiteral(content, index);
+      if (!literal) break;
+      values.push(literal.value);
+      index = literal.endIndex;
+      continue;
+    }
+    // Brackets are tracked so a nested array ends the scan at the right place
+    // rather than at the first `]` the regex happened to reach.
+    if (char === "[") depth += 1;
+    else if (char === "]") depth -= 1;
+    index += 1;
+  }
+
+  return values.filter((value) => value.length > 0);
+}
+
+const QUOTES = new Set(['"', "'", "`"]);
+
+/**
+ * Index of the first non-space character after `prop:`, or -1.
+ *
+ * The leading boundary check stops `notes` from matching the tail of a longer
+ * identifier such as `releaseNotes`.
+ */
+function findPropertyValueStart(content: string, prop: string): number {
+  const pattern = new RegExp(`(^|[^A-Za-z0-9_$])${prop}\\s*:\\s*`);
+  const match = pattern.exec(content);
+  if (!match) return -1;
+  return match.index + match[0].length;
+}
+
+/** Parse one quoted literal, honouring backslash escapes. */
+function readStringLiteral(
+  content: string,
+  start: number,
+): { readonly value: string; readonly endIndex: number } | null {
+  const quote = content[start];
+  if (quote === undefined || !QUOTES.has(quote)) return null;
+
+  let value = "";
+  let index = start + 1;
+  while (index < content.length) {
+    const char = content[index];
+    if (char === undefined) break;
+    if (char === "\\") {
+      const escaped = content[index + 1];
+      if (escaped === undefined) break;
+      value += unescapeChar(escaped);
+      index += 2;
+      continue;
+    }
+    if (char === quote) return { value, endIndex: index + 1 };
+    value += char;
+    index += 1;
+  }
+  return null;
+}
+
+function unescapeChar(char: string): string {
+  if (char === "n") return "\n";
+  if (char === "t") return "\t";
+  if (char === "r") return "\r";
+  return char;
+}

--- a/apps/docs/scripts/sync-code-metadata.ts
+++ b/apps/docs/scripts/sync-code-metadata.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { publicShortcutMetadata } from "../../cli/src/app-shell/keybindings.ts";
+import { extractArray, extractBoolean, extractString } from "../lib/manifest-parsing";
 import {
   computeCliSourceFingerprint,
   computeDocsContentFingerprint,
@@ -82,28 +83,6 @@ function readExistingMetadata(filePath: string): Record<string, unknown> | null 
  */
 export function metadataIdentity(value: Record<string, unknown>): string {
   return JSON.stringify(value);
-}
-
-function extractString(content: string, prop: string): string | null {
-  const regex = new RegExp(`${prop}:\\s*["']([^"']+)["']`);
-  const match = content.match(regex);
-  return match ? match[1] : null;
-}
-
-function extractBoolean(content: string, prop: string): boolean {
-  const regex = new RegExp(`${prop}:\\s*(true|false)`);
-  const match = content.match(regex);
-  return match ? match[1] === "true" : false;
-}
-
-function extractArray(content: string, prop: string): string[] {
-  const regex = new RegExp(`${prop}:\\s*\\[([^\\]]+)\\]`);
-  const match = content.match(regex);
-  if (!match) return [];
-  return match[1]
-    .split(",")
-    .map((val) => val.trim().replace(/['"]/g, ""))
-    .filter((val) => val.length > 0);
 }
 
 function resolveProviderId(rawId: string, fallbackDir: string): string {

--- a/apps/docs/test/manifest-parsing.test.ts
+++ b/apps/docs/test/manifest-parsing.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+
+import { extractArray, extractString } from "../lib/manifest-parsing";
+
+/** `parseManifest` normalizes newlines before extracting, so tests do the same. */
+const normalize = (source: string): string => source.replace(/\n\s*/g, " ");
+
+describe("provider manifest array extraction", () => {
+  test("keeps a comma inside a note as one entry", () => {
+    expect(extractArray(normalize(`notes: ["one note, with a comma", "second"]`), "notes")).toEqual(
+      ["one note, with a comma", "second"],
+    );
+  });
+
+  test("keeps an apostrophe inside a note", () => {
+    expect(
+      extractArray(normalize(`notes: ["Frieren: Beyond Journey's End is supported"]`), "notes"),
+    ).toEqual(["Frieren: Beyond Journey's End is supported"]);
+  });
+
+  test("keeps a bracket inside a note and does not drop later entries", () => {
+    expect(
+      extractArray(normalize(`notes: ["routes map to /cdn [legacy]", "second note"]`), "notes"),
+    ).toEqual(["routes map to /cdn [legacy]", "second note"]);
+  });
+
+  test("reads single quoted, double quoted, and backtick entries alike", () => {
+    expect(
+      extractArray(
+        normalize("capabilities: ['source-resolve', \"multi-source\", `quality-ranked`]"),
+        "capabilities",
+      ),
+    ).toEqual(["source-resolve", "multi-source", "quality-ranked"]);
+  });
+
+  test("unescapes an escaped quote rather than dropping it", () => {
+    expect(extractArray(normalize(`notes: ["a \\"quoted\\" word"]`), "notes")).toEqual([
+      'a "quoted" word',
+    ]);
+  });
+
+  test("tolerates a trailing comma and surrounding whitespace", () => {
+    expect(extractArray(normalize(`notes: [ "first", "second", ]`), "notes")).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+
+  test("returns nothing for an empty array or a missing property", () => {
+    expect(extractArray(normalize(`notes: []`), "notes")).toEqual([]);
+    expect(extractArray(normalize(`status: "active"`), "notes")).toEqual([]);
+  });
+
+  test("reads the named property, not a different array nearby", () => {
+    const source = normalize(`mediaKinds: ["movie", "series"], capabilities: ["source-resolve"]`);
+    expect(extractArray(source, "mediaKinds")).toEqual(["movie", "series"]);
+    expect(extractArray(source, "capabilities")).toEqual(["source-resolve"]);
+  });
+});
+
+describe("provider manifest string extraction", () => {
+  test("keeps an apostrophe instead of truncating at it", () => {
+    expect(extractString(normalize(`description: "ani-cli's parity source"`), "description")).toBe(
+      "ani-cli's parity source",
+    );
+  });
+
+  test("reads single quoted and backtick values", () => {
+    expect(extractString(normalize(`domain: 'videasy.to'`), "domain")).toBe("videasy.to");
+    expect(extractString(normalize("status: `active`"), "status")).toBe("active");
+  });
+
+  test("unescapes an escaped quote", () => {
+    expect(extractString(normalize(`displayName: "the \\"good\\" one"`), "displayName")).toBe(
+      'the "good" one',
+    );
+  });
+
+  test("returns null when the property is absent", () => {
+    expect(extractString(normalize(`status: "active"`), "domain")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #257.

## This is already shipping

I filed #257 saying the bug was latent. It is not — regenerating the metadata with the fix collapses **23 mangled bullets into 8 correct notes** across four live providers. The corrupted text is on the public docs site now.

**allanime** — one sentence shipping as six bullets:

```diff
-  "Source inventory: Default",
-  "Yt-mp4",
-  "S-mp4",
-  "Mp4 (mp4upload scrape)",
-  "Luf-Mp4",
-  "Ak. Filemoon is gone.",
+  "Source inventory: Default, Yt-mp4, S-mp4, Mp4 (mp4upload scrape), Luf-Mp4, Ak. Filemoon is gone.",
```

**miruro** — the split inverts the meaning:

```diff
-  "The default anime priority names AniDB first; that list is ordering",
-  "not an allowlist",
-  "so Miruro remains a registered fallback and manually selectable when the curl/http2 path works.",
+  "The default anime priority names AniDB first; that list is ordering, not an allowlist, so Miruro remains a registered fallback and manually selectable when the curl/http2 path works.",
```

A reader who stops at bullet one is told the priority list **is** an allowlist. It says the opposite.

**anidb** — five fragments instead of two notes, one of which reads only `"embed → HLS master."`. **vidlink** — a sentence broken across two bullets mid-clause.

## Cause

```ts
return match[1]
  .split(",")                          // a comma inside a string is not a separator
  .map((val) => val.trim().replace(/['"]/g, ""))  // deletes apostrophes inside words
  .filter((val) => val.length > 0);
```

plus `[^\]]+` for the array body, which stops at the first `]` even inside a string literal, and `["']([^"']+)["']` in `extractString`, which ends at the first quote of either kind.

Four failure modes, verified against the functions as they stand on `main`:

| Input | Before | After |
| --- | --- | --- |
| `notes: ["one note, with a comma", "second"]` | 3 entries | 2 entries |
| `notes: ["Journey's End"]` | `"Journeys End"` | `"Journey's End"` |
| `description: "ani-cli's parity source"` | `"ani-cli"` | full string |
| `notes: ["/cdn [legacy]", "second"]` | 1 truncated entry, second lost | 2 entries |

## The fix

Both functions scan for **string literals** rather than splitting on commas. Everything between literals — commas, whitespace, a trailing comma — is separator that never reaches the value. Bracket depth is tracked so a nested array ends the scan at the right place, escapes are unescaped, and `"`, `'`, and backtick quoting all read alike.

The helpers move to `apps/docs/lib/manifest-parsing.ts`. They are pure string functions, and a test importing them from `scripts/sync-code-metadata.ts` pulls `apps/cli` source — and its `@/` path aliases — into the docs TypeScript program, which then fails to resolve them. Moving them keeps the test honest and the program clean.

## Tests

Twelve tests, one per failure mode above plus quoting styles, escaped quotes, trailing commas, empty and missing properties, and reading the named property rather than a different array nearby. Written failing first: **8 of 12 failed** against the old implementation.

The script had no direct test coverage before this.

## Verification

| Gate | Result |
| --- | --- |
| `typecheck --force` | 14/14, 0 cached |
| `test --force` | 23/23, **0 fail**, 0 cached |
| `lint` | 0 warnings, 0 errors |
| `fmt` / `verify:doc-paths` | clean |

`apps/docs/lib/generated-metadata.json` is regenerated in the same commit, which is what carries the 23 → 8 correction.

## Review note

The generated-metadata diff is the real payload here — worth reading it directly to confirm each restored note says what the manifest intended.
