### PR TITLE
fix(post-play): report where you stopped, not how far into the season

### DIFF
--- a/apps/cli/src/app-shell/playback-mount-shell.tsx
+++ b/apps/cli/src/app-shell/playback-mount-shell.tsx
@@ -487,6 +487,8 @@ function PlaybackShell({
     queueNextLabel: state.queueNextLabel,
     queueNextEntryId: state.queueNextEntryId,
     resumeLabel: state.resumeLabel,
+    resumePositionSeconds: state.resumePositionSeconds,
+    episodeDurationSeconds: state.episodeDurationSeconds,
     postPlayState,
     recommendations: activeRecommendations,
     totalEpisodes: state.totalEpisodes,

--- a/apps/cli/src/app-shell/post-play-view.ts
+++ b/apps/cli/src/app-shell/post-play-view.ts
@@ -17,6 +17,7 @@
 import { resolveCatalogPosterUrl } from "@/domain/catalog/resolve-catalog-poster-url";
 import type { TitleDetail } from "@/domain/catalog/title-detail";
 import type { PostPlayState } from "@/domain/playback/post-play-state";
+import { formatTimestamp } from "@/services/continuation/history-progress";
 
 import { resolveKeybinding, resolvePostPlaybackBindingResult } from "./keybinding-runtime";
 import { footerKeyFromBinding, KEYBINDINGS, type KeyBinding } from "./keybindings";
@@ -138,6 +139,10 @@ export type BuildPostPlayViewProps = {
   /** Exact queue row id snapped with `queueNextLabel` from one `peekNext()`. */
   readonly queueNextEntryId?: string;
   readonly resumeLabel?: string;
+  /** Where playback stopped, in seconds. Pairs with `episodeDurationSeconds`. */
+  readonly resumePositionSeconds?: number;
+  /** Runtime of what was just playing, in seconds, when the player reported one. */
+  readonly episodeDurationSeconds?: number;
   readonly postPlayState: PostPlayState;
   readonly recommendations?: readonly PlaybackRecommendationRailItem[];
   readonly bindings?: readonly KeyBinding[];
@@ -160,6 +165,34 @@ function buildProgressBar(watched: number, total: number, suffix = ""): PostPlay
   const percent = Math.round((watched / total) * 100);
   const label = `${watched} / ${total}${suffix ? ` ${suffix}` : ""} · ${percent}%`;
   return { watched, total, percent, label };
+}
+
+/**
+ * "12:04 / 48:30 · 25%" — position inside the thing that was just playing.
+ *
+ * The stopped-early hero used the season bar, so quitting 23 seconds into an
+ * episode reported "3 / 10 · 30%": true about the season, and not an answer to
+ * the question the screen is asking, which is where you stopped. Films got no
+ * bar at all for the same reason — they have no episode counts.
+ *
+ * Returns undefined unless the player reported a usable runtime, so an unknown
+ * duration falls back to the season bar rather than inventing a denominator.
+ */
+function buildTimeProgressBar(
+  positionSeconds: number | undefined,
+  durationSeconds: number | undefined,
+): PostPlayProgressBar | undefined {
+  if (positionSeconds === undefined || durationSeconds === undefined) return undefined;
+  if (!Number.isFinite(positionSeconds) || !Number.isFinite(durationSeconds)) return undefined;
+  if (durationSeconds <= 0 || positionSeconds < 0) return undefined;
+  const clamped = Math.min(positionSeconds, durationSeconds);
+  const percent = Math.round((clamped / durationSeconds) * 100);
+  return {
+    watched: Math.round(clamped),
+    total: Math.round(durationSeconds),
+    percent,
+    label: `${formatTimestamp(clamped)} / ${formatTimestamp(durationSeconds)} · ${percent}%`,
+  };
 }
 
 function postPlayShortcut(
@@ -310,6 +343,8 @@ export function buildPostPlayView(props: BuildPostPlayViewProps): PostPlayView {
     autoplayPaused,
     autoskipPaused,
     stopAfterCurrent,
+    resumePositionSeconds,
+    episodeDurationSeconds,
   } = props;
 
   const bindings = props.bindings ?? KEYBINDINGS;
@@ -375,7 +410,11 @@ export function buildPostPlayView(props: BuildPostPlayViewProps): PostPlayView {
       nextUpHero: buildNextUpHero(props, "resume"),
       heroLabel: "⏸ stopped early",
       heroColor: "accent",
-      progressBar: isMovie ? undefined : progressBar,
+      // Where you stopped, not how far into the season you are. Films get one
+      // too — the season bar never applied to them.
+      progressBar:
+        buildTimeProgressBar(resumePositionSeconds, episodeDurationSeconds) ??
+        (isMovie ? undefined : progressBar),
       actions: [
         {
           id: "resume",

--- a/apps/cli/src/app-shell/types.ts
+++ b/apps/cli/src/app-shell/types.ts
@@ -143,6 +143,10 @@ export type PlaybackShellState = {
   autoskipPaused?: boolean;
   stopAfterCurrent?: boolean;
   resumeLabel?: string;
+  /** Where playback stopped, in seconds — the stopped-early progress bar reads it. */
+  resumePositionSeconds?: number;
+  /** Runtime of what was just playing, when the player reported one. */
+  episodeDurationSeconds?: number;
   showMemory: boolean;
   memoryUsage?: string;
   providerHealth?: ShellPanelLine;

--- a/apps/cli/src/app/playback/run-post-playback-menu.ts
+++ b/apps/cli/src/app/playback/run-post-playback-menu.ts
@@ -486,6 +486,10 @@ export async function runPostPlaybackMenu(
               ? `resume S${String(currentEpisode.season).padStart(2, "0")}E${String(currentEpisode.episode).padStart(2, "0")}  ·  ${formatTimestamp(resumeSeconds)}`
               : `resume ${formatTimestamp(resumeSeconds)}`
             : undefined,
+          // The stopped-early bar answers "where did I stop", which needs both
+          // ends of the episode, not the season's episode counts.
+          resumePositionSeconds: resumeSeconds,
+          episodeDurationSeconds: result.duration,
           status: iteration.catalogAutoplayEndBanner
             ? { label: iteration.catalogAutoplayEndBanner, tone: "neutral" }
             : { label: "Ready for next action", tone: "success" },

--- a/apps/cli/src/services/catalog/TitleDetailService.ts
+++ b/apps/cli/src/services/catalog/TitleDetailService.ts
@@ -463,7 +463,7 @@ async function fetchTmdbDetail(
         playableSeasons.push({
           season: seasonNum,
           name: readString(seasonMeta.name) || `Season ${seasonNum}`,
-          episodeCount: Number(seasonMeta.episode_count) || undefined,
+          episodeCount: readEpisodeCount(seasonMeta.episode_count),
           year: seasonAirDate.split("-")[0] || undefined,
           posterUrl: posterPath ? tmdbImage(posterPath, "w342") : undefined,
         });
@@ -826,7 +826,7 @@ async function fetchAniListDetail(
   const rawStatus = readString(media.status).toLowerCase();
   const status = mapAniListStatus(rawStatus);
 
-  const episodeCount = typeof media.episodes === "number" ? media.episodes : undefined;
+  const episodeCount = readEpisodeCount(media.episodes);
   const runtimeMinutes = typeof media.duration === "number" ? media.duration : undefined;
   const format = readString(media.format) || undefined;
 
@@ -938,6 +938,21 @@ function extractAnilistId(id: string): string | null {
 // ---------------------------------------------------------------------------
 // Util
 // ---------------------------------------------------------------------------
+
+/**
+ * An episode count is a whole number of episodes.
+ *
+ * `Number(...)` and a bare `typeof === "number"` both let a fractional or
+ * absurd upstream value through, and it rendered verbatim in the details rail —
+ * "episodes 448.2" is never a thing a catalog can truthfully say. Anything that
+ * is not a positive integer is dropped so the row is omitted, which reads as
+ * "unknown" rather than as a wrong fact.
+ */
+function readEpisodeCount(value: unknown): number | undefined {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) return undefined;
+  return parsed;
+}
 
 function readRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)

--- a/apps/cli/test/unit/app-shell/post-play-view.test.ts
+++ b/apps/cli/test/unit/app-shell/post-play-view.test.ts
@@ -133,3 +133,75 @@ describe("series-complete celebration", () => {
     expect(view.celebration?.watchTimeLine).toBeUndefined();
   });
 });
+
+/**
+ * Stopping 23 seconds into S01E03 of a ten-episode season reported
+ * "3 / 10 · 30%" — true about the season, and not an answer to the question
+ * the stopped-early screen asks, which is where you stopped. Films showed no
+ * bar at all, because the season bar never applied to them.
+ */
+describe("stopped-early progress", () => {
+  const stoppedEarly = {
+    title: "Ozark",
+    episodeLabel: "S01 E03",
+    resumeLabel: "resume S01E03  ·  0:23",
+    postPlayState: { kind: "mid-series" as const },
+    totalEpisodes: 10,
+    watchedEpisodes: 3,
+  };
+
+  it("reports position inside the episode, not progress through the season", () => {
+    const view = buildPostPlayView({
+      ...stoppedEarly,
+      resumePositionSeconds: 23,
+      episodeDurationSeconds: 2891,
+    });
+
+    expect(view.heroKind).toBe("stopped-early");
+    expect(view.progressBar?.label).toBe("0:23 / 48:11 · 1%");
+    expect(view.progressBar?.percent).toBe(1);
+    // The season numbers must not be what the bar reports.
+    expect(view.progressBar?.label).not.toContain("3 / 10");
+    expect(view.progressBar?.percent).not.toBe(30);
+  });
+
+  it("gives a film the same bar the season count could never provide", () => {
+    const view = buildPostPlayView({
+      ...stoppedEarly,
+      titleType: "movie",
+      totalEpisodes: undefined,
+      watchedEpisodes: undefined,
+      resumePositionSeconds: 1800,
+      episodeDurationSeconds: 7200,
+    });
+
+    expect(view.progressBar?.label).toBe("30:00 / 2:00:00 · 25%");
+  });
+
+  it("falls back to the season bar when the player reported no runtime", () => {
+    const view = buildPostPlayView({ ...stoppedEarly, resumePositionSeconds: 23 });
+
+    expect(view.progressBar?.label).toBe("3 / 10 · 30%");
+  });
+
+  it("never invents a denominator from a zero or negative runtime", () => {
+    for (const duration of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const view = buildPostPlayView({
+        ...stoppedEarly,
+        resumePositionSeconds: 23,
+        episodeDurationSeconds: duration,
+      });
+      expect(view.progressBar?.label).toBe("3 / 10 · 30%");
+    }
+  });
+
+  it("clamps a position past the runtime instead of exceeding 100%", () => {
+    const view = buildPostPlayView({
+      ...stoppedEarly,
+      resumePositionSeconds: 5000,
+      episodeDurationSeconds: 2891,
+    });
+
+    expect(view.progressBar?.percent).toBe(100);
+  });
+});

--- a/apps/cli/test/unit/services/catalog/title-detail-service.test.ts
+++ b/apps/cli/test/unit/services/catalog/title-detail-service.test.ts
@@ -801,3 +801,65 @@ describe("anime detail stays coherent across catalogs", () => {
     }
   });
 });
+
+/**
+ * The details rail rendered "episodes 448.2".
+ *
+ * An episode count is a whole number of episodes, and the rail printed whatever
+ * the catalog handed it. `Number(...)` and a bare `typeof === "number"` both let
+ * a fractional value through, so a malformed upstream field became a confident
+ * wrong fact on screen. Anything that is not a positive integer is now dropped,
+ * which renders as an absent row — "unknown" rather than a lie.
+ */
+describe("episode counts are whole numbers", () => {
+  afterEach(() => {
+    clearTitleDetailCache();
+  });
+
+  test("drops a fractional AniList episode count instead of rendering it", async () => {
+    const restore = mockFetch((url) => {
+      if (url.includes("graphql.anilist.co"))
+        return jsonResponse({ data: { Media: anilistMediaPayload({ episodes: 448.2 }) } });
+      return null;
+    });
+
+    try {
+      const detail = await fetchTitleDetail("anilist:21", "series");
+      expect(detail.episodeCount).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  test("keeps a real AniList episode count", async () => {
+    const restore = mockFetch((url) => {
+      if (url.includes("graphql.anilist.co"))
+        return jsonResponse({ data: { Media: anilistMediaPayload({ episodes: 24 }) } });
+      return null;
+    });
+
+    try {
+      const detail = await fetchTitleDetail("anilist:21", "series");
+      expect(detail.episodeCount).toBe(24);
+    } finally {
+      restore();
+    }
+  });
+
+  test("rejects zero, negative, and non-numeric counts alike", async () => {
+    for (const episodes of [0, -5, "many", null, Number.NaN]) {
+      clearTitleDetailCache();
+      const restore = mockFetch((url) => {
+        if (url.includes("graphql.anilist.co"))
+          return jsonResponse({ data: { Media: anilistMediaPayload({ episodes }) } });
+        return null;
+      });
+      try {
+        const detail = await fetchTitleDetail("anilist:21", "series");
+        expect(detail.episodeCount).toBeUndefined();
+      } finally {
+        restore();
+      }
+    }
+  });
+});


### PR DESCRIPTION
## The bug

Stopping **23 seconds** into S01E03 of a ten-episode season rendered this under the *stopped early* hero:

```
⏸ stopped early
████░░░░░░░░░░░░░░░░  3 / 10 · 30%

  ▶ RESUME
    resume S01E03 · 0:23
```

The bar and the card immediately beneath it disagree on screen. `3 / 10 · 30%` is true *about the season* — it is not an answer to the question a stopped-early screen exists to ask, which is **where you stopped**.

Films were worse off. The season bar is built from `watchedEpisodes / totalEpisodes`, which a film has none of, so `progressBar: isMovie ? undefined : progressBar` gave a film stopped forty minutes in **no progress bar at all**.

## The fix

The stopped-early bar now reads position over runtime — `0:23 / 48:11 · 1%` — for episodes and films alike.

Both numbers were already at the call site (`resumeSeconds` and `result.duration` in `run-post-playback-menu.ts`, feeding the resume label two lines above). Nothing new is computed or fetched; they are threaded through shell state to the view.

Guards, each with a test:

- unknown, zero, negative, `NaN`, or `Infinity` runtime → **falls back to the season bar** rather than inventing a denominator
- position past the runtime → **clamps to 100%** instead of reporting more

The right rail keeps season progress. That is the one place it answers a question the reader is actually asking.

## Verification

Cold, turbo cache deleted, real exit codes: `fmt` 0 · `typecheck` 0 · `lint` 0 · `test` 0.

Six new cases in `post-play-view.test.ts` covering the episode bar, the film bar, the no-runtime fallback, the degenerate-runtime fallbacks, and the clamp.

## Seams walked

- **Declaration → reader:** both new props have a reader in `buildPostPlayView`; neither is stored and ignored.
- **Both lanes:** films and series both get a bar now — previously only series did, and it was the wrong one.
- **Entry points:** the stopped-early hero is the only surface that claimed to show where you stopped; the rail keeps its own (correct) season fact.

## Related, not fixed here

The details rail in the same screenshot reads `episodes 448.2`, which is not an episode count. Filed separately — it is a different data path.
