### PR TITLE
fix(anidb): route a season request to a show's final season

### DIFF
--- a/.changeset/quiet-swans-route.md
+++ b/.changeset/quiet-swans-route.md
@@ -1,0 +1,26 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Route an AniDB season request to a show's final season instead of failing.
+
+### Fixes
+
+- AniDB models each season as its own title, and names a show's last run "Final
+  Season" rather than "Season N". The router filtered candidates on an exact
+  `seasonNumber` match, so every candidate was discarded and Attack on Titan
+  season 4 could not be routed at all, while seasons 2 and 3 resolved normally.
+
+### Behavior
+
+- The ordinal is derived from the sibling set rather than the words: a final
+  season is the run after the highest numbered season the show actually has.
+  Attack on Titan carries Season 2 and Season 3, so its Final Season is season
+  4 — and a request for season 6 still resolves to nothing.
+- Sub-parts of a final run are not the run itself. AniDB splits Attack on Titan
+  across "Final Season", "Final Season Part 2" and "Final Season - The Final
+  Chapters"; only the season itself is a routing target.
+- Shows whose sequels are named after story arcs keep failing closed. Demon
+  Slayer carries no numbered sibling, and AniDB, AniList and TMDB disagree about
+  which arc is season 2, so there is no evidence to route on and playing the
+  wrong arc is worse than not resolving.

--- a/.docs/provider-dossiers/anidb-runtime-contract.md
+++ b/.docs/provider-dossiers/anidb-runtime-contract.md
@@ -93,6 +93,9 @@ AniDB models each season as its own title, so `routeAnidbSeason()` in
 - Season 2+ searches `<normalized base> Season N` and requires both a matching parsed season and
   exact/prefix normalized base-title evidence. An ambiguous best score fails closed with a
   structured `not-found` rather than resolving the wrong title.
+- If no numbered sibling matches, a standalone `Final Season` may route to the ordinal immediately
+  after the show's highest explicitly numbered sibling. Movie cards, final-season parts, and
+  prefixed spin-off seasons provide no ordinal evidence; ambiguous or arc-named runs fail closed.
 - `absoluteEpisode` survives CLI adaptation but is consumed **only** when the routed title's own
   resolved AniDB episode catalog contains that exact episode number. A missing season label is not
   evidence. A season-specific title, an unconfirmed base, and every routed season sibling use the

--- a/packages/providers/src/anidb/season-routing.ts
+++ b/packages/providers/src/anidb/season-routing.ts
@@ -218,8 +218,8 @@ async function routeFinalSeason(input: {
   const normalizedBase = input.baseEvidence.normalizedBaseTitle;
   // The numbered siblings are what carry the ordinal, and a `Season N` query
   // does not return them — the base title has to be asked for directly.
-  const siblings = (await input.search(normalizedBase, input.signal)).filter((candidate) =>
-    relatesToBase(candidate, normalizedBase),
+  const siblings = (await input.search(normalizedBase, input.signal)).filter(
+    (candidate) => candidate.kind !== "movie" && relatesToBase(candidate, normalizedBase),
   );
 
   const finals = siblings.filter((candidate) => {
@@ -234,10 +234,12 @@ async function routeFinalSeason(input: {
   if (!finalSeason) return null;
 
   // The base itself is season one, so it is the floor for the highest season.
-  const highestNumberedSeason = siblings.reduce(
-    (highest, candidate) => Math.max(highest, candidate.seasonEvidence.seasonNumber ?? 0),
-    1,
-  );
+  const highestNumberedSeason = siblings.reduce((highest, candidate) => {
+    // A prefixed spin-off is related enough to consider as search noise, but
+    // its own season ordinal is not evidence about the requested show.
+    if (candidate.seasonEvidence.normalizedBaseTitle !== normalizedBase) return highest;
+    return Math.max(highest, candidate.seasonEvidence.seasonNumber ?? 0);
+  }, 1);
   if (highestNumberedSeason + 1 !== input.requestedSeason) return null;
 
   return {

--- a/packages/providers/src/anidb/season-routing.ts
+++ b/packages/providers/src/anidb/season-routing.ts
@@ -140,7 +140,17 @@ export async function routeAnidbSeason(input: {
     );
 
   const selected = candidates[0];
-  if (!selected) return null;
+  if (!selected) {
+    return routeFinalSeason({
+      base: input.base,
+      baseEvidence,
+      requestedSeason,
+      courEpisode,
+      absoluteEpisode,
+      search: input.search,
+      signal: input.signal,
+    });
+  }
   // A tie means we cannot tell which sibling was asked for. Fail closed.
   if (candidates[1]?.score === selected.score) return null;
 
@@ -161,6 +171,94 @@ export async function routeAnidbSeason(input: {
       matchedTitle: selected.candidate.title,
       matchedSeason: requestedSeason,
       titleMatch: selected.titleMatch,
+    },
+  };
+}
+
+/** Whether a sibling's own base title is the requested show rather than a spin-off. */
+function relatesToBase(candidate: AnidbSearchResult, normalizedBase: string): boolean {
+  const normalized = candidate.seasonEvidence.normalizedBaseTitle;
+  return normalized === normalizedBase || normalized.startsWith(`${normalizedBase} `);
+}
+
+/**
+ * What a show calls its last run, once its own base title is removed.
+ *
+ * Only the season itself qualifies. AniDB splits Attack on Titan's final run
+ * into "Final Season", "Final Season Part 2" and "Final Season - The Final
+ * Chapters"; all three say "final season", but the latter two are sub-parts of
+ * it, and matching them would make the set ambiguous and fail closed.
+ */
+const FINAL_SEASON_REMAINDERS = new Set(["final season", "the final season"]);
+
+/**
+ * Route a request that no numbered sibling can satisfy, for shows AniDB names
+ * "Final Season" instead of "Season N".
+ *
+ * The ordinal is never inferred from the words — "final" says nothing about
+ * which season it is. It is derived from the sibling set: the run after the
+ * highest numbered season the show actually has. Attack on Titan carries
+ * Season 2 and Season 3, so its Final Season is season 4, and a request for
+ * season 4 routes there while a request for season 6 does not.
+ *
+ * Everything else fails closed, deliberately. Demon Slayer names every sequel
+ * after a story arc and has no numbered sibling at all, and AniDB, AniList and
+ * TMDB disagree about which arc is "season 2" — so there is no evidence to
+ * route on, and playing the wrong arc is worse than not resolving.
+ */
+async function routeFinalSeason(input: {
+  readonly base: AnidbSearchResult;
+  readonly baseEvidence: AnidbSearchResult["seasonEvidence"];
+  readonly requestedSeason: number;
+  readonly courEpisode: number;
+  readonly absoluteEpisode: number | null;
+  readonly search: (query: string, signal?: AbortSignal) => Promise<readonly AnidbSearchResult[]>;
+  readonly signal?: AbortSignal;
+}): Promise<AnidbSeasonRoute | null> {
+  const normalizedBase = input.baseEvidence.normalizedBaseTitle;
+  // The numbered siblings are what carry the ordinal, and a `Season N` query
+  // does not return them — the base title has to be asked for directly.
+  const siblings = (await input.search(normalizedBase, input.signal)).filter((candidate) =>
+    relatesToBase(candidate, normalizedBase),
+  );
+
+  const finals = siblings.filter((candidate) => {
+    if (candidate.seasonEvidence.seasonNumber !== null) return false;
+    const remainder = candidate.seasonEvidence.normalizedBaseTitle
+      .slice(normalizedBase.length)
+      .trim();
+    return FINAL_SEASON_REMAINDERS.has(remainder);
+  });
+  // Two unnumbered "final" siblings cannot be told apart. Fail closed.
+  const finalSeason = finals.length === 1 ? finals[0] : undefined;
+  if (!finalSeason) return null;
+
+  // The base itself is season one, so it is the floor for the highest season.
+  const highestNumberedSeason = siblings.reduce(
+    (highest, candidate) => Math.max(highest, candidate.seasonEvidence.seasonNumber ?? 0),
+    1,
+  );
+  if (highestNumberedSeason + 1 !== input.requestedSeason) return null;
+
+  return {
+    requestedSeason: input.requestedSeason,
+    baseShowId: input.base.id,
+    routedShowId: finalSeason.id,
+    episodeNumber: input.courEpisode,
+    usedAbsoluteEpisode: false,
+    numberingEvidence: {
+      kind: "cour",
+      reason: "routed-season-sibling",
+      ...(input.absoluteEpisode !== null
+        ? { requestedAbsoluteEpisode: input.absoluteEpisode }
+        : {}),
+    },
+    evidence: {
+      kind: "season-search",
+      query: normalizedBase,
+      matchedTitle: finalSeason.title,
+      matchedSeason: input.requestedSeason,
+      titleMatch: "prefix",
     },
   };
 }

--- a/packages/providers/test/anidb-season-routing.test.ts
+++ b/packages/providers/test/anidb-season-routing.test.ts
@@ -150,3 +150,159 @@ describe("routeAnidbSeason", () => {
     expect(route).toBeNull();
   });
 });
+
+/**
+ * AniDB names a show's last run "Final Season" instead of "Season N", so the
+ * strict `seasonNumber === requestedSeason` filter dropped every candidate and
+ * Attack on Titan season 4 could not be routed at all.
+ *
+ * The ordinal is not guessed from the words: it is derived from the sibling set
+ * the search already returned. Titles here are the real ones AniDB serves.
+ */
+describe("final-season routing", () => {
+  /**
+   * The exact 15 rows `searchAnidb("attack on titan")` returns. Copied from a
+   * live response on purpose: an earlier fixture listed a single "Final Season"
+   * row, which let a rule that could not survive real data pass its tests. The
+   * real set splits that run across three siblings, and the films, OVAs and
+   * spin-offs around them are what the routing has to refuse.
+   */
+  const aotSiblings = [
+    result("attack-on-titan-457", "Attack on Titan"),
+    result("attack-on-titan-the-last-attack-470", "Attack on Titan: The Last Attack"),
+    result("attack-on-titan-final-season-464", "Attack on Titan: Final Season"),
+    result("attack-on-titan-final-season-part-2-466", "Attack on Titan: Final Season Part 2"),
+    result(
+      "attack-on-titan-final-season-the-final-chapters-465",
+      "Attack on Titan: Final Season - The Final Chapters",
+    ),
+    result("attack-on-titan-oad-458", "Attack on Titan OAD"),
+    result("attack-on-titan-junior-high-467", "Attack on Titan: Junior High"),
+    result("attack-on-titan-chronicle-462", "Attack on Titan: Chronicle"),
+    result("attack-on-titan-season-2-459", "Attack on Titan Season 2"),
+    result("attack-on-titan-season-3-460", "Attack on Titan Season 3"),
+    result("attack-on-titan-season-3-part-2-461", "Attack on Titan Season 3 Part 2"),
+    result("attack-on-titan-no-regrets-469", "Attack on Titan: No Regrets"),
+    result("attack-on-titan-lost-girls-468", "Attack on Titan: Lost Girls"),
+    result("attack-on-titan-crimson-bow-and-arrow-463", "Attack on Titan: Crimson Bow and Arrow"),
+    result("attack-on-titan-wings-of-freedom-471", "Attack on Titan: Wings of Freedom"),
+  ];
+
+  test("routes a final season to the ordinal after the highest numbered sibling", async () => {
+    const route = await routeAnidbSeason({
+      base: result("attack-on-titan-457", "Attack on Titan"),
+      episode: { season: 4, episode: 1 },
+      search: async () => aotSiblings,
+      episodes: noEpisodes,
+    });
+
+    expect(route?.routedShowId).toBe("attack-on-titan-final-season-464");
+    expect(route?.requestedSeason).toBe(4);
+    expect(route?.episodeNumber).toBe(1);
+  });
+
+  test("still routes explicitly numbered seasons ahead of the final season", async () => {
+    const route = await routeAnidbSeason({
+      base: result("attack-on-titan-457", "Attack on Titan"),
+      episode: { season: 3, episode: 2 },
+      search: async () => aotSiblings,
+      episodes: noEpisodes,
+    });
+
+    expect(route?.routedShowId).toBe("attack-on-titan-season-3-460");
+  });
+
+  /**
+   * Demon Slayer names every sequel after a story arc and carries no numbered
+   * sibling at all. There is no evidence for which arc is "season 2" — AniDB,
+   * AniList, and TMDB disagree — so this must keep failing closed rather than
+   * route the user to the wrong show.
+   */
+  test("refuses to guess a season when siblings are arc-named", async () => {
+    const demonSlayer = [
+      result("demon-slayer-kimetsu-no-yaiba-1217", "Demon Slayer: Kimetsu no Yaiba"),
+      result(
+        "demon-slayer-kimetsu-no-yaiba-entertainment-district-arc-1222",
+        "Demon Slayer: Kimetsu no Yaiba Entertainment District Arc",
+      ),
+      result(
+        "demon-slayer-kimetsu-no-yaiba-mugen-train-arc-1219",
+        "Demon Slayer: Kimetsu no Yaiba Mugen Train Arc",
+      ),
+    ];
+
+    const route = await routeAnidbSeason({
+      base: result("demon-slayer-kimetsu-no-yaiba-1217", "Demon Slayer: Kimetsu no Yaiba"),
+      episode: { season: 2, episode: 1 },
+      search: async () => demonSlayer,
+      episodes: noEpisodes,
+    });
+
+    expect(route).toBeNull();
+  });
+
+  test("refuses a final season that does not sit at the requested ordinal", async () => {
+    const route = await routeAnidbSeason({
+      base: result("attack-on-titan-457", "Attack on Titan"),
+      episode: { season: 6, episode: 1 },
+      search: async () => aotSiblings,
+      episodes: noEpisodes,
+    });
+
+    expect(route).toBeNull();
+  });
+
+  test("refuses when more than one unnumbered final-season sibling exists", async () => {
+    const ambiguous = [
+      result("show-1", "Show"),
+      result("show-season-2-2", "Show Season 2"),
+      result("show-final-season-3", "Show: Final Season"),
+      result("show-the-final-season-4", "Show: The Final Season"),
+    ];
+
+    const route = await routeAnidbSeason({
+      base: result("show-1", "Show"),
+      episode: { season: 3, episode: 1 },
+      search: async () => ambiguous,
+      episodes: noEpisodes,
+    });
+
+    expect(route).toBeNull();
+  });
+
+  /**
+   * The sub-parts of a final season are not the season. All three of Attack on
+   * Titan's final-run siblings say "final season"; treating them as equals made
+   * the set ambiguous and refused a request that has one correct answer.
+   */
+  test("picks the final season itself over its parts and chapters", async () => {
+    const queries: string[] = [];
+    const route = await routeAnidbSeason({
+      base: result("attack-on-titan-457", "Attack on Titan"),
+      episode: { season: 4, episode: 3 },
+      search: async (query) => {
+        queries.push(query);
+        return aotSiblings;
+      },
+      episodes: noEpisodes,
+    });
+
+    expect(route?.routedShowId).toBe("attack-on-titan-final-season-464");
+    expect(route?.episodeNumber).toBe(3);
+    // The numbered siblings carry the ordinal, and a `Season N` query does not
+    // return them, so the base title must be asked for directly.
+    expect(queries).toContain("attack on titan");
+  });
+
+  test("never routes a season request to a film, OVA, or spin-off", async () => {
+    for (const season of [5, 7]) {
+      const route = await routeAnidbSeason({
+        base: result("attack-on-titan-457", "Attack on Titan"),
+        episode: { season, episode: 1 },
+        search: async () => aotSiblings,
+        episodes: noEpisodes,
+      });
+      expect(route).toBeNull();
+    }
+  });
+});

--- a/packages/providers/test/anidb-season-routing.test.ts
+++ b/packages/providers/test/anidb-season-routing.test.ts
@@ -4,9 +4,15 @@ import type { AnidbEpisodeEntry } from "../src/anidb/client";
 import { parseAnidbSeasonEvidence, type AnidbSearchResult } from "../src/anidb/direct";
 import { routeAnidbSeason } from "../src/anidb/season-routing";
 
-function result(id: string, title: string): AnidbSearchResult {
+function result(id: string, title: string, kind?: "movie"): AnidbSearchResult {
   const numericId = Number(id.match(/-(\d+)$/)?.[1]);
-  return { id, title, numericId, seasonEvidence: parseAnidbSeasonEvidence(title) };
+  return {
+    id,
+    title,
+    numericId,
+    ...(kind ? { kind } : {}),
+    seasonEvidence: parseAnidbSeasonEvidence(title),
+  };
 }
 
 const noEpisodes = async (): Promise<readonly AnidbEpisodeEntry[]> => [];
@@ -268,6 +274,39 @@ describe("final-season routing", () => {
     });
 
     expect(route).toBeNull();
+  });
+
+  test("never treats a movie named Final Season as the requested season", async () => {
+    const route = await routeAnidbSeason({
+      base: result("show-1", "Show"),
+      episode: { season: 4, episode: 1 },
+      search: async () => [
+        result("show-1", "Show"),
+        result("show-season-2-2", "Show Season 2"),
+        result("show-season-3-3", "Show Season 3"),
+        result("show-final-season-4", "Show: Final Season", "movie"),
+      ],
+      episodes: noEpisodes,
+    });
+
+    expect(route).toBeNull();
+  });
+
+  test("does not let a spin-off season inflate the final-season ordinal", async () => {
+    const route = await routeAnidbSeason({
+      base: result("show-1", "Show"),
+      episode: { season: 4, episode: 1 },
+      search: async () => [
+        result("show-1", "Show"),
+        result("show-season-2-2", "Show Season 2"),
+        result("show-season-3-3", "Show Season 3"),
+        result("show-final-season-4", "Show: Final Season"),
+        result("show-junior-high-season-9-9", "Show Junior High Season 9"),
+      ],
+      episodes: noEpisodes,
+    });
+
+    expect(route?.routedShowId).toBe("show-final-season-4");
   });
 
   /**


### PR DESCRIPTION
## The bug

AniDB models each season as its own title, and names a show's last run **"Final Season"** rather than "Season N". `routeAnidbSeason` filtered candidates on an exact `seasonNumber` match, so for such a show every candidate was discarded and the request resolved to nothing.

Measured against live AniDB, before this change:

| Request | Routed to |
| --- | --- |
| Attack on Titan S2 | `attack-on-titan-season-2-459` |
| Attack on Titan S3 | `attack-on-titan-season-3-460` |
| **Attack on Titan S4** | **nothing** |

## The fix

The ordinal is **not** read from the words — "final" says nothing about which season it is. It is derived from the sibling set the search already returns: the run after the highest numbered season the show actually has. Attack on Titan carries Season 2 and Season 3, so its Final Season is season 4.

**Sub-parts of that run are not the run itself.** AniDB splits Attack on Titan's final run across three siblings:

```
Attack on Titan: Final Season
Attack on Titan: Final Season Part 2
Attack on Titan: Final Season - The Final Chapters
```

All three say "final season". Only the first is a routing target.

## A ghost update this nearly shipped as

The first cut of this fix **passed its tests and did not work.** The fixture listed a single "Final Season" row, so a rule requiring exactly one such sibling looked correct. Against live AniDB it matched three, went ambiguous, and failed closed — the exact bug it was meant to fix, still broken, behind a green suite.

The fixture is now the **exact 15 rows** `searchAnidb("attack on titan")` returns, films, OVAs and spin-offs included, and there is a test asserting the base title is queried directly — a `Season N` query does not return the numbered siblings the ordinal is derived from.

## Verified against live AniDB, not just fixtures

```
Attack on Titan S2                 -> attack-on-titan-season-2-459        OK
Attack on Titan S3                 -> attack-on-titan-season-3-460        OK
Attack on Titan S4                 -> attack-on-titan-final-season-464    OK   ← was NULL
Attack on Titan S6                 -> NULL                                OK
Demon Slayer Kimetsu no Yaiba S2   -> NULL                                OK
Jujutsu Kaisen S2                  -> jujutsu-kaisen-season-2-2554        OK
```

## What deliberately still fails

**Shows whose sequels are named after story arcs.** Demon Slayer carries no numbered sibling at all:

```
Demon Slayer: Kimetsu no Yaiba
  … Mugen Train Arc          … Entertainment District Arc
  … Swordsmith Village Arc   … Hashira Training Arc
```

There is no textual rule mapping "Entertainment District Arc" to season 2, and AniDB, AniList and TMDB genuinely disagree about that numbering. Ranking arcs by keyword or broadcast order would route the viewer to the **wrong episode of the right show**, which is the failure this module's own docstring calls worse than not resolving. Closing that gap needs a catalog-to-title mapping, not a text heuristic — worth its own issue.

## Verification

| Gate | Result |
| --- | --- |
| `typecheck --force` | 14/14, 0 cached |
| `test --force` | 23/23, **0 fail**, 0 cached |
| `lint` / `fmt` | 0 warnings, 0 errors |

13 routing tests, including the four fail-closed cases: arc-named siblings, an out-of-range ordinal, two equivalent final-season names, and never routing a season to a film, OVA, or spin-off.

## Provenance

Found while triaging an agent-produced audit. Of its five reported issues, this is the one that survived verification — the other four were refuted, and two of the proposed fixes would have caused regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AniDB routing for uniquely identified “Final Season” entries when numbered seasons are unavailable.
  * Derives the next season number from existing numbered seasons.
  * Excludes final-season parts, chapters, films, OVAs, and spin-offs from season matching.
  * Prevents incorrect matches for ambiguous, misnumbered, or arc-named sequel entries.
  * Maintains accurate routing for explicitly numbered seasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->