### PR TITLE
fix(presence): clear the Discord card inside the shutdown budget

### DIFF
--- a/apps/cli/src/services/presence/PresenceServiceImpl.ts
+++ b/apps/cli/src/services/presence/PresenceServiceImpl.ts
@@ -20,6 +20,16 @@ import type {
 } from "./PresenceService";
 
 const DEFAULT_DISCORD_CLIENT_ID = "1502307419047461025";
+/**
+ * How long a shutdown may spend clearing the Discord card.
+ *
+ * Deliberately a fraction of the shutdown coordinator's own deadline
+ * (`DEFAULT_DEADLINE_MS`, 4s in `app/session/shutdown-coordinator.ts`), so the
+ * clear resolves or gives up while there is still a process to resolve into.
+ * A single Discord IPC frame is otherwise allowed 10s, which is more than the
+ * whole shutdown gets — see `clearWithinShutdownBudget`.
+ */
+export const PRESENCE_SHUTDOWN_CLEAR_BUDGET_MS = 1_500;
 const DISCORD_ACTIVITY_TEXT_LIMIT = 128;
 
 /** Shown in diagnostics when IPC/update fails and another consumer may hold the Discord app pipe. */
@@ -284,17 +294,21 @@ export class PresenceServiceImpl implements PresenceService {
 
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
+    this.playbackPresenceGeneration += 1;
     const clearedClient = this.discordClient;
-    if (clearedClient) {
-      await this.clearPlayback("shutdown");
-    } else {
-      this.stopHeartbeat();
-      this.lastActivityPayload = null;
-    }
+    // Teardown state is set synchronously and the clear jumps the operation
+    // queue: see PRESENCE_SHUTDOWN_CLEAR_BUDGET_MS.
     this.stopHeartbeat();
+    this.resetWatchSession();
+    this.lastPlaybackActivity = null;
+    this.lastActivityPayload = null;
+    this.lastActivityHash = null;
+    if (clearedClient) {
+      await this.clearWithinShutdownBudget(clearedClient);
+    }
     const client = this.discordClient ?? (await this.connectPromise?.catch(() => null));
     if (client && client !== clearedClient) {
-      await this.clearDiscordActivity(client, "shutdown");
+      await this.clearWithinShutdownBudget(client);
     }
     this.discordClient = null;
     this.connectPromise = null;
@@ -307,6 +321,39 @@ export class PresenceServiceImpl implements PresenceService {
     if (!client) return;
     await client.destroy().catch(() => undefined);
     this.status = this.deps.config.presenceProvider === "off" ? "disabled" : "idle";
+  }
+
+  /**
+   * Clear the Discord card inside the shutdown budget, or give up trying.
+   *
+   * Two deadlines used to make this unwinnable. A single Discord IPC frame is
+   * allowed 10s (`DEFAULT_DISCORD_IPC_TIMEOUT_MS`), and the clear went through
+   * `enqueuePresenceOperation`, so it also queued behind whatever `setActivity`
+   * was already in flight. The shutdown coordinator force-exits after 4s. On a
+   * fatal exit the process was therefore gone long before the clear frame was
+   * even attempted, and Discord kept showing "Watching kunai …" for a session
+   * that no longer existed.
+   *
+   * So the clear does not queue — it is the last presence work there will ever
+   * be, and the state it would have raced with is already reset above — and it
+   * is bounded well inside the coordinator's deadline. Losing the race is not a
+   * failure worth reporting: the socket dying is the normal reason a clear does
+   * not land while exiting.
+   */
+  private async clearWithinShutdownBudget(client: DiscordPresenceClient): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        this.clearDiscordActivity(client, "shutdown"),
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, PRESENCE_SHUTDOWN_CLEAR_BUDGET_MS);
+        }),
+      ]);
+    } catch {
+      // clearDiscordActivity already records its own outcome.
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
   private async ensureDiscordClient(): Promise<DiscordPresenceClient | null> {

--- a/apps/cli/test/unit/services/presence/PresenceServiceImpl.test.ts
+++ b/apps/cli/test/unit/services/presence/PresenceServiceImpl.test.ts
@@ -10,6 +10,7 @@ import {
   buildDiscordActivity,
   buildPresenceSnapshot,
   describePresenceConfiguration,
+  PRESENCE_SHUTDOWN_CLEAR_BUDGET_MS,
   PresenceServiceImpl,
   resolvePresenceClientId,
   resolvePresenceClientIdSource,
@@ -771,5 +772,126 @@ describe("PresenceServiceImpl", () => {
     expect(snapshot.status).toBe("unavailable");
     expect(snapshot.detail).toContain("Could not connect to Discord IPC");
     expect(diagnostics.messages).toContain("Discord presence unavailable");
+  });
+});
+
+/**
+ * Discord kept showing "Watching kunai …" after a crash.
+ *
+ * Two deadlines made the clear unwinnable. A Discord IPC frame is allowed 10s,
+ * and `clearPlayback` went through the serial presence-operation queue, so it
+ * also waited behind whatever `setActivity` was already in flight. The shutdown
+ * coordinator force-exits after 4s. The process was gone before the clear frame
+ * was attempted, and the card outlived the session that published it.
+ */
+describe("presence clear during shutdown", () => {
+  test("does not wait behind an in-flight presence update", async () => {
+    const diagnostics = createDiagnostics();
+    const service = new PresenceServiceImpl({
+      config: createConfig({ presenceProvider: "discord" }),
+      diagnostics,
+    });
+    const order: string[] = [];
+    let releaseStuckUpdate: (() => void) | undefined;
+    const stuckUpdate = new Promise<void>((resolve) => {
+      releaseStuckUpdate = resolve;
+    });
+
+    Object.assign(service as unknown as Record<string, unknown>, {
+      discordClient: {
+        async login() {},
+        async setActivity() {
+          order.push("update-start");
+          await stuckUpdate;
+          order.push("update-end");
+        },
+        async clearActivity() {
+          order.push("clear");
+        },
+        async destroy() {},
+        on() {},
+      },
+      status: "ready",
+    });
+
+    // An update the socket never answers — the state a crash interrupts.
+    const pendingUpdate = service.updatePlayback({
+      mode: "series",
+      title: { id: "1", type: "series", name: "Demo" },
+      episode: { season: 1, episode: 2 },
+      providerId: "vidking",
+      startedAtMs: 1000,
+    });
+
+    await service.shutdown();
+
+    // The clear landed while the update was still hanging: `update-end` has not
+    // been recorded, so the socket never answered. Queued behind that update,
+    // the clear could only have run after it — i.e. never, within the budget.
+    expect(order).toContain("clear");
+    expect(order).not.toContain("update-end");
+
+    releaseStuckUpdate?.();
+    await pendingUpdate.catch(() => undefined);
+  });
+
+  test("gives up inside the shutdown budget when the socket never answers", async () => {
+    const diagnostics = createDiagnostics();
+    const service = new PresenceServiceImpl({
+      config: createConfig({ presenceProvider: "discord" }),
+      diagnostics,
+    });
+
+    Object.assign(service as unknown as Record<string, unknown>, {
+      discordClient: {
+        async login() {},
+        async setActivity() {},
+        // The real client would reject only after its own 10s frame timeout.
+        clearActivity: () => new Promise<void>(() => {}),
+        async destroy() {},
+        on() {},
+      },
+      status: "ready",
+    });
+
+    const startedAt = Date.now();
+    await service.shutdown();
+    const elapsed = Date.now() - startedAt;
+
+    // Well inside the coordinator's 4s force-exit, rather than the 10s a single
+    // Discord IPC frame is otherwise allowed.
+    expect(elapsed).toBeLessThan(PRESENCE_SHUTDOWN_CLEAR_BUDGET_MS + 1_000);
+  });
+
+  test("clears the card and drops the payload that would redraw it", async () => {
+    const diagnostics = createDiagnostics();
+    const service = new PresenceServiceImpl({
+      config: createConfig({ presenceProvider: "discord" }),
+      diagnostics,
+    });
+    const calls: string[] = [];
+
+    Object.assign(service as unknown as Record<string, unknown>, {
+      discordClient: {
+        async login() {},
+        async setActivity() {},
+        async clearActivity() {
+          calls.push("clear");
+        },
+        async destroy() {
+          calls.push("destroy");
+        },
+        on() {},
+      },
+      lastActivityPayload: { details: "Still visible" },
+      lastActivityHash: "stale-hash",
+      status: "ready",
+    });
+
+    await service.shutdown();
+
+    expect(calls).toEqual(["clear", "destroy"]);
+    expect((service as unknown as { lastActivityPayload: unknown }).lastActivityPayload).toBeNull();
+    expect((service as unknown as { lastActivityHash: string | null }).lastActivityHash).toBeNull();
   });
 });


### PR DESCRIPTION
## The bug

After a crash, Discord kept showing **"Watching kunai · lofi hip hop radio …"** — a Rich Presence card advertising a session that no longer existed. Reproduced from a real crash.

Two deadlines made the clear unwinnable:

| | Budget | Where |
| --- | --- | --- |
| One Discord IPC frame | **10s** | `DEFAULT_DISCORD_IPC_TIMEOUT_MS`, `discord-ipc-client.ts` |
| Whole shutdown | **4s** | `DEFAULT_DEADLINE_MS`, `app/session/shutdown-coordinator.ts` |

And `clearPlayback` went through `enqueuePresenceOperation` — a serial chain — so the clear *also* waited behind whatever `setActivity` was already in flight. On a fatal exit the process was gone long before the clear frame was attempted.

## The fix

`shutdown()` resets presence state synchronously and clears **without queueing**. That is safe precisely here: it is the last presence work there will ever be, and the state the queue would have protected against (`lastActivityPayload`, the dedupe hash, the generation counter) is already reset one line above.

The attempt is bounded by `PRESENCE_SHUTDOWN_CLEAR_BUDGET_MS` (1.5s) — a deliberate fraction of the coordinator deadline, documented against it so the two cannot silently drift apart. Losing that race stays silent: a dying socket is the ordinary reason a clear does not land while exiting, and `clearDiscordActivity` already records its own outcome.

## Verification

Cold, turbo cache deleted: `fmt` 0 · `typecheck` 0 · `lint` 0 · `test` 0.

Three new tests. The decisive one — *"gives up inside the shutdown budget when the socket never answers"* — against the previous code does not merely fail, it **hangs for the full 20s test timeout**. That is the defect stated exactly: an unanswered socket blocked shutdown indefinitely, five times past the force-exit that was supposed to bound it.

The other two pin that the clear no longer waits behind an in-flight update, and that the payload which would redraw the card is dropped.

## Seams walked

- **Reverse states:** publishing a card had a teardown that could not run in the time it was given; it now can.
- **Declaration → reader:** the new budget constant is read by `clearWithinShutdownBudget` and documented against the coordinator deadline it is derived from.
- **Every platform:** the path is the IPC client, which is a Unix socket on Linux/macOS and a named pipe on Windows; the budget is transport-independent.

## Honest limit

This bounds the *graceful* path. A `SIGKILL` — from the memory watchdog, or `kill -9` — still cannot run any cleanup; there, clearing depends on Discord noticing the socket close. This fix ensures that when Kunai *does* get to shut down, the clear actually fits in the time available.
