### PR TITLE
fix(playback,presence): stop a malformed language tag from crashing a resolve

### DIFF
--- a/.changeset/tidy-owls-label.md
+++ b/.changeset/tidy-owls-label.md
@@ -1,0 +1,23 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Stop a malformed language tag from crashing playback, and clear the encoded ref out of the Discord state row.
+
+### Fixes
+
+- **A language label could take down a resolve.** The playback source inventory
+  formatted language names with `Intl.DisplayNames.of()` and no guard, and that
+  call throws `RangeError: argument is not a language id` for anything that is
+  not a well-formed BCP-47 tag. Several values reaching it are not: YouTube's
+  `a.en` auto-caption codes, `live_chat`, and `none` — which Kunai ships itself
+  as the default series subtitle preference. The result was an unhandled
+  rejection as a stream was being resolved. Labels are now derived from
+  progressively less specific candidates, so a valid tag keeps its precise name
+  (`en-US` stays "American English"), `a.en` resolves to "English", and anything
+  unmappable degrades to the raw value instead of throwing.
+- **The Discord state row no longer carries the encoded `kunai://` ref.** It was
+  appended there from when the ref could not be a button. Discord truncates that
+  row, so a long ref cut off mid-query and crowded out the progress beside it.
+  The ref now has its own button and remains in `playable_ref`, so the visible
+  text stays readable.

--- a/.changeset/tidy-owls-label.md
+++ b/.changeset/tidy-owls-label.md
@@ -15,7 +15,9 @@ Stop a malformed language tag from crashing playback, and clear the encoded ref 
   rejection as a stream was being resolved. Labels are now derived from
   progressively less specific candidates, so a valid tag keeps its precise name
   (`en-US` stays "American English"), `a.en` resolves to "English", and anything
-  unmappable degrades to the raw value instead of throwing.
+  unmappable degrades to the raw value instead of throwing. YouTube subtitle
+  filtering now also recognizes dotted auto-caption tags and drops its
+  `live_chat` metadata track before it can reach the picker.
 - **The Discord state row no longer carries the encoded `kunai://` ref.** It was
   appended there from when the ref could not be a button. Discord truncates that
   row, so a long ref cut off mid-query and crowded out the progress beside it.

--- a/apps/cli/src/services/playback/PlaybackSourceInventoryProjection.ts
+++ b/apps/cli/src/services/playback/PlaybackSourceInventoryProjection.ts
@@ -991,8 +991,38 @@ function subtitleDeliveryLabel(delivery: PlaybackSubtitleOptionView["delivery"])
 
 function formatLanguageLabel(language: string | undefined): string {
   if (!language) return "unknown";
-  const displayName = new Intl.DisplayNames(["en"], { type: "language" }).of(language);
-  return displayName ?? language.toUpperCase();
+  return languageDisplayName(language) ?? language.toUpperCase();
+}
+
+/**
+ * `Intl.DisplayNames.of` throws `RangeError` on anything that is not a
+ * well-formed BCP-47 tag, and several values that reach here are not:
+ * `none` from the default subtitle profile, `auto`, and YouTube's `a.en`
+ * auto-caption codes. This label is decoration on an inventory row — it must
+ * never take down a resolve, which is what an unguarded call did.
+ *
+ * Progressively less specific candidates are tried so a tag that *is* valid
+ * keeps its precise name (`en-US` stays "American English") while
+ * `a.en` still resolves to "English" rather than being shouted back as `A.EN`.
+ */
+function languageDisplayName(tag: string): string | undefined {
+  const normalized = tag.trim();
+  if (!normalized) return undefined;
+  const afterDot = normalized.includes(".")
+    ? normalized.slice(normalized.lastIndexOf(".") + 1)
+    : normalized;
+  const base = afterDot.toLowerCase().split(/[-_]/)[0] ?? "";
+
+  for (const candidate of [normalized, afterDot, base]) {
+    if (!candidate) continue;
+    try {
+      const name = new Intl.DisplayNames(["en"], { type: "language" }).of(candidate);
+      if (name) return name;
+    } catch {
+      // Not a language id. Fall through to the next, less specific candidate.
+    }
+  }
+  return undefined;
 }
 
 function sortByStateThenLabel<T extends { state: PlaybackInventoryOptionState; label: string }>(

--- a/apps/cli/src/services/presence/PresenceServiceImpl.ts
+++ b/apps/cli/src/services/presence/PresenceServiceImpl.ts
@@ -610,9 +610,8 @@ export function buildDiscordActivity(
   };
   const buttons = buildDiscordPresenceButtons(activity, privacy);
   const urlFields = buildDiscordActivityUrlFields(activity, privacy);
-  const playableRef = urlFields.playable_ref;
   const stateLine = appendWatchSessionSuffix(
-    buildDiscordPlaybackStateLine(activity, progressLabel, playableRef),
+    buildDiscordPlaybackStateLine(activity, progressLabel),
     activity.paused === true,
     context,
   );
@@ -630,19 +629,25 @@ export function buildDiscordActivity(
   };
 }
 
+/**
+ * The state row is read at a glance, so it carries only what a reader can use:
+ * position for a movie, episode for a series.
+ *
+ * It used to have the encoded `kunai://play?...` ref appended to it, from when
+ * that ref could not be a button. Discord truncates the row, so a long ref cut
+ * off mid-query and pushed out the progress it was sitting next to. The ref now
+ * has a real button and stays in `playable_ref` for anything reading the
+ * payload, so it no longer belongs in the visible text.
+ */
 function buildDiscordPlaybackStateLine(
   activity: PresencePlaybackActivity,
   progressLabel: string | null,
-  playableRef?: string,
 ): string {
   if (activity.title.type === "movie") {
     if (activity.paused) {
-      return appendPlayablePresenceRef(
-        progressLabel ? `Paused at ${progressLabel}` : "Paused",
-        playableRef,
-      );
+      return progressLabel ? `Paused at ${progressLabel}` : "Paused";
     }
-    return appendPlayablePresenceRef(activity.title.year ?? "Movie", playableRef);
+    return activity.title.year ?? "Movie";
   }
 
   const episodeName = activity.episode.name?.trim();
@@ -650,20 +655,14 @@ function buildDiscordPlaybackStateLine(
   const episodeLabel = episodeName ? `${numbered} · ${episodeName}` : numbered;
   if (activity.paused) {
     if (hasDiscordPlaybackTimeline(activity)) {
-      return appendPlayablePresenceRef(episodeLabel, playableRef);
+      return episodeLabel;
     }
-    return appendPlayablePresenceRef(
-      compact([episodeLabel, progressLabel ? `Paused at ${progressLabel}` : "Paused"]).join(" · "),
-      playableRef,
+    return compact([episodeLabel, progressLabel ? `Paused at ${progressLabel}` : "Paused"]).join(
+      " · ",
     );
   }
 
-  return appendPlayablePresenceRef(episodeLabel, playableRef);
-}
-
-function appendPlayablePresenceRef(line: string, playableRef?: string): string {
-  if (!playableRef) return line;
-  return `${line} · ${playableRef}`;
+  return episodeLabel;
 }
 
 function hasDiscordPlaybackTimeline(

--- a/apps/cli/test/unit/services/playback/playback-source-inventory-projection.test.ts
+++ b/apps/cli/test/unit/services/playback/playback-source-inventory-projection.test.ts
@@ -591,3 +591,75 @@ test("availableAudioModesFromTrace exposes dual sub/dub rows only when trace con
   });
   expect(single).toEqual([]);
 });
+
+/**
+ * `Intl.DisplayNames.of` throws `RangeError: argument is not a language id` for
+ * anything that is not a well-formed BCP-47 tag. Several values that reach the
+ * projection are not: YouTube's `a.en` auto-caption codes, `none` from the
+ * default series subtitle profile, and `live_chat`. An unguarded call turned a
+ * decorative label into an unhandled rejection that killed the resolve.
+ */
+test("labels malformed language tags instead of throwing on them", () => {
+  const malformed = ["a.en", "none", "auto", "live_chat", "en_US", "N/A", "--"];
+
+  const view = projectPlaybackSourceInventory({
+    status: "resolved",
+    providerId: "youtube",
+    selectedStreamId: "stream-a",
+    streams: [stream({ id: "stream-a", providerId: "youtube", sourceId: "source-a" })],
+    subtitles: malformed.map((language, index) => ({
+      id: `sub-${index}`,
+      providerId: "youtube",
+      sourceId: "source-a",
+      url: `https://subs.example/${index}.vtt`,
+      language,
+      source: "provider" as const,
+      confidence: 0.5,
+      cachePolicy: { ...cachePolicy, ttlClass: "subtitle-list" as const },
+    })),
+    trace: trace(),
+    failures: [],
+  });
+
+  // Every malformed tag still produced a row rather than aborting the projection.
+  for (const [index] of malformed.entries()) {
+    expect(
+      view.subtitleOptions.find((option) => option.id === `subtitle:sub-${index}`),
+    ).toBeDefined();
+  }
+
+  // A dotted auto-caption code still resolves to the real language name.
+  const auto = view.subtitleOptions.find((option) => option.id === "subtitle:sub-0");
+  expect(auto?.label).toContain("English");
+
+  // An unmappable tag degrades to the raw value rather than disappearing.
+  const none = view.subtitleOptions.find((option) => option.id === "subtitle:sub-1");
+  expect(none?.label).toContain("NONE");
+});
+
+test("well-formed language tags keep their specific display names", () => {
+  const view = projectPlaybackSourceInventory({
+    status: "resolved",
+    providerId: "rivestream",
+    selectedStreamId: "stream-a",
+    streams: [stream({ id: "stream-a", providerId: "rivestream", sourceId: "source-a" })],
+    subtitles: [
+      {
+        id: "sub-en-us",
+        providerId: "rivestream",
+        sourceId: "source-a",
+        url: "https://subs.example/en-us.vtt",
+        language: "en-US",
+        source: "provider" as const,
+        confidence: 0.9,
+        cachePolicy: { ...cachePolicy, ttlClass: "subtitle-list" as const },
+      },
+    ],
+    trace: trace(),
+    failures: [],
+  });
+
+  expect(
+    view.subtitleOptions.find((option) => option.id === "subtitle:sub-en-us")?.label,
+  ).toContain("American English");
+});

--- a/apps/cli/test/unit/services/presence/PresenceServiceImpl.test.ts
+++ b/apps/cli/test/unit/services/presence/PresenceServiceImpl.test.ts
@@ -265,6 +265,45 @@ describe("PresenceServiceImpl", () => {
     expect(JSON.stringify(payload)).not.toContain("signed-provider.example");
   });
 
+  /**
+   * The ref used to be appended to the visible state row, from when it could not
+   * be a button. Discord truncates that row, so a long ref cut off mid-query and
+   * crowded out the progress beside it. It now has a button and stays in
+   * `playable_ref`, so the visible text must stay clean.
+   */
+  test("keeps the encoded ref out of the visible state row", () => {
+    const activity = {
+      mode: "series" as const,
+      title: {
+        id: "tmdb:969681",
+        type: "movie" as const,
+        name: "Spider-Man: Brand New Day",
+        externalIds: { tmdbId: "969681" },
+      },
+      episode: { season: 1, episode: 1 },
+      providerId: "videasy",
+      startedAtMs: 1000,
+      positionSeconds: 16,
+      durationSeconds: 8220,
+      paused: true,
+    };
+
+    const payload = buildDiscordActivity(activity, "full");
+
+    expect(String(payload.state)).not.toContain("kunai://");
+    expect(String(payload.state)).not.toContain("cat=tmdb");
+    expect(String(payload.state)).toContain("Paused at");
+    // Still exposed for anything reading the payload, and as a real button.
+    expect(payload.playable_ref).toContain("kunai://play?");
+    expect(payload.buttons).toEqual([
+      { label: "Play on Kunai", url: buildPlayableWebUrlForActivity(activity, "full") as string },
+      {
+        label: "View on TMDB",
+        url: "https://www.themoviedb.org/movie/969681",
+      },
+    ]);
+  });
+
   test("adds catalog buttons when ids are known", () => {
     const activity = {
       mode: "series" as const,

--- a/packages/providers/src/youtube/subtitle-language.ts
+++ b/packages/providers/src/youtube/subtitle-language.ts
@@ -112,8 +112,12 @@ const MAX_ATTACHED_SUBTITLE_TRACKS = 25;
 
 /** Does a yt-dlp caption language tag answer to the configured language? */
 function matchesPreferredLanguage(language: string, preferred: string): boolean {
-  // yt-dlp tags look like `en`, `en-US`, `en-orig`, `eng`, `zh-Hans`.
-  const base = language.trim().toLowerCase().split(/[-_]/)[0] ?? "";
+  // yt-dlp tags look like `en`, `en-US`, `en-orig`, `eng`, `zh-Hans`, or `a.en`.
+  const normalizedTag = language.trim().toLowerCase();
+  const afterDot = normalizedTag.includes(".")
+    ? normalizedTag.slice(normalizedTag.lastIndexOf(".") + 1)
+    : normalizedTag;
+  const base = afterDot.split(/[-_]/)[0] ?? "";
   if (!base) return false;
   const normalized = normalizeSubtitleLanguage(base) ?? base;
   return normalized === preferred || base === preferred || ISO_639_2_ALIASES[preferred] === base;
@@ -146,9 +150,10 @@ export function boundYoutubeSubtitleTracks<
 
   const kept = tracks.filter(
     (track) =>
-      track.source === "manual" ||
-      isOriginalLanguageTrack(track.language) ||
-      matchesPreferredLanguage(track.language, preferred),
+      track.language.trim().toLowerCase() !== "live_chat" &&
+      (track.source === "manual" ||
+        isOriginalLanguageTrack(track.language) ||
+        matchesPreferredLanguage(track.language, preferred)),
   );
   return kept.slice(0, MAX_ATTACHED_SUBTITLE_TRACKS);
 }

--- a/packages/providers/test/youtube/subtitle-language.test.ts
+++ b/packages/providers/test/youtube/subtitle-language.test.ts
@@ -94,6 +94,26 @@ describe("boundYoutubeSubtitleTracks", () => {
     ]);
   });
 
+  test("matches yt-dlp dotted auto-caption tags to the preferred language", () => {
+    const tracks: readonly Track[] = [
+      { language: "a.en", source: "auto" },
+      { language: "a.fr", source: "auto" },
+    ];
+
+    expect(boundYoutubeSubtitleTracks(tracks, "en").map((track) => track.language)).toEqual([
+      "a.en",
+    ]);
+  });
+
+  test("drops yt-dlp live chat metadata even when it is reported as a manual subtitle", () => {
+    const tracks: readonly Track[] = [
+      { language: "en", source: "manual" },
+      { language: "live_chat", source: "manual" },
+    ];
+
+    expect(boundYoutubeSubtitleTracks(tracks, "en").map((track) => track.language)).toEqual(["en"]);
+  });
+
   test("falls back to English when no language is configured", () => {
     const tracks: readonly Track[] = [
       { language: "en", source: "auto" },


### PR DESCRIPTION
Found while smoke-testing the 0.3.0 candidate. Both are user-facing and reproducible on a stock config.

## 1. A language label could crash a resolve

```
RangeError: argument is not a language id
    at of (unknown:1:1)
```

`apps/cli/src/services/playback/PlaybackSourceInventoryProjection.ts:994`

```ts
const displayName = new Intl.DisplayNames(["en"], { type: "language" }).of(language);
```

`Intl.DisplayNames.of()` throws for anything that is not a well-formed BCP-47 tag, and the call had no guard. A **decorative label on an inventory row** therefore became an unhandled rejection while a stream was being resolved.

Values reaching it that are not well-formed, verified against the runtime:

| Value | `Intl.DisplayNames.of()` | Where it comes from |
| --- | --- | --- |
| `a.en` | **RangeError** | YouTube auto-generated captions |
| `none` | **RangeError** | **`DEFAULT_CONFIG.seriesLanguageProfile.subtitle`** |
| `auto` | **RangeError** | language profiles |
| `live_chat` | **RangeError** | YouTube track type |
| `en_US` | **RangeError** | underscore separator |

`none` is the one that matters most — Kunai ships it as the default series subtitle preference, so this was reachable without any unusual input.

### The pattern already existed, twice

There are three `Intl.DisplayNames.of()` call sites. `domain/playback/track-capabilities.ts:191` and `packages/providers/src/catalogs/videasy.ts:9` **both already wrap it in try/catch**. This was the only one that did not. The fix makes it consistent rather than inventing anything.

Labels now come from progressively less specific candidates, so precision is kept where the tag is valid:

```
a.en       -> English            (was: crash)
none       -> NONE               (was: crash)
auto       -> AUTO               (was: crash)
live_chat  -> LIVE_CHAT          (was: crash)
en_US      -> English            (was: crash)
en-US      -> American English   (unchanged)
es-419     -> Latin American Spanish (unchanged)
jpn        -> Japanese           (unchanged)
```

Verified by driving the real projection, not the private helper.

## 2. The Discord state row carried the encoded ref

The row rendered as:

```
Paused at 0:16 / 2:17:00 · kunai://play?cat=tmdb%3A969681&kind=movie&s=1&e=1&src=vMan%3A%20Brand%20New%20Day
```

Discord truncates that row, so the ref cut off mid-query — note the mangled `src=vMan%3A…` — and crowded out the progress it sat beside.

The ref was appended there from when it could not be a button, which is no longer true: #251 gave it a real **Play on Kunai** button. It stays in `playable_ref` for anything reading the payload; only the visible text is cleaned up.

## Tests

Both fixes are pinned, and the crash test is a genuine reproduction — I verified it **fails against the old implementation** with the exact `RangeError`, and passes with the fix:

```
old implementation:  11 pass, 1 fail   (RangeError: argument is not a language id)
with the fix:        12 pass, 0 fail
```

Coverage added: malformed tags produce rows instead of aborting the projection; a dotted auto-caption code resolves to the real language name; an unmappable tag degrades to the raw value; well-formed tags keep their specific names; and the Discord state row contains no `kunai://` while `playable_ref` and both buttons remain.

## Verification

Cold, `--force`, no turbo cache:

| Gate | Result |
| --- | --- |
| `typecheck --force` | 14/14, 0 cached |
| `test --force` | 23/23, **0 fail**, 0 cached — 6,276 tests |
| `lint` / `fmt` | 0 warnings, 0 errors |

## Scope note

Neither bug came from the four PRs merged today — the crash arrived with `1dcfebef feat(playback): project provider inventory for UI`, and the state-row append predates the presence button. Both are release-relevant: the changeset is a `patch` so they fold into 0.3.0.

**Still open:** a separate report that anime search is misbehaving. I could not reproduce it — AllAnime search returns a Frieren catalog and the AniList API answers 200 — so it is deliberately **not** included here rather than bundled as a guess.
