### PR TITLE
feat(analytics): publish the day-by-day series that was already being stored

### DIFF
--- a/apps/analytics-ingest/api/metrics/series.ts
+++ b/apps/analytics-ingest/api/metrics/series.ts
@@ -1,0 +1,64 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import { PUBLIC_METRICS_CACHE_CONTROL, snapshotDayKey } from "../../src/public-metrics.js";
+import { buildPublicSeries, clampSeriesDays, seriesStartDay } from "../../src/public-series.js";
+import { loadAnalyticsRuntimeConfig } from "../../src/runtime-config.js";
+
+/**
+ * Public read-only day-by-day aggregates. Same guarantees as the daily
+ * snapshot — no install hashes, IPs, or raw ids — with suppression applied
+ * across the whole window rather than per day, so a bucket near the small-cell
+ * floor cannot blink in and out.
+ *
+ * Reads `daily_rollup`, which retention never prunes, so this adds no
+ * collection and no new payload. `?days=` clamps to the served maximum.
+ *
+ * A 404 means no rollup has ever been computed, matching `daily.json`. A window
+ * that simply contains no rollups yet is still a 404 rather than an empty
+ * series, so a caller never renders an axis for a period with no data.
+ *
+ * Served as /metrics/series.json via vercel rewrite.
+ */
+export default async function handler(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if ((req.method ?? "GET") !== "GET") {
+    res.statusCode = 405;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({ ok: false, error: "method_not_allowed" }));
+    return;
+  }
+
+  const runtime = loadAnalyticsRuntimeConfig();
+  if (!runtime) {
+    res.statusCode = 503;
+    res.setHeader("Cache-Control", "no-store");
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({ ok: false, error: "misconfigured" }));
+    return;
+  }
+
+  try {
+    const requested = new URL(req.url ?? "/", "http://localhost").searchParams.get("days");
+    const days = clampSeriesDays(requested ?? undefined);
+    const toDay = snapshotDayKey();
+    const rollups = await runtime.store.readRollups(seriesStartDay(toDay, days), toDay);
+    const series = buildPublicSeries(rollups);
+
+    if (!series) {
+      res.statusCode = 404;
+      res.setHeader("Cache-Control", "public, s-maxage=60, max-age=60");
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ ok: false, error: "not_ready" }));
+      return;
+    }
+
+    res.statusCode = 200;
+    res.setHeader("Cache-Control", PUBLIC_METRICS_CACHE_CONTROL);
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify(series));
+  } catch {
+    res.statusCode = 503;
+    res.setHeader("Cache-Control", "no-store");
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({ ok: false, error: "upstream_unavailable" }));
+  }
+}

--- a/apps/analytics-ingest/src/public-metrics.ts
+++ b/apps/analytics-ingest/src/public-metrics.ts
@@ -76,6 +76,22 @@ export function suppressSmallBuckets(
     else kept[bucket] = count;
   }
 
+  return sealResidual(kept, other, valueSpace);
+}
+
+/**
+ * Fold surviving buckets into `other` until it can no longer be attributed by
+ * elimination, then attach it.
+ *
+ * Shared by the snapshot and the series so both close the same hole: with a
+ * closed dimension, publishing every value but one makes `other` that value.
+ */
+export function sealResidual(
+  kept: Record<string, number>,
+  residual: number,
+  valueSpace: number,
+): Record<string, number> {
+  let other = residual;
   // Only a non-empty `other` can be attributed by elimination.
   while (other > 0 && valueSpace - Object.keys(kept).length < 2) {
     const smallest = Object.entries(kept).sort(

--- a/apps/analytics-ingest/src/public-series.ts
+++ b/apps/analytics-ingest/src/public-series.ts
@@ -1,0 +1,150 @@
+/**
+ * The published day-by-day series.
+ *
+ * `daily_rollup` is never pruned — retention only removes `ping_day` and
+ * `install_lifetime` — so the aggregate history is already on disk. This module
+ * decides how much of it is safe to publish, and answers a question the daily
+ * snapshot cannot: does a release actually propagate?
+ *
+ * No new collection, no payload change, no consent change. Serving only.
+ */
+
+import {
+  DIMENSION_VALUE_SPACE,
+  METRICS_SCHEMA_VERSION,
+  OTHER_BUCKET,
+  SMALL_CELL_FLOOR,
+  sealResidual,
+} from "./public-metrics.js";
+import type { DailyRollup } from "./store.js";
+
+/** Longest window the endpoint will serve, in days. */
+export const MAX_SERIES_DAYS = 180;
+
+/** Window served when the caller does not ask for one. */
+export const DEFAULT_SERIES_DAYS = 90;
+
+export type PublicSeriesPoint = {
+  readonly day: string;
+  readonly activeInstalls: number;
+  readonly lifetimeInstalls: number;
+  readonly byVersion: Readonly<Record<string, number>>;
+  readonly byOs: Readonly<Record<string, number>>;
+  readonly byArch: Readonly<Record<string, number>>;
+};
+
+export type PublicAnalyticsSeries = {
+  readonly schemaVersion: typeof METRICS_SCHEMA_VERSION;
+  readonly from: string;
+  readonly to: string;
+  readonly points: readonly PublicSeriesPoint[];
+  readonly updatedAt: string;
+};
+
+/**
+ * Which buckets of one dimension may be published across the whole window.
+ *
+ * Suppressing per-day would make a bucket sitting near the floor blink in and
+ * out, and the blink is itself a signal about a small population — the snapshot
+ * leaks "this bucket was under five" once, a per-day series leaks it on every
+ * boundary crossing. So a bucket that is ever under the floor is folded into
+ * `other` for every day of the window.
+ *
+ * A day where the bucket is simply absent does not disqualify it. A version
+ * that did not exist yet is not a small cell, and counting absence as zero
+ * would hide every new release — which is the one thing this series exists to
+ * show.
+ */
+export function windowPublishableBuckets(
+  perDay: readonly Readonly<Record<string, number>>[],
+  floor: number = SMALL_CELL_FLOOR,
+): ReadonlySet<string> {
+  const seen = new Set<string>();
+  const disqualified = new Set<string>();
+
+  for (const day of perDay) {
+    for (const [bucket, count] of Object.entries(day)) {
+      // A stored `other` is already a residual, never a publishable value.
+      if (bucket === OTHER_BUCKET) continue;
+      seen.add(bucket);
+      if (count < floor) disqualified.add(bucket);
+    }
+  }
+
+  const publishable = new Set<string>();
+  for (const bucket of seen) {
+    if (!disqualified.has(bucket)) publishable.add(bucket);
+  }
+  return publishable;
+}
+
+/** Apply a window-wide keep set to one day, then seal the residual. */
+function suppressDay(
+  counts: Readonly<Record<string, number>>,
+  publishable: ReadonlySet<string>,
+  valueSpace: number,
+): Record<string, number> {
+  const kept: Record<string, number> = {};
+  let other = 0;
+  for (const [bucket, count] of Object.entries(counts)) {
+    if (bucket !== OTHER_BUCKET && publishable.has(bucket)) kept[bucket] = count;
+    else other += count;
+  }
+  return sealResidual(kept, other, valueSpace);
+}
+
+/**
+ * Build the published series. Input order does not matter — it is sorted here.
+ *
+ * `updatedAt` reports the newest `computedAt` in the window, matching the
+ * snapshot's staleness signal.
+ */
+export function buildPublicSeries(rollups: readonly DailyRollup[]): PublicAnalyticsSeries | null {
+  if (rollups.length === 0) return null;
+
+  // Sorted here rather than trusted from the caller. Both stores already order
+  // by day, but `from`/`to` and the published point order are read straight off
+  // the ends of this array — a caller that ever stopped sorting would publish a
+  // window whose bounds silently disagree with its contents.
+  const ordered = [...rollups].sort((a, b) => a.day.localeCompare(b.day));
+
+  const versionKeep = windowPublishableBuckets(ordered.map((r) => r.byVersion));
+  const osKeep = windowPublishableBuckets(ordered.map((r) => r.byOs));
+  const archKeep = windowPublishableBuckets(ordered.map((r) => r.byArch));
+
+  const points = ordered.map((rollup) => ({
+    day: rollup.day,
+    activeInstalls: Math.max(0, Math.floor(rollup.activeInstalls)),
+    lifetimeInstalls: Math.max(0, Math.floor(rollup.lifetimeInstalls)),
+    byVersion: suppressDay(rollup.byVersion, versionKeep, DIMENSION_VALUE_SPACE.version),
+    byOs: suppressDay(rollup.byOs, osKeep, DIMENSION_VALUE_SPACE.os),
+    byArch: suppressDay(rollup.byArch, archKeep, DIMENSION_VALUE_SPACE.arch),
+  }));
+
+  const updatedAt = ordered.reduce(
+    (newest, rollup) => (rollup.computedAt > newest ? rollup.computedAt : newest),
+    ordered[0]?.computedAt ?? "",
+  );
+
+  return {
+    schemaVersion: METRICS_SCHEMA_VERSION,
+    from: points[0]?.day ?? "",
+    to: points.at(-1)?.day ?? "",
+    points,
+    updatedAt,
+  };
+}
+
+/** Clamp a caller-supplied `days` query to the window this endpoint will serve. */
+export function clampSeriesDays(raw: string | undefined): number {
+  const parsed = Number.parseInt((raw ?? "").trim(), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_SERIES_DAYS;
+  return Math.min(parsed, MAX_SERIES_DAYS);
+}
+
+/** The inclusive start day for a window of `days` ending on `endDay`. */
+export function seriesStartDay(endDay: string, days: number): string {
+  const end = new Date(`${endDay}T00:00:00.000Z`);
+  end.setUTCDate(end.getUTCDate() - (days - 1));
+  return end.toISOString().slice(0, 10);
+}

--- a/apps/analytics-ingest/test/public-series.test.ts
+++ b/apps/analytics-ingest/test/public-series.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+
+import { OTHER_BUCKET, SMALL_CELL_FLOOR } from "../src/public-metrics";
+import {
+  buildPublicSeries,
+  clampSeriesDays,
+  DEFAULT_SERIES_DAYS,
+  MAX_SERIES_DAYS,
+  seriesStartDay,
+  windowPublishableBuckets,
+} from "../src/public-series";
+import type { DailyRollup } from "../src/store";
+
+function rollup(day: string, over: Partial<DailyRollup> = {}): DailyRollup {
+  return {
+    day,
+    computedAt: `${day}T00:05:00.000Z`,
+    activeInstalls: 100,
+    lifetimeInstalls: 400,
+    byVersion: { "0.3.0": 100 },
+    byOs: { linux: 60, darwin: 40 },
+    byArch: { x64: 60, arm64: 40 },
+    ...over,
+  };
+}
+
+describe("windowPublishableBuckets", () => {
+  test("a bucket under the floor on any single day is suppressed for the whole window", () => {
+    const publishable = windowPublishableBuckets([
+      { "0.3.0": 100, "0.3.1": 50 },
+      { "0.3.0": 100, "0.3.1": SMALL_CELL_FLOOR - 1 },
+      { "0.3.0": 100, "0.3.1": 80 },
+    ]);
+    expect(publishable.has("0.3.0")).toBe(true);
+    // The dip is the whole point: publishing it on days 1 and 3 but not 2 would
+    // announce that a small population crossed the threshold.
+    expect(publishable.has("0.3.1")).toBe(false);
+  });
+
+  test("absence before a version launches does not disqualify it", () => {
+    const publishable = windowPublishableBuckets([
+      { "0.3.0": 100 },
+      { "0.3.0": 100 },
+      { "0.3.0": 60, "0.3.1": 40 },
+    ]);
+    // A version that did not exist yet is not a small cell.
+    expect(publishable.has("0.3.1")).toBe(true);
+  });
+
+  test("a stored `other` residual is never publishable", () => {
+    const publishable = windowPublishableBuckets([{ "0.3.0": 100, [OTHER_BUCKET]: 40 }]);
+    expect(publishable.has(OTHER_BUCKET)).toBe(false);
+  });
+
+  test("an empty window publishes nothing", () => {
+    expect(windowPublishableBuckets([]).size).toBe(0);
+  });
+});
+
+describe("buildPublicSeries", () => {
+  test("no rollups yields no series rather than an empty shell", () => {
+    expect(buildPublicSeries([])).toBeNull();
+  });
+
+  test("a dipping version is folded into other on every day, including its healthy ones", () => {
+    const series = buildPublicSeries([
+      rollup("2026-08-01", { byVersion: { "0.3.0": 100, "0.3.1": 50 } }),
+      rollup("2026-08-02", { byVersion: { "0.3.0": 100, "0.3.1": 2 } }),
+    ]);
+    expect(series).not.toBeNull();
+    if (!series) return;
+
+    for (const point of series.points) {
+      expect(point.byVersion["0.3.1"]).toBeUndefined();
+    }
+    // Folding must preserve the total, not discard it.
+    expect(series.points[0]?.byVersion[OTHER_BUCKET]).toBe(50);
+    expect(series.points[1]?.byVersion[OTHER_BUCKET]).toBe(2);
+  });
+
+  test("a closed dimension is not recoverable by elimination on any day", () => {
+    // arch has two values, so publishing x64 alongside a non-empty other would
+    // name arm64 in as many words.
+    const series = buildPublicSeries([rollup("2026-08-01", { byArch: { x64: 80, arm64: 2 } })]);
+    expect(series).not.toBeNull();
+    if (!series) return;
+
+    const arch = series.points[0]?.byArch ?? {};
+    expect(arch.x64).toBeUndefined();
+    expect(arch.arm64).toBeUndefined();
+    expect(arch[OTHER_BUCKET]).toBe(82);
+  });
+
+  test("unsorted rollups are ordered before the window bounds are read", () => {
+    // from/to are read off the ends of the array, so an unsorted caller would
+    // publish a window whose bounds disagree with its own contents.
+    const series = buildPublicSeries([
+      rollup("2026-08-10"),
+      rollup("2026-08-01"),
+      rollup("2026-08-20"),
+    ]);
+    expect(series?.from).toBe("2026-08-01");
+    expect(series?.to).toBe("2026-08-20");
+    expect(series?.points.map((p) => p.day)).toEqual(["2026-08-01", "2026-08-10", "2026-08-20"]);
+  });
+
+  test("day ordering and window bounds come straight from the rollups", () => {
+    const series = buildPublicSeries([rollup("2026-08-01"), rollup("2026-08-02")]);
+    expect(series?.from).toBe("2026-08-01");
+    expect(series?.to).toBe("2026-08-02");
+    expect(series?.points.map((p) => p.day)).toEqual(["2026-08-01", "2026-08-02"]);
+  });
+
+  test("updatedAt reports the newest computedAt in the window", () => {
+    const series = buildPublicSeries([
+      rollup("2026-08-01", { computedAt: "2026-08-01T00:05:00.000Z" }),
+      rollup("2026-08-02", { computedAt: "2026-08-02T00:05:00.000Z" }),
+    ]);
+    expect(series?.updatedAt).toBe("2026-08-02T00:05:00.000Z");
+  });
+
+  test("a single day is a valid series — a fresh deploy must still render", () => {
+    const series = buildPublicSeries([rollup("2026-08-01")]);
+    expect(series?.points).toHaveLength(1);
+    expect(series?.from).toBe(series?.to);
+  });
+
+  test("counts are floored to integers and never negative", () => {
+    const series = buildPublicSeries([
+      rollup("2026-08-01", { activeInstalls: 12.7, lifetimeInstalls: -3 }),
+    ]);
+    expect(series?.points[0]?.activeInstalls).toBe(12);
+    expect(series?.points[0]?.lifetimeInstalls).toBe(0);
+  });
+});
+
+describe("window bounds", () => {
+  test("an absent or unusable days query falls back to the default", () => {
+    expect(clampSeriesDays(undefined)).toBe(DEFAULT_SERIES_DAYS);
+    expect(clampSeriesDays("")).toBe(DEFAULT_SERIES_DAYS);
+    expect(clampSeriesDays("nonsense")).toBe(DEFAULT_SERIES_DAYS);
+    expect(clampSeriesDays("0")).toBe(DEFAULT_SERIES_DAYS);
+    expect(clampSeriesDays("-7")).toBe(DEFAULT_SERIES_DAYS);
+  });
+
+  test("a caller cannot ask for more than the maximum window", () => {
+    expect(clampSeriesDays("100000")).toBe(MAX_SERIES_DAYS);
+    expect(clampSeriesDays("30")).toBe(30);
+  });
+
+  test("the start day is inclusive of the end day", () => {
+    expect(seriesStartDay("2026-08-10", 1)).toBe("2026-08-10");
+    expect(seriesStartDay("2026-08-10", 3)).toBe("2026-08-08");
+  });
+
+  test("the window spans month and year boundaries", () => {
+    expect(seriesStartDay("2026-03-02", 3)).toBe("2026-02-28");
+    expect(seriesStartDay("2026-01-01", 2)).toBe("2025-12-31");
+  });
+});

--- a/apps/analytics-ingest/test/series-store-integration.test.ts
+++ b/apps/analytics-ingest/test/series-store-integration.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+
+import { createMemoryAnalyticsStore } from "../src/memory-store";
+import { OTHER_BUCKET } from "../src/public-metrics";
+import { buildPublicSeries, seriesStartDay } from "../src/public-series";
+
+/**
+ * The range read plus the series builder — the path `/metrics/series.json`
+ * actually runs. The handler itself is thin glue over these two calls.
+ */
+
+async function seed(
+  store: ReturnType<typeof createMemoryAnalyticsStore>,
+  day: string,
+  installs: readonly { hash: string; version: string; os: string; arch: string }[],
+): Promise<void> {
+  for (const install of installs) {
+    await store.recordPing({
+      day,
+      installHash: install.hash,
+      version: install.version,
+      os: install.os,
+      arch: install.arch,
+    });
+  }
+  await store.rollUpDay(day);
+}
+
+function population(day: string, version: string, count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    hash: `${day}-${version}-${i}`,
+    version,
+    os: "linux",
+    arch: "x64",
+  }));
+}
+
+describe("series over a real store", () => {
+  test("a range read feeds a series covering exactly the seeded days", async () => {
+    const store = createMemoryAnalyticsStore();
+    await seed(store, "2026-08-01", population("2026-08-01", "0.3.0", 10));
+    await seed(store, "2026-08-02", population("2026-08-02", "0.3.0", 12));
+    await seed(store, "2026-08-03", population("2026-08-03", "0.3.0", 14));
+
+    const rollups = await store.readRollups(seriesStartDay("2026-08-03", 3), "2026-08-03");
+    const series = buildPublicSeries(rollups);
+
+    expect(series).not.toBeNull();
+    expect(series?.points.map((p) => p.day)).toEqual(["2026-08-01", "2026-08-02", "2026-08-03"]);
+    expect(series?.points.map((p) => p.activeInstalls)).toEqual([10, 12, 14]);
+  });
+
+  test("a version that dips below the floor stays folded across the whole window", async () => {
+    const store = createMemoryAnalyticsStore();
+    // 0.3.1 launches healthy, dips to 3, recovers.
+    await seed(store, "2026-08-01", [
+      ...population("2026-08-01", "0.3.0", 20),
+      ...population("2026-08-01", "0.3.1", 8),
+    ]);
+    await seed(store, "2026-08-02", [
+      ...population("2026-08-02", "0.3.0", 20),
+      ...population("2026-08-02", "0.3.1", 3),
+    ]);
+    await seed(store, "2026-08-03", [
+      ...population("2026-08-03", "0.3.0", 20),
+      ...population("2026-08-03", "0.3.1", 9),
+    ]);
+
+    const rollups = await store.readRollups("2026-08-01", "2026-08-03");
+    const series = buildPublicSeries(rollups);
+    expect(series).not.toBeNull();
+    if (!series) return;
+
+    for (const point of series.points) {
+      expect(point.byVersion["0.3.1"]).toBeUndefined();
+      expect(point.byVersion[OTHER_BUCKET]).toBeGreaterThan(0);
+    }
+    // 0.3.0 is comfortably above the floor every day, so it still publishes.
+    expect(series.points.every((p) => p.byVersion["0.3.0"] === 20)).toBe(true);
+  });
+
+  test("a version launching mid-window above the floor is published from its first day", async () => {
+    const store = createMemoryAnalyticsStore();
+    await seed(store, "2026-08-01", population("2026-08-01", "0.3.0", 30));
+    await seed(store, "2026-08-02", [
+      ...population("2026-08-02", "0.3.0", 20),
+      ...population("2026-08-02", "0.3.1", 10),
+    ]);
+
+    const rollups = await store.readRollups("2026-08-01", "2026-08-02");
+    const series = buildPublicSeries(rollups);
+
+    expect(series?.points[0]?.byVersion["0.3.1"]).toBeUndefined();
+    expect(series?.points[1]?.byVersion["0.3.1"]).toBe(10);
+  });
+
+  test("a window with no rollups yields no series rather than empty points", async () => {
+    const store = createMemoryAnalyticsStore();
+    const rollups = await store.readRollups("2026-01-01", "2026-01-07");
+    expect(buildPublicSeries(rollups)).toBeNull();
+  });
+
+  test("every published day's buckets sum to that day's active installs", async () => {
+    const store = createMemoryAnalyticsStore();
+    await seed(store, "2026-08-01", [
+      ...population("2026-08-01", "0.3.0", 20),
+      ...population("2026-08-01", "0.3.1", 2),
+    ]);
+
+    const series = buildPublicSeries(await store.readRollups("2026-08-01", "2026-08-01"));
+    const point = series?.points[0];
+    expect(point).toBeDefined();
+    if (!point) return;
+
+    // Suppression moves counts between buckets; it must never lose them.
+    const total = Object.values(point.byVersion).reduce((sum, n) => sum + n, 0);
+    expect(total).toBe(point.activeInstalls);
+  });
+});

--- a/apps/analytics-ingest/vercel.json
+++ b/apps/analytics-ingest/vercel.json
@@ -4,6 +4,10 @@
     {
       "source": "/metrics/daily.json",
       "destination": "/api/metrics/daily"
+    },
+    {
+      "source": "/metrics/series.json",
+      "destination": "/api/metrics/series"
     }
   ],
   "crons": [
@@ -23,6 +27,9 @@
       "maxDuration": 5
     },
     "api/metrics/admin.ts": {
+      "maxDuration": 10
+    },
+    "api/metrics/series.ts": {
       "maxDuration": 10
     }
   },


### PR DESCRIPTION
**Stack 2 of 4** — base `stack/1-docs-context`. `apps/analytics-ingest` only.

Replaces #254, which GitHub auto-marked "merged" when the stack was reordered — its head became an ancestor of its old base. **Nothing reached `main`**; `apps/analytics-ingest/api/metrics/series.ts` is absent from `main` and present here.

### Why this moved ahead of the charts

The endpoint has to be **deployed and verified before** the charts that consume it are worth merging. Previously this sat above the docs-site PR, which made that impossible. New order:

`main` → #252 docs-context → **this** → #253 charts → #255 anti-slop *(held until after 0.3.0)*

### What it does

`daily_rollup` is never pruned — retention only removes `ping_day` and `install_lifetime` — so the aggregate history was already on disk while `/metrics/daily.json` served a single row of it. `/metrics/series.json` serves a window (90 days default, 180 max, `?days=` clamped).

**No new collection, no payload change, no consent change.** This was only ever a serving question.

Suppression runs across the whole window, not per day: a bucket below the floor on any day folds into `other` on every day, because a bucket blinking in and out at the floor is itself a signal about a small population. A day where a bucket is simply *absent* does not disqualify it — treating absence as zero would hide every new release, which is the one thing this series exists to show.

The elimination guard is extracted as `sealResidual` and shared with the snapshot rather than reimplemented. The builder sorts its input rather than trusting the caller, since `from`/`to` are read off the array ends.

### Verification

20 tests cover the privacy rules as invariants — the dip fold, the mid-window launch, per-day elimination on a two-value dimension, and that suppression never loses counts. Five run the real path over a memory store.

Gates standing alone: typecheck 14/14, lint 12/12, fmt:check, doc-paths, doc-frontmatter, full suite 23/23 — all forced, 0 cached.

### After merge

Deploy the ingest, confirm `/metrics/series.json` answers, then point a local docs build at it to exercise the charts against real data before #253 goes to prod.