### PR TITLE
fix(setup,sync): give each lane its own language, and let a sign-in be cancelled

### DIFF
--- a/.docs/download-offline-onboarding.md
+++ b/.docs/download-offline-onboarding.md
@@ -54,8 +54,8 @@ accounts, usage ping, done. Implementation is
   showed. Hydrated download enablement is clamped to whether `yt-dlp` is
   actually present, the same clamp `[r]` re-probe applies.
 - **`s` applies this screen's recommendation and advances.** It resets only the
-  current screen's decision — mode to shows, language to original/en, playback to
-  all on, quality to 1080p. Standing decisions (account links, downloads
+  current screen's decision — mode to shows, every language lane to its own
+  recommendation, playback to all on, quality to 1080p. Standing decisions (account links, downloads
   enablement, presence) have no recommendation other than what the user already
   has, so `s` never flips one.
 - **`S` accepts every remaining recommendation and finishes.** On the consent
@@ -67,9 +67,15 @@ accounts, usage ping, done. Implementation is
   first screen leaves `onboardingVersion` below the onboarded floor so the next
   launch offers setup again; an abort after answering records the offer and
   touches nothing else.
-- **The language answer reaches all four lanes** — anime, series, movie, and
-  YouTube — for both audio and subtitles. Writing three of them was what made
-  screen 3 configure every lane except the one a YouTube user had just picked.
+- **Each media lane keeps its own language profile.** The language screen edits
+  one lane at a time — `1`–`4` pick Shows, Movies, Anime, or YouTube, `tab` (or
+  `←→`) switches audio/subtitles, `↑↓` chooses — and every lane is hydrated from,
+  and written back to, its own `*LanguageProfile`. Two earlier shapes were both
+  wrong: writing anime only left films and shows on original audio for a user who
+  picked English and skipped YouTube entirely (#229); writing one answer to all
+  four then flattened per-lane values that `/settings` → Language lets you set
+  independently, so a rerun silently discarded them. Fields the screen does not
+  ask about — `quality` — are preserved per lane.
 - **Analytics is keystroke-gated.** Consent is recorded when the user presses a
   key on the consent screen, never when they arrive on it. Arriving and stepping
   back leaves the value `unchanged`, which is neither an opt-in nor an opt-out.
@@ -79,6 +85,16 @@ accounts, usage ping, done. Implementation is
   standing "yes" in config always has a token behind it. An already-connected
   adapter short-circuits rather than opening a second browser round-trip, and no
   abort path connects anything.
+- **A link attempt is a screen you can leave.** Approval happens in a browser and
+  can take as long as the user takes, so the wait is an owned surface
+  (`apps/cli/src/app-shell/tracker-connect-shell.tsx`) that reports progress,
+  takes `esc`/`q` to cancel, and offers `r` to retry a failure. The abort reaches
+  the adapter through a real `AbortSignal`: the call previously passed
+  `new AbortController().signal` — a signal from a controller nobody held, so
+  cancelling was impossible and the wizard sat on an unresponsive screen until
+  the tracker's own deadline expired. A cancelled attempt leaves sync disabled
+  and says nothing further; only a genuine failure suggests
+  `/sync-connect-<tracker>`.
 - **One restore point per setup run.** Before a completing run writes, the
   current config is copied to `config.json.pre-setup.bak` — but only when the
   patch actually changes a field the user would miss (`RESTORABLE_SETUP_FIELDS`

--- a/.plans/2026-08-27-release-setup-and-oauth-hardening.md
+++ b/.plans/2026-08-27-release-setup-and-oauth-hardening.md
@@ -1,0 +1,48 @@
+# Release setup and OAuth hardening
+
+**Status:** IN PROGRESS
+
+**Goal:** Make the first-run wizard truthful and recoverable before 0.3.0: each
+media lane keeps its own language profile, recommendations are visible and
+safe, and account linking has visible progress, cancellation, retry, and no
+fire-and-forget work.
+
+## Contract
+
+- Hydrate and persist separate Shows, Movies, Anime, and YouTube audio/subtitle
+  profiles. Rerunning setup must not flatten existing per-lane choices.
+- On the language screen, `1`-`4` switch the active media lane, `Tab` switches
+  audio/subtitles, arrows choose, and `Enter` advances. The selected lane and
+  values remain visible.
+- Show both `s` (recommend this screen) and `S` (safe remaining defaults).
+  Neither shortcut may enable analytics, accounts, downloads, or presence.
+- Keep playback recommendations explicit: auto-next, intro skip, and credits
+  skip default on, remain independently toggleable, and appear in the done
+  summary.
+- Account linking stays in an owned UI state until it succeeds, fails, or the
+  user cancels with `Esc`/`q`. A cancelled or failed attempt leaves sync
+  disabled and offers a retry path.
+- Preserve the explicit analytics-keystroke contract and all existing setup
+  abort/restore-point behavior.
+
+## Implementation sequence
+
+1. Add state/write-map regressions for independent language profiles, safe
+   recommendations, and the done summary.
+2. Replace the single language pair in setup state with a four-lane profile
+   model; update hydration, reducers/input handling, rendering, and persistence.
+3. Add a cancellable tracker-connect workflow result and an owned setup linking
+   surface; cover success, failure, cancellation, and already-connected paths.
+4. Update `.docs/download-offline-onboarding.md`, `.docs/tracker-sync.md`, and
+   setup captures/keybinding tests to match the shipped interaction.
+5. Run targeted tests, setup captures, forced typecheck/lint, formatting, docs
+   path verification, full tests, build, and an isolated real-terminal setup
+   walkthrough.
+
+## Release gate
+
+The PR is mergeable only when declaration-reader seams are explicit: each
+profile field has a playback reader, account enablement follows a successful
+token connection, every opt-in has a visible off/cancel state, and Linux,
+macOS, and Windows CI are green. Analytics remains off unless its dedicated
+consent screen receives the explicit enable keystroke.

--- a/.plans/roadmap.md
+++ b/.plans/roadmap.md
@@ -54,14 +54,14 @@ archive and put only the residue here.
 
 ### Offline and release stability
 
-| Track                        | Remaining                                                                                    | Plan                                                                                                           |
-| ---------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| 0.3.0 merge train            | Merge order, chain-A publication, regression watch                                           | [2026-08-24-0-3-0-merge-train.md](./2026-08-24-0-3-0-merge-train.md)                                           |
-| Provider-independent offline | Keep downloads playable after provider retirement                                            | [offline-provider-independent-playback.md](./offline-provider-independent-playback.md)                         |
-| Offline artwork cache        | Library previews                                                                             | [offline-artwork-cache-and-library-previews.md](./offline-artwork-cache-and-library-previews.md)               |
-| Boundary + downloads         | Reviewed adaptive-download design, not started                                               | [boundary-hardening-and-adaptive-downloads.md](./boundary-hardening-and-adaptive-downloads.md)                 |
-| Poster release smokes        | Real-terminal Kitty, iTerm2, Sixel, and multiplexer pass                                     | [poster-protocol-release-smokes.md](./poster-protocol-release-smokes.md)                                       |
-| Setup wizard testing residue | Core landed in #235; residue is real-terminal `esc`-in-PTY and the restore-point walkthrough | [../.archive/plans/2026-08-25-setup-wizard-redesign.md](../.archive/plans/2026-08-25-setup-wizard-redesign.md) |
+| Track                          | Remaining                                                                                            | Plan                                                                                                 |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| 0.3.0 merge train              | Merge order, chain-A publication, regression watch                                                   | [2026-08-24-0-3-0-merge-train.md](./2026-08-24-0-3-0-merge-train.md)                                 |
+| Provider-independent offline   | Keep downloads playable after provider retirement                                                    | [offline-provider-independent-playback.md](./offline-provider-independent-playback.md)               |
+| Offline artwork cache          | Library previews                                                                                     | [offline-artwork-cache-and-library-previews.md](./offline-artwork-cache-and-library-previews.md)     |
+| Boundary + downloads           | Reviewed adaptive-download design, not started                                                       | [boundary-hardening-and-adaptive-downloads.md](./boundary-hardening-and-adaptive-downloads.md)       |
+| Poster release smokes          | Real-terminal Kitty, iTerm2, Sixel, and multiplexer pass                                             | [poster-protocol-release-smokes.md](./poster-protocol-release-smokes.md)                             |
+| Setup wizard release hardening | Independent media language profiles, cancellable OAuth, then real-terminal restore-point walkthrough | [2026-08-27-release-setup-and-oauth-hardening.md](./2026-08-27-release-setup-and-oauth-hardening.md) |
 
 ### Analytics
 

--- a/apps/cli/src/app-shell/settings/SettingsShell.tsx
+++ b/apps/cli/src/app-shell/settings/SettingsShell.tsx
@@ -1,6 +1,6 @@
 import type { Container } from "@/container";
 import { useInput } from "ink";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { buildSettingsPage } from "./build-page";
 import { SettingsFooter } from "./components/SettingsFooter";
@@ -37,6 +37,7 @@ export function SettingsShell({
   readonly onStatus: (message: string | null) => void;
   readonly onRedraw: () => void;
 }) {
+  const actionAbortRef = useRef<AbortController | null>(null);
   const [state, setState] = useState<SettingsUiState>(() => {
     const base = createSettingsUiState(container.config.getRaw());
     const ctx = buildSettingsRegistryContext(container, base.draft);
@@ -86,11 +87,16 @@ export function SettingsShell({
     async (actionId: string) => {
       const def = page.defById.get(actionId);
       if (!def || def.kind !== "action") {
-        setState((current) => ({ ...current, busy: false }));
+        setState((current) => ({ ...current, busy: false, activeActionId: null }));
         return;
       }
+      const controller = new AbortController();
+      actionAbortRef.current = controller;
       try {
-        const message = await def.run(registryCtx);
+        const message = await def.run(registryCtx, {
+          signal: controller.signal,
+          onStatus,
+        });
         if (message) onStatus(message);
         // An action's message is its result, not a failure. Storing it in
         // `error` is what painted "Connected to AniList as @you." in red.
@@ -98,15 +104,29 @@ export function SettingsShell({
           ...current,
           draft: container.config.getRaw(),
           busy: false,
+          activeActionId: null,
           error: null,
           revision: current.revision + 1,
         }));
       } catch (error) {
+        if (controller.signal.aborted) {
+          onStatus("Action cancelled.");
+          setState((current) => ({
+            ...current,
+            busy: false,
+            activeActionId: null,
+            error: null,
+          }));
+          return;
+        }
         setState((current) => ({
           ...current,
           busy: false,
+          activeActionId: null,
           error: `Action failed: ${String(error)}`,
         }));
+      } finally {
+        if (actionAbortRef.current === controller) actionAbortRef.current = null;
       }
     },
     [container, onStatus, page.defById, registryCtx],
@@ -121,9 +141,20 @@ export function SettingsShell({
     return () => clearTimeout(timer);
   }, [state.draft, container]);
 
+  useEffect(() => () => actionAbortRef.current?.abort(), []);
+
   useInput(
     (input, key) => {
       if (commandMode) return;
+      if (state.busy && (key.escape || input.toLowerCase() === "q")) {
+        const activeDef = state.activeActionId ? page.defById.get(state.activeActionId) : null;
+        if (activeDef?.kind === "action" && activeDef.cancellable) {
+          actionAbortRef.current?.abort();
+          onStatus("Cancelling…");
+          onRedraw();
+        }
+        return;
+      }
       const result = handleSettingsKey(input, key, state, { container, registryCtx });
       if (!result.handled) return;
 

--- a/apps/cli/src/app-shell/settings/components/SettingsFooter.tsx
+++ b/apps/cli/src/app-shell/settings/components/SettingsFooter.tsx
@@ -13,8 +13,9 @@ export const SettingsFooter = React.memo(function SettingsFooter({
   readonly mode: "main" | "submenu" | "input";
 }) {
   const dirty = !settingsEqual(state.draft, state.snapshot);
-  const hints =
-    mode === "input"
+  const hints = state.busy
+    ? "Working… · Esc cancel"
+    : mode === "input"
       ? "Enter save · Esc cancel · Ctrl+U clear"
       : mode === "submenu"
         ? "Enter pick · [ ] reorder · Esc back"

--- a/apps/cli/src/app-shell/settings/controller.ts
+++ b/apps/cli/src/app-shell/settings/controller.ts
@@ -427,7 +427,7 @@ export function handleSettingsKey(
       if (state.busy) return { handled: true, state };
       return {
         handled: true,
-        state: { ...state, busy: true, error: null },
+        state: { ...state, busy: true, activeActionId: def.id, error: null },
         runActionId: def.id,
       };
     }

--- a/apps/cli/src/app-shell/settings/registry/sync.ts
+++ b/apps/cli/src/app-shell/settings/registry/sync.ts
@@ -2,6 +2,7 @@ import { describePauseState, pauseUntil, resolvePauseState } from "@/services/sy
 import type { SyncAdapter } from "@/services/sync/SyncAdapter";
 import type { ConnectionState, TrackerId } from "@/services/sync/types";
 
+import { connectNamedTracker } from "../../workflows/tracker-connect";
 import type { SettingRowDef, SettingsRegistryContext } from "../types";
 
 /**
@@ -79,32 +80,28 @@ function trackerRows(ctx: SettingsRegistryContext, adapter: SyncAdapter): Settin
           ? "Sign out locally. Your history and queued changes are kept."
           : "Opens your browser to approve. Nothing to configure.",
       ...(connected ? { tone: "danger" as const } : {}),
-      run: async (context) => {
+      cancellable: true,
+      run: async (context, options) => {
         const service = context.container.syncService;
         const target = service.adapters.find((candidate) => candidate.id === tracker);
         if (!target) return `${adapter.displayName} is not available.`;
+        // A caller that predates the cancellable contract still gets a real
+        // signal object; nothing aborts it, which is the old behaviour.
+        const fallbackController = new AbortController();
+        const signal = options?.signal ?? fallbackController.signal;
 
         if (target.getConnection().state === "connected") {
-          await target.disconnect({ signal: new AbortController().signal });
+          await target.disconnect({ signal });
           return `Disconnected ${adapter.displayName}.`;
         }
 
-        // TMDB's flow has an out-of-band step and says so through `onPrompt`.
-        // Dropping it on the floor is why Connect TMDB looked like it did
-        // nothing: the browser opened and nothing on screen explained the wait.
-        const result = await target.connect({
-          signal: new AbortController().signal,
-          onPrompt: (note) =>
-            context.container.stateManager.dispatch({
-              type: "SET_PLAYBACK_FEEDBACK",
-              note,
-            }),
+        const outcome = await connectNamedTracker(context.container, tracker, {
+          signal,
+          onPrompt: (message) => options?.onStatus(message),
         });
-        if (!result.ok) return `${adapter.displayName}: ${result.error}`;
-
-        // Reconnecting is only finished when the work it was blocking moves.
-        const resumed = service.resumeAfterReauth(tracker);
-        if (resumed > 0) await service.drain();
+        if (outcome.status === "cancelled") return `${adapter.displayName} connection cancelled.`;
+        if (outcome.status === "failed") return `${adapter.displayName}: ${outcome.error}`;
+        if (outcome.status === "unavailable") return `${adapter.displayName} is not available.`;
         const now = target.getConnection();
         const who = now.state === "connected" && now.username ? ` as @${now.username}` : "";
         return `Connected to ${adapter.displayName}${who}.`;

--- a/apps/cli/src/app-shell/settings/state.ts
+++ b/apps/cli/src/app-shell/settings/state.ts
@@ -14,6 +14,7 @@ export function createSettingsUiState(snapshot: KitsuneConfig): SettingsUiState 
     selectedIndex: 0,
     error: null,
     busy: false,
+    activeActionId: null,
     revision: 0,
   };
 }

--- a/apps/cli/src/app-shell/settings/types.ts
+++ b/apps/cli/src/app-shell/settings/types.ts
@@ -39,6 +39,11 @@ export type EnumOption = {
   readonly detail?: string;
 };
 
+export type SettingActionOptions = {
+  readonly signal: AbortSignal;
+  readonly onStatus: (message: string | null) => void;
+};
+
 type SettingRowMetadata = {
   readonly configKeys?: readonly (keyof KitsuneConfig)[];
 };
@@ -119,7 +124,11 @@ export type SettingRowDef = SettingRowMetadata &
         readonly label: string;
         readonly detail?: string;
         readonly tone?: "danger";
-        readonly run: (ctx: SettingsRegistryContext) => Promise<string | void>;
+        readonly cancellable?: boolean;
+        readonly run: (
+          ctx: SettingsRegistryContext,
+          options?: SettingActionOptions,
+        ) => Promise<string | void>;
         readonly gate?: SettingGate;
       }
     | {
@@ -152,6 +161,7 @@ export type SettingsUiState = {
   readonly selectedIndex: number;
   readonly error: string | null;
   readonly busy: boolean;
+  readonly activeActionId: string | null;
   /**
    * Bumped when an action completes. Actions can change state the draft cannot
    * see — connecting a tracker moves adapter state, not config — so this is

--- a/apps/cli/src/app-shell/setup-shell.tsx
+++ b/apps/cli/src/app-shell/setup-shell.tsx
@@ -91,10 +91,27 @@ export const KUNAI_VERSION: string = packageJson.version;
  */
 export type SetupFlowResult = "completed" | "defaults" | "aborted";
 
+export type SetupLanguageLane = "series" | "movie" | "anime" | "youtube";
+export type SetupLanguageProfile = {
+  readonly audio: string;
+  readonly subtitle: string;
+};
+export type SetupLanguageProfiles = Readonly<Record<SetupLanguageLane, SetupLanguageProfile>>;
+
+export const SETUP_LANGUAGE_LANES: readonly {
+  readonly value: SetupLanguageLane;
+  readonly label: string;
+  readonly key: string;
+}[] = [
+  { value: "series", label: "Shows", key: "1" },
+  { value: "movie", label: "Movies", key: "2" },
+  { value: "anime", label: "Anime", key: "3" },
+  { value: "youtube", label: "YouTube", key: "4" },
+];
+
 export interface SetupPrefs {
   mode: "series" | "anime" | "youtube";
-  audio: string;
-  subtitle: string;
+  languageProfiles: SetupLanguageProfiles;
   autoNext: boolean;
   skipIntro: boolean;
   skipCredits: boolean;
@@ -130,8 +147,7 @@ export interface SetupPrefs {
  */
 export interface SetupInitialState {
   readonly mode: "series" | "anime" | "youtube";
-  readonly audio: string;
-  readonly subtitle: string;
+  readonly languageProfiles: SetupLanguageProfiles;
   readonly autoNext: boolean;
   readonly skipIntro: boolean;
   readonly skipCredits: boolean;
@@ -144,8 +160,7 @@ export interface SetupInitialState {
 
 export const FACTORY_INITIAL_STATE: SetupInitialState = {
   mode: "series",
-  audio: RECOMMENDED_AUDIO_PREFERENCE,
-  subtitle: RECOMMENDED_SUBTITLE_PREFERENCE,
+  languageProfiles: recommendedLanguageProfiles(),
   autoNext: true,
   skipIntro: true,
   skipCredits: true,
@@ -159,6 +174,23 @@ export const FACTORY_INITIAL_STATE: SetupInitialState = {
 /** The value `s` ("use recommended") restores on a screen, per screen kind. */
 const MODE_RECOMMENDED = "series";
 const DOWNLOAD_QUALITY_RECOMMENDED = "1080p";
+
+function recommendedLanguageProfiles(): SetupLanguageProfiles {
+  const profile = (): SetupLanguageProfile => ({
+    audio: RECOMMENDED_AUDIO_PREFERENCE,
+    subtitle: RECOMMENDED_SUBTITLE_PREFERENCE,
+  });
+  return {
+    series: profile(),
+    movie: profile(),
+    anime: profile(),
+    youtube: profile(),
+  };
+}
+
+function languageLaneForMode(mode: SetupPrefs["mode"]): SetupLanguageLane {
+  return mode;
+}
 
 /** Index of `value`, or 0 when it somehow left the list — never -1. */
 function indexOfValue(values: readonly string[], value: string): number {
@@ -219,11 +251,9 @@ export function SetupShell({
       initial.mode,
     ),
   );
-  const [audioIdx, setAudioIdx] = useState(() =>
-    recommendedIndex(AUDIO_PREFERENCE_OPTIONS, initial.audio),
-  );
-  const [subtitleIdx, setSubtitleIdx] = useState(() =>
-    recommendedIndex(SUBTITLE_PREFERENCE_OPTIONS, initial.subtitle),
+  const [languageProfiles, setLanguageProfiles] = useState(initial.languageProfiles);
+  const [languageLane, setLanguageLane] = useState<SetupLanguageLane>(() =>
+    languageLaneForMode(initial.mode),
   );
   const [langFocus, setLangFocus] = useState<"audio" | "subtitle">("audio");
   const [playbackIdx, setPlaybackIdx] = useState(0);
@@ -270,6 +300,9 @@ export function SetupShell({
   });
 
   const mode = MODE_OPTIONS[modeIdx]?.value ?? "series";
+  const activeLanguageProfile = languageProfiles[languageLane];
+  const audioIdx = recommendedIndex(AUDIO_PREFERENCE_OPTIONS, activeLanguageProfile.audio);
+  const subtitleIdx = recommendedIndex(SUBTITLE_PREFERENCE_OPTIONS, activeLanguageProfile.subtitle);
 
   /**
    * `analyticsChoice` is passed in rather than derived: every caller has to say
@@ -279,8 +312,7 @@ export function SetupShell({
   function buildPrefs(analyticsChoice: SetupPrefs["analyticsChoice"]): SetupPrefs {
     return {
       mode,
-      audio: AUDIO_PREFERENCE_OPTIONS[audioIdx]?.value ?? RECOMMENDED_AUDIO_PREFERENCE,
-      subtitle: SUBTITLE_PREFERENCE_OPTIONS[subtitleIdx]?.value ?? RECOMMENDED_SUBTITLE_PREFERENCE,
+      languageProfiles,
       autoNext,
       skipIntro,
       skipCredits,
@@ -295,6 +327,7 @@ export function SetupShell({
 
   function advance() {
     if (screenIdx < SCREEN_ORDER.length - 1) {
+      if (screen === "mode") setLanguageLane(languageLaneForMode(mode));
       setShowFix(false);
       setConfirmingAbort(false);
       deepestRef.current = Math.max(deepestRef.current, screenIdx + 1);
@@ -321,7 +354,21 @@ export function SetupShell({
    * action.
    */
   function acceptRemainingDefaults() {
-    finish("defaults", buildPrefs(analyticsDecision), deepestRef.current);
+    const prefs = buildPrefs(analyticsDecision);
+    const remaining = new Set(SCREEN_ORDER.slice(screenIdx));
+    finish(
+      "defaults",
+      {
+        ...prefs,
+        ...(remaining.has("mode") ? { mode: MODE_RECOMMENDED } : {}),
+        ...(remaining.has("language") ? { languageProfiles: recommendedLanguageProfiles() } : {}),
+        ...(remaining.has("playback")
+          ? { autoNext: true, skipIntro: true, skipCredits: true }
+          : {}),
+        ...(remaining.has("library") ? { downloadQuality: DOWNLOAD_QUALITY_RECOMMENDED } : {}),
+      },
+      deepestRef.current,
+    );
   }
 
   function abort() {
@@ -370,10 +417,7 @@ export function SetupShell({
         );
         break;
       case "language":
-        setAudioIdx(recommendedIndex(AUDIO_PREFERENCE_OPTIONS, RECOMMENDED_AUDIO_PREFERENCE));
-        setSubtitleIdx(
-          recommendedIndex(SUBTITLE_PREFERENCE_OPTIONS, RECOMMENDED_SUBTITLE_PREFERENCE),
-        );
+        setLanguageProfiles(recommendedLanguageProfiles());
         break;
       case "playback":
         setAutoNext(true);
@@ -417,9 +461,19 @@ export function SetupShell({
     else if (screen === "mode") setModeIdx((i) => clamp(i + delta, MODE_OPTIONS.length - 1));
     else if (screen === "language") {
       if (langFocus === "audio") {
-        setAudioIdx((i) => clamp(i + delta, AUDIO_PREFERENCE_OPTIONS.length - 1));
+        const next = clamp(audioIdx + delta, AUDIO_PREFERENCE_OPTIONS.length - 1);
+        const value = AUDIO_PREFERENCE_OPTIONS[next]?.value ?? RECOMMENDED_AUDIO_PREFERENCE;
+        setLanguageProfiles((current) => ({
+          ...current,
+          [languageLane]: { ...current[languageLane], audio: value },
+        }));
       } else {
-        setSubtitleIdx((i) => clamp(i + delta, SUBTITLE_PREFERENCE_OPTIONS.length - 1));
+        const next = clamp(subtitleIdx + delta, SUBTITLE_PREFERENCE_OPTIONS.length - 1);
+        const value = SUBTITLE_PREFERENCE_OPTIONS[next]?.value ?? RECOMMENDED_SUBTITLE_PREFERENCE;
+        setLanguageProfiles((current) => ({
+          ...current,
+          [languageLane]: { ...current[languageLane], subtitle: value },
+        }));
       }
     } else if (screen === "playback") setPlaybackIdx((i) => clamp(i + delta, 2));
     else if (screen === "library") setLibraryIdx((i) => clamp(i + delta, 4));
@@ -515,9 +569,24 @@ export function SetupShell({
       return;
     }
 
-    if (key.tab && screen === "language") {
-      setLangFocus((f) => (f === "audio" ? "subtitle" : "audio"));
-      return;
+    if (screen === "language") {
+      const selectedLane = SETUP_LANGUAGE_LANES.find((lane) => lane.key === input);
+      if (selectedLane) {
+        setLanguageLane(selectedLane.value);
+        return;
+      }
+      if (key.tab) {
+        setLangFocus((f) => (f === "audio" ? "subtitle" : "audio"));
+        return;
+      }
+      if (key.leftArrow) {
+        setLangFocus("audio");
+        return;
+      }
+      if (key.rightArrow) {
+        setLangFocus("subtitle");
+        return;
+      }
     }
 
     if (input === " ") {
@@ -566,6 +635,9 @@ export function SetupShell({
         {screen === "mode" ? <ModeScreen selected={modeIdx} /> : null}
         {screen === "language" ? (
           <LanguageScreen
+            lanes={SETUP_LANGUAGE_LANES}
+            activeLane={languageLane}
+            profiles={languageProfiles}
             audioOptions={AUDIO_PREFERENCE_OPTIONS}
             subtitleOptions={SUBTITLE_PREFERENCE_OPTIONS}
             audioIndex={audioIdx}
@@ -626,11 +698,19 @@ function buildFooter(
         { key: "↑↓", label: "choose" },
         ...back,
         { key: "s", label: "recommended" },
+        { key: "S", label: "remaining defaults" },
       ];
     case "language":
       // tab and ↑↓ are named in the screen body, right where they act; the
       // footer keeps only the decisions.
-      return [{ key: "enter", label: "confirm" }, { key: "s", label: "recommended" }, ...back];
+      return [
+        { key: "enter", label: "next" },
+        { key: "1-4", label: "profile" },
+        { key: "tab", label: "audio / subs" },
+        { key: "s", label: "recommended" },
+        { key: "S", label: "remaining defaults" },
+        ...back,
+      ];
     case "playback":
     case "library":
       return [
@@ -638,6 +718,7 @@ function buildFooter(
         { key: "↑↓", label: "choose" },
         { key: "enter", label: "next" },
         { key: "s", label: "recommended" },
+        { key: "S", label: "remaining defaults" },
         ...back,
       ];
     case "analytics":
@@ -657,16 +738,25 @@ function buildFooter(
 
 function describeChoice(prefs: SetupPrefs): string {
   const modeLabel = MODE_OPTIONS.find((option) => option.value === prefs.mode)?.label ?? "Shows";
-  const audio =
-    AUDIO_PREFERENCE_OPTIONS.find((option) => option.value === prefs.audio)?.label ?? prefs.audio;
-  const subtitle =
-    SUBTITLE_PREFERENCE_OPTIONS.find((option) => option.value === prefs.subtitle)?.label ??
-    prefs.subtitle;
-  return `${modeLabel} · ${audio} audio · ${subtitle} subtitles`;
+  return `${modeLabel} first · every profile stays editable`;
 }
 
 function summaryLines(prefs: SetupPrefs): readonly SummaryLine[] {
   const lines: SummaryLine[] = [];
+  for (const lane of SETUP_LANGUAGE_LANES) {
+    const profile = prefs.languageProfiles[lane.value];
+    const audio =
+      AUDIO_PREFERENCE_OPTIONS.find((option) => option.value === profile.audio)?.label ??
+      profile.audio;
+    const subtitle =
+      SUBTITLE_PREFERENCE_OPTIONS.find((option) => option.value === profile.subtitle)?.label ??
+      profile.subtitle;
+    lines.push({
+      ok: true,
+      label: `${lane.label} language`,
+      detail: `${audio} audio · ${subtitle} subtitles`,
+    });
+  }
   lines.push({
     ok: prefs.downloadsEnabled,
     label: prefs.downloadsEnabled ? "Downloads on" : "Downloads off",

--- a/apps/cli/src/app-shell/setup/SetupScreens.tsx
+++ b/apps/cli/src/app-shell/setup/SetupScreens.tsx
@@ -145,7 +145,7 @@ export function dependencyFooter(hasFix: boolean): readonly FooterKey[] {
     { key: "enter", label: "continue" },
     ...(hasFix ? [{ key: "d", label: "how to fix" }] : []),
     { key: "r", label: "recheck" },
-    { key: "S", label: "use recommended" },
+    { key: "S", label: "remaining defaults" },
     // The one destructive key the grammar names. Deeper screens rely on the
     // two-press guard; here quitting has cost nothing yet, so it is safe to show.
     { key: "esc", label: "quit" },
@@ -198,7 +198,7 @@ function LanguageColumn({
 }) {
   const active = options[index];
   return (
-    <Box flexDirection="column" width="45%">
+    <Box flexDirection="column" width="48%">
       <Text color={focused ? palette.accent : palette.dim} bold>
         {focused ? "❯ " : "  "}
         {heading}
@@ -222,7 +222,7 @@ function LanguageColumn({
       {focused && active ? (
         <Box>
           <Text color={palette.dim}>{"  "}</Text>
-          <Text color={palette.muted}>{active.detail}</Text>
+          <Text color={palette.textDim}>↳ {active.detail}</Text>
         </Box>
       ) : null}
     </Box>
@@ -230,12 +230,24 @@ function LanguageColumn({
 }
 
 export function LanguageScreen({
+  lanes,
+  activeLane,
+  profiles,
   audioOptions,
   subtitleOptions,
   audioIndex,
   subtitleIndex,
   focus,
 }: {
+  readonly lanes: readonly {
+    readonly value: "series" | "movie" | "anime" | "youtube";
+    readonly label: string;
+    readonly key: string;
+  }[];
+  readonly activeLane: "series" | "movie" | "anime" | "youtube";
+  readonly profiles: Readonly<
+    Record<"series" | "movie" | "anime" | "youtube", { audio: string; subtitle: string }>
+  >;
   readonly audioOptions: readonly { value: string; label: string; detail: string }[];
   readonly subtitleOptions: readonly { value: string; label: string; detail: string }[];
   readonly audioIndex: number;
@@ -246,9 +258,30 @@ export function LanguageScreen({
     <Box flexDirection="column">
       <ScreenTitle
         text="Language"
-        sub="Applies to anime, shows, films, and YouTube alike. Change either per episode."
+        sub="Each media type keeps its own defaults. Change either again per episode."
       />
-      <Box gap={4}>
+      <Box marginBottom={1} gap={1} flexWrap="wrap">
+        {lanes.map((lane) => {
+          const active = lane.value === activeLane;
+          const profile = profiles[lane.value];
+          const audio = audioOptions.find((option) => option.value === profile.audio)?.label;
+          const subtitle = subtitleOptions.find(
+            (option) => option.value === profile.subtitle,
+          )?.label;
+          return (
+            <Box key={lane.value} backgroundColor={active ? palette.accentFill : undefined}>
+              <Text color={active ? palette.accent : palette.dim}>[{lane.key}] </Text>
+              <Text color={active ? palette.text : palette.muted} bold={active}>
+                {lane.label}
+              </Text>
+              <Text
+                color={palette.dim}
+              >{` ${audio ?? profile.audio}/${subtitle ?? profile.subtitle}`}</Text>
+            </Box>
+          );
+        })}
+      </Box>
+      <Box gap={2}>
         <LanguageColumn
           heading="Audio"
           focused={focus === "audio"}
@@ -264,7 +297,7 @@ export function LanguageScreen({
       </Box>
       <Box marginTop={1}>
         <Text color={palette.dim} dimColor>
-          tab switches columns · ↑↓ chooses
+          1–4 switches profile · tab or ←→ switches field · ↑↓ chooses
         </Text>
       </Box>
     </Box>

--- a/apps/cli/src/app-shell/tracker-connect-shell.tsx
+++ b/apps/cli/src/app-shell/tracker-connect-shell.tsx
@@ -1,0 +1,166 @@
+import type { Container } from "@/container";
+import { Box, Text, useInput } from "ink";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+import { mountRootContent } from "./root-content-state";
+import { ShellFooter, ViewportResizeGate } from "./shell-primitives";
+import { palette } from "./shell-theme";
+import { useShellDimensions } from "./use-viewport-policy";
+import { connectNamedTracker, type TrackerConnectOutcome } from "./workflows/tracker-connect";
+
+export type { TrackerConnectOutcome } from "./workflows/tracker-connect";
+
+type TrackerConnect = (
+  signal: AbortSignal,
+  onPrompt: (message: string) => void,
+) => Promise<TrackerConnectOutcome>;
+
+type ConnectPhase =
+  | { readonly kind: "connecting"; readonly message: string }
+  | { readonly kind: "failed"; readonly message: string };
+
+export function TrackerConnectShell({
+  trackerName,
+  connect,
+  finish,
+}: {
+  readonly trackerName: string;
+  readonly connect: TrackerConnect;
+  readonly finish: (outcome: TrackerConnectOutcome) => void;
+}) {
+  const { cols } = useShellDimensions();
+  const [attempt, setAttempt] = useState(0);
+  const [phase, setPhase] = useState<ConnectPhase>({
+    kind: "connecting",
+    message: "Opening your browser…",
+  });
+  const controllerRef = useRef<AbortController | null>(null);
+  const finishedRef = useRef(false);
+
+  const finishOnce = useCallback(
+    (outcome: TrackerConnectOutcome) => {
+      if (finishedRef.current) return;
+      finishedRef.current = true;
+      finish(outcome);
+    },
+    [finish],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    let active = true;
+
+    setPhase({ kind: "connecting", message: "Opening your browser…" });
+
+    const run = async () => {
+      try {
+        const outcome = await connect(controller.signal, (message) => {
+          if (active && !controller.signal.aborted) {
+            setPhase({ kind: "connecting", message });
+          }
+        });
+        if (!active) return;
+        if (outcome.status === "failed") {
+          setPhase({ kind: "failed", message: outcome.error });
+          return;
+        }
+        finishOnce(outcome);
+      } catch (error) {
+        // A tracker adapter that *throws* rather than returning a failed
+        // outcome must not escape as an unhandled rejection: `main.ts` treats
+        // one as fatal and shuts the whole session down. Linking an account is
+        // optional, so a thrown error becomes the same retryable failure a
+        // returned one does.
+        if (!active) return;
+        setPhase({
+          kind: "failed",
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    };
+    void run();
+
+    return () => {
+      active = false;
+      controller.abort();
+      if (controllerRef.current === controller) controllerRef.current = null;
+    };
+  }, [attempt, connect, finishOnce]);
+
+  useInput((input, key) => {
+    if (key.escape || input.toLowerCase() === "q") {
+      controllerRef.current?.abort();
+      finishOnce({ status: "cancelled" });
+      return;
+    }
+    if (phase.kind === "failed" && input.toLowerCase() === "r") {
+      setAttempt((current) => current + 1);
+    }
+  });
+
+  const failed = phase.kind === "failed";
+
+  return (
+    <ViewportResizeGate kind="picker" message="Resize terminal to connect an account">
+      <Box flexDirection="column" flexGrow={1} paddingX={2}>
+        <Box flexDirection="column" flexGrow={1} justifyContent="center" alignItems="center">
+          <Box flexDirection="column" width={Math.min(68, Math.max(36, cols - 8))}>
+            <Text color={failed ? palette.danger : palette.accent} bold>
+              {failed ? `Could not connect ${trackerName}` : `Connecting ${trackerName}`}
+            </Text>
+            <Box marginTop={1}>
+              <Text color={failed ? palette.text : palette.muted}>{phase.message}</Text>
+            </Box>
+            <Box marginTop={1}>
+              <Text color={palette.dim}>
+                {failed
+                  ? "Retry here or close this screen. Your settings were not changed."
+                  : "Complete approval in the browser. Kunai will continue here automatically."}
+              </Text>
+            </Box>
+          </Box>
+        </Box>
+        <ShellFooter
+          taskLabel={failed ? `${trackerName} sign-in failed` : `Waiting for ${trackerName}`}
+          actions={
+            failed
+              ? [
+                  { key: "r", label: "retry", primary: true },
+                  { key: "esc", label: "close" },
+                ]
+              : [{ key: "esc", label: "cancel", primary: true }]
+          }
+          mode="minimal"
+          terminalWidth={cols}
+        />
+      </Box>
+    </ViewportResizeGate>
+  );
+}
+
+export async function openTrackerConnectShell(
+  container: Container,
+  tracker: "anilist" | "tmdb",
+): Promise<TrackerConnectOutcome> {
+  const adapter = container.syncService.adapters.find((candidate) => candidate.id === tracker);
+  if (!adapter || adapter.getConnection().state === "connected") {
+    return connectNamedTracker(container, tracker, {
+      signal: new AbortController().signal,
+    });
+  }
+
+  const trackerName = adapter.displayName ?? (tracker === "anilist" ? "AniList" : "TMDB");
+  const connect: TrackerConnect = (signal, onPrompt) =>
+    connectNamedTracker(container, tracker, { signal, onPrompt });
+  const fallbackValue: TrackerConnectOutcome = { status: "cancelled" };
+  const session = mountRootContent<TrackerConnectOutcome>({
+    kind: "picker",
+    headerLabel: `Connect ${trackerName}`,
+    renderContent: (finish) => (
+      <TrackerConnectShell trackerName={trackerName} connect={connect} finish={finish} />
+    ),
+    fallbackValue,
+  });
+  return session.result;
+}

--- a/apps/cli/src/app-shell/workflows/setup-workflows.ts
+++ b/apps/cli/src/app-shell/workflows/setup-workflows.ts
@@ -17,7 +17,7 @@ import { probeCapabilities } from "@/ui";
 import type { KitsuneConfig } from "@kunai/config";
 
 import { runSetupFlow, type SetupInitialState } from "../setup-shell";
-import { connectNamedTracker } from "./tracker-connect";
+import { openTrackerConnectShell, type TrackerConnectOutcome } from "../tracker-connect-shell";
 
 export type { SetupWizardResult } from "@/app/bootstrap/startup-setup";
 
@@ -27,16 +27,18 @@ export type { SetupWizardResult } from "@/app/bootstrap/startup-setup";
  *
  * Without this a rerun showed factory defaults in every control while claiming
  * to be *your* settings — completing it then rewrote `sync.*.enabled` to false
- * and severed linked trackers nobody asked to disconnect (#228). The audio and
- * subtitle lanes are written together by the wizard, so the anime lane is a
- * faithful source for both; the component clamps anything that has drifted out
- * of its catalog.
+ * and severed linked trackers nobody asked to disconnect (#228). Each language
+ * profile hydrates independently so changing one media lane never rewrites the
+ * other three; the component clamps values that have drifted out of its catalog.
  */
 export function wizardInitialStateFromConfig(
   current: Pick<
     KitsuneConfig,
     | "defaultMode"
     | "animeLanguageProfile"
+    | "seriesLanguageProfile"
+    | "movieLanguageProfile"
+    | "youtubeLanguageProfile"
     | "autoNext"
     | "skipIntro"
     | "skipCredits"
@@ -49,8 +51,24 @@ export function wizardInitialStateFromConfig(
 ): SetupInitialState {
   return {
     mode: current.defaultMode,
-    audio: current.animeLanguageProfile.audio,
-    subtitle: current.animeLanguageProfile.subtitle,
+    languageProfiles: {
+      series: {
+        audio: current.seriesLanguageProfile.audio,
+        subtitle: current.seriesLanguageProfile.subtitle,
+      },
+      movie: {
+        audio: current.movieLanguageProfile.audio,
+        subtitle: current.movieLanguageProfile.subtitle,
+      },
+      anime: {
+        audio: current.animeLanguageProfile.audio,
+        subtitle: current.animeLanguageProfile.subtitle,
+      },
+      youtube: {
+        audio: current.youtubeLanguageProfile.audio,
+        subtitle: current.youtubeLanguageProfile.subtitle,
+      },
+    },
     autoNext: current.autoNext,
     skipIntro: current.skipIntro,
     skipCredits: current.skipCredits,
@@ -188,30 +206,28 @@ export async function runSetupWizard({
         tmdb: { ...current.sync.tmdb, ...(prefs.connectTmdb ? {} : { enabled: false }) },
       },
       ...analyticsPatch,
-      // Audio reaches every lane. It previously landed on anime only, while
-      // the slide asked which audio Kunai should prefer generally — so a user
-      // who chose English still got original audio for films and shows. The
-      // YouTube lane was then skipped entirely, which made screen 3 configure
-      // exactly the three lanes a YouTube user did not pick (#229).
+      // Every lane is written from its own answer. Two earlier shapes were both
+      // wrong: writing anime only left films and shows on original audio for a
+      // user who picked English, and skipped YouTube entirely (#229); writing
+      // one answer to all four then flattened per-lane choices that Settings
+      // lets you set independently, so rerunning setup silently discarded them.
+      // The `...current` spread keeps each profile's other fields — `quality`
+      // among them — which this screen does not ask about.
       animeLanguageProfile: {
         ...current.animeLanguageProfile,
-        audio: prefs.audio,
-        subtitle: prefs.subtitle,
+        ...prefs.languageProfiles.anime,
       },
       seriesLanguageProfile: {
         ...current.seriesLanguageProfile,
-        audio: prefs.audio,
-        subtitle: prefs.subtitle,
+        ...prefs.languageProfiles.series,
       },
       movieLanguageProfile: {
         ...current.movieLanguageProfile,
-        audio: prefs.audio,
-        subtitle: prefs.subtitle,
+        ...prefs.languageProfiles.movie,
       },
       youtubeLanguageProfile: {
         ...current.youtubeLanguageProfile,
-        audio: prefs.audio,
-        subtitle: prefs.subtitle,
+        ...prefs.languageProfiles.youtube,
       },
     } satisfies Partial<KitsuneConfig>;
 
@@ -256,9 +272,9 @@ export async function runSetupWizard({
       ["tmdb", prefs.connectTmdb, () => (tmdbLinked = true)],
     ] as const) {
       if (!wanted) continue;
-      let connected: boolean;
+      let connectOutcome: TrackerConnectOutcome;
       try {
-        connected = await connectNamedTracker(container, tracker);
+        connectOutcome = await openTrackerConnectShell(container, tracker);
       } catch (error) {
         container.diagnosticsService.record({
           category: "session",
@@ -268,15 +284,17 @@ export async function runSetupWizard({
         note(container, `${tracker} not linked — run /sync-connect-${tracker} to try again.`);
         continue;
       }
-      if (connected) {
+      if (connectOutcome.status === "connected") {
         linkedFlag();
       } else {
         container.diagnosticsService.record({
           category: "session",
           message: `Setup could not finish linking ${tracker}`,
-          context: { reason: "connect did not complete" },
+          context: { reason: connectOutcome.status },
         });
-        note(container, `${tracker} not linked — run /sync-connect-${tracker} to try again.`);
+        if (connectOutcome.status !== "cancelled") {
+          note(container, `${tracker} not linked — run /sync-connect-${tracker} to try again.`);
+        }
       }
     }
 

--- a/apps/cli/src/app-shell/workflows/shell-workflows.ts
+++ b/apps/cli/src/app-shell/workflows/shell-workflows.ts
@@ -86,11 +86,11 @@ import type { SyncPushSummary } from "@/services/sync/SyncService";
 import { fetchEpisodes } from "@/tmdb";
 import type { MediaKind } from "@kunai/types";
 
+import { openTrackerConnectShell } from "../tracker-connect-shell";
 import type { ShellAction } from "../types";
 import { relativeHistoryDate } from "./history-workflows";
 import { promptPlaylistName } from "./playlist-name-prompt";
 import { openSetupWizardFromShell } from "./setup-workflows";
-import { connectNamedTracker } from "./tracker-connect";
 
 export function waitForOverlayClose(
   stateManager: import("@/domain/session/SessionStateManager").SessionStateManager,
@@ -3247,37 +3247,7 @@ async function handleSync(container: Container): Promise<"handled"> {
     if (picked.type === "connect") {
       const adapter = adapters.find((a) => a.id === picked.id);
       if (!adapter) continue;
-
-      container.stateManager.dispatch({
-        type: "SET_PLAYBACK_FEEDBACK",
-        note: `Connecting to ${adapter.displayName}…`,
-      });
-
-      const controller = new AbortController();
-      const result = await adapter.connect({
-        signal: controller.signal,
-        // Adapters must not print: stdout writes paint over the Ink frame.
-        onPrompt: (note) =>
-          container.stateManager.dispatch({ type: "SET_PLAYBACK_FEEDBACK", note }),
-      });
-
-      if (result.ok) {
-        // Rows parked on this tracker's dead credential are unparked and drained
-        // now, so a reconnect actually delivers what it was blocking.
-        const resumed = syncService.resumeAfterReauth(adapter.id);
-        const summary = resumed > 0 ? await syncService.drain() : null;
-        container.stateManager.dispatch({
-          type: "SET_PLAYBACK_FEEDBACK",
-          note: summary
-            ? `Connected to ${adapter.displayName}. ${describeSyncSummary(summary)}`
-            : `Connected to ${adapter.displayName}.`,
-        });
-      } else {
-        container.stateManager.dispatch({
-          type: "SET_PLAYBACK_FEEDBACK",
-          note: `Failed: ${result.error}`,
-        });
-      }
+      await openTrackerConnectShell(container, adapter.id);
       continue;
     }
 
@@ -3308,12 +3278,12 @@ async function handleSync(container: Container): Promise<"handled"> {
 }
 
 async function handleSyncConnectAniList(container: Container): Promise<"handled"> {
-  await connectNamedTracker(container, "anilist");
+  await openTrackerConnectShell(container, "anilist");
   return "handled";
 }
 
 async function handleSyncConnectTmdb(container: Container): Promise<"handled"> {
-  await connectNamedTracker(container, "tmdb");
+  await openTrackerConnectShell(container, "tmdb");
   return "handled";
 }
 

--- a/apps/cli/src/app-shell/workflows/tracker-connect.ts
+++ b/apps/cli/src/app-shell/workflows/tracker-connect.ts
@@ -9,6 +9,17 @@
 
 import type { Container } from "@/container";
 
+export type TrackerConnectOutcome =
+  | { readonly status: "connected"; readonly alreadyConnected?: boolean }
+  | { readonly status: "cancelled" }
+  | { readonly status: "failed"; readonly error: string }
+  | { readonly status: "unavailable" };
+
+export type TrackerConnectOptions = {
+  readonly signal: AbortSignal;
+  readonly onPrompt?: (message: string) => void;
+};
+
 /**
  * Link a tracker account, reporting whether it is connected when this settles.
  *
@@ -28,32 +39,62 @@ import type { Container } from "@/container";
 export async function connectNamedTracker(
   container: Container,
   tracker: "anilist" | "tmdb",
-): Promise<boolean> {
+  options: TrackerConnectOptions,
+): Promise<TrackerConnectOutcome> {
   const adapter = container.syncService.adapters.find((candidate) => candidate.id === tracker);
   if (!adapter) {
     container.stateManager.dispatch({
       type: "SET_PLAYBACK_FEEDBACK",
       note: `Sync service ${tracker} is not available.`,
     });
-    return false;
+    return { status: "unavailable" };
   }
   if (adapter.getConnection().state === "connected") {
     container.stateManager.dispatch({
       type: "SET_PLAYBACK_FEEDBACK",
       note: `${adapter.displayName} is already connected.`,
     });
-    return true;
+    return { status: "connected", alreadyConnected: true };
   }
-  const result = await adapter.connect({
-    signal: new AbortController().signal,
-    onPrompt: (note) => container.stateManager.dispatch({ type: "SET_PLAYBACK_FEEDBACK", note }),
-  });
+  if (options.signal.aborted) return { status: "cancelled" };
+
+  let result: Awaited<ReturnType<typeof adapter.connect>>;
+  try {
+    result = await adapter.connect({
+      signal: options.signal,
+      onPrompt: (note) => {
+        container.stateManager.dispatch({ type: "SET_PLAYBACK_FEEDBACK", note });
+        options.onPrompt?.(note);
+      },
+    });
+  } catch (error) {
+    if (options.signal.aborted) {
+      container.stateManager.dispatch({
+        type: "SET_PLAYBACK_FEEDBACK",
+        note: `${adapter.displayName} connection cancelled.`,
+      });
+      return { status: "cancelled" };
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    container.stateManager.dispatch({
+      type: "SET_PLAYBACK_FEEDBACK",
+      note: `Failed: ${message}`,
+    });
+    return { status: "failed", error: message };
+  }
+  if (options.signal.aborted) {
+    container.stateManager.dispatch({
+      type: "SET_PLAYBACK_FEEDBACK",
+      note: `${adapter.displayName} connection cancelled.`,
+    });
+    return { status: "cancelled" };
+  }
   if (!result.ok) {
     container.stateManager.dispatch({
       type: "SET_PLAYBACK_FEEDBACK",
       note: `Failed: ${result.error}`,
     });
-    return false;
+    return { status: "failed", error: result.error };
   }
   const resumed = container.syncService.resumeAfterReauth(adapter.id);
   if (resumed > 0) container.syncService.deliverSoon();
@@ -61,5 +102,5 @@ export async function connectNamedTracker(
     type: "SET_PLAYBACK_FEEDBACK",
     note: `Connected to ${adapter.displayName}.`,
   });
-  return true;
+  return { status: "connected" };
 }

--- a/apps/cli/test/unit/app-shell/setup-abort-guard.useinput.test.tsx
+++ b/apps/cli/test/unit/app-shell/setup-abort-guard.useinput.test.tsx
@@ -32,8 +32,12 @@ const READY: CapabilitySnapshot = {
 
 const BASE_INITIAL: SetupInitialState = {
   mode: "series",
-  audio: "original",
-  subtitle: "en",
+  languageProfiles: {
+    series: { audio: "original", subtitle: "en" },
+    movie: { audio: "original", subtitle: "en" },
+    anime: { audio: "original", subtitle: "en" },
+    youtube: { audio: "original", subtitle: "en" },
+  },
   autoNext: true,
   skipIntro: true,
   skipCredits: true,
@@ -115,6 +119,21 @@ test("[s] applies the screen's recommendation, not wherever the cursor sits (#23
   }
 });
 
+test("every pre-consent screen exposes the safe remaining-defaults shortcut", () => {
+  const { handle } = start();
+  try {
+    handle.stdin.enqueue("\r"); // -> mode
+    expect(handle.lastFrame()).toContain("[S]");
+    expect(handle.lastFrame()).toContain("remaining defaults");
+
+    handle.stdin.enqueue("\r"); // -> language
+    expect(handle.lastFrame()).toContain("[S]");
+    expect(handle.lastFrame()).toContain("remaining defaults");
+  } finally {
+    handle.unmount();
+  }
+});
+
 test("[s] never flips a hydrated-on standing decision off (#231, with #228)", () => {
   const { handle, results } = start({ anilistSync: true });
   try {
@@ -147,6 +166,59 @@ test("the focused language column names its choice's detail (#233)", () => {
     // The detail wraps at this width, so assert a wrap-safe substring.
     expect(handle.lastFrame()).toContain("❯ Audio");
     expect(handle.lastFrame()).toContain("the title was made");
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("language profile hotkeys edit one media lane without rewriting the others", () => {
+  const { handle } = start({
+    languageProfiles: {
+      series: { audio: "original", subtitle: "en" },
+      movie: { audio: "en", subtitle: "es" },
+      anime: { audio: "ja", subtitle: "none" },
+      // `dub`/`interactive` — the assertion below reads their labels. Seeding a
+      // value outside the option catalogs would instead exercise the raw-value
+      // fallback and prove nothing about lane isolation.
+      youtube: { audio: "dub", subtitle: "interactive" },
+    },
+  });
+  try {
+    handle.stdin.enqueue("\r"); // -> mode
+    handle.stdin.enqueue("\r"); // -> language
+    expect(handle.lastFrame()).toContain("Shows Original/English");
+    expect(handle.lastFrame()).toContain("Anime Japanese/None");
+
+    handle.stdin.enqueue("\x1b[B"); // Shows audio: Original -> English
+    handle.stdin.enqueue("3"); // edit Anime
+    handle.stdin.enqueue("\x1b[C"); // focus subtitles
+    handle.stdin.enqueue("\x1b[B"); // None -> Arabic
+
+    const frame = handle.lastFrame();
+    expect(frame).toContain("Shows English/English");
+    expect(frame).toContain("Anime Japanese/Arabic");
+    expect(frame).toContain("Movies English/Spanish");
+    expect(frame).toContain("YouTube Any dub/Pick each time");
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("the done screen reports every media language profile", () => {
+  const { handle } = start();
+  try {
+    handle.stdin.enqueue("\r"); // -> mode
+    handle.stdin.enqueue("\r"); // -> language
+    handle.stdin.enqueue("\r"); // -> playback
+    handle.stdin.enqueue("\r"); // -> library
+    handle.stdin.enqueue("\r"); // -> analytics
+    handle.stdin.enqueue("s"); // keep analytics off -> done
+
+    const frame = handle.lastFrame();
+    expect(frame).toContain("Shows language");
+    expect(frame).toContain("Movies language");
+    expect(frame).toContain("Anime language");
+    expect(frame).toContain("YouTube language");
   } finally {
     handle.unmount();
   }

--- a/apps/cli/test/unit/app-shell/setup-analytics-consent.test.ts
+++ b/apps/cli/test/unit/app-shell/setup-analytics-consent.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { forceCloseRootContent } from "@/app-shell/root-content-state";
-import type { SetupFlowPayload } from "@/app-shell/setup-shell";
+import { FACTORY_INITIAL_STATE, type SetupFlowPayload } from "@/app-shell/setup-shell";
 import { runSetupWizard } from "@/app-shell/workflows/setup-workflows";
 import type { Container } from "@/container";
 import { getKunaiPaths } from "@/services/storage/storage-read-models";
@@ -90,8 +90,7 @@ function fakeContainer(overrides: Partial<Parameters<typeof runSetupWizard>[0]["
 
 const UNTOUCHED_PREFS = {
   mode: "series",
-  audio: "original",
-  subtitle: "en",
+  languageProfiles: FACTORY_INITIAL_STATE.languageProfiles,
   autoNext: true,
   skipIntro: true,
   skipCredits: true,

--- a/apps/cli/test/unit/app-shell/setup-analytics-keystroke.useinput.test.tsx
+++ b/apps/cli/test/unit/app-shell/setup-analytics-keystroke.useinput.test.tsx
@@ -45,8 +45,12 @@ const READY: CapabilitySnapshot = {
 
 const BASE_INITIAL: SetupInitialState = {
   mode: "series",
-  audio: "original",
-  subtitle: "en",
+  languageProfiles: {
+    series: { audio: "original", subtitle: "en" },
+    movie: { audio: "original", subtitle: "en" },
+    anime: { audio: "original", subtitle: "en" },
+    youtube: { audio: "original", subtitle: "en" },
+  },
   autoNext: true,
   skipIntro: true,
   skipCredits: true,

--- a/apps/cli/test/unit/app-shell/setup-write-back.test.ts
+++ b/apps/cli/test/unit/app-shell/setup-write-back.test.ts
@@ -4,8 +4,12 @@ import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { forceCloseRootContent } from "@/app-shell/root-content-state";
-import type { SetupFlowPayload } from "@/app-shell/setup-shell";
+import {
+  forceCloseRootContent,
+  getRootContentSession,
+  subscribeRootContentSession,
+} from "@/app-shell/root-content-state";
+import { FACTORY_INITIAL_STATE, type SetupFlowPayload } from "@/app-shell/setup-shell";
 import {
   runSetupWizard,
   wizardInitialStateFromConfig,
@@ -18,7 +22,9 @@ import {
 } from "@/services/persistence/pre-setup-snapshot";
 import { getKunaiPaths } from "@/services/storage/storage-read-models";
 import { DEFAULT_CONFIG } from "@kunai/config";
+import { act } from "react";
 
+import { render } from "../../harness/render-capture";
 import { applyStorageRootEnv } from "../../helpers/storage-env";
 
 // `runSetupWizard` now writes a real restore point beside the real config, so
@@ -42,6 +48,27 @@ afterAll(() => {
 
 function clearSnapshot(): void {
   rmSync(preSetupSnapshotPath(), { recursive: true, force: true });
+}
+
+async function renderTrackerConnectSurface() {
+  const waitForSession = () =>
+    new Promise<NonNullable<ReturnType<typeof getRootContentSession>>>((resolve) => {
+      const inspect = () => {
+        const session = getRootContentSession();
+        if (!session?.headerLabel?.startsWith("Connect ")) return;
+        unsubscribe();
+        resolve(session);
+      };
+      const unsubscribe = subscribeRootContentSession(inspect);
+      inspect();
+    });
+
+  const session = await waitForSession();
+  const handle = render(session.element, { columns: 100, rows: 32 });
+  await act(async () => {
+    for (let flush = 0; flush < 4; flush += 1) await Promise.resolve();
+  });
+  return handle;
 }
 
 /**
@@ -129,8 +156,7 @@ function fakeContainer(
 
 const BASE_PREFS: SetupFlowPayload["prefs"] = {
   mode: "series",
-  audio: "original",
-  subtitle: "en",
+  languageProfiles: FACTORY_INITIAL_STATE.languageProfiles,
   autoNext: true,
   skipIntro: true,
   skipCredits: true,
@@ -141,6 +167,15 @@ const BASE_PREFS: SetupFlowPayload["prefs"] = {
   presenceDiscord: false,
   analyticsChoice: "unchanged",
 };
+
+function allLanguageProfiles(audio: string, subtitle: string) {
+  return {
+    series: { audio, subtitle },
+    movie: { audio, subtitle },
+    anime: { audio, subtitle },
+    youtube: { audio, subtitle },
+  };
+}
 
 function payload(
   overrides: {
@@ -157,7 +192,11 @@ test("the language choice reaches all four lanes, including YouTube (#229)", asy
   const { container, config } = fakeContainer();
 
   const pending = runSetupWizard({ container, force: true });
-  expect(forceCloseRootContent(payload({ prefs: { audio: "ja", subtitle: "es" } }))).toBe(true);
+  expect(
+    forceCloseRootContent(
+      payload({ prefs: { languageProfiles: allLanguageProfiles("ja", "es") } }),
+    ),
+  ).toBe(true);
   await pending;
 
   for (const lane of [
@@ -235,12 +274,16 @@ test("a failed browser handoff does not flip the standing decision on (#232)", a
 
   const pending = runSetupWizard({ container, force: true });
   expect(forceCloseRootContent(payload({ prefs: { connectAniList: true } }))).toBe(true);
+  const connectSurface = await renderTrackerConnectSurface();
+  expect(connectSurface.lastFrame()).toContain("browser never opened");
+  connectSurface.stdin.enqueue("q");
+  connectSurface.unmount();
   await pending;
 
   expect(anilist?.connectCalls).toBe(1);
   expect(config.sync.anilist.enabled).toBe(false);
   expect(diagnostics.some((m) => m.includes("linking anilist"))).toBe(true);
-  expect(notes.some((n) => n.includes("/sync-connect-anilist"))).toBe(true);
+  expect(notes.some((n) => n.includes("browser never opened"))).toBe(true);
 });
 
 test("a successful handoff flips enabled on after the fact (#232)", async () => {
@@ -257,6 +300,8 @@ test("a successful handoff flips enabled on after the fact (#232)", async () => 
 
   const pending = runSetupWizard({ container, force: true });
   expect(forceCloseRootContent(payload({ prefs: { connectTmdb: true } }))).toBe(true);
+  const connectSurface = await renderTrackerConnectSurface();
+  connectSurface.unmount();
   await pending;
 
   expect(tmdb?.connectCalls).toBe(1);
@@ -332,6 +377,9 @@ describe("wizardInitialStateFromConfig", () => {
         ...DEFAULT_CONFIG,
         defaultMode: "anime",
         animeLanguageProfile: { audio: "en", subtitle: "none", quality: "best" },
+        seriesLanguageProfile: { audio: "original", subtitle: "en", quality: "best" },
+        movieLanguageProfile: { audio: "ja", subtitle: "es", quality: "best" },
+        youtubeLanguageProfile: { audio: "en", subtitle: "interactive", quality: "best" },
         autoNext: false,
         skipIntro: false,
         skipCredits: false,
@@ -344,8 +392,12 @@ describe("wizardInitialStateFromConfig", () => {
     );
     expect(initial).toEqual({
       mode: "anime",
-      audio: "en",
-      subtitle: "none",
+      languageProfiles: {
+        series: { audio: "original", subtitle: "en" },
+        movie: { audio: "ja", subtitle: "es" },
+        anime: { audio: "en", subtitle: "none" },
+        youtube: { audio: "en", subtitle: "interactive" },
+      },
       autoNext: false,
       skipIntro: false,
       skipCredits: false,
@@ -370,13 +422,7 @@ describe("wizardInitialStateFromConfig", () => {
 
 // ─── Pre-setup restore point ──────────────────────────────────────────────────
 
-/**
- * A configuration whose four language lanes already agree, so a run that
- * answers with those same values produces a patch identical to what is stored.
- * With stock defaults that is impossible: `seriesLanguageProfile.subtitle` is
- * `"none"` while the other three are `"en"`, and the wizard writes one answer to
- * all four — so every run would look like a change and every run would snapshot.
- */
+/** A configuration whose four language lanes already agree. */
 const SETTLED_CONFIG = {
   seriesLanguageProfile: { ...DEFAULT_CONFIG.seriesLanguageProfile, subtitle: "en" },
 };
@@ -384,8 +430,7 @@ const SETTLED_CONFIG = {
 /** Prefs that re-answer `SETTLED_CONFIG` with exactly what it already holds. */
 const SETTLED_PREFS = {
   mode: "series",
-  audio: "original",
-  subtitle: "en",
+  languageProfiles: allLanguageProfiles("original", "en"),
   downloadQuality: "best",
 } as const;
 
@@ -395,7 +440,11 @@ describe("pre-setup restore point", () => {
     const { container, config, notes } = fakeContainer();
 
     const pending = runSetupWizard({ container, force: true });
-    expect(forceCloseRootContent(payload({ prefs: { audio: "ja", subtitle: "es" } }))).toBe(true);
+    expect(
+      forceCloseRootContent(
+        payload({ prefs: { languageProfiles: allLanguageProfiles("ja", "es") } }),
+      ),
+    ).toBe(true);
     await pending;
 
     const snapshot = await readPreSetupSnapshot();
@@ -454,7 +503,11 @@ describe("pre-setup restore point", () => {
     const { container, config, diagnostics } = fakeContainer();
 
     const pending = runSetupWizard({ container, force: true });
-    expect(forceCloseRootContent(payload({ prefs: { audio: "ja" } }))).toBe(true);
+    expect(
+      forceCloseRootContent(
+        payload({ prefs: { languageProfiles: allLanguageProfiles("ja", "en") } }),
+      ),
+    ).toBe(true);
     await expect(pending).resolves.toBe("completed");
 
     expect(config.animeLanguageProfile.audio).toBe("ja");
@@ -470,7 +523,11 @@ describe("pre-setup restore point", () => {
     const before = JSON.parse(JSON.stringify(config));
 
     const pending = runSetupWizard({ container, force: true });
-    expect(forceCloseRootContent(payload({ prefs: { audio: "ja", subtitle: "es" } }))).toBe(true);
+    expect(
+      forceCloseRootContent(
+        payload({ prefs: { languageProfiles: allLanguageProfiles("ja", "es") } }),
+      ),
+    ).toBe(true);
     await pending;
 
     expect(JSON.parse(await readFile(preSetupSnapshotPath(), "utf8"))).toEqual(before);

--- a/apps/cli/test/unit/app-shell/tracker-connect-shell.useinput.test.tsx
+++ b/apps/cli/test/unit/app-shell/tracker-connect-shell.useinput.test.tsx
@@ -1,0 +1,79 @@
+import { expect, test } from "bun:test";
+
+import { TrackerConnectShell, type TrackerConnectOutcome } from "@/app-shell/tracker-connect-shell";
+import React, { act } from "react";
+
+import { render } from "../../harness/render-capture";
+
+async function flushMicrotasks(times = 4): Promise<void> {
+  for (let index = 0; index < times; index += 1) await Promise.resolve();
+}
+
+test("the visible tracker handoff owns cancellation", async () => {
+  let connectSignal: AbortSignal | undefined;
+  const results: TrackerConnectOutcome[] = [];
+  const handle = render(
+    <TrackerConnectShell
+      trackerName="AniList"
+      connect={(signal, onPrompt) => {
+        connectSignal = signal;
+        onPrompt("Approve Kunai in the browser.");
+        return new Promise((resolve) => {
+          signal.addEventListener("abort", () => resolve({ status: "cancelled" }), {
+            once: true,
+          });
+        });
+      }}
+      finish={(result) => results.push(result)}
+    />,
+    { columns: 100, rows: 32 },
+  );
+
+  try {
+    expect(handle.lastFrame()).toContain("Approve Kunai in the browser.");
+    expect(handle.lastFrame()).toContain("[esc]");
+    expect(handle.lastFrame()).toContain("cancel");
+
+    handle.stdin.enqueue("q");
+    await act(async () => flushMicrotasks());
+
+    expect(connectSignal?.aborted).toBe(true);
+    expect(results).toEqual([{ status: "cancelled" }]);
+  } finally {
+    handle.unmount();
+  }
+});
+
+test("a failed tracker handoff stays visible and retries in place", async () => {
+  let attempts = 0;
+  const results: TrackerConnectOutcome[] = [];
+  const handle = render(
+    <TrackerConnectShell
+      trackerName="TMDB"
+      connect={async () => {
+        attempts += 1;
+        return attempts === 1
+          ? { status: "failed", error: "The browser approval expired." }
+          : { status: "connected" };
+      }}
+      finish={(result) => results.push(result)}
+    />,
+    { columns: 100, rows: 32 },
+  );
+
+  try {
+    await act(async () => flushMicrotasks());
+    expect(handle.lastFrame()).toContain("The browser approval expired.");
+    expect(handle.lastFrame()).toContain("[r]");
+    expect(handle.lastFrame()).toContain("retry");
+    expect(results).toHaveLength(0);
+
+    handle.stdin.enqueue("r");
+    await act(async () => flushMicrotasks());
+
+    expect(attempts).toBe(2);
+    expect(results).toEqual([{ status: "connected" }]);
+  } finally {
+    handle.unmount();
+  }
+});

--- a/apps/cli/test/unit/app-shell/tracker-connect.test.ts
+++ b/apps/cli/test/unit/app-shell/tracker-connect.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import { connectNamedTracker } from "@/app-shell/workflows/tracker-connect";
+import type { Container } from "@/container";
+
+function fakeContainer(
+  connect: (signal: AbortSignal) => Promise<{ ok: true } | { ok: false; error: string }>,
+) {
+  const notes: string[] = [];
+  const container = {
+    stateManager: {
+      dispatch: (action: { type: string; note?: string }) => {
+        if (action.note) notes.push(action.note);
+      },
+    },
+    syncService: {
+      adapters: [
+        {
+          id: "anilist",
+          displayName: "AniList",
+          getConnection: () => ({ state: "disconnected" }),
+          connect: ({ signal }: { signal: AbortSignal }) => connect(signal),
+        },
+      ],
+      resumeAfterReauth: () => 0,
+      deliverSoon: () => undefined,
+    },
+  } as unknown as Container;
+  return { container, notes };
+}
+
+describe("connectNamedTracker", () => {
+  test("threads the caller's abort signal and reports cancellation distinctly", async () => {
+    let observedSignal: AbortSignal | null = null;
+    const { container, notes } = fakeContainer(async (signal) => {
+      observedSignal = signal;
+      await new Promise<void>((resolve) => signal.addEventListener("abort", () => resolve()));
+      return { ok: false, error: "cancelled" };
+    });
+    const controller = new AbortController();
+
+    const pending = connectNamedTracker(container, "anilist", { signal: controller.signal });
+    controller.abort();
+
+    await expect(pending).resolves.toEqual({ status: "cancelled" });
+    expect(observedSignal === controller.signal).toBe(true);
+    expect(notes.at(-1)).toContain("cancelled");
+  });
+
+  test("reports a failed handoff without claiming the tracker is connected", async () => {
+    const { container, notes } = fakeContainer(async () => ({
+      ok: false,
+      error: "approval expired",
+    }));
+
+    await expect(
+      connectNamedTracker(container, "anilist", { signal: new AbortController().signal }),
+    ).resolves.toEqual({ status: "failed", error: "approval expired" });
+    expect(notes.at(-1)).toContain("approval expired");
+  });
+});


### PR DESCRIPTION
## Why

Two setup defects. One silently destroys user settings; the other leaves the wizard unresponsive.

### 1. Rerunning `/setup` flattened every language lane

`/settings` → Language sets audio and subtitles **independently** for Shows, Movies, Anime, and YouTube (`apps/cli/src/app-shell/settings/registry/language.ts` — four separate read/write pairs). The wizard read only `animeLanguageProfile` and then wrote its single answer to **all four**.

So a user with Japanese anime audio and English film audio who reran `/setup` saw the *anime* value preselected in one control, and finishing silently overwrote the other three lanes with it. No warning, no restore prompt — the restore point covers it, but nothing told them to use it.

Each lane now hydrates from and writes back to its own profile. `1`–`4` pick the lane, `tab` (or `←→`) switches audio/subtitles, `↑↓` chooses, and every lane stays visible with its current pair. Fields the screen does not ask about — `quality` — are preserved per lane.

This replaces the previous copy *"Applies to anime, shows, films, and YouTube alike"*, which described the flatten as if it were the feature.

### 2. A tracker sign-in could not be cancelled

`connectNamedTracker` called `adapter.connect({ signal: new AbortController().signal })` — a signal from a controller **nobody holds**. The parameter was accepted and structurally dead: nothing could ever abort it. Cancelling an OAuth approval in the browser left the wizard on an unresponsive screen until the tracker's own deadline expired, with no feedback and no way out.

Linking now runs in an owned surface (`tracker-connect-shell.tsx`) that reports progress, takes `esc`/`q` to cancel, and offers `r` to retry a failure. The abort reaches the adapter through a real `AbortSignal`. A cancelled attempt leaves sync disabled and says nothing further; only a genuine failure suggests `/sync-connect-<tracker>`.

## Found during review of this branch

Three defects in the new code, fixed here:

1. **Missing `catch` on the connect promise.** The effect awaited `connect(...)` with no rejection path. An adapter that *throws* rather than returning a failed outcome would have escaped as an unhandled rejection — which `main.ts` treats as **fatal**, shutting down the whole session over an optional account link. It now degrades to the same retryable failure a returned error produces.
2. **A test fixture using values that do not exist.** `setup-abort-guard` seeded the YouTube lane with `{audio: "any", subtitle: "pick"}` — neither is in `AUDIO_PREFERENCE_OPTIONS`/`SUBTITLE_PREFERENCE_OPTIONS`. The assertion read the labels for `dub`/`interactive`, so the test exercised the raw-value fallback and failed. Seeding the real values makes it prove lane isolation, which was the point.
3. **`react-hooks(exhaustive-deps)` error and a non-null assertion**, both blocking `lint`.

## Verification

Cold — turbo cache deleted, real exit codes:

| Gate | Result |
| --- | --- |
| typecheck | 0 |
| lint | 0 — **0 warnings**, was 1 error + 2 warnings |
| fmt | 0 |
| test | 0 — 5148 unit + 238 integration, **0 fail** (was 1 fail) |
| verify:doc-paths | 0 |
| verify:doc-coverage | 0 |

## Seams walked

- **Declaration → reader:** the `signal` parameter had no reader that could fire it; it does now. Every language profile field has a playback reader.
- **Reverse states:** connect gained cancel and retry; a cancelled link leaves sync *disabled* rather than half-on.
- **Both lanes / every lane:** all four language profiles are decided explicitly rather than three inheriting a fourth's answer.
- **Docs:** `.docs/download-offline-onboarding.md` updated — it documented the flatten as intended behavior.

## Still open (separate PRs)

- Post-play shows **season** progress (`3 / 10 · 30%`) after stopping an episode early, instead of position in that episode.
- Discord Rich Presence survives a crash — the shutdown deadline is 4s while a Discord IPC op can take 10s.
