### PR TITLE
feat(docs): give every share link its own social card

### DIFF
--- a/apps/docs/app/opengraph-image.tsx
+++ b/apps/docs/app/opengraph-image.tsx
@@ -6,7 +6,7 @@ export const alt = "Kunai Docs — terminal-first playback guides";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
-// Inlined at build time by `scripts/sync-repo-content.ts`. Reading the PNG here
+// Inlined at build time by `apps/docs/scripts/sync-repo-content.ts`. Reading the PNG here
 // put a filesystem probe in the runtime bundle, which the Turbopack tracer
 // could not follow — see that script's header. An empty value means the
 // generator could not read the source PNG; the card renders without a mascot

--- a/apps/docs/app/w/[code]/opengraph-image.tsx
+++ b/apps/docs/app/w/[code]/opengraph-image.tsx
@@ -1,0 +1,116 @@
+import { KunaiSocialCard } from "@/lib/brand/social-card";
+import generatedMascot from "@/lib/generated-mascot.json";
+import { catalogFor, positionFor, titleFor } from "@/lib/share-presentation";
+import { decodePlaybackTargetWebCode } from "@kunai/types";
+import { ImageResponse } from "next/og";
+
+export const alt = "A title shared with Kunai";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+// Inlined at build time, same as the root card — see `app/opengraph-image.tsx`
+// for why this cannot read the PNG from disk here.
+const mascotSrc =
+  generatedMascot.mascotDataUrl.length > 0 ? generatedMascot.mascotDataUrl : undefined;
+
+/**
+ * The card a person actually sees when a share link is pasted into WhatsApp,
+ * Twitter, or Discord.
+ *
+ * The share code already carries the title, so the unfurl names the work rather
+ * than describing the docs site. Everything comes out of the code itself: this
+ * route never fetches poster art, which would put TMDB/AniList in the unfurl
+ * latency path and tell them which titles get shared.
+ *
+ * A code that does not decode falls back to the generic card. Unfurlers treat a
+ * failed image as no image at all, so throwing here would cost the preview.
+ */
+export default async function ShareOpenGraphImage({
+  params,
+}: {
+  readonly params: Promise<{ readonly code: string }>;
+}) {
+  const { code } = await params;
+  const shared = decodePlaybackTargetWebCode(code);
+
+  if (!shared) {
+    return new ImageResponse(
+      <KunaiSocialCard
+        eyebrow="KUNAI"
+        headline={["Shared link", "not readable"]}
+        subline="Kunai never guesses a title from a damaged code."
+        command="kunai --open <link>"
+        footer="share · kunai"
+        mascotSrc={mascotSrc}
+      />,
+      { ...size },
+    );
+  }
+
+  const title = titleFor(shared.ref);
+
+  return new ImageResponse(
+    <KunaiSocialCard
+      eyebrow="SHARED WITH KUNAI"
+      headline={splitHeadline(title)}
+      subline={`${positionFor(shared.ref)} · ${catalogFor(shared.ref)}`}
+      command="kunai --open <link>"
+      footer="share · kunai"
+      mascotSrc={mascotSrc}
+    />,
+    { ...size },
+  );
+}
+
+/** Characters one headline line fits at the card's type size. */
+const LINE_BUDGET = 22;
+
+/**
+ * Break a title across at most two lines near its middle.
+ *
+ * The card's headline slot is two lines tall. Satori does not wrap for us here
+ * because each line is its own element, so a long title has to be split before
+ * it is handed over or it overflows the card.
+ */
+export function splitHeadline(title: string): string[] {
+  // Collapse every whitespace run, not just the ends. A title carrying a newline
+  // or tab reaches satori as literal control characters inside one text node,
+  // which lays out unpredictably; and a title that is only whitespace would
+  // otherwise render an empty headline on an otherwise complete card.
+  const trimmed = title.replace(/\s+/g, " ").trim();
+  if (trimmed.length === 0) return ["Shared with Kunai"];
+  if (trimmed.length <= LINE_BUDGET) return [trimmed];
+
+  const words = trimmed.split(/\s+/);
+  if (words.length === 1) {
+    // One unbroken token cannot wrap. Cutting it silently would drop the tail
+    // without the reader ever knowing the title continued, so the ellipsis is
+    // part of the contract, not decoration.
+    if (trimmed.length <= LINE_BUDGET * 2) {
+      return [trimmed.slice(0, LINE_BUDGET), trimmed.slice(LINE_BUDGET)];
+    }
+    return [trimmed.slice(0, LINE_BUDGET), `${trimmed.slice(LINE_BUDGET, LINE_BUDGET * 2 - 1)}…`];
+  }
+
+  // Balance the two lines rather than filling the first: a title split as
+  // "Attack on" / "Titan" reads better than "Attack on Titan: The Final" / "Season".
+  let best = 1;
+  let bestDelta = Number.POSITIVE_INFINITY;
+  for (let cut = 1; cut < words.length; cut++) {
+    const head = words.slice(0, cut).join(" ").length;
+    const tail = words.slice(cut).join(" ").length;
+    const delta = Math.abs(head - tail);
+    if (delta < bestDelta) {
+      bestDelta = delta;
+      best = cut;
+    }
+  }
+  const head = words.slice(0, best).join(" ");
+  const tail = words.slice(best).join(" ");
+  return [truncate(head), truncate(tail)];
+}
+
+/** Cut an over-long line, marking it so a dropped tail is never silent. */
+function truncate(line: string): string {
+  return line.length <= LINE_BUDGET ? line : `${line.slice(0, LINE_BUDGET - 1)}…`;
+}

--- a/apps/docs/app/w/[code]/page.tsx
+++ b/apps/docs/app/w/[code]/page.tsx
@@ -1,11 +1,11 @@
 import { CopyButton } from "@/components/ui/copy-button";
 import { NATIVE_INSTALL_PS1, NATIVE_INSTALL_SH } from "@/lib/install-commands";
 import { buildPageMetadata } from "@/lib/page-metadata";
+import { catalogFor, initialFor, positionFor, titleFor } from "@/lib/share-presentation";
 import {
   decodePlaybackTargetWebCode,
   encodePlaybackTargetRef,
   type ParsedKunaiShare,
-  type PlaybackTargetRef,
 } from "@kunai/types";
 import { IconArrowRight, IconPlayerPlayFilled, IconTerminal2 } from "@tabler/icons-react";
 import type { Metadata } from "next";
@@ -174,28 +174,4 @@ function InvalidShareLanding() {
       </section>
     </main>
   );
-}
-
-function titleFor(ref: PlaybackTargetRef): string {
-  if (ref.title) return ref.title;
-  if (ref.anchor.by === "catalog") return `${ref.anchor.ns.toUpperCase()} ${ref.anchor.id}`;
-  return ref.anchor.query;
-}
-
-function catalogFor(ref: PlaybackTargetRef): string {
-  return ref.anchor.by === "catalog"
-    ? `${ref.anchor.ns.toUpperCase()} · ${ref.anchor.id}`
-    : "Search fallback";
-}
-
-function positionFor(ref: PlaybackTargetRef): string {
-  if (ref.season !== undefined && ref.episode !== undefined) {
-    return `Season ${ref.season} · Episode ${ref.episode}`;
-  }
-  if (ref.absoluteEpisode !== undefined) return `Episode ${ref.absoluteEpisode}`;
-  return ref.kind === "movie" ? "Movie" : ref.kind === "video" ? "Video" : "Series";
-}
-
-function initialFor(title: string): string {
-  return Array.from(title.trim())[0]?.toUpperCase() ?? "K";
 }

--- a/apps/docs/lib/release-notes.ts
+++ b/apps/docs/lib/release-notes.ts
@@ -31,7 +31,7 @@ export type ReleaseNotesArtifact = {
 /**
  * Every release artifact the site renders, newest first.
  *
- * Baked from `.release/*.json` at build time by `scripts/sync-repo-content.ts`.
+ * Baked from `.release/*.json` at build time by `apps/docs/scripts/sync-repo-content.ts`.
  * This module used to `readdirSync` that directory at request time, which
  * static tracing cannot follow — see that script's header.
  */

--- a/apps/docs/lib/share-presentation.ts
+++ b/apps/docs/lib/share-presentation.ts
@@ -1,0 +1,38 @@
+/**
+ * How a decoded share ref is described to a human.
+ *
+ * Shared by the `/w/[code]` landing page and its social card so a link's
+ * unfurl and its page cannot disagree about what was shared. Keep this pure —
+ * the social card renders inside `ImageResponse`, which has no DOM and no
+ * network.
+ */
+
+import type { PlaybackTargetRef } from "@kunai/types";
+
+/** The title to show, falling back through the anchor when the ref carries no title. */
+export function titleFor(ref: PlaybackTargetRef): string {
+  if (ref.title) return ref.title;
+  if (ref.anchor.by === "catalog") return `${ref.anchor.ns.toUpperCase()} ${ref.anchor.id}`;
+  return ref.anchor.query;
+}
+
+/** Which catalog anchored this share, or that it will fall back to search. */
+export function catalogFor(ref: PlaybackTargetRef): string {
+  return ref.anchor.by === "catalog"
+    ? `${ref.anchor.ns.toUpperCase()} · ${ref.anchor.id}`
+    : "Search fallback";
+}
+
+/** Where in the work the share points — season/episode, absolute episode, or the kind. */
+export function positionFor(ref: PlaybackTargetRef): string {
+  if (ref.season !== undefined && ref.episode !== undefined) {
+    return `Season ${ref.season} · Episode ${ref.episode}`;
+  }
+  if (ref.absoluteEpisode !== undefined) return `Episode ${ref.absoluteEpisode}`;
+  return ref.kind === "movie" ? "Movie" : ref.kind === "video" ? "Video" : "Series";
+}
+
+/** First character of the title, for the artwork placeholder. */
+export function initialFor(title: string): string {
+  return Array.from(title.trim())[0]?.toUpperCase() ?? "K";
+}

--- a/apps/docs/lib/troubleshooting-faq.ts
+++ b/apps/docs/lib/troubleshooting-faq.ts
@@ -8,7 +8,7 @@ export type TroubleshootingFaqEntry = {
 /**
  * The FAQ rendered as JSON-LD on `/docs/users/troubleshooting`.
  *
- * Parsed out of `docs/` at build time by `scripts/sync-repo-content.ts` — the
+ * Parsed out of `docs/` at build time by `apps/docs/scripts/sync-repo-content.ts` — the
  * reading and parsing live there, this module is only the typed handle on the
  * result. See that script's header for why the runtime must not read `docs/`
  * itself.

--- a/apps/docs/scripts/sync-repo-content.ts
+++ b/apps/docs/scripts/sync-repo-content.ts
@@ -13,7 +13,7 @@
  * them is `force-static`, so there was never request-time data to lose.
  *
  * Outputs are committed, like `lib/generated-metadata.json`, and
- * `scripts/check-codegen-freshness.ts` fails CI when they drift from source.
+ * `apps/docs/scripts/check-codegen-freshness.ts` fails CI when they drift from source.
  */
 import fs from "node:fs";
 import path from "node:path";

--- a/apps/docs/test/share-social-card.test.ts
+++ b/apps/docs/test/share-social-card.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+
+import { decodePlaybackTargetWebCode, encodePlaybackTargetShortCode } from "@kunai/types";
+
+import { splitHeadline } from "../app/w/[code]/opengraph-image";
+import { catalogFor, initialFor, positionFor, titleFor } from "../lib/share-presentation";
+
+describe("splitHeadline", () => {
+  test("a short title stays on one line", () => {
+    expect(splitHeadline("Dune")).toEqual(["Dune"]);
+    expect(splitHeadline("Attack on Titan")).toEqual(["Attack on Titan"]);
+  });
+
+  test("a long title balances across two lines instead of filling the first", () => {
+    const [head, tail] = splitHeadline("Attack on Titan The Final Season Part 2");
+    expect(tail).toBeDefined();
+    // The point of balancing: neither line is a scrap.
+    expect(Math.abs((head?.length ?? 0) - (tail?.length ?? 0))).toBeLessThan(10);
+    expect(`${head} ${tail}`).toBe("Attack on Titan The Final Season Part 2");
+  });
+
+  test("a single unbroken word is cut rather than allowed to overflow", () => {
+    const lines = splitHeadline("Supercalifragilisticexpialidocious");
+    expect(lines).toHaveLength(2);
+    expect(lines.every((line) => line.length <= 22)).toBe(true);
+  });
+
+  test("surrounding whitespace never becomes a line", () => {
+    expect(splitHeadline("   Dune   ")).toEqual(["Dune"]);
+  });
+
+  test("a single token past two lines is marked, never silently cut", () => {
+    const long = "Pneumonoultramicroscopicsilicovolcanoconiosisandmore";
+    expect(long.length).toBeGreaterThan(44);
+    const lines = splitHeadline(long);
+    expect(lines).toHaveLength(2);
+    // The reader must be able to tell the title continued.
+    expect(lines[1]?.endsWith("\u2026")).toBe(true);
+  });
+
+  test("a single token that fits two lines keeps every character", () => {
+    const exact = "a".repeat(44);
+    expect(splitHeadline(exact).join("")).toBe(exact);
+  });
+
+  test("a title that is only whitespace still names the card", () => {
+    // An empty headline on an otherwise complete card reads as a broken render.
+    expect(splitHeadline("")).toEqual(["Shared with Kunai"]);
+    expect(splitHeadline("   \t\n ")).toEqual(["Shared with Kunai"]);
+  });
+
+  test("embedded newlines and tabs collapse instead of reaching satori raw", () => {
+    expect(splitHeadline("Attack\non\nTitan")).toEqual(["Attack on Titan"]);
+    expect(splitHeadline("A\tB")).toEqual(["A B"]);
+  });
+
+  test("a long word run is marked rather than overflowing the card", () => {
+    const lines = splitHeadline(`${"alpha ".repeat(12)}omega`);
+    expect(lines).toHaveLength(2);
+    for (const line of lines) expect(line.length).toBeLessThanOrEqual(22);
+  });
+});
+
+describe("share presentation is shared with the landing page", () => {
+  const ref = {
+    kind: "series",
+    title: "Frieren",
+    anchor: { by: "catalog", ns: "anilist", id: "154587" },
+    season: 1,
+    episode: 4,
+  } as const;
+
+  test("a round-tripped code presents the same title, position and catalog", () => {
+    const code = encodePlaybackTargetShortCode(ref);
+    expect(code).not.toBeNull();
+    if (!code) return;
+
+    const decoded = decodePlaybackTargetWebCode(code);
+    expect(decoded).not.toBeNull();
+    if (!decoded) return;
+
+    expect(titleFor(decoded.ref)).toBe("Frieren");
+    expect(positionFor(decoded.ref)).toBe("Season 1 · Episode 4");
+    expect(catalogFor(decoded.ref)).toBe("ANILIST · 154587");
+  });
+
+  test("a damaged code decodes to null so the card can fall back", () => {
+    expect(decodePlaybackTargetWebCode("not-a-real-code")).toBeNull();
+  });
+
+  test("initialFor survives a title that is only whitespace", () => {
+    expect(initialFor("   ")).toBe("K");
+  });
+});


### PR DESCRIPTION
Fixes a live defect: every `/w/<code>` share link currently unfurls with the generic "Terminal-first playback guides" card. Verified against production right now —

```
og:title  ->  "Frieren Beyond Journeys End — shared with Kunai"   correct
og:image  ->  /opengraph-image                                     generic
```

The title is right in the metadata; the **picture** says nothing about what was shared, and the picture is what people look at in WhatsApp, Discord, or Twitter.

### Approach

`app/w/[code]/opengraph-image.tsx` decodes the share code and renders the title as the headline, with season/episode and the anchoring catalog beneath.

- **Never fetches poster art.** That would put TMDB/AniList in the unfurl latency path and tell them which titles get shared.
- **An undecodable code renders the generic card, never throws** — unfurlers treat a failed image as *no* image, so throwing costs the whole preview.
- **Presentation helpers extracted** to `lib/share-presentation.ts`, shared with the landing page, so a link's unfurl and its page cannot disagree.

### Edge cases covered

`splitHeadline` balances a long title across two lines (satori does not wrap — each line is its own element). An over-long single token gets an ellipsis rather than losing its tail silently; a whitespace-only title names the card instead of rendering empty; newlines and tabs collapse rather than reaching satori raw.

Four drifted comment paths fixed as a rider.

### Scope

8 files, no new dependencies, nothing touching the CLI binary. Split out of the larger docs-site branch so the analytics charts — which currently render "not enough data" until there are 5+ installs on a version — can be reviewed separately.

### Verification

Rendered from a built production server: a real Frieren code returns a 1200x630 PNG with the title as headline; a 52-character token comes back ellipsised; a damaged code returns the fallback.

Gates standing alone: typecheck 14/14, lint 12/12, fmt:check, full suite 23/23 — forced, 0 cached. Earlier CodeRabbit review on this code found 5 issues, all fixed.