### PR TITLE
feat(docs): chart the analytics history on the static page

### DIFF
--- a/apps/docs/app/analytics/page.tsx
+++ b/apps/docs/app/analytics/page.tsx
@@ -1,5 +1,7 @@
+import { TrendSection } from "@/components/analytics/trend-section";
 import { UsagePanel } from "@/components/analytics/usage-panel";
 import { fetchDocsAnalyticsMetrics } from "@/lib/analytics-metrics";
+import { fetchDocsAnalyticsSeries } from "@/lib/analytics-series";
 import { buildPageMetadata } from "@/lib/page-metadata";
 import type { Metadata } from "next";
 
@@ -16,7 +18,11 @@ export const metadata: Metadata = buildPageMetadata({
 });
 
 export default async function AnalyticsPage() {
-  const metrics = await fetchDocsAnalyticsMetrics();
+  // Both are optional: the page renders whichever the endpoints can supply.
+  const [metrics, series] = await Promise.all([
+    fetchDocsAnalyticsMetrics(),
+    fetchDocsAnalyticsSeries(),
+  ]);
 
   return (
     <main className="kunai-home relative mx-auto flex w-full max-w-5xl flex-1 flex-col gap-10 px-6 py-14 md:px-10">
@@ -32,6 +38,7 @@ export default async function AnalyticsPage() {
       </header>
 
       <UsagePanel metrics={metrics} />
+      <TrendSection series={series} />
     </main>
   );
 }

--- a/apps/docs/app/styles/charts.css
+++ b/apps/docs/app/styles/charts.css
@@ -183,7 +183,7 @@
 @media (forced-colors: active), print {
   .kunai-plot-band {
     fill: transparent;
-    stroke: currentColor;
+    stroke: currentcolor;
     stroke-width: 1;
   }
 
@@ -269,12 +269,12 @@ table.kunai-chart tr.kunai-chart-row:hover th {
  */
 @media (forced-colors: active), print {
   .kunai-chart-bar {
-    outline: 1px solid currentColor;
+    outline: 1px solid currentcolor;
     background-color: transparent;
-    background-image: repeating-linear-gradient(45deg, currentColor 0 1px, transparent 1px 4px);
+    background-image: repeating-linear-gradient(45deg, currentcolor 0 1px, transparent 1px 4px);
   }
 
   .kunai-chart-bar[data-residual="true"] {
-    background-image: repeating-linear-gradient(135deg, currentColor 0 1px, transparent 1px 6px);
+    background-image: repeating-linear-gradient(135deg, currentcolor 0 1px, transparent 1px 6px);
   }
 }

--- a/apps/docs/app/styles/charts.css
+++ b/apps/docs/app/styles/charts.css
@@ -36,6 +36,163 @@
 }
 
 /*
+ * Ordinal version ramp.
+ *
+ * Releases are an ordered sequence, not a set of names, so the bands take one
+ * hue with monotone lightness rather than eight categorical slots — the reader
+ * sees the ordering in the color. Oldest is dimmest; the newest release is the
+ * loudest band on the surface it renders against, which is why the light and
+ * dark ramps run in opposite directions instead of being flipped.
+ *
+ * Both ramps are machine-checked (monotone L, adjacent ΔL >= 0.06, light-end
+ * contrast, single hue). Five steps is the ceiling, not a preference: a sixth
+ * step lands at ΔL 0.057 and fails, so the sixth version folds into the
+ * residual instead. `MAX_VERSION_BANDS` in `lib/analytics-series.ts` holds that
+ * limit on the data side.
+ *
+ *   dark  — #6b4b53 … #ff9cbd on #1c1620, light end 2.33:1
+ *   light — #d5a8b2 … #8b1345 on #fcfcfb, light end 2.03:1
+ */
+:root {
+  --kunai-chart-band-1: #d5a8b2;
+  --kunai-chart-band-2: #c58595;
+  --kunai-chart-band-3: #b36379;
+  --kunai-chart-band-4: #a0405e;
+  --kunai-chart-band-5: #8b1345;
+}
+
+:root.dark {
+  --kunai-chart-band-1: #6b4b53;
+  --kunai-chart-band-2: #915e6c;
+  --kunai-chart-band-3: #b97286;
+  --kunai-chart-band-4: #e387a1;
+  --kunai-chart-band-5: #ff9cbd;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not(.light) {
+    --kunai-chart-band-1: #6b4b53;
+    --kunai-chart-band-2: #915e6c;
+    --kunai-chart-band-3: #b97286;
+    --kunai-chart-band-4: #e387a1;
+    --kunai-chart-band-5: #ff9cbd;
+  }
+}
+
+/*
+ * Time-series plot. Hairline axes one shade off the surface, never dashed —
+ * dashing reads as "projection" when it is just a grid.
+ */
+.kunai-plot {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.kunai-plot-axis {
+  stroke: var(--kunai-chart-axis);
+  stroke-width: 1;
+  fill: none;
+  vector-effect: non-scaling-stroke;
+}
+
+.kunai-plot-line {
+  fill: none;
+  stroke: var(--kunai-chart-series);
+  stroke-width: 2;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.kunai-plot-area {
+  fill: color-mix(in oklab, var(--kunai-chart-series) 14%, transparent);
+  stroke: none;
+}
+
+/* The endpoint is the one point worth marking; the rest live in the table. */
+.kunai-plot-endpoint {
+  fill: var(--kunai-chart-series);
+  stroke: var(--kunai-chart-surface);
+  stroke-width: 2;
+}
+
+/*
+ * Stacked bands. The 2px separator is the surface showing through, not a
+ * border drawn around each mark.
+ */
+.kunai-plot-band {
+  stroke: var(--kunai-chart-surface);
+  stroke-width: 2;
+  stroke-linejoin: round;
+}
+
+.kunai-plot-band[data-residual="true"] {
+  fill: var(--kunai-chart-residual);
+}
+
+.kunai-plot-band[data-band="1"] {
+  fill: var(--kunai-chart-band-1);
+}
+.kunai-plot-band[data-band="2"] {
+  fill: var(--kunai-chart-band-2);
+}
+.kunai-plot-band[data-band="3"] {
+  fill: var(--kunai-chart-band-3);
+}
+.kunai-plot-band[data-band="4"] {
+  fill: var(--kunai-chart-band-4);
+}
+.kunai-plot-band[data-band="5"] {
+  fill: var(--kunai-chart-band-5);
+}
+
+/* Legend swatches reuse the band tokens so identity can never drift. */
+.kunai-legend-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex: none;
+}
+
+.kunai-legend-swatch[data-residual="true"] {
+  background-color: var(--kunai-chart-residual);
+}
+
+.kunai-legend-swatch[data-band="1"] {
+  background-color: var(--kunai-chart-band-1);
+}
+.kunai-legend-swatch[data-band="2"] {
+  background-color: var(--kunai-chart-band-2);
+}
+.kunai-legend-swatch[data-band="3"] {
+  background-color: var(--kunai-chart-band-3);
+}
+.kunai-legend-swatch[data-band="4"] {
+  background-color: var(--kunai-chart-band-4);
+}
+.kunai-legend-swatch[data-band="5"] {
+  background-color: var(--kunai-chart-band-5);
+}
+
+/*
+ * Forced-colors and print drop the hue channel entirely. Bands keep their
+ * order as an ordered hatch density rather than collapsing into one block.
+ */
+@media (forced-colors: active), print {
+  .kunai-plot-band {
+    fill: transparent;
+    stroke: currentColor;
+    stroke-width: 1;
+  }
+
+  .kunai-plot-area {
+    fill: transparent;
+  }
+}
+
+/*
  * Ranked horizontal bars. Table semantics — the printed value beside each bar
  * IS the table view — but none of the page's editorial table chrome. The
  * `.kunai-home table` rules (serif small caps, boxed cells, `!important`

--- a/apps/docs/components/analytics/trend-plot.tsx
+++ b/apps/docs/components/analytics/trend-plot.tsx
@@ -1,0 +1,101 @@
+import { dayOffsets, type SeriesPoint } from "@/lib/analytics-series";
+
+/**
+ * Active installs over time.
+ *
+ * One series, so no legend box — the caption names it. The line carries the
+ * shape, the endpoint is the only marked point, and every value is also in the
+ * table below: the SVG `<title>` tooltips enhance, they never gate a value.
+ *
+ * Server-rendered on purpose. The analytics page is static ISR, so the plot
+ * ships as markup rather than waiting on a client chart runtime.
+ */
+
+const VIEW_W = 720;
+const VIEW_H = 180;
+const PAD_L = 8;
+// Endpoint marker is r=4 with a 2px ring, so the right pad must clear 6px.
+const PAD_R = 12;
+const PAD_T = 12;
+// Leaves room for the x-axis band so the card never grows a nested scrollbar.
+const PAD_B = 22;
+
+type Props = {
+  readonly points: readonly SeriesPoint[];
+  readonly caption: string;
+};
+
+/**
+ * A round axis maximum that always sits ABOVE the peak.
+ *
+ * A plain power-of-ten ceiling returns the value itself for 10, 100, or 1000 —
+ * all ordinary install counts — which pins the line to the top of the frame with
+ * no headroom and puts the endpoint marker half outside the plot. The 1-2-5
+ * ladder gives a round number with room left over.
+ */
+const NICE_STEPS = [1, 1.25, 1.5, 2, 2.5, 3, 4, 5, 6, 8, 10] as const;
+
+function niceCeiling(value: number): number {
+  // Small counts get a fixed floor so a peak of exactly 4 still has headroom.
+  if (value <= 4) return 5;
+  const magnitude = 10 ** Math.floor(Math.log10(value));
+  const normalized = value / magnitude;
+  const step = NICE_STEPS.find((candidate) => candidate > normalized) ?? 10;
+  return step * magnitude;
+}
+
+export function TrendPlot({ points, caption }: Props) {
+  if (points.length === 0) return null;
+
+  const max = niceCeiling(Math.max(...points.map((p) => p.activeInstalls), 1));
+  const plotW = VIEW_W - PAD_L - PAD_R;
+  const plotH = VIEW_H - PAD_T - PAD_B;
+
+  // A single day has no width to span; anchor it mid-plot rather than at x=0,
+  // where the marker would sit half outside the axis.
+  const offsets = dayOffsets(points.map((p) => p.day));
+  const x = (i: number) => PAD_L + (offsets[i] ?? 0) * plotW;
+  const y = (v: number) => PAD_T + plotH - (v / max) * plotH;
+
+  const line = points
+    .map((p, i) => `${i === 0 ? "M" : "L"}${x(i)},${y(p.activeInstalls)}`)
+    .join(" ");
+  const area = `${line} L${x(points.length - 1)},${PAD_T + plotH} L${x(0)},${PAD_T + plotH} Z`;
+  const last = points.at(-1);
+  const titleId = "kunai-trend-plot-title";
+
+  return (
+    <figure className="flex flex-col gap-3">
+      <svg className="kunai-plot" viewBox={`0 0 ${VIEW_W} ${VIEW_H}`} aria-labelledby={titleId}>
+        {/* Named by its own <title>: the accessible name lives in the SVG,
+            which screen readers announce without a role override. */}
+        <title id={titleId}>{caption}</title>
+        {points.length > 1 ? <path className="kunai-plot-area" d={area} /> : null}
+        <path className="kunai-plot-line" d={line} />
+        {last ? (
+          <circle
+            className="kunai-plot-endpoint"
+            cx={x(points.length - 1)}
+            cy={y(last.activeInstalls)}
+            r={4}
+          />
+        ) : null}
+        {/* Baseline last so it sits above the area fill. */}
+        <path className="kunai-plot-axis" d={`M${PAD_L},${PAD_T + plotH} H${VIEW_W - PAD_R}`} />
+        {points.map((p, i) => (
+          <circle key={p.day} cx={x(i)} cy={y(p.activeInstalls)} r={12} fill="transparent">
+            <title>{`${p.day}: ${p.activeInstalls} active`}</title>
+          </circle>
+        ))}
+      </svg>
+      <div className="text-muted-foreground flex justify-between text-xs tabular-nums">
+        <span>{points[0]?.day}</span>
+        <span>{last?.day}</span>
+      </div>
+      <figcaption className="text-muted-foreground text-xs">
+        {caption} Peak {max === 4 ? Math.max(...points.map((p) => p.activeInstalls)) : max} on this
+        axis.
+      </figcaption>
+    </figure>
+  );
+}

--- a/apps/docs/components/analytics/trend-plot.tsx
+++ b/apps/docs/components/analytics/trend-plot.tsx
@@ -47,7 +47,11 @@ function niceCeiling(value: number): number {
 export function TrendPlot({ points, caption }: Props) {
   if (points.length === 0) return null;
 
-  const max = niceCeiling(Math.max(...points.map((p) => p.activeInstalls), 1));
+  // Two different numbers, and the caption must not confuse them: `peak` is the
+  // highest value actually observed, `axisMax` is the round ceiling drawn above
+  // it so the line has headroom.
+  const peak = Math.max(...points.map((p) => p.activeInstalls), 0);
+  const axisMax = niceCeiling(Math.max(peak, 1));
   const plotW = VIEW_W - PAD_L - PAD_R;
   const plotH = VIEW_H - PAD_T - PAD_B;
 
@@ -55,7 +59,7 @@ export function TrendPlot({ points, caption }: Props) {
   // where the marker would sit half outside the axis.
   const offsets = dayOffsets(points.map((p) => p.day));
   const x = (i: number) => PAD_L + (offsets[i] ?? 0) * plotW;
-  const y = (v: number) => PAD_T + plotH - (v / max) * plotH;
+  const y = (v: number) => PAD_T + plotH - (v / axisMax) * plotH;
 
   const line = points
     .map((p, i) => `${i === 0 ? "M" : "L"}${x(i)},${y(p.activeInstalls)}`)
@@ -93,8 +97,7 @@ export function TrendPlot({ points, caption }: Props) {
         <span>{last?.day}</span>
       </div>
       <figcaption className="text-muted-foreground text-xs">
-        {caption} Peak {max === 4 ? Math.max(...points.map((p) => p.activeInstalls)) : max} on this
-        axis.
+        {caption} Peak {peak} active, on an axis to {axisMax}.
       </figcaption>
     </figure>
   );

--- a/apps/docs/components/analytics/trend-section.tsx
+++ b/apps/docs/components/analytics/trend-section.tsx
@@ -1,0 +1,110 @@
+import { TrendPlot } from "@/components/analytics/trend-plot";
+import { VersionAdoption } from "@/components/analytics/version-adoption";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import type { DocsAnalyticsSeries } from "@/lib/analytics-series";
+
+/**
+ * The over-time half of the page.
+ *
+ * `daily_rollup` is never pruned, so this history was already being stored
+ * while the page showed a single day of it. Nothing new is collected to draw
+ * these; the ingest suppresses across the whole window before publishing.
+ *
+ * Absent when the series endpoint has not been deployed or has no rollups —
+ * the daily snapshot above still renders on its own.
+ */
+export function TrendSection({ series }: { readonly series: DocsAnalyticsSeries | null }) {
+  if (!series) return null;
+
+  const points = series.points;
+  const first = points[0];
+  const last = points.at(-1);
+  const delta = (last?.activeInstalls ?? 0) - (first?.activeInstalls ?? 0);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">Over time</CardTitle>
+        <CardDescription>
+          {points.length === 1
+            ? "One day of history so far — the window fills in as daily rollups accumulate."
+            : `${points.length} days, ${series.from} to ${series.to}.`}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-8">
+        <section className="flex flex-col gap-3">
+          <h3 className="text-foreground m-0 text-sm font-medium">Active installs</h3>
+          <TrendPlot
+            points={points}
+            caption={
+              points.length > 1
+                ? `Installs seen on each day, ${delta >= 0 ? "up" : "down"} ${Math.abs(delta)} across the window.`
+                : "Installs seen on the only day recorded so far."
+            }
+          />
+          <TrendTable points={points} />
+        </section>
+
+        <Separator />
+
+        <section className="flex flex-col gap-3">
+          <h3 className="text-foreground m-0 text-sm font-medium">Version share</h3>
+          <VersionAdoption series={series} />
+        </section>
+
+        <p className="text-muted-foreground m-0 text-xs text-pretty">
+          These counts are anonymous and best-effort. Anyone willing to fake pings can inflate them,
+          so read them as a pulse rather than a measurement — Kunai deliberately collects no IP or
+          identity that would let it prove otherwise.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * The table twin.
+ *
+ * Every plotted value is reachable here, so the plot's tooltips enhance rather
+ * than gate. Collapsed by default because it restates the chart — it is the
+ * accessible equivalent, not a second reading.
+ */
+function TrendTable({
+  points,
+}: {
+  readonly points: readonly { day: string; activeInstalls: number }[];
+}) {
+  return (
+    <details className="text-xs">
+      <summary className="text-muted-foreground hover:text-foreground cursor-pointer">
+        Table view — {points.length} {points.length === 1 ? "day" : "days"}
+      </summary>
+      <div className="mt-3 max-h-64 overflow-y-auto">
+        <table className="kunai-chart">
+          <caption className="sr-only">Active installs per day</caption>
+          <thead>
+            <tr>
+              <th scope="col" className="text-muted-foreground text-left font-normal">
+                Day
+              </th>
+              <th scope="col" className="text-muted-foreground text-right font-normal">
+                Active
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {points.map((point) => (
+              <tr key={point.day} className="kunai-chart-row">
+                <th scope="row" className="text-foreground text-left font-normal tabular-nums">
+                  {point.day}
+                </th>
+                <td className="text-foreground text-right tabular-nums">{point.activeInstalls}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </details>
+  );
+}

--- a/apps/docs/components/analytics/version-adoption.tsx
+++ b/apps/docs/components/analytics/version-adoption.tsx
@@ -1,0 +1,156 @@
+import {
+  dayOffsets,
+  isFullySuppressed,
+  MAX_VERSION_BANDS,
+  RESIDUAL_LABEL,
+  versionBands,
+  type DocsAnalyticsSeries,
+} from "@/lib/analytics-series";
+
+/**
+ * Version share over time — does a release actually propagate?
+ *
+ * Bands stack oldest at the bottom, newest on top, colored by the ordinal ramp
+ * so the release order is visible in the color rather than only in the legend.
+ * Share, not counts: the question is what fraction has moved, and a count chart
+ * answers "how many installs" instead.
+ *
+ * With a small population every bucket sits under the small-cell floor and the
+ * whole chart is residual. That is suppression working, not a broken chart, so
+ * this says so in words instead of drawing one grey band.
+ */
+
+const VIEW_W = 720;
+const VIEW_H = 200;
+const PAD_L = 8;
+const PAD_R = 10;
+const PAD_T = 12;
+const PAD_B = 22;
+
+type Props = {
+  readonly series: DocsAnalyticsSeries;
+};
+
+export function VersionAdoption({ series }: Props) {
+  const bands = versionBands(series);
+  const suppressed = isFullySuppressed(series);
+
+  if (suppressed) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        Every version bucket is below the five-install reporting floor, so the whole window folds
+        into <span className="text-foreground font-medium">other</span>. Version share appears here
+        once a release is running on enough machines to publish without identifying anyone.
+      </p>
+    );
+  }
+
+  const plotW = VIEW_W - PAD_L - PAD_R;
+  const plotH = VIEW_H - PAD_T - PAD_B;
+  const offsets = dayOffsets(series.points.map((p) => p.day));
+  const x = (i: number) => PAD_L + (offsets[i] ?? 0) * plotW;
+
+  // Bottom-up: residual first, then oldest to newest.
+  const stackOrder = [RESIDUAL_LABEL, ...bands];
+
+  const dayShares = series.points.map((point) => {
+    const total = Object.values(point.byVersion).reduce((sum, n) => sum + n, 0);
+    const named = bands.reduce((sum, b) => sum + (point.byVersion[b] ?? 0), 0);
+    const residual = Math.max(0, total - named);
+    const shares = new Map<string, number>();
+    if (total > 0) {
+      shares.set(RESIDUAL_LABEL, residual / total);
+      for (const b of bands) shares.set(b, (point.byVersion[b] ?? 0) / total);
+    }
+    return shares;
+  });
+
+  const bandPath = (bucket: string, index: number): string => {
+    const below = stackOrder.slice(0, index);
+    const top: string[] = [];
+    const bottom: string[] = [];
+    series.points.forEach((_, i) => {
+      const base = below.reduce((sum, b) => sum + (dayShares[i]?.get(b) ?? 0), 0);
+      const value = dayShares[i]?.get(bucket) ?? 0;
+      const yBase = PAD_T + plotH - base * plotH;
+      const yTop = PAD_T + plotH - (base + value) * plotH;
+      top.push(`${i === 0 ? "M" : "L"}${x(i)},${yTop}`);
+      bottom.unshift(`L${x(i)},${yBase}`);
+    });
+    // A single day has no span, so give the band a visible column.
+    if (series.points.length === 1) {
+      const base = below.reduce((sum, b) => sum + (dayShares[0]?.get(b) ?? 0), 0);
+      const value = dayShares[0]?.get(bucket) ?? 0;
+      const yBase = PAD_T + plotH - base * plotH;
+      const yTop = PAD_T + plotH - (base + value) * plotH;
+      const half = Math.min(40, plotW / 4);
+      const cx = PAD_L + plotW / 2;
+      return `M${cx - half},${yTop} L${cx + half},${yTop} L${cx + half},${yBase} L${cx - half},${yBase} Z`;
+    }
+    return `${top.join(" ")} ${bottom.join(" ")} Z`;
+  };
+
+  const titleId = "kunai-version-adoption-title";
+  const latest = series.points.at(-1);
+  const latestShares = dayShares.at(-1);
+
+  return (
+    <figure className="flex flex-col gap-3">
+      <svg className="kunai-plot" viewBox={`0 0 ${VIEW_W} ${VIEW_H}`} aria-labelledby={titleId}>
+        <title id={titleId}>
+          {`Share of active installs by version, ${series.from} to ${series.to}`}
+        </title>
+        {stackOrder.map((bucket, index) => {
+          const residual = bucket === RESIDUAL_LABEL;
+          // Band 1 is the oldest published version; the residual has no slot.
+          const slot = residual ? undefined : String(Math.min(index, MAX_VERSION_BANDS));
+          const share = latestShares?.get(bucket) ?? 0;
+          return (
+            <path
+              key={bucket}
+              className="kunai-plot-band"
+              data-band={slot}
+              data-residual={residual ? "true" : undefined}
+              d={bandPath(bucket, index)}
+            >
+              <title>{`${bucket}: ${Math.round(share * 100)}% on ${latest?.day}`}</title>
+            </path>
+          );
+        })}
+        <path className="kunai-plot-axis" d={`M${PAD_L},${PAD_T + plotH} H${VIEW_W - PAD_R}`} />
+      </svg>
+
+      <div className="text-muted-foreground flex justify-between text-xs tabular-nums">
+        <span>{series.from}</span>
+        <span>{series.to}</span>
+      </div>
+
+      {/* Identity is never colour alone: a legend is always present for >= 2 bands. */}
+      <ul className="flex flex-wrap gap-x-4 gap-y-1.5 text-xs">
+        {[...stackOrder].reverse().map((bucket) => {
+          const residual = bucket === RESIDUAL_LABEL;
+          const index = stackOrder.indexOf(bucket);
+          const slot = residual ? undefined : String(Math.min(index, MAX_VERSION_BANDS));
+          return (
+            <li key={bucket} className="flex items-center gap-1.5">
+              <span
+                className="kunai-legend-swatch"
+                data-band={slot}
+                data-residual={residual ? "true" : undefined}
+                aria-hidden="true"
+              />
+              <span className={residual ? "text-muted-foreground" : "text-foreground"}>
+                {bucket}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+
+      <figcaption className="text-muted-foreground text-xs">
+        Share of active installs by version. Bands stack oldest to newest; buckets under the
+        five-install floor fold into <span className="text-foreground">other</span>.
+      </figcaption>
+    </figure>
+  );
+}

--- a/apps/docs/lib/analytics-series.ts
+++ b/apps/docs/lib/analytics-series.ts
@@ -1,0 +1,217 @@
+/**
+ * The published day-by-day series, as the docs site consumes it.
+ *
+ * Mirrors `analytics-metrics.ts`: parse defensively, return `null` rather than a
+ * half-built shape, and let the page decide what to render. The ingest applies
+ * small-cell suppression across the whole window before this is ever fetched —
+ * nothing here re-derives privacy, it only draws what it is given.
+ */
+
+import { resolveAnalyticsMetricsUrl } from "./analytics-metrics";
+
+/** The residual bucket. Never a real version, OS, or arch value. */
+export const RESIDUAL_LABEL = "other";
+
+/**
+ * How many named version bands the adoption chart draws before folding the rest
+ * into the residual.
+ *
+ * This is a *color* limit, not an editorial one: the ordinal ramp is validated
+ * at five steps and fails the adjacent-lightness check at six, so a sixth band
+ * would be indistinguishable from its neighbour. See `app/styles/charts.css`.
+ */
+export const MAX_VERSION_BANDS = 5;
+
+export type SeriesPoint = {
+  readonly day: string;
+  readonly activeInstalls: number;
+  readonly lifetimeInstalls: number;
+  readonly byVersion: Readonly<Record<string, number>>;
+};
+
+export type DocsAnalyticsSeries = {
+  readonly from: string;
+  readonly to: string;
+  readonly points: readonly SeriesPoint[];
+  readonly updatedAt: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseCounts(value: unknown): Record<string, number> | null {
+  if (!isRecord(value)) return null;
+  const counts: Record<string, number> = {};
+  for (const [bucket, raw] of Object.entries(value)) {
+    if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 0) return null;
+    counts[bucket] = Math.floor(raw);
+  }
+  return counts;
+}
+
+/**
+ * A real calendar date, not merely the right shape.
+ *
+ * The format check alone accepts `2026-13-45` and `2026-00-00`, which
+ * `Date.parse` returns NaN for. That NaN reaches the x-scale and every SVG path
+ * on the chart becomes `MNaN,NaN` — which browsers drop silently, so the plot
+ * disappears with no error anywhere.
+ */
+function isCalendarDay(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+function parsePoint(value: unknown): SeriesPoint | null {
+  if (!isRecord(value)) return null;
+  const { day, activeInstalls, lifetimeInstalls } = value;
+  if (typeof day !== "string" || !isCalendarDay(day)) return null;
+  if (typeof activeInstalls !== "number" || !Number.isFinite(activeInstalls)) return null;
+  if (typeof lifetimeInstalls !== "number" || !Number.isFinite(lifetimeInstalls)) return null;
+  const byVersion = parseCounts(value.byVersion);
+  if (!byVersion) return null;
+  return {
+    day,
+    activeInstalls: Math.max(0, Math.floor(activeInstalls)),
+    lifetimeInstalls: Math.max(0, Math.floor(lifetimeInstalls)),
+    byVersion,
+  };
+}
+
+export function parseDocsAnalyticsSeries(raw: unknown): DocsAnalyticsSeries | null {
+  if (!isRecord(raw)) return null;
+  const { from, to, updatedAt, points } = raw;
+  if (typeof from !== "string" || typeof to !== "string") return null;
+  if (typeof updatedAt !== "string") return null;
+  if (!Array.isArray(points) || points.length === 0) return null;
+
+  const parsed: SeriesPoint[] = [];
+  for (const point of points) {
+    const next = parsePoint(point);
+    // One malformed day makes the whole window untrustworthy: a chart drawn from
+    // a partially parsed series would quietly misstate a trend.
+    if (!next) return null;
+    // Strictly ascending. Both stores already order by day, but this is the
+    // trust boundary for an HTTP response, and the x-scale positions points by
+    // date — an out-of-order day yields a NEGATIVE offset and paints its mark
+    // outside the plot, which `overflow: visible` then shows over the page.
+    // A duplicate day is equally untrustworthy: the window would double-count.
+    const previous = parsed.at(-1);
+    if (previous && previous.day >= next.day) return null;
+    parsed.push(next);
+  }
+  return { from, to, updatedAt, points: parsed };
+}
+
+/**
+ * The version bands worth drawing, newest release last.
+ *
+ * Versions are *ordered*, so the bands are sorted by version rather than by
+ * size — the reader's question is "is the newest one taking over", and a chart
+ * sorted by magnitude destroys exactly that reading. The residual always sits
+ * first so the named bands stack above it.
+ */
+export function versionBands(
+  series: DocsAnalyticsSeries,
+  limit: number = MAX_VERSION_BANDS,
+): readonly string[] {
+  const totals = new Map<string, number>();
+  for (const point of series.points) {
+    for (const [bucket, count] of Object.entries(point.byVersion)) {
+      if (bucket === RESIDUAL_LABEL) continue;
+      totals.set(bucket, (totals.get(bucket) ?? 0) + count);
+    }
+  }
+  // Biggest-by-total decides *which* bands survive the color limit; version
+  // order decides how they stack.
+  const kept = [...totals.entries()]
+    .sort((a, b) => b[1] - a[1] || compareVersions(a[0], b[0]))
+    .slice(0, limit)
+    .map(([bucket]) => bucket);
+  return kept.sort(compareVersions);
+}
+
+/** Numeric-aware version compare, so `0.10.0` sorts after `0.9.0`. */
+export function compareVersions(left: string, right: string): number {
+  const a = left.split(/[.-]/);
+  const b = right.split(/[.-]/);
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const x = a[i] ?? "";
+    const y = b[i] ?? "";
+    const nx = Number.parseInt(x, 10);
+    const ny = Number.parseInt(y, 10);
+    if (Number.isFinite(nx) && Number.isFinite(ny) && nx !== ny) return nx - ny;
+    if (!Number.isFinite(nx) || !Number.isFinite(ny)) {
+      const cmp = x.localeCompare(y);
+      if (cmp !== 0) return cmp;
+    }
+  }
+  return 0;
+}
+
+/**
+ * True when suppression has folded everything into the residual.
+ *
+ * With a small population this is the normal state, not a failure — the floor
+ * is doing its job. The page says so rather than drawing an all-grey band and
+ * letting the reader think the chart is broken.
+ */
+export function isFullySuppressed(series: DocsAnalyticsSeries): boolean {
+  return versionBands(series).length === 0;
+}
+
+/**
+ * Where each day sits along the x-axis, as a 0..1 fraction of the window.
+ *
+ * Positioned by DATE, not by array index. `readRollups` returns only the days
+ * that actually have a rollup, so a missed cron run leaves a hole — and spacing
+ * by index would draw a one-day gap and an eleven-day gap at the same width,
+ * making the line misstate time. A single point sits mid-plot, where a marker
+ * has room on both sides.
+ */
+export function dayOffsets(days: readonly string[]): readonly number[] {
+  if (days.length === 0) return [];
+  if (days.length === 1) return [0.5];
+  const at = (d: string) => Date.parse(`${d}T00:00:00.000Z`);
+  const start = at(days[0] ?? "");
+  const end = at(days.at(-1) ?? "");
+  const span = end - start;
+  // Every row carrying the same day is possible if a window holds one date.
+  if (!Number.isFinite(span) || span <= 0) {
+    return days.map((_, i) => i / (days.length - 1));
+  }
+  // Clamped: an unparseable or out-of-order day must never place a mark outside
+  // the plot. The parser rejects both, so this is the second line, not the first.
+  return days.map((d, i) => {
+    const offset = (at(d) - start) / span;
+    return Number.isFinite(offset) ? Math.min(1, Math.max(0, offset)) : i / (days.length - 1);
+  });
+}
+
+export function resolveAnalyticsSeriesUrl(): string {
+  const daily = resolveAnalyticsMetricsUrl();
+  if (!daily) return "";
+  return daily.replace(/daily\.json$/, "series.json");
+}
+
+export async function fetchDocsAnalyticsSeries(options?: {
+  readonly url?: string;
+  readonly fetchImpl?: typeof fetch;
+}): Promise<DocsAnalyticsSeries | null> {
+  const url = options?.url ?? resolveAnalyticsSeriesUrl();
+  if (!url) return null;
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  try {
+    const response = await fetchImpl(url, {
+      headers: { accept: "application/json" },
+      next: { revalidate: 3600 },
+    });
+    if (!response.ok) return null;
+    const json: unknown = await response.json();
+    return parseDocsAnalyticsSeries(json);
+  } catch {
+    return null;
+  }
+}

--- a/apps/docs/lib/analytics-series.ts
+++ b/apps/docs/lib/analytics-series.ts
@@ -83,7 +83,14 @@ function parsePoint(value: unknown): SeriesPoint | null {
 export function parseDocsAnalyticsSeries(raw: unknown): DocsAnalyticsSeries | null {
   if (!isRecord(raw)) return null;
   const { from, to, updatedAt, points } = raw;
-  if (typeof from !== "string" || typeof to !== "string") return null;
+  // The window is held to the same standard as the points inside it. It is
+  // rendered as the axis labels, so a malformed bound prints as the range the
+  // chart claims to cover, and a reversed pair describes a window that ran
+  // backwards. Every point is already rejected on a bad day; the window that
+  // frames them cannot be the one thing taken on trust.
+  if (typeof from !== "string" || !isCalendarDay(from)) return null;
+  if (typeof to !== "string" || !isCalendarDay(to)) return null;
+  if (from > to) return null;
   if (typeof updatedAt !== "string") return null;
   if (!Array.isArray(points) || points.length === 0) return null;
 

--- a/apps/docs/test/analytics-series.test.ts
+++ b/apps/docs/test/analytics-series.test.ts
@@ -43,6 +43,30 @@ describe("parseDocsAnalyticsSeries", () => {
     expect(parsed?.points[1]?.activeInstalls).toBe(12);
   });
 
+  /**
+   * `from`/`to` are rendered as the axis labels, so they are a claim about what
+   * the chart covers. Every point inside is already rejected on a bad day; the
+   * window that frames them cannot be the one value taken on trust.
+   */
+  test("a malformed window bound rejects the series", () => {
+    expect(parseDocsAnalyticsSeries({ ...valid, from: "nope" })).toBeNull();
+    expect(parseDocsAnalyticsSeries({ ...valid, to: "2026-13-45" })).toBeNull();
+    expect(parseDocsAnalyticsSeries({ ...valid, from: "" })).toBeNull();
+  });
+
+  test("a window that runs backwards is refused", () => {
+    expect(parseDocsAnalyticsSeries({ ...valid, from: "2026-08-02", to: "2026-08-01" })).toBeNull();
+    // A single-day window is legitimate — from and to may be equal.
+    expect(
+      parseDocsAnalyticsSeries({
+        ...valid,
+        from: "2026-08-01",
+        to: "2026-08-01",
+        points: [valid.points[0]],
+      }),
+    ).not.toBeNull();
+  });
+
   test("one malformed day rejects the whole window", () => {
     // A partially parsed series would quietly misstate a trend.
     const broken = { ...valid, points: [valid.points[0], { day: "nope", activeInstalls: 1 }] };

--- a/apps/docs/test/analytics-series.test.ts
+++ b/apps/docs/test/analytics-series.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  compareVersions,
+  dayOffsets,
+  isFullySuppressed,
+  MAX_VERSION_BANDS,
+  parseDocsAnalyticsSeries,
+  versionBands,
+  type DocsAnalyticsSeries,
+} from "../lib/analytics-series";
+
+function series(
+  points: readonly { day: string; active?: number; byVersion?: Record<string, number> }[],
+): DocsAnalyticsSeries {
+  return {
+    from: points[0]?.day ?? "",
+    to: points.at(-1)?.day ?? "",
+    updatedAt: "2026-08-26T00:05:00.000Z",
+    points: points.map((p) => ({
+      day: p.day,
+      activeInstalls: p.active ?? 10,
+      lifetimeInstalls: 50,
+      byVersion: p.byVersion ?? { "0.3.0": 10 },
+    })),
+  };
+}
+
+describe("parseDocsAnalyticsSeries", () => {
+  const valid = {
+    from: "2026-08-01",
+    to: "2026-08-02",
+    updatedAt: "2026-08-02T00:05:00.000Z",
+    points: [
+      { day: "2026-08-01", activeInstalls: 10, lifetimeInstalls: 40, byVersion: { "0.3.0": 10 } },
+      { day: "2026-08-02", activeInstalls: 12, lifetimeInstalls: 42, byVersion: { "0.3.0": 12 } },
+    ],
+  };
+
+  test("a well-formed payload round-trips", () => {
+    const parsed = parseDocsAnalyticsSeries(valid);
+    expect(parsed?.points).toHaveLength(2);
+    expect(parsed?.points[1]?.activeInstalls).toBe(12);
+  });
+
+  test("one malformed day rejects the whole window", () => {
+    // A partially parsed series would quietly misstate a trend.
+    const broken = { ...valid, points: [valid.points[0], { day: "nope", activeInstalls: 1 }] };
+    expect(parseDocsAnalyticsSeries(broken)).toBeNull();
+  });
+
+  test("negative or non-finite counts are refused", () => {
+    expect(
+      parseDocsAnalyticsSeries({
+        ...valid,
+        points: [{ ...valid.points[0], byVersion: { "0.3.0": -1 } }],
+      }),
+    ).toBeNull();
+  });
+
+  test("an empty or absent point list is not a series", () => {
+    expect(parseDocsAnalyticsSeries({ ...valid, points: [] })).toBeNull();
+    expect(parseDocsAnalyticsSeries({ ...valid, points: undefined })).toBeNull();
+    expect(parseDocsAnalyticsSeries(null)).toBeNull();
+    expect(parseDocsAnalyticsSeries("nope")).toBeNull();
+  });
+});
+
+describe("versionBands", () => {
+  test("bands come back in version order, not by size", () => {
+    // The reader's question is "is the newest taking over" — sorting by
+    // magnitude would destroy exactly that reading.
+    const bands = versionBands(
+      series([{ day: "2026-08-01", byVersion: { "0.3.1": 5, "0.2.9": 40, "0.3.0": 20 } }]),
+    );
+    expect(bands).toEqual(["0.2.9", "0.3.0", "0.3.1"]);
+  });
+
+  test("the band count is capped at the ramp's validated ceiling", () => {
+    const byVersion = Object.fromEntries(
+      Array.from({ length: 9 }, (_, i) => [`0.${i}.0`, (i + 1) * 10]),
+    );
+    const bands = versionBands(series([{ day: "2026-08-01", byVersion }]));
+    expect(bands).toHaveLength(MAX_VERSION_BANDS);
+  });
+
+  test("the residual is never a band", () => {
+    const bands = versionBands(series([{ day: "2026-08-01", byVersion: { other: 40 } }]));
+    expect(bands).toEqual([]);
+  });
+});
+
+describe("the fully suppressed case — the live one today", () => {
+  test("a single install with everything folded reports as suppressed", () => {
+    const live = series([{ day: "2026-08-25", active: 1, byVersion: { other: 1 } }]);
+    expect(isFullySuppressed(live)).toBe(true);
+  });
+
+  test("one published band is enough to stop being suppressed", () => {
+    expect(isFullySuppressed(series([{ day: "2026-08-25", byVersion: { "0.3.0": 9 } }]))).toBe(
+      false,
+    );
+  });
+});
+
+describe("compareVersions", () => {
+  test("sorts numerically, so 0.10.0 lands after 0.9.0", () => {
+    expect(["0.10.0", "0.9.0", "0.2.5"].sort(compareVersions)).toEqual([
+      "0.2.5",
+      "0.9.0",
+      "0.10.0",
+    ]);
+  });
+
+  test("prerelease tags order after their release", () => {
+    expect(compareVersions("0.3.0", "0.3.0-rc1")).toBeLessThan(0);
+  });
+});
+
+describe("dayOffsets — spacing follows the calendar, not the array", () => {
+  test("a cron outage does not compress into an even line", () => {
+    // readRollups returns only days that HAVE a rollup, so a missed run leaves a
+    // hole. Spacing by index would draw the 1-day gap and the 11-day gap the
+    // same width and make the line misstate time.
+    const offsets = dayOffsets(["2026-08-01", "2026-08-02", "2026-08-13"]);
+    expect(offsets[0]).toBe(0);
+    expect(offsets[2]).toBe(1);
+    // 1 of 12 days elapsed, not 1 of 2 points.
+    expect(offsets[1]).toBeCloseTo(1 / 12, 5);
+    expect(offsets[1]).toBeLessThan(0.1);
+  });
+
+  test("evenly spaced days stay evenly spaced", () => {
+    const offsets = dayOffsets(["2026-08-01", "2026-08-02", "2026-08-03"]);
+    expect(offsets).toEqual([0, 0.5, 1]);
+  });
+
+  test("a single day sits mid-plot so its marker has room both sides", () => {
+    expect(dayOffsets(["2026-08-01"])).toEqual([0.5]);
+  });
+
+  test("an empty window has no positions", () => {
+    expect(dayOffsets([])).toEqual([]);
+  });
+
+  test("a zero-span window falls back to even spacing instead of dividing by zero", () => {
+    const offsets = dayOffsets(["2026-08-01", "2026-08-01", "2026-08-01"]);
+    expect(offsets).toEqual([0, 0.5, 1]);
+    expect(offsets.every((o) => Number.isFinite(o))).toBe(true);
+  });
+
+  test("the window spans a month boundary correctly", () => {
+    const offsets = dayOffsets(["2026-07-30", "2026-07-31", "2026-08-01"]);
+    expect(offsets).toEqual([0, 0.5, 1]);
+  });
+});
+
+describe("the parse boundary rejects what the x-scale cannot draw", () => {
+  const days = (...list: string[]) =>
+    parseDocsAnalyticsSeries({
+      from: list[0],
+      to: list.at(-1),
+      updatedAt: "2026-08-26T00:00:00.000Z",
+      points: list.map((day) => ({
+        day,
+        activeInstalls: 1,
+        lifetimeInstalls: 1,
+        byVersion: { "0.3.0": 1 },
+      })),
+    });
+
+  test("a date that matches the format but is not a real day is refused", () => {
+    // `Date.parse` returns NaN for these, and that NaN reaches the x-scale:
+    // every path becomes `MNaN,NaN`, which browsers drop silently.
+    expect(days("2026-13-45")).toBeNull();
+    expect(days("2026-00-00")).toBeNull();
+    expect(days("2026-02-30")).toBeNull();
+    expect(days("2026-08-01")).not.toBeNull();
+  });
+
+  test("out-of-order days are refused rather than drawn off-plot", () => {
+    // An earlier day after a later one yields a negative offset, and
+    // `overflow: visible` paints that mark over the surrounding page.
+    expect(days("2026-08-03", "2026-08-01")).toBeNull();
+    expect(days("2026-08-01", "2026-08-03")).not.toBeNull();
+  });
+
+  test("a duplicated day is refused so the window cannot double-count", () => {
+    expect(days("2026-08-01", "2026-08-01")).toBeNull();
+  });
+});
+
+describe("dayOffsets is safe even when handed unparsed input", () => {
+  test("an out-of-order day is clamped into the plot, never negative", () => {
+    const offsets = dayOffsets(["2026-08-10", "2026-08-01", "2026-08-20"]);
+    expect(offsets.every((o) => o >= 0 && o <= 1)).toBe(true);
+  });
+
+  test("an unparseable day never yields NaN", () => {
+    const offsets = dayOffsets(["2026-08-01", "not-a-date", "2026-08-20"]);
+    expect(offsets.every(Number.isFinite)).toBe(true);
+  });
+});


### PR DESCRIPTION
Draws the `/metrics/series.json` endpoint (shipped in #261, live in production) as two server-rendered SVG plots plus a table twin for every value.

**Independent of #262** — no shared files, either can merge first.

### Honest framing on urgency

These render **"below the five-install reporting floor"** today. Verified against live production data: eight days of real history, every bucket suppressed because there is one active install. They become useful once a version has 5+ installs; until then the panel correctly says there is nothing to show.

So this is not urgent. It is correct, tested, and verified end-to-end against the deployed endpoint — but it displays a "not enough data" message until adoption grows. Reviewed accordingly.

### Why hand-rolled SVG instead of a chart library

`/analytics` is static ISR with no `"use client"` in its tree. Recharts (via shadcn's Chart) would force a client boundary, ship ~100KB to a docs page, and render empty HTML until hydration. **No new dependencies.**

### The design decision worth checking

**Version is ordinal, not categorical** — swapping release order changes the meaning — so bands take one hue with monotone lightness rather than eight categorical slots. Both ramps are machine-validated:

```
dark   #6b4b53 .. #ff9cbd on #1c1620   light end 2.33:1   ALL PASS
light  #d5a8b2 .. #8b1345 on #fcfcfb   light end 2.03:1   ALL PASS
```

**Five bands is a measured ceiling** — a sixth step lands at ΔL 0.057 and *fails* the adjacency check, so the sixth version folds into the residual. Bands sort by version, never by size: a magnitude-sorted stack destroys the "is the newest taking over" reading.

### Bugs already found and fixed here

Found by probing shapes the endpoint can actually return, not the fixture:

- Points spaced by array index, not date — a missed cron run made a 1-day gap and an 11-day gap draw the same width. `daily.ts` already documents cron failure as a real scenario.
- The axis ceiling returned the value itself for 10, 100, 1000, pinning the line to the frame.
- `2026-13-45` passed the format check, parsed to NaN, and made every path `MNaN,NaN` — which browsers drop silently.
- An out-of-order day produced a negative offset, painted outside the plot by `overflow: visible`.
- A duplicate day would double-count the window.

### Verification

Gates standing alone: typecheck 14/14, lint 12/12, fmt:check, full suite 23/23 — forced, 0 cached. Rendered from a built server against both a gapped fixture and live production data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics history with active-install trends and daily data.
  * Added version adoption breakdowns with “other” category handling.
  * Added interactive chart tooltips, legends, date ranges, and accessible data tables.
  * Added messaging for limited or suppressed analytics data.

* **Bug Fixes**
  * Improved handling of missing, malformed, or unavailable analytics data.
  * Charts now support sparse and single-day reporting periods gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->