### PR TITLE
fix(docs): stop the home and releases pages clipping content on phones

### DIFF
--- a/apps/docs/app/(home)/home-page-interactive.tsx
+++ b/apps/docs/app/(home)/home-page-interactive.tsx
@@ -59,7 +59,7 @@ export default function HomePageInteractive() {
       <div className="install-section kunai-surface-shell">
         <div className="kunai-surface-shell__inner p-6 md:p-8">
           <div
-            className="border-fd-border mb-8 flex gap-3 border-b pb-6"
+            className="os-tab-list border-fd-border mb-8 flex gap-3 border-b pb-6"
             role="tablist"
             aria-label="Operating system"
           >

--- a/apps/docs/app/styles/home.css
+++ b/apps/docs/app/styles/home.css
@@ -622,9 +622,30 @@
   box-shadow: var(--kunai-card-shadow);
 }
 
+/*
+ * The OS tablist scrolls rather than clips.
+ *
+ * Three tabs at full padding measure ~315px, which does not fit the ~270px
+ * content box of a 390px phone. The shell's `overflow-x-hidden` turned that
+ * into a silently truncated "WINDOWS" tab — an option the user cannot see or
+ * reach. Scrolling keeps every tab reachable; the tighter padding below means
+ * most phones never need to scroll at all.
+ */
+.os-tab-list {
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.os-tab-list::-webkit-scrollbar {
+  display: none;
+}
+
 .os-tab-button {
   position: relative;
   padding: 0.6rem 1.25rem;
+  white-space: nowrap;
+  flex: 0 0 auto;
   font-size: 0.825rem;
   font-weight: 700;
   border-radius: 0.5rem;
@@ -889,5 +910,11 @@
 
   .kunai-hero-install__os {
     width: 4.5rem;
+  }
+}
+
+@media (max-width: 30rem) {
+  .os-tab-button {
+    padding: 0.6rem 0.75rem;
   }
 }

--- a/apps/docs/app/styles/surfaces.css
+++ b/apps/docs/app/styles/surfaces.css
@@ -21,10 +21,22 @@
   background: color-mix(in oklab, var(--kunai-bg) 92%, transparent);
 }
 
+/*
+ * A command beside a copy button.
+ *
+ * Flex children default to `min-width: auto`, which means they refuse to
+ * shrink below their content — so a long install URL pushes the row wider than
+ * its card instead of wrapping, and the copy button is clipped off the right
+ * edge. The page hides that with `overflow-x-hidden` on the shell, so it
+ * presents as a truncated button rather than a scrollbar. Every rule below
+ * exists to let the row give way at phone widths.
+ */
 .kunai-code-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  min-width: 0;
   gap: 0.5rem;
   border-radius: var(--kunai-radius-inner);
   border: 1px solid var(--kunai-line);
@@ -33,6 +45,16 @@
   font-family: var(--font-mono), ui-monospace, monospace;
   font-size: 0.6875rem;
   color: color-mix(in oklab, var(--color-fd-foreground) 82%, transparent);
+}
+
+.kunai-code-row > * {
+  min-width: 0;
+}
+
+/* A URL has no spaces to break on, so it needs an explicit break opportunity. */
+.kunai-code-row code,
+.kunai-code-row span:not([class*="sr-only"]) {
+  overflow-wrap: anywhere;
 }
 
 .kunai-fd-card {

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "8c2ac929bf5cb63efab7d1b33ef219164174bc56b19dabf4f7f2e8742b2d8a77",
-  "docsContentFingerprint": "f0b118edd6dbca9b4e36a5d70b93a0b182be90efb7333e623f3b6bdd1f58e73f",
+  "docsContentFingerprint": "15b86aec812b31ee908cc5a567abc1dfeece10e9b879a2dc7941b994b1f84cff",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/docs/developer/release-checklist.mdx
+++ b/docs/developer/release-checklist.mdx
@@ -86,6 +86,7 @@ If the metadata push fails under branch protection, recover manually with a cont
 
 ## After release
 
+- Repoint the `/install.sh` redirect in `apps/docs/next.config.mjs` at the tag just published, e.g. `.../KitsuneKode/kunai/v0.3.0/install.sh`. It otherwise serves `main`, so every new `curl … | bash` runs whatever last landed on the default branch rather than the installer that shipped with the release. The installer verifies SHA-256 of the binaries it downloads, but an unpinned installer is the script that enforces those checksums — pin it after the tag exists, never before, or the redirect points at the previous release's script.
 - Verify `/releases` shows the new tag as **published** latest (staged-only versions stay under Upcoming)
 - Optional local Lighthouse: `bun run --cwd apps/docs lighthouse:docs`
 


### PR DESCRIPTION
At 390px the home shell overflowed its own width by 65px. `overflow-x-hidden` on `main.kunai-home` meant this never showed up as a scrollbar — it **silently cut content off the right edge**, which is the worse failure mode: the `WINDOWS` install tab and a `Copy` button were unreachable rather than merely awkward.

Measured at a 390px viewport, after a real layout settle:

| element | scrollWidth | clientWidth |
|---|---|---|
| `main.kunai-home` | 435 | 370 |
| OS tablist | 315 | 270 |
| `code.kunai-code-row` | 330 | 226 |

### Two causes

**`.kunai-code-row` could not shrink.** It is a flex row, and flex children default to `min-width: auto` — they refuse to shrink below their content. A long install URL pushed the row wider than its card and clipped the copy button off the edge. The row now wraps, its children may shrink, and URLs get an explicit break opportunity, so the button drops below the command instead of disappearing.

**Three OS tabs did not fit.** At full padding they measure ~315px against a ~270px content box. The tablist now scrolls instead of clipping, and the padding tightens under `30rem` so most phones never need to scroll at all.

`.kunai-code-row` is shared, so `/releases` is fixed by the same change.

### Verification

- After: **no clipped overflow** on either page; `main` measures 370/370.
- Rendered and inspected at 390px and 1440px through CDP with a settled layout — `--virtual-time-budget` screenshots are unreliable here because they capture before ResizeObserver runs.
- Desktop layout unchanged: at full width there was always room, so nothing wraps.
- `typecheck`, `lint`, `fmt:check` clean; 144 tests pass.

`/feedback` was checked and is clean. The `/docs` hits under the same measurement are intentional `truncate`, not defects.

https://claude.ai/code/session_019Y5YVCB6rqeKqh2cbTsSa7

---

### Also in this PR

**Release checklist: pin the `/install.sh` redirect.** `kunai.kitsunekode.in/install.sh` 307s to `raw.githubusercontent.com/.../main/install.sh`, so every new `curl … | bash` runs whatever last landed on the default branch rather than the installer that shipped with a release. The installer *does* verify SHA-256 of the binaries it downloads against a published manifest, so the binary supply chain is sound — the gap is one level up: an unpinned installer is the very script that enforces those checksums.

This is a checklist item rather than a code change **because the pin is only correct after the tag exists**. Pinning today would point at `v0.2.5` — 8,061 bytes from June, against 68,438 on `main` — and serve the previous release's installer to everyone installing 0.3.0.
