### PR TITLE
fix: close silent-failure, cache-poisoning, and episode-numbering gaps

### DIFF
--- a/.changeset/tidy-pandas-shake.md
+++ b/.changeset/tidy-pandas-shake.md
@@ -1,0 +1,14 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Fix a set of silent failures found while auditing the tree.
+
+- Quitting immediately after changing a setting could lose the change: a debounced save that had already started was not awaited by the shutdown flush.
+- A single offline blip or navigating away mid-load could leave trending empty for 30 minutes, because a failed discovery fetch was cached as "no results".
+- "Keep the last N watched" retained nothing for absolute-numbered anime, and the same numbering mismatch stopped watched anime downloads from ever being reclaimed and stopped the resume position being restored after a crash.
+- Analytics now refuses a non-https endpoint override instead of sending in cleartext. A rejected override stops sending entirely rather than falling back to the built-in URL.
+- A self-hosted relay behind a sub-path (`https://host/prod`) is now called correctly instead of 404ing and silently falling back to direct.
+- Long CJK and emoji titles could still produce a Windows path over `MAX_PATH`; the path is now measured and tightened rather than estimated.
+- An intro-skip window from AniSkip is no longer discarded when IntroDB answers with an untimed segment.
+- A config file that is unreadable, or that vanishes mid-read, no longer throws or overwrites its own corrupt-backup with an empty file.

--- a/.changeset/tidy-pandas-shake.md
+++ b/.changeset/tidy-pandas-shake.md
@@ -12,3 +12,4 @@ Fix a set of silent failures found while auditing the tree.
 - Long CJK and emoji titles could still produce a Windows path over `MAX_PATH`; the path is now measured and tightened rather than estimated.
 - An intro-skip window from AniSkip is no longer discarded when IntroDB answers with an untimed segment.
 - A config file that is unreadable, or that vanishes mid-read, no longer throws or overwrites its own corrupt-backup with an empty file.
+- The config path is now resolved when it is first needed rather than when the module loads, so a sandboxed run can never fall back to the real profile.

--- a/.docs/agents/audit-findings-bar.md
+++ b/.docs/agents/audit-findings-bar.md
@@ -1,0 +1,99 @@
+---
+status: current
+lastReviewed: "2026-08-31"
+---
+
+# The bar for an audit finding
+
+> Agent-facing (L3). Never linked from published docs.
+
+Four audit passes over this repo produced ~38 distinct claims. Roughly a third
+dissolved when someone opened the twenty lines around the cited one. The line
+numbers were nearly always right; the inference from them was not.
+
+This file is the bar. Apply it before filing, and when reviewing findings
+someone else filed.
+
+## The recurring failure
+
+**A true observation about a line, plus a false inference about what that line
+does.** Every refuted finding had this shape:
+
+| Filed as                                                               | What one more hop showed                                                                                   |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| "Empty catch swallows read errors, watchdog stops protecting"          | The catch is inside a template literal that becomes Worker source, and the fallback is a valid RSS reading |
+| "N+1 fan-out: dozens of concurrent TMDB calls for long-running series" | The list is filtered to seasons with _no air date_; One Piece exits before the `Promise.all`               |
+| "Naming regressions would pass — `Frieren - E03.mp4` is untested"      | That exact string is asserted in `download-service.test.ts:65`                                             |
+| "crypto-js on the hot decrypt path in `vidrock/direct.ts:2050`"        | That file is 124 lines and already uses `node:crypto`; a test pins the migration                           |
+| "`NUL.mp4` bypasses the reserved-name guard"                           | Sanitisation runs on the bare title, before an extension exists                                            |
+| "Config save failures are swallowed"                                   | A test named "store rejection rejects both save() and flushPending()"                                      |
+
+## Six rules
+
+1. **Read the callee, not the call site.** If a finding depends on what a
+   predicate admits, a helper returns, or a constant holds — open it. Two of the
+   refutations above died on the function one hop away.
+
+2. **Grep the test file before claiming something is untested.** Cheapest check
+   available, and three findings would not have been filed.
+
+3. **An empty `catch` is a finding only if it is undefended.** Quote the comment
+   above it, or state there isn't one. This codebase comments its deliberate
+   silences — `memory-watchdog.ts:72`, `atomic-write.ts:135`,
+   `ConfigServiceImpl.ts:758` all carry their rationale.
+
+4. **State the disproof you attempted.** Not a confidence label — _what did you
+   check that would have made this wrong?_ Across four passes, stated confidence
+   had no relationship to whether a finding survived: a HIGH-confidence item
+   cited line 2050 of a 124-line file. Treat the label as noise; read the
+   evidence.
+
+5. **Check `.plans/roadmap.md` before filing anything architectural.** Four
+   findings in one pass restated plans 010/011/012/014/015, which are already
+   written, prioritised, and dependency-ordered with a stated reason for being
+   BLOCKED.
+
+6. **Reproduce; do not reason.** Especially for anything platform-shaped. See
+   below — this one is written in the author's own blood.
+
+## Reproduce, do not reason
+
+The `FileStorage` lazy-path test in this same change set failed CI **three
+times**, each for a different host-dependent assertion the author reasoned their
+way into:
+
+- hard-coded that the sandboxed config lands under the temp dir (macOS puts it
+  under `Library/Application Support`, Linux under XDG, Windows under APPDATA);
+- compared path _spelling_ — macOS reports `/var/...` for a directory resolving
+  to `/private/var/...`, Windows reports the 8.3 form (`RUNNER~1`);
+- read a file with `.catch(() => null)` and asserted `not.toContain` on it,
+  which throws on a null receiver — passing only on a machine that happens to
+  have a real `config.json`.
+
+Each was "obviously fine" by inspection. The fix each time was to simulate the
+condition instead: an empty `HOME` with XDG and APPDATA unset reproduced the
+third failure locally in one command.
+
+Corollary: **a cross-platform assertion you have not run on that platform is a
+guess.** Prefer assertions that hold everywhere — compare against the same
+resolver production calls, or assert an inequality, rather than a path shape.
+
+## Parallel agents
+
+Two sweeps that start from the same grep produce the same blind spot twice.
+Agreement between them is duplication, not corroboration. Deduplicate before
+reporting, and never raise confidence because two agents said it.
+
+## What a filed finding must carry
+
+- The failing input or state, and the wrong output — concretely.
+- `file:line` for the defect **and** for the code that makes it reachable.
+- What you checked that would have falsified it.
+- Whether a test already covers it, and if so why it does not catch this.
+- Whether `.plans/` already owns it.
+
+## Related
+
+- [issue-tracker.md](./issue-tracker.md) — where findings become issues
+- [triage-labels.md](./triage-labels.md) — labels for the result
+- [../../AGENTS.md](../../AGENTS.md) — the four hazards and the "hit every seam" list

--- a/.docs/analytics-privacy-contract.md
+++ b/.docs/analytics-privacy-contract.md
@@ -44,6 +44,16 @@ Read this before touching `apps/cli/src/services/analytics/`,
   `analyticsEndpoint` (the shipped default) means “use the built-in URL”, not
   “disable sending”. Disable in Settings, or with `DO_NOT_TRACK` / `CI` / a
   non-TTY session.
+- **An override must be https.** `http://localhost`, `127.0.0.1`, and `[::1]`
+  are the only cleartext exceptions, so `apps/analytics-ingest` can be developed
+  against locally. Anything else — an `http://` host, a non-URL — is refused and
+  **stops sending entirely**; it is never redirected to the built-in default,
+  because someone who pointed their installs at their own ingest did not consent
+  to sending here instead. The wire carries `sha256(installId)` with version,
+  OS, and architecture: over http that is readable on the path and one install
+  is followable day to day, which is exactly what the digest exists to prevent.
+  Same rule and same loopback exception as `normalizeRelayBaseUrl` in
+  `packages/relay`.
 - The default is a domain Kunai controls, never a hosting provider's own URL.
   This string is baked into immutable npm tarballs and compiled binaries, so it
   must outlive whatever serves it today: DNS can be re-pointed, a published

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,10 @@ legacy implementation details.
 Issues are GitHub Issues on `KitsuneKode/kunai` — workflow in
 [.docs/agents/issue-tracker.md](.docs/agents/issue-tracker.md), labels in
 [.docs/agents/triage-labels.md](.docs/agents/triage-labels.md). Domain language
-is [.docs/agents/domain.md](.docs/agents/domain.md). Kunai is single-context:
+is [.docs/agents/domain.md](.docs/agents/domain.md). Before filing an audit
+finding — or acting on one someone else filed — read
+[.docs/agents/audit-findings-bar.md](.docs/agents/audit-findings-bar.md): about a
+third of the findings this repo has received were true about a line and wrong
+about what it does. Kunai is single-context:
 one system-wide ADR set in `.docs/adr/`, no per-package context files, and new
 ADRs take the next sequential number.

--- a/apps/cli/src/app/discover/discover-sections.ts
+++ b/apps/cli/src/app/discover/discover-sections.ts
@@ -7,6 +7,7 @@
 
 import { loadDiscoveryList } from "@/app/discover/discovery-lists";
 import type { Container } from "@/container";
+import type { SearchResult } from "@/domain/types";
 import {
   historyContentType,
   readLatestHistoryByTitle,
@@ -65,11 +66,13 @@ export async function buildDiscoverSections(
           .getForTitle(recentHistoryId, historyContentType(mostRecentCompleted[1]))
           .then((s) => ({ ...s, label: `Because you watched ${mostRecentCompleted[1].title}` }))
       : null,
-    loadDiscoveryList(mode).then((items) => ({
-      label: mode === "anime" ? "Anime trending this week" : "Trending this week",
-      reason: "trending" as const,
-      items,
-    })),
+    loadDiscoveryList(mode)
+      .catch((): readonly SearchResult[] => [])
+      .then((items) => ({
+        label: mode === "anime" ? "Anime trending this week" : "Trending this week",
+        reason: "trending" as const,
+        items,
+      })),
     !options.light && mode !== "anime" && completedHistorySeeds.length > 0
       ? container.recommendationService
           .getPersonalizedByHistory(completedHistorySeeds)

--- a/apps/cli/src/app/search/SearchPhase.ts
+++ b/apps/cli/src/app/search/SearchPhase.ts
@@ -819,7 +819,13 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
             // the empty-state copy below rather than tearing down the phase.
             const results = await observeOnline(container, "search-error", () =>
               loadDiscoveryList(mode, context.signal),
-            ).catch((): SearchResult[] => []);
+            ).catch((error: unknown): SearchResult[] => {
+              // A cancelled navigation is not an empty tray. Swallowing it here
+              // recorded a "succeeded / healthy" discovery event and pushed state
+              // into a phase the user had already left.
+              if (context.signal.aborted) throw error;
+              return [];
+            });
 
             logger.info("Discovery list loaded", {
               mode,
@@ -1244,7 +1250,12 @@ async function loadSearchRoute(
   const bundle =
     route === "trending"
       ? {
-          results: await loadDiscoveryList(mode, context.signal).catch((): SearchResult[] => []),
+          results: await loadDiscoveryList(mode, context.signal).catch(
+            (error: unknown): SearchResult[] => {
+              if (context.signal.aborted) throw error;
+              return [];
+            },
+          ),
           subtitle:
             mode === "anime"
               ? "AniList trending"

--- a/apps/cli/src/app/search/SearchPhase.ts
+++ b/apps/cli/src/app/search/SearchPhase.ts
@@ -814,9 +814,12 @@ export class SearchPhase implements Phase<SearchPhaseInput | void, TitleInfo> {
             stateManager.dispatch({ type: "SET_SEARCH_QUERY", query: "" });
             stateManager.dispatch({ type: "SET_SEARCH_STATE", state: "loading" });
             const mode = stateManager.getState().mode;
+            // Trending rejects when the upstream is down, which is what lets
+            // `observeOnline` see the failure at all. Browse still degrades to
+            // the empty-state copy below rather than tearing down the phase.
             const results = await observeOnline(container, "search-error", () =>
               loadDiscoveryList(mode, context.signal),
-            );
+            ).catch((): SearchResult[] => []);
 
             logger.info("Discovery list loaded", {
               mode,
@@ -1241,7 +1244,7 @@ async function loadSearchRoute(
   const bundle =
     route === "trending"
       ? {
-          results: await loadDiscoveryList(mode, context.signal),
+          results: await loadDiscoveryList(mode, context.signal).catch((): SearchResult[] => []),
           subtitle:
             mode === "anime"
               ? "AniList trending"

--- a/apps/cli/src/domain/lists/StatsService.ts
+++ b/apps/cli/src/domain/lists/StatsService.ts
@@ -149,8 +149,10 @@ export class StatsService {
     const windowStart = windowStartIso(windowDays);
 
     const totals = this.repo.totalsSince(windowStart, mediaKind);
+    // One scan feeds both the activity metrics and the heatmap — they are the
+    // same rows, and `history_progress` is large enough that a second identical
+    // query is a full table scan for nothing.
     const dayRows = this.repo.dailyActivitySince(windowStart, mediaKind);
-    const heatmapRows = this.repo.dailyActivitySince(windowStart, mediaKind);
     const showRows = this.repo.topShowsSince(windowStart, mediaKind);
     const weeklyRows = this.repo.weeklyBucketsSince(windowStart, mediaKind);
     const kindRows = this.repo.kindBreakdownSince(windowStart, mediaKind);
@@ -220,7 +222,7 @@ export class StatsService {
       providerBreakdown,
       hourOfDay,
       dailyKindMix: [...dailyKindByDate.values()],
-      heatmap: heatmapRows.map((row) => ({
+      heatmap: dayRows.map((row) => ({
         date: row.date,
         watchedCount: row.watchedCount,
         totalSeconds: row.totalSeconds,

--- a/apps/cli/src/domain/media/episode-numbering.ts
+++ b/apps/cli/src/domain/media/episode-numbering.ts
@@ -1,0 +1,28 @@
+/**
+ * The one rule for "these two records mean the same episode".
+ *
+ * Anime arrives numbered two ways. Absolute-numbered sources carry no season
+ * and put the number in `absoluteEpisode`; season-relative sources carry
+ * `season` + `episode`, and a history row for the same playback may carry both.
+ * Every comparison that normalized one side only — `(entry.season ?? 1) ===
+ * job.season`, or `left.absoluteEpisode === right.absoluteEpisode` when a
+ * single side had an absolute number — compared a number against `undefined`
+ * and matched nothing, silently.
+ */
+export type EpisodeNumbering = {
+  readonly season?: number;
+  readonly episode?: number;
+  readonly absoluteEpisode?: number;
+};
+
+export function sameEpisodeNumbering(left: EpisodeNumbering, right: EpisodeNumbering): boolean {
+  // Absolute numbers are authoritative, but only when both sides carry one:
+  // an absolute number on its own says nothing about the other side's season.
+  if (left.absoluteEpisode !== undefined && right.absoluteEpisode !== undefined) {
+    return left.absoluteEpisode === right.absoluteEpisode;
+  }
+  return (
+    (left.season ?? 1) === (right.season ?? 1) &&
+    (left.episode ?? left.absoluteEpisode ?? 1) === (right.episode ?? right.absoluteEpisode ?? 1)
+  );
+}

--- a/apps/cli/src/domain/media/episode-numbering.ts
+++ b/apps/cli/src/domain/media/episode-numbering.ts
@@ -18,6 +18,14 @@ export type EpisodeNumbering = {
 export function sameEpisodeNumbering(left: EpisodeNumbering, right: EpisodeNumbering): boolean {
   // Absolute numbers are authoritative, but only when both sides carry one:
   // an absolute number on its own says nothing about the other side's season.
+  //
+  // This under-matches on purpose, and there is a real case it gets wrong. For a
+  // show whose first season has twelve episodes, absolute 13 *is* S02E01, and
+  // this returns false. Nothing in the tree knows per-season episode counts, so
+  // any rule without that data has to choose a direction: a false negative
+  // leaves two rows unmerged, while a false positive merges two different
+  // episodes and loses one of them. Only the second is unrecoverable, so this
+  // errs toward not matching. Give it season lengths and the rule can tighten.
   if (left.absoluteEpisode !== undefined && right.absoluteEpisode !== undefined) {
     return left.absoluteEpisode === right.absoluteEpisode;
   }

--- a/apps/cli/src/domain/queue/restore-queue-session.ts
+++ b/apps/cli/src/domain/queue/restore-queue-session.ts
@@ -7,6 +7,7 @@
 // already belongs to the restored session — never to invent a new queue row.
 // =============================================================================
 
+import { sameEpisodeNumbering } from "@/domain/media/episode-numbering";
 import type { QueueEntry } from "@kunai/storage";
 import type { HistoryProgress } from "@kunai/storage";
 import { isHistoryProgressFinished as isFinished } from "@kunai/storage";
@@ -54,13 +55,17 @@ function isResumable(progress: HistoryProgress): boolean {
   return !isFinished(progress) && progress.positionSeconds >= RESUME_MIN_POSITION_SECONDS;
 }
 
-/** Exact media identity, including absolute anime episode when present. */
+/**
+ * Exact media identity, including absolute anime episode when present.
+ *
+ * The numbering rule is shared with the offline keep/delete sets. Requiring
+ * only *one* side to carry an absolute episode compared `13 === undefined`, so
+ * an absolute-numbered history row never matched its own season-relative queue
+ * entry and the resume head was never promoted after a crash.
+ */
 function sameEpisodeIdentity(left: EpisodeIdentity, right: EpisodeIdentity): boolean {
   if (left.titleId !== right.titleId) return false;
-  if (left.absoluteEpisode !== undefined || right.absoluteEpisode !== undefined) {
-    return left.absoluteEpisode === right.absoluteEpisode;
-  }
-  return (left.season ?? 1) === (right.season ?? 1) && (left.episode ?? 0) === (right.episode ?? 0);
+  return sameEpisodeNumbering(left, right);
 }
 
 function withinSessionWindow(

--- a/apps/cli/src/infra/storage/FileStorage.ts
+++ b/apps/cli/src/infra/storage/FileStorage.ts
@@ -15,24 +15,36 @@ import { getKunaiPaths } from "@kunai/storage";
 
 import type { StorageService } from "./StorageService";
 
-// Key → file path mapping (history and cache are SQLite — no JSON paths here)
-const PATHS: Record<string, string> = {
-  config: join(getKunaiPaths().configDir, "config.json"),
-};
+/**
+ * Key → file path mapping (history and cache are SQLite — no JSON paths here).
+ *
+ * Built on first use, never at import. As a module-level constant this called
+ * `getKunaiPaths()` while the module was being loaded, so the developer's real
+ * `config.json` path was frozen in before a test could point HOME/XDG/APPDATA
+ * at a sandbox — a suite that imported this file early, however indirectly,
+ * then wrote the live profile. Resolving lazily means the environment in effect
+ * when a path is actually needed is the one that decides it.
+ */
+function defaultPaths(): Record<string, string> {
+  return {
+    config: join(getKunaiPaths().configDir, "config.json"),
+  };
+}
 
 export class FileStorage implements StorageService {
   // Simple mutex to prevent concurrent writes from interleaving and corrupting files
   private writeLock: Promise<void> = Promise.resolve();
+  private resolvedPaths: Record<string, string> | undefined;
 
   constructor(
-    private readonly paths: Record<string, string> = PATHS,
+    /** Explicit paths win; omitted means resolve the real profile on first use. */
+    private readonly paths?: Record<string, string>,
     /** Warn channel for user-relevant events; debug-only detail goes through dbg(). */
     private readonly warn?: (message: string, context?: Record<string, unknown>) => void,
   ) {}
 
   async read<T>(key: string): Promise<T | null> {
-    const path = this.paths[key];
-    if (!path) throw new Error(`Unknown storage key: ${key}`);
+    const path = this.pathFor(key);
 
     const file = Bun.file(path);
 
@@ -74,8 +86,7 @@ export class FileStorage implements StorageService {
   }
 
   async write<T>(key: string, data: T): Promise<void> {
-    const path = this.paths[key];
-    if (!path) throw new Error(`Unknown storage key: ${key}`);
+    const path = this.pathFor(key);
 
     const task = this.writeLock.then(async () => {
       await writeAtomicSecretJson(path, data);
@@ -87,8 +98,7 @@ export class FileStorage implements StorageService {
   }
 
   async delete(key: string): Promise<void> {
-    const path = this.paths[key];
-    if (!path) throw new Error(`Unknown storage key: ${key}`);
+    const path = this.pathFor(key);
 
     const task = this.writeLock.then(async () => {
       if (await Bun.file(path).exists()) await unlink(path);
@@ -99,8 +109,19 @@ export class FileStorage implements StorageService {
     await task;
   }
 
+  private lookupPath(key: string): string | undefined {
+    this.resolvedPaths ??= this.paths ?? defaultPaths();
+    return this.resolvedPaths[key];
+  }
+
+  private pathFor(key: string): string {
+    const path = this.lookupPath(key);
+    if (!path) throw new Error(`Unknown storage key: ${key}`);
+    return path;
+  }
+
   async exists(key: string): Promise<boolean> {
-    const path = this.paths[key];
+    const path = this.lookupPath(key);
     if (!path) return false;
     return Bun.file(path).exists();
   }

--- a/apps/cli/src/infra/storage/FileStorage.ts
+++ b/apps/cli/src/infra/storage/FileStorage.ts
@@ -35,17 +35,36 @@ export class FileStorage implements StorageService {
     if (!path) throw new Error(`Unknown storage key: ${key}`);
 
     const file = Bun.file(path);
-    if (!(await file.exists())) return null;
-    if (process.platform !== "win32") await chmod(path, 0o600);
+
+    let raw: string;
     try {
-      return (await file.json()) as T;
+      if (process.platform !== "win32") await chmod(path, 0o600);
+      raw = await file.text();
     } catch (error) {
-      // Corrupt JSON — back it up so we don't nuke it permanently, and say so:
-      // a silently reset config used to look exactly like a fresh install.
+      // "Not there" is nothing stored, not a read error for the caller to
+      // handle. An `exists()` pre-check used to answer this, but it left both
+      // the chmod and the read outside the guard: a file that vanished in
+      // between (another process, a concurrent `delete()`) made `read()` reject
+      // with ENOENT instead of returning null.
+      if (errorCode(error) === "ENOENT") return null;
+      // Unreadable for another reason (permissions, I/O). Nothing was read, so
+      // there is no content to preserve — writing a backup here would replace a
+      // good earlier `.corrupt.bak` with an empty file.
+      dbgErr("storage.file", `Unreadable file at ${path}`, error);
+      this.warn?.("Config file could not be read; defaults are in use", { path });
+      return null;
+    }
+
+    try {
+      return JSON.parse(raw) as T;
+    } catch (error) {
+      // Corrupt JSON — back up the bytes we actually read so we don't nuke them
+      // permanently, and say so: a silently reset config used to look exactly
+      // like a fresh install.
       const corruptPath = `${path}.corrupt.bak`;
       const parent = dirname(corruptPath);
       if (parent) await mkdir(parent, { recursive: true }).catch(() => {});
-      await writeAtomicSecretText(corruptPath, await file.text().catch(() => "")).catch(() => {});
+      await writeAtomicSecretText(corruptPath, raw).catch(() => {});
       dbgErr("storage.file", `Corrupt JSON at ${path}; backed up to ${corruptPath}`, error);
       this.warn?.("Config file was unreadable and has been reset to defaults", {
         corruptBackup: corruptPath,
@@ -85,4 +104,8 @@ export class FileStorage implements StorageService {
     if (!path) return false;
     return Bun.file(path).exists();
   }
+}
+
+function errorCode(error: unknown): string | undefined {
+  return (error as NodeJS.ErrnoException | null)?.code;
 }

--- a/apps/cli/src/infra/timing/merge-timing.ts
+++ b/apps/cli/src/infra/timing/merge-timing.ts
@@ -1,4 +1,4 @@
-import type { PlaybackTimingMetadata } from "@/domain/types";
+import type { PlaybackTimingMetadata, PlaybackTimingSegment } from "@/domain/types";
 
 export function mergeTimingMetadata(
   primary: PlaybackTimingMetadata | null,
@@ -11,9 +11,36 @@ export function mergeTimingMetadata(
   return {
     tmdbId: primary.tmdbId,
     type: primary.type,
-    intro: primary.intro.length ? primary.intro : secondary.intro,
-    recap: primary.recap.length ? primary.recap : secondary.recap,
-    credits: primary.credits.length ? primary.credits : secondary.credits,
-    preview: primary.preview.length ? primary.preview : secondary.preview,
+    intro: preferUsable(primary.intro, secondary.intro),
+    recap: preferUsable(primary.recap, secondary.recap),
+    credits: preferUsable(primary.credits, secondary.credits),
+    preview: preferUsable(primary.preview, secondary.preview),
   };
+}
+
+/**
+ * A segment only counts if something could actually be skipped with it.
+ *
+ * `normalizeSegments` in `introdb.ts` builds a segment per upstream row without
+ * dropping a degenerate one, so IntroDB can answer with `[{startMs: 0, endMs: 0}]`.
+ * Choosing on `.length` alone treated that as "the primary source has intro
+ * timing" and discarded a real AniSkip window in `secondary` — the skip prompt
+ * then never appeared, even though a usable window had been fetched.
+ *
+ * The usable test mirrors `normalizeEndSeconds` in `infra/player/playback-skip.ts`,
+ * which is what ultimately decides whether a segment can drive a skip.
+ */
+function preferUsable(
+  primary: readonly PlaybackTimingSegment[],
+  secondary: readonly PlaybackTimingSegment[],
+): readonly PlaybackTimingSegment[] {
+  if (primary.some(isUsableSegment)) return primary;
+  if (secondary.some(isUsableSegment)) return secondary;
+  // Neither can drive a skip; keep whichever is non-empty so callers that only
+  // ask "did any source answer?" still see the primary's shape.
+  return primary.length ? primary : secondary;
+}
+
+function isUsableSegment(segment: PlaybackTimingSegment): boolean {
+  return typeof segment.endMs === "number" && Number.isFinite(segment.endMs) && segment.endMs > 0;
 }

--- a/apps/cli/src/infra/timing/merge-timing.ts
+++ b/apps/cli/src/infra/timing/merge-timing.ts
@@ -42,5 +42,13 @@ function preferUsable(
 }
 
 function isUsableSegment(segment: PlaybackTimingSegment): boolean {
-  return typeof segment.endMs === "number" && Number.isFinite(segment.endMs) && segment.endMs > 0;
+  const { startMs, endMs } = segment;
+  if (typeof endMs !== "number" || !Number.isFinite(endMs) || endMs <= 0) return false;
+  // `findPlaybackSegmentAtPosition` also requires the window to move forwards, so
+  // an inverted segment is not something this can defer to either. Checking only
+  // the end let `{startMs: 9999, endMs: 1}` count as timing here and then be
+  // dropped by the player — the same "present but unusable" shape the degenerate
+  // `{0, 0}` case already caused.
+  const start = typeof startMs === "number" && Number.isFinite(startMs) ? startMs : 0;
+  return endMs > start;
 }

--- a/apps/cli/src/services/analytics/usage-analytics-service.ts
+++ b/apps/cli/src/services/analytics/usage-analytics-service.ts
@@ -272,6 +272,10 @@ export class UsageAnalyticsService {
         headers: { "content-type": "application/json", accept: "application/json" },
         body: JSON.stringify(payload),
         signal: controller.signal,
+        // An https endpoint that 302s to http:// would carry the payload right
+        // back out in cleartext, so the scheme check above has to survive the
+        // hop. Refusing to follow one at all is simpler than re-validating each.
+        redirect: "error",
       });
       return response.status >= 500 ? "retry" : "permanent";
     } catch {

--- a/apps/cli/src/services/analytics/usage-analytics-service.ts
+++ b/apps/cli/src/services/analytics/usage-analytics-service.ts
@@ -5,6 +5,7 @@ import {
   resolveConsentState,
   type ConsentEnv,
 } from "@/domain/analytics/consent-policy";
+import { dbgErr } from "@/logger";
 import type { KitsuneConfig } from "@/services/persistence/ConfigService";
 
 import { ensureInstallId, installIdDigest } from "./install-id";
@@ -221,6 +222,9 @@ export class UsageAnalyticsService {
 
     const endpoint = this.deps.endpoint.trim();
     if (!endpoint) return;
+    // Second gate, not a duplicate of `resolveAnalyticsEndpoint`: the endpoint
+    // is injected, so nothing else guarantees what arrives here.
+    if (!isTransportSafeAnalyticsEndpoint(endpoint)) return;
 
     const now = this.now();
     if (
@@ -279,13 +283,62 @@ export class UsageAnalyticsService {
   }
 }
 
+/**
+ * Loopback hosts allowed over cleartext http, so a self-hoster can develop
+ * against `apps/analytics-ingest` locally. Same list, same reason as
+ * `normalizeRelayBaseUrl` in `packages/relay`.
+ */
+const LOOPBACK_ANALYTICS_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
+/**
+ * https only, plus the loopback exception above.
+ *
+ * The payload carries `sha256(installId)` with version, OS, and architecture.
+ * Over cleartext http anything on the path reads it and can follow one install
+ * from day to day — the digest exists so no *endpoint* holds the raw id, and
+ * that is worth little if the wire is readable.
+ */
+export function isTransportSafeAnalyticsEndpoint(endpoint: string): boolean {
+  const trimmed = endpoint.trim();
+  if (!trimmed) return false;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol === "https:") return true;
+    return url.protocol === "http:" && LOOPBACK_ANALYTICS_HOSTS.has(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Where this install would ping: `KUNAI_ANALYTICS_URL`, then
+ * `analyticsEndpoint`, then the built-in default.
+ *
+ * An override that is not transport-safe returns `""`, which stops sending
+ * entirely — it is **not** redirected to the built-in default. Somebody who
+ * pointed their installs at their own ingest asked for their telemetry to go
+ * there and nowhere else; quietly sending it to Kunai's endpoint instead would
+ * be the same class of breach as enabling analytics for them. This is the
+ * posture `normalizeRelayBaseUrl` already takes: an unusable base URL turns the
+ * feature off rather than substituting one the user did not choose.
+ */
 export function resolveAnalyticsEndpoint(
   env: NodeJS.ProcessEnv = process.env,
   configured = "",
 ): string {
   const fromEnv = typeof env.KUNAI_ANALYTICS_URL === "string" ? env.KUNAI_ANALYTICS_URL.trim() : "";
-  if (fromEnv) return fromEnv;
+  if (fromEnv) return acceptOverride(fromEnv, "KUNAI_ANALYTICS_URL");
   const fromConfig = configured.trim();
-  if (fromConfig) return fromConfig;
+  if (fromConfig) return acceptOverride(fromConfig, "analyticsEndpoint");
   return DEFAULT_ANALYTICS_ENDPOINT;
+}
+
+function acceptOverride(endpoint: string, source: string): string {
+  if (isTransportSafeAnalyticsEndpoint(endpoint)) return endpoint;
+  dbgErr(
+    "analytics.endpoint",
+    `${source} must be https (loopback http allowed); analytics will not send`,
+    new Error("rejected non-https analytics endpoint"),
+  );
+  return "";
 }

--- a/apps/cli/src/services/catalog/CatalogDiscoveryService.ts
+++ b/apps/cli/src/services/catalog/CatalogDiscoveryService.ts
@@ -12,6 +12,23 @@ type DiscoveryCacheEntry = {
   readonly results: readonly SearchResult[];
 };
 
+/**
+ * Raised when a discovery source could not be read — offline, upstream error,
+ * malformed payload, or an aborted request.
+ *
+ * A loader must reject rather than fold a failure into `[]`: the service caches
+ * a resolved list for the whole TTL, so `[]`-on-failure poisons trending for
+ * half an hour and the only way out is `clearTrendingCache()`. Rejecting keeps
+ * "the upstream is down" distinct from "the provider genuinely has nothing",
+ * and only the second is worth caching.
+ */
+export class DiscoveryUnavailableError extends Error {
+  constructor(source: string, reason: string, options?: { readonly cause?: unknown }) {
+    super(`${source} discovery is unavailable: ${reason}`, options);
+    this.name = "DiscoveryUnavailableError";
+  }
+}
+
 export type CatalogDiscoveryLoader = (signal?: AbortSignal) => Promise<readonly SearchResult[]>;
 export type CatalogSurpriseLoader = (
   options: CatalogSurpriseLoadOptions,
@@ -64,18 +81,7 @@ export class CatalogDiscoveryService {
         : mode === "youtube"
           ? (this.loaders.youtube ?? loadYoutubeDiscoveryList)
           : this.loaders.tmdb;
-    const task = loader(signal).then((results) => {
-      this.cache.set(key, {
-        expiresAt: this.now() + DISCOVERY_CACHE_TTL_MS,
-        results,
-      });
-      return results;
-    });
-    this.inflight.set(key, task);
-
-    const results = await task.finally(() => {
-      this.inflight.delete(key);
-    });
+    const results = await this.runLoad(key, DISCOVERY_CACHE_TTL_MS, () => loader(signal));
     return [...results];
   }
 
@@ -99,19 +105,37 @@ export class CatalogDiscoveryService {
         : mode === "youtube"
           ? (this.loaders.youtubeSurprise ?? loadYoutubeSurpriseList)
           : (this.loaders.tmdbSurprise ?? loadTmdbSurpriseList);
-    const task = loader(options, signal).then((results) => {
-      this.cache.set(key, {
-        expiresAt: this.now() + SURPRISE_CACHE_TTL_MS,
-        results,
-      });
+    const results = await this.runLoad(key, SURPRISE_CACHE_TTL_MS, () => loader(options, signal));
+    return shuffleResults(results, options.random);
+  }
+
+  /**
+   * Runs a loader once per key, caching only a load that actually succeeded.
+   *
+   * A rejection — an offline blip, an upstream error, or the `AbortError` from
+   * navigating away mid-fetch — leaves the cache untouched and propagates, so
+   * the next call retries instead of serving an empty tray for the rest of the
+   * TTL. An empty resolved list is not cached either: the loaders below reject
+   * on failure, but an injected loader that still folds one into `[]` must not
+   * be able to poison the cache through this path. In-flight dedup is
+   * unchanged — concurrent callers share the one promise, success or failure.
+   */
+  private async runLoad(
+    key: string,
+    ttlMs: number,
+    load: () => Promise<readonly SearchResult[]>,
+  ): Promise<readonly SearchResult[]> {
+    const task = load().then((results) => {
+      if (results.length > 0) {
+        this.cache.set(key, { expiresAt: this.now() + ttlMs, results });
+      }
       return results;
     });
     this.inflight.set(key, task);
 
-    const results = await task.finally(() => {
+    return task.finally(() => {
       this.inflight.delete(key);
     });
-    return shuffleResults(results, options.random);
   }
 }
 
@@ -139,9 +163,13 @@ async function loadTmdbDiscoveryList(signal?: AbortSignal): Promise<SearchResult
     "/trending/all/week?language=en-US&page=1",
     signal,
     3500,
-  ).catch(() => null)) as Record<string, unknown> | null;
-  if (!data) return [];
-  const rawResults = Array.isArray(data.results) ? data.results : [];
+  ).catch((error: unknown) => {
+    throw new DiscoveryUnavailableError("TMDB trending", "request failed", { cause: error });
+  })) as Record<string, unknown> | null;
+  if (!data || !Array.isArray(data.results)) {
+    throw new DiscoveryUnavailableError("TMDB trending", "malformed payload");
+  }
+  const rawResults = data.results;
 
   return rawResults
     .map(readRecord)
@@ -182,9 +210,13 @@ async function loadTmdbSurpriseList(
     `/discover/${mediaType}?language=en-US&page=${page}&sort_by=${sortBy}&vote_count.gte=${voteFloor}`,
     signal,
     3500,
-  ).catch(() => null)) as Record<string, unknown> | null;
-  if (!data) return [];
-  const rawResults = Array.isArray(data.results) ? data.results : [];
+  ).catch((error: unknown) => {
+    throw new DiscoveryUnavailableError("TMDB surprise", "request failed", { cause: error });
+  })) as Record<string, unknown> | null;
+  if (!data || !Array.isArray(data.results)) {
+    throw new DiscoveryUnavailableError("TMDB surprise", "malformed payload");
+  }
+  const rawResults = data.results;
   return rawResults
     .map(readRecord)
     .filter((record) => record.id !== null && record.id !== undefined)
@@ -228,26 +260,8 @@ async function loadAnimeDiscoveryList(signal?: AbortSignal): Promise<SearchResul
     }
   }`;
 
-  const response = await fetch(ANILIST_GRAPHQL_URL, {
-    method: "POST",
-    signal: signal ?? AbortSignal.timeout(3500),
-    headers: {
-      "content-type": "application/json",
-      accept: "application/json",
-    },
-    body: JSON.stringify({ query: gqlQuery }),
-  }).catch(() => null);
-  if (!response?.ok) return [];
-
-  const data = (await response.json()) as {
-    readonly data?: {
-      readonly Page?: {
-        readonly media?: readonly AniListDiscoveryMedia[];
-      };
-    };
-  };
-
-  return (data.data?.Page?.media ?? []).map(anilistMediaToSearchResult);
+  const media = await fetchAniListMedia("AniList trending", { query: gqlQuery }, signal);
+  return media.map(anilistMediaToSearchResult);
 }
 
 async function loadAnimeSurpriseList(
@@ -289,6 +303,31 @@ async function loadAnimeSurpriseList(
     }
   }`;
 
+  const media = await fetchAniListMedia(
+    "AniList surprise",
+    { query: gqlQuery, variables: { page, sort: [sort], genre } },
+    signal,
+  );
+
+  return media.map((entry) => ({
+    ...anilistMediaToSearchResult(entry),
+    metadataSource: `AniList surprise · ${genre ?? "mixed"} · ${sort.toLowerCase().replace("_desc", "")}`,
+  }));
+}
+
+/**
+ * Posts a GraphQL document to AniList and returns the media page.
+ *
+ * Rejects with {@link DiscoveryUnavailableError} on every failure shape —
+ * transport error, non-2xx, unparseable body, or a GraphQL error (AniList
+ * answers those with HTTP 200 and no `data`). An empty `media` array is a
+ * genuine "nothing matched" and resolves normally.
+ */
+async function fetchAniListMedia(
+  source: string,
+  body: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<readonly AniListDiscoveryMedia[]> {
   const response = await fetch(ANILIST_GRAPHQL_URL, {
     method: "POST",
     signal: signal ?? AbortSignal.timeout(3500),
@@ -296,11 +335,15 @@ async function loadAnimeSurpriseList(
       "content-type": "application/json",
       accept: "application/json",
     },
-    body: JSON.stringify({ query: gqlQuery, variables: { page, sort: [sort], genre } }),
-  }).catch(() => null);
-  if (!response?.ok) return [];
+    body: JSON.stringify(body),
+  }).catch((error: unknown) => {
+    throw new DiscoveryUnavailableError(source, "request failed", { cause: error });
+  });
+  if (!response.ok) throw new DiscoveryUnavailableError(source, `HTTP ${response.status}`);
 
-  const data = (await response.json()) as {
+  const payload = (await response.json().catch((error: unknown) => {
+    throw new DiscoveryUnavailableError(source, "unreadable payload", { cause: error });
+  })) as {
     readonly data?: {
       readonly Page?: {
         readonly media?: readonly AniListDiscoveryMedia[];
@@ -308,10 +351,9 @@ async function loadAnimeSurpriseList(
     };
   };
 
-  return (data.data?.Page?.media ?? []).map((media) => ({
-    ...anilistMediaToSearchResult(media),
-    metadataSource: `AniList surprise · ${genre ?? "mixed"} · ${sort.toLowerCase().replace("_desc", "")}`,
-  }));
+  const media = payload.data?.Page?.media;
+  if (!media) throw new DiscoveryUnavailableError(source, "response carried no media page");
+  return media;
 }
 
 type AniListDiscoveryMedia = {

--- a/apps/cli/src/services/continuation/history-progress.ts
+++ b/apps/cli/src/services/continuation/history-progress.ts
@@ -85,7 +85,9 @@ function hasHistoryEpisodeIdentity(
  * theatrical films persist as `mediaKind: "anime"` with no episode identity;
  * collapsing every anime row to `"series"` relaunches them as S01E01.
  */
-export function historyContentType(progress: HistoryProgress): ContentType {
+export function historyContentType(
+  progress: Pick<HistoryProgress, "mediaKind" | "episode" | "absoluteEpisode">,
+): ContentType {
   if (progress.mediaKind === "video") {
     return hasHistoryEpisodeIdentity(progress) ? "series" : "movie";
   }

--- a/apps/cli/src/services/download/download-cleanup-policy.ts
+++ b/apps/cli/src/services/download/download-cleanup-policy.ts
@@ -1,4 +1,7 @@
-import { shouldAutoCleanupOfflineJob } from "@/services/offline/offline-sync-policy";
+import {
+  historyMatchesDownloadJob,
+  shouldAutoCleanupOfflineJob,
+} from "@/services/offline/offline-sync-policy";
 import type { DownloadJobRecord, HistoryProgress } from "@kunai/storage";
 
 export type ProtectedDownloadEpisode = {
@@ -93,12 +96,10 @@ function selectRetainedWatchedJobs(input: {
       .map((job) => ({
         job,
         history: historyEntries
-          .filter(
-            (entry) =>
-              entry.completed &&
-              (entry.season ?? 1) === job.season &&
-              (entry.episode ?? entry.absoluteEpisode) === job.episode,
-          )
+          // Same rule the delete side uses, so the keep set can never disagree
+          // with it: an absolute-numbered anime episode matched nothing here,
+          // and "keep the last 3 watched" retained zero of them.
+          .filter((entry) => entry.completed && historyMatchesDownloadJob(entry, job))
           .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))[0],
       }))
       .filter((item): item is { job: DownloadJobRecord; history: HistoryProgress } =>
@@ -107,7 +108,7 @@ function selectRetainedWatchedJobs(input: {
       .sort(
         (left, right) =>
           Date.parse(right.history.updatedAt) - Date.parse(left.history.updatedAt) ||
-          (right.job.season ?? 0) - (left.job.season ?? 0) ||
+          (right.job.season ?? 1) - (left.job.season ?? 1) ||
           (right.job.episode ?? 0) - (left.job.episode ?? 0),
       )
       .slice(0, policy.count)
@@ -122,7 +123,9 @@ function isProtectedEpisode(
 ): boolean {
   return protectedEpisodes.some((episode) => {
     if (episode.titleId !== job.titleId) return false;
-    if (episode.season !== undefined && episode.season !== job.season) return false;
+    // `?? 1` on the job side for the same reason the keep set needs it: an
+    // absolute-numbered anime job carries no season.
+    if (episode.season !== undefined && episode.season !== (job.season ?? 1)) return false;
     if (episode.episode !== undefined && episode.episode !== job.episode) return false;
     return true;
   });

--- a/apps/cli/src/services/download/download-path-naming.ts
+++ b/apps/cli/src/services/download/download-path-naming.ts
@@ -62,16 +62,21 @@ function utf8Length(value: string): number {
  * pairs), and slicing those by UTF-16 index produces a lone surrogate that some
  * filesystems reject and others store as a name the user cannot delete.
  */
-function truncateToBytes(value: string, maxBytes: number): string {
-  if (utf8Length(value) <= maxBytes) return value;
+function truncateToLimits(value: string, maxBytes: number, maxUtf16: number): string {
+  if (utf8Length(value) <= maxBytes && value.length <= maxUtf16) return value;
 
   let out = "";
-  let used = 0;
+  let usedBytes = 0;
+  let usedUtf16 = 0;
   for (const char of value) {
     const size = utf8Length(char);
-    if (used + size > maxBytes) break;
+    if (usedBytes + size > maxBytes) break;
+    // `char.length` is UTF-16 code units — 2 for an astral character. That is
+    // the unit Windows counts, so it is measured separately from the bytes.
+    if (usedUtf16 + char.length > maxUtf16) break;
     out += char;
-    used += size;
+    usedBytes += size;
+    usedUtf16 += char.length;
   }
   return out;
 }
@@ -107,16 +112,23 @@ export function sanitizePathPart(value: string): string {
  * The extension is what makes the file playable and what mpv and the library
  * scanner match on, so it is preserved and the stem absorbs the truncation.
  */
-export function clampComponent(name: string, maxBytes: number = MAX_COMPONENT_BYTES): string {
-  if (utf8Length(name) <= maxBytes) return name;
+export function clampComponent(
+  name: string,
+  limits: number | ComponentLimits = MAX_COMPONENT_BYTES,
+): string {
+  const { maxBytes, maxUtf16 } =
+    typeof limits === "number" ? { maxBytes: limits, maxUtf16: Number.POSITIVE_INFINITY } : limits;
+
+  if (utf8Length(name) <= maxBytes && name.length <= maxUtf16) return name;
 
   const dot = name.lastIndexOf(".");
   const hasExtension = dot > 0 && dot > name.length - 12;
   const extension = hasExtension ? name.slice(dot) : "";
   const stem = hasExtension ? name.slice(0, dot) : name;
 
-  const budget = Math.max(1, maxBytes - utf8Length(extension));
-  return `${stripTrailingDotsAndSpaces(truncateToBytes(stem, budget)) || "file"}${extension}`;
+  const byteBudget = Math.max(1, maxBytes - utf8Length(extension));
+  const utf16Budget = Math.max(1, maxUtf16 - extension.length);
+  return `${stripTrailingDotsAndSpaces(truncateToLimits(stem, byteBudget, utf16Budget)) || "file"}${extension}`;
 }
 
 export type DownloadPathInput = {
@@ -180,8 +192,30 @@ export function resolveDownloadOutputPath(input: DownloadPathInput): string {
     join,
   });
 
-  const safeComponents = components.map((part) => clampComponent(part, budget));
-  const safeFile = clampComponent(`${fileStem}${input.extension}`, budget);
+  let limits = budget;
+  let safeComponents = components.map((part) => clampComponent(part, limits));
+  let safeFile = clampComponent(`${fileStem}${input.extension}`, limits);
+
+  if (platform === "win32") {
+    // `componentBudget` is an estimate: it shares the overrun across every
+    // component, but a "Season 01" folder and the SxxEyy suffix cannot shrink,
+    // so the estimate can still land over MAX_PATH. Measuring the real joined
+    // path and tightening is exact, and this runs once per download.
+    const cap = WINDOWS_MAX_PATH - WINDOWS_PATH_RESERVE;
+    const variableCount = Math.max(1, components.length);
+    for (let attempt = 0; attempt < 32; attempt += 1) {
+      const overrun = join(input.baseDir, ...safeComponents, safeFile).length - cap;
+      if (overrun <= 0) break;
+      const next = Math.max(16, limits.maxUtf16 - Math.max(1, Math.ceil(overrun / variableCount)));
+      // Floor reached: the base directory alone is too deep. Truncating the
+      // title further destroys it without making the path legal, so stop and
+      // let the write surface the real error rather than silently mangling.
+      if (next === limits.maxUtf16) break;
+      limits = { ...limits, maxUtf16: next };
+      safeComponents = components.map((part) => clampComponent(part, limits));
+      safeFile = clampComponent(`${fileStem}${input.extension}`, limits);
+    }
+  }
 
   return join(input.baseDir, ...safeComponents, safeFile);
 }
@@ -194,6 +228,21 @@ export function resolveDownloadOutputPath(input: DownloadPathInput): string {
  * overrun has to be shared between them rather than charged to whichever
  * component happens to be clamped first.
  */
+/**
+ * What one path component may spend, in each unit that actually constrains it.
+ *
+ * The two are not interchangeable and used to be conflated: the Windows
+ * `MAX_PATH` arithmetic below counts UTF-16 code units, while the per-component
+ * cap and the truncator count UTF-8 bytes. Returning one number meant a budget
+ * derived from UTF-16 lengths was spent as bytes, so a CJK title (1 unit, 3
+ * bytes per character) was measured against the wrong limit.
+ */
+export type ComponentLimits = {
+  readonly maxBytes: number;
+  /** UTF-16 code units — the unit Windows `MAX_PATH` counts. */
+  readonly maxUtf16: number;
+};
+
 function componentBudget(input: {
   readonly platform: NodeJS.Platform;
   readonly baseDir: string;
@@ -201,16 +250,23 @@ function componentBudget(input: {
   readonly fileStem: string;
   readonly extension: string;
   readonly join: (...segments: string[]) => string;
-}): number {
-  if (input.platform !== "win32") return MAX_COMPONENT_BYTES;
+}): ComponentLimits {
+  const unconstrained: ComponentLimits = {
+    maxBytes: MAX_COMPONENT_BYTES,
+    maxUtf16: Number.POSITIVE_INFINITY,
+  };
+  if (input.platform !== "win32") return unconstrained;
 
   const full = input.join(
     input.baseDir,
     ...input.components,
     `${input.fileStem}${input.extension}`,
   );
+  // `.length` throughout this block: MAX_PATH is a UTF-16 code-unit budget, so
+  // the overrun and the per-component allowance derived from it are too. The
+  // byte cap rides alongside rather than being conflated with it.
   const overrun = full.length - (WINDOWS_MAX_PATH - WINDOWS_PATH_RESERVE);
-  if (overrun <= 0) return MAX_COMPONENT_BYTES;
+  if (overrun <= 0) return unconstrained;
 
   // Only the title-derived components can shrink; separators, the season
   // folder and the SxxEyy suffix are structure the user needs to keep.
@@ -219,12 +275,15 @@ function componentBudget(input: {
     ...input.components.map((part) => part.length),
     input.fileStem.length + input.extension.length,
   );
-  return Math.max(16, longest - Math.ceil(overrun / variableCount));
+  return {
+    maxBytes: MAX_COMPONENT_BYTES,
+    maxUtf16: Math.max(16, longest - Math.ceil(overrun / variableCount)),
+  };
 }
 
 export const __testing = {
   MAX_COMPONENT_BYTES,
   WINDOWS_MAX_PATH,
   WINDOWS_PATH_RESERVE,
-  truncateToBytes,
+  truncateToLimits,
 };

--- a/apps/cli/src/services/offline/offline-sync-policy.ts
+++ b/apps/cli/src/services/offline/offline-sync-policy.ts
@@ -1,3 +1,4 @@
+import { sameEpisodeNumbering } from "@/domain/media/episode-numbering";
 import { historyContentType } from "@/services/continuation/history-progress";
 import type { DownloadJobRecord, HistoryProgress } from "@kunai/storage";
 
@@ -7,6 +8,32 @@ export type OfflineCleanupDecision =
       readonly reason: "not-completed" | "not-watched" | "grace-period";
     }
   | { readonly shouldDelete: true; readonly reason: "watched"; readonly watchedAt: string };
+
+/**
+ * Does this history row describe the episode a download job holds?
+ *
+ * Both sides are normalized, and that symmetry is the point. Absolute-numbered
+ * anime carries no season and puts its number in the history row's
+ * `absoluteEpisode` while the job keeps it in `episode`, so a match that
+ * normalized only one side (`(entry.season ?? 1) === job.season`) compared
+ * `1 === undefined` and never matched anything.
+ *
+ * The keep-set and the delete-set both read this: a rule that answered
+ * differently on the two sides deleted episodes the retention policy had been
+ * asked to keep.
+ */
+export function historyMatchesDownloadJob(
+  entry: Pick<
+    HistoryProgress,
+    "season" | "episode" | "absoluteEpisode" | "mediaKind" | "completed"
+  >,
+  job: Pick<DownloadJobRecord, "season" | "episode" | "mediaKind">,
+): boolean {
+  const historyKind = job.mediaKind === "movie" ? "movie" : "series";
+  if (historyContentType(entry) !== historyKind) return false;
+  if (historyKind === "movie") return true;
+  return sameEpisodeNumbering(entry, job);
+}
 
 export function shouldAutoCleanupOfflineJob(input: {
   readonly job: DownloadJobRecord;
@@ -20,16 +47,12 @@ export function shouldAutoCleanupOfflineJob(input: {
 
   const graceMs = Math.max(0, input.graceDays) * 24 * 60 * 60 * 1000;
   const cutoff = input.nowMs - graceMs;
-  const watched = input.historyEntries.find((entry) => {
-    if (!entry.completed) return false;
-    const historyKind = input.job.mediaKind === "movie" ? "movie" : "series";
-    if (historyContentType(entry) !== historyKind) return false;
-    if (historyKind !== "movie") {
-      if ((entry.season ?? 1) !== (input.job.season ?? 1)) return false;
-      if ((entry.episode ?? entry.absoluteEpisode ?? 1) !== (input.job.episode ?? 1)) return false;
-    }
-    return Number.isFinite(Date.parse(entry.updatedAt));
-  });
+  const watched = input.historyEntries.find(
+    (entry) =>
+      entry.completed &&
+      historyMatchesDownloadJob(entry, input.job) &&
+      Number.isFinite(Date.parse(entry.updatedAt)),
+  );
 
   if (!watched) return { shouldDelete: false, reason: "not-watched" };
   if (Date.parse(watched.updatedAt) > cutoff) {

--- a/apps/cli/src/services/offline/offline-sync-policy.ts
+++ b/apps/cli/src/services/offline/offline-sync-policy.ts
@@ -27,9 +27,14 @@ export function historyMatchesDownloadJob(
     HistoryProgress,
     "season" | "episode" | "absoluteEpisode" | "mediaKind" | "completed"
   >,
-  job: Pick<DownloadJobRecord, "season" | "episode" | "mediaKind">,
+  job: Pick<DownloadJobRecord, "season" | "episode" | "mediaKind" | "contentType">,
 ): boolean {
-  const historyKind = job.mediaKind === "movie" ? "movie" : "series";
+  // `contentType` is the job's own answer and outranks the badge: an anime film
+  // is `mediaKind: "anime"` with `contentType: "movie"`, and deriving from the
+  // badge alone called it a series, then demanded an episode match it could
+  // never satisfy. `historyContentType` already resolves the history side this
+  // way, so without this the two sides disagreed on exactly that title.
+  const historyKind = job.contentType ?? (job.mediaKind === "movie" ? "movie" : "series");
   if (historyContentType(entry) !== historyKind) return false;
   if (historyKind === "movie") return true;
   return sameEpisodeNumbering(entry, job);

--- a/apps/cli/src/services/persistence/ConfigServiceImpl.ts
+++ b/apps/cli/src/services/persistence/ConfigServiceImpl.ts
@@ -793,6 +793,11 @@ export class ConfigServiceImpl implements ConfigService {
     this.savePending = null;
     this.savePendingResolve = null;
     this.savePendingReject = null;
+    // Tracked *before* the write starts. `store.save()` throwing synchronously
+    // runs the catch and the finally before this assignment would have happened,
+    // so assigning afterwards left an already-rejected promise in `saveInFlight`
+    // that every later `flushPending()` would await.
+    this.saveInFlight = pending;
     void (async () => {
       try {
         await this.store.save(this.config);
@@ -803,11 +808,6 @@ export class ConfigServiceImpl implements ConfigService {
         if (this.saveInFlight === pending) this.saveInFlight = null;
       }
     })();
-    // Tracked so a `flushPending()` landing after this point still awaits the
-    // write. `pending` always carries a handler — the debounce timer attaches
-    // one, and the direct flush path awaits it — so this cannot surface as an
-    // unhandled rejection.
-    this.saveInFlight = pending;
     return pending;
   }
 

--- a/apps/cli/src/services/persistence/ConfigServiceImpl.ts
+++ b/apps/cli/src/services/persistence/ConfigServiceImpl.ts
@@ -740,6 +740,13 @@ export class ConfigServiceImpl implements ConfigService {
   private savePending: Promise<void> | null = null;
   private savePendingResolve: (() => void) | null = null;
   private savePendingReject: ((reason: unknown) => void) | null = null;
+  /**
+   * The store write started by a fired debounce, until it settles.
+   *
+   * `savePending` is cleared the moment the write starts, so it alone cannot
+   * tell shutdown that a write is still running.
+   */
+  private saveInFlight: Promise<void> | null = null;
 
   // Trailing debounce: every call re-arms the timer so the latest config wins,
   // and all callers in a burst share one promise that settles once the write
@@ -764,8 +771,14 @@ export class ConfigServiceImpl implements ConfigService {
 
   /** Persist any pending debounced save immediately (shutdown path). */
   async flushPending(): Promise<void> {
-    if (!this.savePending) return;
-    await this.persistPendingSave();
+    if (this.savePending) {
+      await this.persistPendingSave();
+      return;
+    }
+    // A debounce that already fired cleared `savePending` while its store write
+    // is still running. Returning here let shutdown reach `process.exit()`
+    // under an in-flight write and truncate config.json.
+    if (this.saveInFlight) await this.saveInFlight;
   }
 
   private persistPendingSave(): Promise<void> {
@@ -786,8 +799,15 @@ export class ConfigServiceImpl implements ConfigService {
         resolve?.();
       } catch (error) {
         reject?.(error);
+      } finally {
+        if (this.saveInFlight === pending) this.saveInFlight = null;
       }
     })();
+    // Tracked so a `flushPending()` landing after this point still awaits the
+    // write. `pending` always carries a handler — the debounce timer attaches
+    // one, and the direct flush path awaits it — so this cannot surface as an
+    // unhandled rejection.
+    this.saveInFlight = pending;
     return pending;
   }
 

--- a/apps/cli/src/services/youtube/YoutubeRecommendationService.ts
+++ b/apps/cli/src/services/youtube/YoutubeRecommendationService.ts
@@ -220,7 +220,10 @@ export async function loadYoutubeRecommendations(input: {
 /** YouTube trending for `/trending` in youtube shell mode. */
 export async function loadYoutubeTrending(signal?: AbortSignal): Promise<readonly SearchResult[]> {
   const preferredInstanceUrl = getYoutubeProviderConfig().invidiousInstanceUrl;
-  const items = await invidiousGetTrending({ preferredInstanceUrl, signal }).catch(() => []);
+  // Rejects when every instance is down: callers decide whether to degrade to an
+  // empty tray. Folding it into `[]` here hid the failure from the discovery
+  // cache, which then served that empty tray for the rest of its TTL.
+  const items = await invidiousGetTrending({ preferredInstanceUrl, signal });
   return mapInvidiousTrendingVideos([...items]).map(providerResultToSearchResult);
 }
 

--- a/apps/cli/test/helpers/storage-env.ts
+++ b/apps/cli/test/helpers/storage-env.ts
@@ -21,7 +21,9 @@ export function storageRootEnv(dir: string): Record<string, string> {
     // Windows.
     LOCALAPPDATA: dir,
     APPDATA: dir,
-    // macOS and the `homedir()` fallbacks both derive from HOME/USERPROFILE.
+    // macOS derives every root from home, and so do the non-XDG fallbacks.
+    // `getKunaiPaths` reads these before `homedir()` precisely so this works;
+    // `homedir()` itself does not honour HOME on macOS.
     HOME: dir,
     USERPROFILE: dir,
   };
@@ -30,9 +32,11 @@ export function storageRootEnv(dir: string): Record<string, string> {
 /**
  * Point this process's storage roots at `dir` and return the undo.
  *
- * `getKunaiPaths` reads `process.env` (and `homedir()`, which reads `HOME`) on
- * every call rather than memoizing, so an in-process swap is enough for a test
- * that drives real code writing real files — no subprocess needed. Restoring
+ * `getKunaiPaths` reads `process.env` on every call rather than memoizing, so an
+ * in-process swap is enough for a test that drives real code writing real files —
+ * no subprocess needed. It prefers `HOME`/`USERPROFILE` over `homedir()` for the
+ * same reason: `homedir()` does not follow `HOME` on macOS, so without that
+ * preference this helper isolated nothing there. Restoring
  * exactly what was there, including keys that were unset, keeps one test file
  * from leaking a storage root into the next one in the same worker.
  */

--- a/apps/cli/test/unit/domain/media/episode-numbering.test.ts
+++ b/apps/cli/test/unit/domain/media/episode-numbering.test.ts
@@ -44,6 +44,13 @@ describe("sameEpisodeNumbering", () => {
     test("a season beyond the first is not assumed to map onto an absolute number", () => {
       // Absolute 13 may or may not be S02E01; nothing here knows the season
       // boundaries, so the conservative answer is "not the same episode".
+      //
+      // Pinned as a KNOWN false negative, not as desired behaviour: for a show
+      // whose first season has twelve episodes this pair really is one episode.
+      // A false positive merges two different episodes and loses one, which is
+      // unrecoverable; a false negative leaves two rows unmerged, which is not.
+      // If season lengths ever reach this seam, this assertion is the one to
+      // revisit first.
       expect(sameEpisodeNumbering({ absoluteEpisode: 13 }, { season: 2, episode: 1 })).toBe(false);
     });
   });

--- a/apps/cli/test/unit/domain/media/episode-numbering.test.ts
+++ b/apps/cli/test/unit/domain/media/episode-numbering.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+
+import { sameEpisodeNumbering } from "@/domain/media/episode-numbering";
+
+/**
+ * The contract for the one rule shared by the offline keep set, the offline
+ * delete set, the protected-episode check, and queue restore. Those four
+ * disagreeing is what made "keep the last 3 watched" delete all three, so the
+ * rule is pinned here rather than only through each caller.
+ */
+describe("sameEpisodeNumbering", () => {
+  describe("absolute numbering on both sides", () => {
+    test("equal absolute episodes match", () => {
+      expect(sameEpisodeNumbering({ absoluteEpisode: 13 }, { absoluteEpisode: 13 })).toBe(true);
+    });
+
+    test("different absolute episodes do not match", () => {
+      expect(sameEpisodeNumbering({ absoluteEpisode: 13 }, { absoluteEpisode: 14 })).toBe(false);
+    });
+
+    test("absolute wins over a disagreeing season", () => {
+      expect(
+        sameEpisodeNumbering(
+          { season: 1, absoluteEpisode: 13 },
+          { season: 2, absoluteEpisode: 13 },
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("absolute on one side only", () => {
+    test("an absolute episode matches its season-relative twin", () => {
+      // The regression: returning early whenever *either* side carried an
+      // absolute number compared `13 === undefined`, so a history row written by
+      // an absolute-numbered source never matched its own queue entry and the
+      // resume head was not promoted after a crash.
+      expect(sameEpisodeNumbering({ absoluteEpisode: 13 }, { season: 1, episode: 13 })).toBe(true);
+    });
+
+    test("a different episode number still does not match", () => {
+      expect(sameEpisodeNumbering({ absoluteEpisode: 13 }, { season: 1, episode: 12 })).toBe(false);
+    });
+
+    test("a season beyond the first is not assumed to map onto an absolute number", () => {
+      // Absolute 13 may or may not be S02E01; nothing here knows the season
+      // boundaries, so the conservative answer is "not the same episode".
+      expect(sameEpisodeNumbering({ absoluteEpisode: 13 }, { season: 2, episode: 1 })).toBe(false);
+    });
+  });
+
+  describe("season-relative numbering", () => {
+    test("the same season and episode match", () => {
+      expect(sameEpisodeNumbering({ season: 2, episode: 5 }, { season: 2, episode: 5 })).toBe(true);
+    });
+
+    test("a different season does not match", () => {
+      expect(sameEpisodeNumbering({ season: 1, episode: 5 }, { season: 2, episode: 5 })).toBe(
+        false,
+      );
+    });
+
+    test("a missing season means season 1 on both sides", () => {
+      // The regression: normalizing only one side compared `1 === undefined`, so
+      // an absolute-numbered anime job (which carries no season) matched nothing
+      // and "keep the last 3 watched" retained zero of them.
+      expect(sameEpisodeNumbering({ episode: 5 }, { season: 1, episode: 5 })).toBe(true);
+      expect(sameEpisodeNumbering({ season: 1, episode: 5 }, { episode: 5 })).toBe(true);
+    });
+
+    test("a missing episode on both sides means episode 1", () => {
+      expect(sameEpisodeNumbering({}, {})).toBe(true);
+      expect(sameEpisodeNumbering({}, { season: 1, episode: 1 })).toBe(true);
+    });
+  });
+
+  test("the rule is symmetric", () => {
+    const cases: readonly [Record<string, number>, Record<string, number>][] = [
+      [{ absoluteEpisode: 13 }, { season: 1, episode: 13 }],
+      [{ absoluteEpisode: 13 }, { season: 2, episode: 1 }],
+      [{ episode: 5 }, { season: 1, episode: 5 }],
+      [
+        { season: 2, episode: 5 },
+        { season: 2, episode: 5 },
+      ],
+      [
+        { season: 1, episode: 5 },
+        { season: 2, episode: 5 },
+      ],
+      [{ absoluteEpisode: 13 }, { absoluteEpisode: 14 }],
+      [{}, { season: 1, episode: 1 }],
+    ];
+
+    for (const [left, right] of cases) {
+      expect(sameEpisodeNumbering(left, right)).toBe(sameEpisodeNumbering(right, left));
+    }
+  });
+});

--- a/apps/cli/test/unit/infra/storage/FileStorage.test.ts
+++ b/apps/cli/test/unit/infra/storage/FileStorage.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -12,6 +12,47 @@ afterEach(async () => {
     const dir = tempDirs.pop();
     if (dir) await rm(dir, { recursive: true, force: true });
   }
+});
+
+describe("FileStorage default path resolution", () => {
+  // The module used to build its path map as a module-level constant, so
+  // `getKunaiPaths()` ran while the file was being imported and froze the
+  // developer's real config.json in. A suite that imported this file — however
+  // indirectly — before pointing HOME/XDG/APPDATA at a sandbox then wrote the
+  // live profile. Import has already happened by the time this test runs, which
+  // is exactly the condition that used to lose: the environment set here must
+  // still win.
+  const ENV_KEYS = ["HOME", "USERPROFILE", "XDG_CONFIG_HOME", "APPDATA"] as const;
+
+  test("honours a storage root set after this module was imported", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kunai-file-storage-root-"));
+    tempDirs.push(dir);
+
+    const saved = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
+    for (const key of ENV_KEYS) process.env[key] = dir;
+    process.env.XDG_CONFIG_HOME = join(dir, ".config");
+
+    try {
+      await new FileStorage().write("config", { sandboxed: true });
+
+      // Written somewhere under the sandbox, and nowhere else.
+      const files = await readdir(dir, { recursive: true });
+      expect(files.some((entry) => String(entry).endsWith("config.json"))).toBe(true);
+    } finally {
+      for (const key of ENV_KEYS) {
+        const value = saved.get(key);
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  });
+
+  test("an unknown key still throws, and exists() still answers false", async () => {
+    const storage = new FileStorage({ config: "/tmp/kunai-unused.json" });
+
+    expect(storage.read("nope")).rejects.toThrow("Unknown storage key: nope");
+    expect(await storage.exists("nope")).toBe(false);
+  });
 });
 
 describe("FileStorage", () => {

--- a/apps/cli/test/unit/infra/storage/FileStorage.test.ts
+++ b/apps/cli/test/unit/infra/storage/FileStorage.test.ts
@@ -65,6 +65,36 @@ describe("FileStorage", () => {
     },
   );
 
+  test("reads a missing file as nothing stored, without a backup or a warning", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kunai-file-storage-"));
+    tempDirs.push(dir);
+    const configPath = join(dir, "config.json");
+    const warnings: string[] = [];
+    const storage = new FileStorage({ config: configPath }, (message) => warnings.push(message));
+
+    // The read path used to chmod outside its guard, so a file that vanished
+    // after the existence check rejected with ENOENT instead of returning null.
+    await expect(storage.read("config")).resolves.toBeNull();
+    expect(warnings).toEqual([]);
+    await expect(stat(`${configPath}.corrupt.bak`)).rejects.toThrow();
+  });
+
+  test("backs up the corrupt file's actual bytes, not an empty placeholder", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kunai-file-storage-"));
+    tempDirs.push(dir);
+    const configPath = join(dir, "config.json");
+    const corrupt = '{"providerRelay":{"token":"secret"}';
+    await writeFile(configPath, corrupt);
+
+    const warnings: string[] = [];
+    const storage = new FileStorage({ config: configPath }, (message) => warnings.push(message));
+
+    await expect(storage.read("config")).resolves.toBeNull();
+    // The backup exists to preserve the content — an empty one destroys it.
+    await expect(readFile(`${configPath}.corrupt.bak`, "utf8")).resolves.toBe(corrupt);
+    expect(warnings).toHaveLength(1);
+  });
+
   test("keeps the write queue usable after a failed write", async () => {
     const dir = await mkdtemp(join(tmpdir(), "kunai-file-storage-"));
     tempDirs.push(dir);

--- a/apps/cli/test/unit/infra/storage/FileStorage.test.ts
+++ b/apps/cli/test/unit/infra/storage/FileStorage.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmod, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 
 import { FileStorage } from "@/infra/storage/FileStorage";
 import { getKunaiPaths } from "@kunai/storage";
@@ -28,24 +28,32 @@ describe("FileStorage default path resolution", () => {
     const dir = await mkdtemp(join(tmpdir(), "kunai-file-storage-root-"));
     tempDirs.push(dir);
 
+    // Captured before the override so the guard below is a plain inequality.
+    // Comparing path *spelling* is what two earlier versions of this test got
+    // wrong: macOS hands out `/var/...` for a directory that resolves to
+    // `/private/var/...`, and Windows reports the 8.3 form (`RUNNER~1`) where
+    // `realpath` gives the long one. Neither is the point.
+    const liveConfigPath = getKunaiPaths().configPath;
+
     const restore = applyStorageRootEnv(dir);
     try {
-      // The same resolver the production default uses, evaluated now. Asserting
-      // against it rather than a hard-coded layout keeps this honest on every
-      // platform: Linux reads XDG, macOS `~/Library/Application Support`, and
-      // Windows `%APPDATA%`, and none of that is what this test is about.
+      // The same resolver the production default calls, evaluated now — so this
+      // asserts deferral without hard-coding any platform's storage layout.
       const expected = getKunaiPaths().configPath;
 
-      // Refuse to write until the sandbox is proven to be in effect. `realpath`
-      // because macOS hands out `/var/folders/...` for a directory that resolves
-      // to `/private/var/folders/...`.
-      expect(await realpath(dirname(expected)).catch(() => expected)).toStartWith(
-        await realpath(dir),
-      );
+      // Refuse to write until the sandbox is proven to be in effect. If a
+      // platform ever stops honouring the override this fails here, rather than
+      // writing the developer's real profile.
+      expect(expected).not.toBe(liveConfigPath);
 
       await new FileStorage().write("config", { sandboxed: true });
 
       expect(await Bun.file(expected).exists()).toBe(true);
+      expect(
+        await Bun.file(liveConfigPath)
+          .text()
+          .catch(() => null),
+      ).not.toContain("sandboxed");
     } finally {
       restore();
     }

--- a/apps/cli/test/unit/infra/storage/FileStorage.test.ts
+++ b/apps/cli/test/unit/infra/storage/FileStorage.test.ts
@@ -49,11 +49,15 @@ describe("FileStorage default path resolution", () => {
       await new FileStorage().write("config", { sandboxed: true });
 
       expect(await Bun.file(expected).exists()).toBe(true);
-      expect(
-        await Bun.file(liveConfigPath)
-          .text()
-          .catch(() => null),
-      ).not.toContain("sandboxed");
+
+      // Empty string, never null: `toContain` rejects a null receiver, and
+      // whether the machine running this happens to have a real config.json is
+      // not something the test may depend on — it does on a developer box and
+      // does not on a fresh CI runner.
+      const liveContents = await Bun.file(liveConfigPath)
+        .text()
+        .catch(() => "");
+      expect(liveContents).not.toContain("sandboxed");
     } finally {
       restore();
     }

--- a/apps/cli/test/unit/infra/storage/FileStorage.test.ts
+++ b/apps/cli/test/unit/infra/storage/FileStorage.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmod, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { FileStorage } from "@/infra/storage/FileStorage";
+import { getKunaiPaths } from "@kunai/storage";
+
+import { applyStorageRootEnv } from "../../../helpers/storage-env";
 
 const tempDirs: string[] = [];
 
@@ -18,32 +21,33 @@ describe("FileStorage default path resolution", () => {
   // The module used to build its path map as a module-level constant, so
   // `getKunaiPaths()` ran while the file was being imported and froze the
   // developer's real config.json in. A suite that imported this file — however
-  // indirectly — before pointing HOME/XDG/APPDATA at a sandbox then wrote the
+  // indirectly — before pointing its storage root at a sandbox then wrote the
   // live profile. Import has already happened by the time this test runs, which
-  // is exactly the condition that used to lose: the environment set here must
-  // still win.
-  const ENV_KEYS = ["HOME", "USERPROFILE", "XDG_CONFIG_HOME", "APPDATA"] as const;
-
+  // is exactly the condition that used to lose: the root set here must still win.
   test("honours a storage root set after this module was imported", async () => {
     const dir = await mkdtemp(join(tmpdir(), "kunai-file-storage-root-"));
     tempDirs.push(dir);
 
-    const saved = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
-    for (const key of ENV_KEYS) process.env[key] = dir;
-    process.env.XDG_CONFIG_HOME = join(dir, ".config");
-
+    const restore = applyStorageRootEnv(dir);
     try {
+      // The same resolver the production default uses, evaluated now. Asserting
+      // against it rather than a hard-coded layout keeps this honest on every
+      // platform: Linux reads XDG, macOS `~/Library/Application Support`, and
+      // Windows `%APPDATA%`, and none of that is what this test is about.
+      const expected = getKunaiPaths().configPath;
+
+      // Refuse to write until the sandbox is proven to be in effect. `realpath`
+      // because macOS hands out `/var/folders/...` for a directory that resolves
+      // to `/private/var/folders/...`.
+      expect(await realpath(dirname(expected)).catch(() => expected)).toStartWith(
+        await realpath(dir),
+      );
+
       await new FileStorage().write("config", { sandboxed: true });
 
-      // Written somewhere under the sandbox, and nowhere else.
-      const files = await readdir(dir, { recursive: true });
-      expect(files.some((entry) => String(entry).endsWith("config.json"))).toBe(true);
+      expect(await Bun.file(expected).exists()).toBe(true);
     } finally {
-      for (const key of ENV_KEYS) {
-        const value = saved.get(key);
-        if (value === undefined) delete process.env[key];
-        else process.env[key] = value;
-      }
+      restore();
     }
   });
 

--- a/apps/cli/test/unit/infra/timing/merge-timing.test.ts
+++ b/apps/cli/test/unit/infra/timing/merge-timing.test.ts
@@ -37,6 +37,19 @@ describe("mergeTimingMetadata", () => {
     ]);
   });
 
+  test("an inverted primary segment defers to a usable secondary window", () => {
+    // `findPlaybackSegmentAtPosition` requires the window to move forwards, so a
+    // segment whose end precedes its start is no more skippable than `{0, 0}`.
+    // Checking only the end let this count as timing here and be dropped by the
+    // player, which is the failure this merge rule exists to prevent.
+    const primary = timing({ intro: [{ startMs: 9_999, endMs: 1 }] });
+    const secondary = timing({ intro: [{ startMs: 80_000, endMs: 90_000 }] });
+
+    expect(mergeTimingMetadata(primary, secondary)?.intro).toEqual([
+      { startMs: 80_000, endMs: 90_000 },
+    ]);
+  });
+
   test("a usable primary window still wins", () => {
     const primary = timing({ intro: [{ startMs: 10_000, endMs: 100_000 }] });
     const secondary = timing({ intro: [{ startMs: 80_000, endMs: 90_000 }] });

--- a/apps/cli/test/unit/infra/timing/merge-timing.test.ts
+++ b/apps/cli/test/unit/infra/timing/merge-timing.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import type { PlaybackTimingMetadata } from "@/domain/types";
+import { mergeTimingMetadata } from "@/infra/timing/merge-timing";
+
+function timing(overrides: Partial<PlaybackTimingMetadata> = {}): PlaybackTimingMetadata {
+  return {
+    tmdbId: "1396",
+    type: "series",
+    intro: [],
+    recap: [],
+    credits: [],
+    preview: [],
+    ...overrides,
+  };
+}
+
+describe("mergeTimingMetadata", () => {
+  test("a degenerate primary segment does not suppress a usable secondary window", () => {
+    // IntroDB answers with a row it could not time. Choosing on array length
+    // alone read that as "primary has intro timing" and dropped AniSkip's real
+    // 80-90s window, so the skip prompt never appeared.
+    const primary = timing({ intro: [{ startMs: 0, endMs: 0 }] });
+    const secondary = timing({ intro: [{ startMs: 80_000, endMs: 90_000 }] });
+
+    expect(mergeTimingMetadata(primary, secondary)?.intro).toEqual([
+      { startMs: 80_000, endMs: 90_000 },
+    ]);
+  });
+
+  test("a null-timed primary segment defers to a usable secondary window", () => {
+    const primary = timing({ credits: [{ startMs: null, endMs: null }] });
+    const secondary = timing({ credits: [{ startMs: 1_200_000, endMs: 1_260_000 }] });
+
+    expect(mergeTimingMetadata(primary, secondary)?.credits).toEqual([
+      { startMs: 1_200_000, endMs: 1_260_000 },
+    ]);
+  });
+
+  test("a usable primary window still wins", () => {
+    const primary = timing({ intro: [{ startMs: 10_000, endMs: 100_000 }] });
+    const secondary = timing({ intro: [{ startMs: 80_000, endMs: 90_000 }] });
+
+    expect(mergeTimingMetadata(primary, secondary)?.intro).toEqual([
+      { startMs: 10_000, endMs: 100_000 },
+    ]);
+  });
+
+  test("groups resolve independently", () => {
+    const primary = timing({
+      intro: [{ startMs: 0, endMs: 0 }],
+      credits: [{ startMs: 1_200_000, endMs: 1_260_000 }],
+    });
+    const secondary = timing({
+      intro: [{ startMs: 80_000, endMs: 90_000 }],
+      credits: [{ startMs: 999, endMs: 1_000 }],
+    });
+
+    const merged = mergeTimingMetadata(primary, secondary);
+    expect(merged?.intro).toEqual([{ startMs: 80_000, endMs: 90_000 }]);
+    expect(merged?.credits).toEqual([{ startMs: 1_200_000, endMs: 1_260_000 }]);
+  });
+
+  test("when neither side can drive a skip the primary shape is kept", () => {
+    const primary = timing({ intro: [{ startMs: 0, endMs: 0 }] });
+    const secondary = timing({ intro: [{ startMs: null, endMs: null }] });
+
+    expect(mergeTimingMetadata(primary, secondary)?.intro).toEqual([{ startMs: 0, endMs: 0 }]);
+  });
+
+  test("a missing side is returned whole", () => {
+    const only = timing({ intro: [{ startMs: 80_000, endMs: 90_000 }] });
+
+    expect(mergeTimingMetadata(null, only)).toBe(only);
+    expect(mergeTimingMetadata(only, null)).toBe(only);
+    expect(mergeTimingMetadata(null, null)).toBeNull();
+  });
+});

--- a/apps/cli/test/unit/services/analytics/usage-analytics-service.test.ts
+++ b/apps/cli/test/unit/services/analytics/usage-analytics-service.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   ANALYTICS_PAYLOAD_KEYS,
   DEFAULT_ANALYTICS_ENDPOINT,
+  isTransportSafeAnalyticsEndpoint,
   resolveAnalyticsEndpoint,
   UNSET_INSTALL_ID_PLACEHOLDER,
   UsageAnalyticsService,
@@ -42,12 +43,16 @@ function makeConfig(overrides: Partial<KitsuneConfig> = {}) {
 
 function makeService(
   config: ReturnType<typeof makeConfig>,
-  options: { fetchImpl?: AnalyticsFetch; env?: { DO_NOT_TRACK?: string; CI?: string } } = {},
+  options: {
+    fetchImpl?: AnalyticsFetch;
+    env?: { DO_NOT_TRACK?: string; CI?: string };
+    endpoint?: string;
+  } = {},
 ) {
   return new UsageAnalyticsService({
     config,
     currentVersion: "0.3.0",
-    endpoint: TEST_ENDPOINT,
+    endpoint: options.endpoint ?? TEST_ENDPOINT,
     fetchImpl:
       options.fetchImpl ??
       (async () => {
@@ -230,6 +235,47 @@ describe("endpoint configuration", () => {
     expect(resolveAnalyticsEndpoint({}, "https://config.test/ping")).toBe(
       "https://config.test/ping",
     );
+  });
+
+  test("a cleartext http override is refused rather than redirected to the default", async () => {
+    // The payload carries sha256(installId) with version/os/arch. Over http it
+    // is readable on the path, and an install is followable day to day.
+    expect(resolveAnalyticsEndpoint({ KUNAI_ANALYTICS_URL: "http://ingest.test/ping" })).toBe("");
+    expect(resolveAnalyticsEndpoint({}, "http://ingest.test/ping")).toBe("");
+    expect(resolveAnalyticsEndpoint({ KUNAI_ANALYTICS_URL: "not a url" })).toBe("");
+    // Never silently redirected to Kunai's ingest: somebody who pointed their
+    // installs elsewhere did not consent to sending here instead.
+    expect(resolveAnalyticsEndpoint({}, "http://ingest.test/ping")).not.toBe(
+      DEFAULT_ANALYTICS_ENDPOINT,
+    );
+  });
+
+  test("loopback http stays allowed for local ingest development", () => {
+    expect(
+      resolveAnalyticsEndpoint({ KUNAI_ANALYTICS_URL: "http://localhost:3000/api/ping" }),
+    ).toBe("http://localhost:3000/api/ping");
+    expect(resolveAnalyticsEndpoint({}, "http://127.0.0.1:3000/api/ping")).toBe(
+      "http://127.0.0.1:3000/api/ping",
+    );
+    expect(isTransportSafeAnalyticsEndpoint("http://[::1]:3000/api/ping")).toBe(true);
+    expect(isTransportSafeAnalyticsEndpoint("http://ingest.test/ping")).toBe(false);
+  });
+
+  test("an opted-in install sends nothing to a non-https endpoint", async () => {
+    const config = makeConfig({ analytics: "enabled", installId: UUID });
+    let calls = 0;
+    const service = makeService(config, {
+      endpoint: "http://ingest.test/ping",
+      fetchImpl: async () => {
+        calls += 1;
+        return new Response(null, { status: 204 });
+      },
+    });
+
+    await service.maybePing();
+
+    expect(calls).toBe(0);
+    expect(config.rawRef.lastAnalyticsPingAt).toBe(0);
   });
 
   test("a default endpoint is not consent: the gates are unchanged by it", () => {

--- a/apps/cli/test/unit/services/catalog/catalog-discovery-service.test.ts
+++ b/apps/cli/test/unit/services/catalog/catalog-discovery-service.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "bun:test";
 
-import { CatalogDiscoveryService } from "@/services/catalog/CatalogDiscoveryService";
+import {
+  CatalogDiscoveryService,
+  DiscoveryUnavailableError,
+} from "@/services/catalog/CatalogDiscoveryService";
 
 test("CatalogDiscoveryService reuses cached trending results until ttl expires", async () => {
   let now = 1_000;
@@ -73,3 +76,121 @@ test("CatalogDiscoveryService keeps anime and series caches isolated", async () 
   expect((await service.loadTrending("anime"))[0]?.id).toBe("anime");
   expect((await service.loadTrending("series"))[0]?.id).toBe("tmdb");
 });
+
+test("CatalogDiscoveryService never caches a failed trending load", async () => {
+  let calls = 0;
+  const service = new CatalogDiscoveryService({
+    anime: async () => [],
+    tmdb: async () => {
+      calls += 1;
+      if (calls === 1) throw new DiscoveryUnavailableError("TMDB trending", "request failed");
+      return [
+        { id: "1", type: "movie", title: "Movie", year: "2026", overview: "", posterPath: null },
+      ];
+    },
+  });
+
+  await expect(service.loadTrending("series")).rejects.toThrow(DiscoveryUnavailableError);
+  // The failure must not have been cached: the very next call retries upstream.
+  expect((await service.loadTrending("series"))[0]?.title).toBe("Movie");
+  expect(calls).toBe(2);
+});
+
+test("CatalogDiscoveryService never caches an aborted trending load", async () => {
+  let calls = 0;
+  const controller = new AbortController();
+  const service = new CatalogDiscoveryService({
+    anime: async () => [],
+    tmdb: async (signal) => {
+      calls += 1;
+      if (signal?.aborted) throw new DOMException("The operation was aborted.", "AbortError");
+      return [
+        { id: "1", type: "movie", title: "Movie", year: "2026", overview: "", posterPath: null },
+      ];
+    },
+  });
+
+  controller.abort();
+  await expect(service.loadTrending("series", controller.signal)).rejects.toThrow("aborted");
+  expect((await service.loadTrending("series"))[0]?.title).toBe("Movie");
+  expect(calls).toBe(2);
+});
+
+test("CatalogDiscoveryService does not cache an empty trending result", async () => {
+  let calls = 0;
+  const service = new CatalogDiscoveryService({
+    anime: async () => [],
+    // Stands in for a loader that still folds a failure into `[]`.
+    tmdb: async () => {
+      calls += 1;
+      return [];
+    },
+  });
+
+  expect(await service.loadTrending("series")).toEqual([]);
+  expect(await service.loadTrending("series")).toEqual([]);
+  expect(calls).toBe(2);
+});
+
+test("CatalogDiscoveryService shares one failure across in-flight callers and retries after", async () => {
+  let calls = 0;
+  const firstLoad = Promise.withResolvers<never>();
+  const loadStarted = Promise.withResolvers<void>();
+  const service = new CatalogDiscoveryService({
+    anime: async () => [],
+    tmdb: async () => {
+      calls += 1;
+      if (calls === 1) {
+        loadStarted.resolve();
+        return firstLoad.promise;
+      }
+      return [
+        { id: "1", type: "movie", title: "Movie", year: "2026", overview: "", posterPath: null },
+      ];
+    },
+  });
+
+  const first = captureRejection(service.loadTrending("series"));
+  await loadStarted.promise;
+  const second = captureRejection(service.loadTrending("series"));
+  // Both handlers are attached before the rejection lands: a rejection with no
+  // handler yet is an unhandled rejection, not a test signal.
+  firstLoad.reject(new DiscoveryUnavailableError("TMDB trending", "request failed"));
+
+  expect(await first).toBeInstanceOf(DiscoveryUnavailableError);
+  expect(await second).toBeInstanceOf(DiscoveryUnavailableError);
+  expect(calls).toBe(1);
+
+  expect((await service.loadTrending("series"))[0]?.title).toBe("Movie");
+  expect(calls).toBe(2);
+});
+
+test("CatalogDiscoveryService never caches a failed surprise load", async () => {
+  let calls = 0;
+  const service = new CatalogDiscoveryService({
+    anime: async () => [],
+    tmdb: async () => [],
+    tmdbSurprise: async () => {
+      calls += 1;
+      if (calls === 1) throw new DiscoveryUnavailableError("TMDB surprise", "request failed");
+      return [
+        { id: "1", type: "movie", title: "Spin", year: "2026", overview: "", posterPath: null },
+      ];
+    },
+  });
+
+  const options = { random: () => 0 };
+  await expect(service.loadSurprise("series", undefined, options)).rejects.toThrow(
+    DiscoveryUnavailableError,
+  );
+  expect((await service.loadSurprise("series", undefined, options))[0]?.title).toBe("Spin");
+  expect(calls).toBe(2);
+});
+
+/** Settles to the rejection reason, with the handler attached up front. */
+function captureRejection(promise: Promise<unknown>): Promise<unknown> {
+  return promise.then(
+    () => null,
+    (error: unknown) => error,
+  );
+}

--- a/apps/cli/test/unit/services/download/download-cleanup-policy.test.ts
+++ b/apps/cli/test/unit/services/download/download-cleanup-policy.test.ts
@@ -129,6 +129,69 @@ describe("download cleanup policy", () => {
     expect(candidates.map((candidate) => candidate.job.id)).toEqual(["older"]);
   });
 
+  test("keeps the last watched absolute-numbered anime episode", () => {
+    // Absolute numbering: the job has no season and carries the number in
+    // `episode`; history carries it in `absoluteEpisode`. The keep set used to
+    // compare `1 === undefined`, retained nothing, and every episode came back
+    // as a deletion candidate — a delete/re-download loop.
+    const older = job({ id: "older", season: undefined, episode: 12, mode: "anime" });
+    const newest = job({ id: "newest", season: undefined, episode: 13, mode: "anime" });
+    const candidates = selectDownloadCleanupCandidates({
+      jobs: [older, newest],
+      historyByTitle: new Map([
+        [
+          "title-1",
+          [
+            watched({
+              season: undefined,
+              episode: undefined,
+              absoluteEpisode: 12,
+              updatedAt: "2026-05-08T00:00:00.000Z",
+            }),
+            watched({
+              season: undefined,
+              episode: undefined,
+              absoluteEpisode: 13,
+              updatedAt: "2026-05-10T00:00:00.000Z",
+            }),
+          ],
+        ],
+      ]),
+      nowMs: Date.parse("2026-05-14T00:00:00.000Z"),
+      graceDays: 2,
+      titlePolicies: new Map([["title-1", { mode: "keep-last-watched", count: 1 }]]),
+    });
+
+    expect(candidates.map((candidate) => candidate.job.id)).toEqual(["older"]);
+  });
+
+  test("keep-last-watched retains every absolute-numbered episode it was asked to", () => {
+    const jobs = [12, 13, 14].map((episode) =>
+      job({ id: `ep-${episode}`, season: undefined, episode, mode: "anime" }),
+    );
+    const candidates = selectDownloadCleanupCandidates({
+      jobs,
+      historyByTitle: new Map([
+        [
+          "title-1",
+          [12, 13, 14].map((absoluteEpisode) =>
+            watched({
+              season: undefined,
+              episode: undefined,
+              absoluteEpisode,
+              updatedAt: `2026-05-${String(absoluteEpisode - 2).padStart(2, "0")}T00:00:00.000Z`,
+            }),
+          ),
+        ],
+      ]),
+      nowMs: Date.parse("2026-05-20T00:00:00.000Z"),
+      graceDays: 2,
+      titlePolicies: new Map([["title-1", { mode: "keep-last-watched", count: 3 }]]),
+    });
+
+    expect(candidates).toEqual([]);
+  });
+
   test("title policy cleanup grace overrides the global cleanup suggestion window", () => {
     const record = job();
     const candidates = selectDownloadCleanupCandidates({

--- a/apps/cli/test/unit/services/download/download-path-naming.test.ts
+++ b/apps/cli/test/unit/services/download/download-path-naming.test.ts
@@ -50,6 +50,54 @@ describe("sanitizePathPart", () => {
   });
 });
 
+describe("Windows path budget units", () => {
+  // The budget is derived from MAX_PATH, which counts UTF-16 code units, but it
+  // is spent by a truncator that counts UTF-8 bytes. Conflating the two let a
+  // CJK title (1 unit, 3 bytes per character) be measured against the wrong
+  // limit and still overrun MAX_PATH on a default Windows install.
+  const WINDOWS_LIMIT = 260 - 12;
+
+  test("a long CJK series path stays inside MAX_PATH", () => {
+    const path = resolveDownloadOutputPath({
+      baseDir: "C:\\Users\\kitsune\\Videos\\Kunai",
+      titleName: "鋼の錬金術師 フルメタル・アルケミスト".repeat(6),
+      extension: ".mp4",
+      position: { kind: "episode", season: 1, episode: 3, seasonIsMeaningful: true },
+      platform: "win32",
+    });
+
+    expect(path.length).toBeLessThanOrEqual(WINDOWS_LIMIT);
+  });
+
+  test("an astral-character title stays inside MAX_PATH and keeps whole characters", () => {
+    const path = resolveDownloadOutputPath({
+      baseDir: "C:\\Users\\kitsune\\Videos\\Kunai",
+      titleName: "🎬".repeat(120),
+      extension: ".mp4",
+      position: { kind: "episode", season: 1, episode: 3, seasonIsMeaningful: true },
+      platform: "win32",
+    });
+
+    expect(path.length).toBeLessThanOrEqual(WINDOWS_LIMIT);
+    // No lone surrogate survived the truncation.
+    expect(path).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+  });
+
+  test("POSIX keeps the byte cap and is not constrained by MAX_PATH", () => {
+    const path = resolveDownloadOutputPath({
+      baseDir: "/home/kitsune/Videos/Kunai",
+      titleName: "鋼の錬金術師".repeat(20),
+      extension: ".mp4",
+      position: { kind: "episode", season: 1, episode: 3, seasonIsMeaningful: true },
+      platform: "linux",
+    });
+
+    for (const part of path.split("/").filter(Boolean)) {
+      expect(new TextEncoder().encode(part).length).toBeLessThanOrEqual(255);
+    }
+  });
+});
+
 describe("clampComponent", () => {
   test("leaves short names untouched", () => {
     expect(clampComponent("Dune.mp4", 255)).toBe("Dune.mp4");

--- a/apps/cli/test/unit/services/offline/offline-sync-policy.test.ts
+++ b/apps/cli/test/unit/services/offline/offline-sync-policy.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  historyMatchesDownloadJob,
+  shouldAutoCleanupOfflineJob,
+} from "@/services/offline/offline-sync-policy";
+import type { DownloadJobRecord, HistoryProgress } from "@kunai/storage";
+
+/**
+ * This module decides whether a file the user downloaded gets deleted, and it
+ * had no tests. The matching half is shared with the retention keep-set, so a
+ * disagreement between them deleted episodes the policy was told to keep.
+ */
+function job(patch: Partial<DownloadJobRecord> = {}): DownloadJobRecord {
+  return {
+    id: "job-1",
+    titleId: "title-1",
+    titleName: "Demo",
+    mediaKind: "series",
+    season: 1,
+    episode: 2,
+    providerId: "vidking",
+    streamUrl: "https://provider.example/stream.m3u8",
+    headers: {},
+    status: "completed",
+    progressPercent: 100,
+    outputPath: "/downloads/demo.mp4",
+    tempPath: "/downloads/demo.tmp",
+    retryCount: 0,
+    attempt: 1,
+    maxAttempts: 3,
+    createdAt: "2026-05-01T00:00:00.000Z",
+    updatedAt: "2026-05-01T00:00:00.000Z",
+    completedAt: "2026-05-01T00:00:00.000Z",
+    ...patch,
+  };
+}
+
+function watched(patch: Partial<HistoryProgress> = {}): HistoryProgress {
+  return {
+    key: "k",
+    titleId: "title-1",
+    mediaKind: "series",
+    title: "Demo",
+    season: 1,
+    episode: 2,
+    positionSeconds: 1_200,
+    durationSeconds: 1_200,
+    completed: true,
+    providerId: "local:vidking",
+    updatedAt: "2026-05-10T00:00:00.000Z",
+    createdAt: "2026-05-10T00:00:00.000Z",
+    ...patch,
+  };
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MAY_20 = Date.parse("2026-05-20T00:00:00.000Z");
+
+describe("historyMatchesDownloadJob", () => {
+  test("matches a season-relative episode", () => {
+    expect(historyMatchesDownloadJob(watched(), job())).toBe(true);
+  });
+
+  test("matches an absolute-numbered anime episode against a seasonless job", () => {
+    // The regression this module shared with the retention keep-set: only the
+    // history side was normalized, so `1 === undefined` matched nothing and an
+    // absolute-numbered anime download was never recognised as watched.
+    const entry = watched({
+      mediaKind: "anime",
+      season: undefined,
+      episode: undefined,
+      absoluteEpisode: 13,
+    });
+    const record = job({ mediaKind: "anime", season: undefined, episode: 13 });
+
+    expect(historyMatchesDownloadJob(entry, record)).toBe(true);
+  });
+
+  test("does not match a different episode", () => {
+    expect(historyMatchesDownloadJob(watched({ episode: 3 }), job())).toBe(false);
+  });
+
+  test("a movie matches on kind alone, without episode numbering", () => {
+    const entry = watched({ mediaKind: "movie", season: undefined, episode: undefined });
+    expect(historyMatchesDownloadJob(entry, job({ mediaKind: "movie" }))).toBe(true);
+  });
+
+  test("a movie job never matches an episodic history row", () => {
+    expect(historyMatchesDownloadJob(watched(), job({ mediaKind: "movie" }))).toBe(false);
+  });
+});
+
+describe("shouldAutoCleanupOfflineJob", () => {
+  test("an unfinished download is never deleted", () => {
+    const decision = shouldAutoCleanupOfflineJob({
+      job: job({ status: "running" }),
+      historyEntries: [watched()],
+      nowMs: MAY_20,
+      graceDays: 3,
+    });
+
+    expect(decision).toEqual({ shouldDelete: false, reason: "not-completed" });
+  });
+
+  test("an unwatched download is never deleted", () => {
+    const decision = shouldAutoCleanupOfflineJob({
+      job: job(),
+      historyEntries: [watched({ completed: false })],
+      nowMs: MAY_20,
+      graceDays: 3,
+    });
+
+    expect(decision).toEqual({ shouldDelete: false, reason: "not-watched" });
+  });
+
+  test("a watched download inside the grace window is kept", () => {
+    const decision = shouldAutoCleanupOfflineJob({
+      job: job(),
+      historyEntries: [watched({ updatedAt: new Date(MAY_20 - DAY_MS).toISOString() })],
+      nowMs: MAY_20,
+      graceDays: 3,
+    });
+
+    expect(decision).toEqual({ shouldDelete: false, reason: "grace-period" });
+  });
+
+  test("a watched download past the grace window is deleted", () => {
+    const watchedAt = new Date(MAY_20 - 5 * DAY_MS).toISOString();
+    const decision = shouldAutoCleanupOfflineJob({
+      job: job(),
+      historyEntries: [watched({ updatedAt: watchedAt })],
+      nowMs: MAY_20,
+      graceDays: 3,
+    });
+
+    expect(decision).toEqual({ shouldDelete: true, reason: "watched", watchedAt });
+  });
+
+  test("an absolute-numbered anime episode is recognised as watched", () => {
+    // Before the shared matcher this returned "not-watched" forever, so the
+    // grace period never started and the file was never reclaimed.
+    const watchedAt = new Date(MAY_20 - 5 * DAY_MS).toISOString();
+    const decision = shouldAutoCleanupOfflineJob({
+      job: job({ mediaKind: "anime", season: undefined, episode: 13 }),
+      historyEntries: [
+        watched({
+          mediaKind: "anime",
+          season: undefined,
+          episode: undefined,
+          absoluteEpisode: 13,
+          updatedAt: watchedAt,
+        }),
+      ],
+      nowMs: MAY_20,
+      graceDays: 3,
+    });
+
+    expect(decision).toEqual({ shouldDelete: true, reason: "watched", watchedAt });
+  });
+
+  test("a corrupt updatedAt is not treated as a watch", () => {
+    const decision = shouldAutoCleanupOfflineJob({
+      job: job(),
+      historyEntries: [watched({ updatedAt: "not-a-date" })],
+      nowMs: MAY_20,
+      graceDays: 3,
+    });
+
+    expect(decision).toEqual({ shouldDelete: false, reason: "not-watched" });
+  });
+
+  test("a zero grace period deletes as soon as it is watched", () => {
+    const watchedAt = new Date(MAY_20 - 1).toISOString();
+    const decision = shouldAutoCleanupOfflineJob({
+      job: job(),
+      historyEntries: [watched({ updatedAt: watchedAt })],
+      nowMs: MAY_20,
+      graceDays: 0,
+    });
+
+    expect(decision).toEqual({ shouldDelete: true, reason: "watched", watchedAt });
+  });
+});

--- a/apps/cli/test/unit/services/offline/offline-sync-policy.test.ts
+++ b/apps/cli/test/unit/services/offline/offline-sync-policy.test.ts
@@ -86,6 +86,39 @@ describe("historyMatchesDownloadJob", () => {
     expect(historyMatchesDownloadJob(entry, job({ mediaKind: "movie" }))).toBe(true);
   });
 
+  test("an anime film matches on contentType, not the anime badge", () => {
+    // `mediaKind: "anime"` with `contentType: "movie"` is a film. Deriving the
+    // kind from the badge alone called it a series and then demanded an episode
+    // match it could never satisfy, so the film was never seen as watched.
+    const entry = watched({ mediaKind: "anime", season: undefined, episode: undefined });
+    const record = job({
+      mediaKind: "anime",
+      contentType: "movie",
+      season: undefined,
+      episode: undefined,
+    });
+
+    expect(historyMatchesDownloadJob(entry, record)).toBe(true);
+  });
+
+  test("an anime series is still matched by episode", () => {
+    const entry = watched({
+      mediaKind: "anime",
+      season: undefined,
+      absoluteEpisode: 13,
+      episode: undefined,
+    });
+    const series = job({
+      mediaKind: "anime",
+      contentType: "series",
+      season: undefined,
+      episode: 13,
+    });
+
+    expect(historyMatchesDownloadJob(entry, series)).toBe(true);
+    expect(historyMatchesDownloadJob(entry, job({ ...series, episode: 14 }))).toBe(false);
+  });
+
   test("a movie job never matches an episodic history row", () => {
     expect(historyMatchesDownloadJob(watched(), job({ mediaKind: "movie" }))).toBe(false);
   });

--- a/apps/cli/test/unit/services/persistence/config-save-debounce.test.ts
+++ b/apps/cli/test/unit/services/persistence/config-save-debounce.test.ts
@@ -131,6 +131,37 @@ describe("ConfigService.save debounce", () => {
     expect((await saved)?.message).toBe("disk full");
     expect((await flushed)?.message).toBe("disk full");
   });
+
+  test("a synchronous store throw does not strand the in-flight handle", async () => {
+    // `store.save()` throwing synchronously runs the catch and the finally before
+    // `saveInFlight` was assigned, so assigning afterwards parked an
+    // already-rejected promise there and every later flushPending() awaited it.
+    let mode: "throw" | "ok" = "throw";
+    let saves = 0;
+    const store = {
+      load: async () => ({ ...DEFAULT_CONFIG }),
+      save: () => {
+        if (mode === "throw") throw new Error("disk full");
+        saves += 1;
+        return Promise.resolve();
+      },
+      reset: async () => {},
+    };
+    const service = await ConfigServiceImpl.load(store);
+
+    await service.save().then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    // The failed write must not be left behind as a permanent flush target.
+    mode = "ok";
+    await service.flushPending();
+
+    await service.save();
+    expect(saves).toBe(1);
+    await service.flushPending();
+  });
 });
 
 /**

--- a/apps/cli/test/unit/services/persistence/config-save-debounce.test.ts
+++ b/apps/cli/test/unit/services/persistence/config-save-debounce.test.ts
@@ -65,6 +65,47 @@ describe("ConfigService.save debounce", () => {
     expect(store.saves).toBe(0);
   });
 
+  test("flushPending awaits a store write that is already in flight", async () => {
+    // The shutdown race: once the debounce fires, `savePending` is null while
+    // the store write is still running. `flushPending()` used to return there,
+    // letting `process.exit()` truncate the write.
+    let releaseSave!: () => void;
+    let saves = 0;
+    const store = {
+      load: async () => ({ ...DEFAULT_CONFIG }),
+      save: () => {
+        saves += 1;
+        return new Promise<void>((resolve) => {
+          releaseSave = resolve;
+        });
+      },
+      reset: async () => {},
+    };
+    const service = await ConfigServiceImpl.load(store);
+
+    const pending = service.save();
+    // Stands in for the debounce timer firing: the write starts and
+    // `savePending` is cleared.
+    const started = service.flushPending();
+    expect(saves).toBe(1);
+
+    let lateFlushSettled = false;
+    const lateFlush = service.flushPending().then(() => {
+      lateFlushSettled = true;
+      return null;
+    });
+    await drainMicrotasks();
+
+    // Without the in-flight handle this is already true — shutdown would have
+    // continued under a half-written config.json.
+    expect(lateFlushSettled).toBe(false);
+
+    releaseSave();
+    await Promise.all([pending, started, lateFlush]);
+    expect(lateFlushSettled).toBe(true);
+    expect(saves).toBe(1);
+  });
+
   test("store rejection rejects both save() and flushPending()", async () => {
     let rejectSave!: (reason: unknown) => void;
     const store = {
@@ -91,3 +132,12 @@ describe("ConfigService.save debounce", () => {
     expect((await flushed)?.message).toBe("disk full");
   });
 });
+
+/**
+ * Drains the microtask queue. Not a timer: a `flushPending()` that returned
+ * early settles within a microtask or two, so this makes the wrong behaviour
+ * observable without waiting on the clock.
+ */
+async function drainMicrotasks(): Promise<void> {
+  for (let turn = 0; turn < 10; turn += 1) await Promise.resolve();
+}

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "9399f4e19c122a598078ee554d5ef0659a4c62985eef9ea2a9a7b0aa8ac691de",
-  "docsContentFingerprint": "300798430d59e1edc19fc4ea6c726c9c4f6c07503ec952ca6734b7102d42bf1e",
+  "docsContentFingerprint": "2bf338ad3df7fdc901a32bffc4074d3fd4b376a45195b409c5fa8a92803e050b",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/docs/users/reliability-and-privacy.mdx
+++ b/docs/users/reliability-and-privacy.mdx
@@ -119,8 +119,11 @@ Preview the exact JSON with `/analytics show`.
 
 If you turn analytics on, pings go to `analytics.kunai.kitsunekode.in`. Point
 them somewhere else by setting a **non-empty** `KUNAI_ANALYTICS_URL` or
-`analyticsEndpoint`. An empty `analyticsEndpoint` (the shipped default) means
-“use the built-in URL”, not “disable”. Turn analytics off in Settings, or set
+`analyticsEndpoint`. That address must use **https** — `http://localhost` and
+`127.0.0.1` are the only exceptions, for testing your own ingest. Any other
+cleartext address is refused and nothing is sent at all; your pings are never
+silently rerouted to the built-in URL. An empty `analyticsEndpoint` (the shipped
+default) means “use the built-in URL”, not “disable”. Turn analytics off in Settings, or set
 `DO_NOT_TRACK=1`, to send nothing. Leaving analytics off, running without a
 terminal, or setting `DO_NOT_TRACK` means nothing is ever sent, whatever the
 endpoint says.

--- a/docs/users/reliability-and-privacy.mdx
+++ b/docs/users/reliability-and-privacy.mdx
@@ -119,8 +119,8 @@ Preview the exact JSON with `/analytics show`.
 
 If you turn analytics on, pings go to `analytics.kunai.kitsunekode.in`. Point
 them somewhere else by setting a **non-empty** `KUNAI_ANALYTICS_URL` or
-`analyticsEndpoint`. That address must use **https** — `http://localhost` and
-`127.0.0.1` are the only exceptions, for testing your own ingest. Any other
+`analyticsEndpoint`. That address must use **https** — `http://localhost`, `127.0.0.1`, and `[::1]`
+are the only exceptions, for testing your own ingest. Any other
 cleartext address is refused and nothing is sent at all; your pings are never
 silently rerouted to the built-in URL. An empty `analyticsEndpoint` (the shipped
 default) means “use the built-in URL”, not “disable”. Turn analytics off in Settings, or set

--- a/packages/providers/src/shared/provider-episode-number.ts
+++ b/packages/providers/src/shared/provider-episode-number.ts
@@ -3,6 +3,12 @@ import type { EpisodeIdentity } from "@kunai/types";
 /**
  * Provider requests follow the proven season-relative identity when it exists.
  * Absolute numbering is reserved for inputs that carry no relative episode.
+ *
+ * An absent or empty identity resolves to episode 1. Both callers are anime-only
+ * providers, where a film is catalogued as its single first episode, so 1 is the
+ * right request rather than a placeholder — see the default's test in
+ * `test/provider-episode-number.test.ts`. Callers that must not guess should
+ * resolve an episode before calling, not read a sentinel back out of this.
  */
 export function selectProviderEpisodeNumber(episode: EpisodeIdentity | undefined): number {
   return episode?.episode ?? episode?.absoluteEpisode ?? 1;

--- a/packages/relay/src/create-relay-fetch-port.ts
+++ b/packages/relay/src/create-relay-fetch-port.ts
@@ -29,7 +29,12 @@ export function createRelayFetchPort(options: RelayFetchPortOptions): RelayFetch
         return fetchImpl(input, init);
       }
 
-      const relayUrl = new URL(`/rpc/${entry.providerId}`, baseUrl);
+      // Appended, not resolved against the base: `new URL("/rpc/x", base)`
+      // treats a leading slash as absolute and drops the base's own path, so a
+      // relay hosted under a sub-path (`https://host/prod`) was called at
+      // `/rpc/x` and 404ed into permanent direct fallback. `normalizeRelayBaseUrl`
+      // deliberately preserves that path, so it is a supported deployment.
+      const relayUrl = new URL(`${baseUrl}/rpc/${encodeURIComponent(entry.providerId)}`);
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
       };

--- a/packages/relay/test/relay-fetch-port.test.ts
+++ b/packages/relay/test/relay-fetch-port.test.ts
@@ -57,6 +57,29 @@ test("createRelayFetchPort routes allowlisted provider requests through RPC", as
   });
 });
 
+test("createRelayFetchPort keeps a relay base URL's sub-path", async () => {
+  // `new URL("/rpc/x", base)` read the leading slash as absolute and dropped
+  // `/prod`, so a self-hosted relay behind a path prefix 404ed and every request
+  // fell back to direct — silently, and for as long as the relay stayed configured.
+  let called = "";
+  const port = createRelayFetchPort({
+    relayConfig: { baseUrl: "https://relay.example/prod" },
+    registry,
+    async fetch(input) {
+      called = String(input);
+      return Response.json({ ok: true });
+    },
+  });
+
+  await port.fetch("https://api.allanime.day/api", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: '{"query":"x"}',
+  });
+
+  expect(called).toBe("https://relay.example/prod/rpc/allanime");
+});
+
 test("createRelayFetchPort uses direct fetch when relay is not configured", async () => {
   let direct = false;
   const port = createRelayFetchPort({

--- a/packages/storage/src/paths.ts
+++ b/packages/storage/src/paths.ts
@@ -58,7 +58,7 @@ export function getKunaiPaths(options: KunaiPathOptions = {}): KunaiPaths {
   // redirect its storage root from the environment at all: a test that set the
   // documented variables still resolved the real `~/Library/Application Support`
   // and wrote the developer's live profile.
-  const home = options.homeDir ?? env.HOME ?? env.USERPROFILE ?? homedir();
+  const home = options.homeDir ?? firstNonEmpty(env.HOME, env.USERPROFILE) ?? homedir();
   const join = joinerFor(platform);
 
   const dirs = getBaseDirs(platform, env, home);
@@ -79,6 +79,21 @@ function normalizePlatform(platform: NodeJS.Platform): StoragePlatform {
   }
 
   return "linux";
+}
+
+/**
+ * `??` treats an empty string as a value, not as absent.
+ *
+ * `HOME=""` therefore survived the fallback chain and became the storage root,
+ * and every path joined from it came out relative to the process's working
+ * directory rather than to a profile. An empty variable means "unset" here.
+ */
+function firstNonEmpty(...values: readonly (string | undefined)[]): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
 }
 
 function getBaseDirs(

--- a/packages/storage/src/paths.ts
+++ b/packages/storage/src/paths.ts
@@ -51,7 +51,14 @@ export function joinerForNodePlatform(
 export function getKunaiPaths(options: KunaiPathOptions = {}): KunaiPaths {
   const platform = options.platform ?? normalizePlatform(process.platform);
   const env = options.env ?? process.env;
-  const home = options.homeDir ?? homedir();
+  // `homedir()` is the last resort, not the first. On Linux the XDG variables
+  // below already override every root, and on Windows APPDATA/LOCALAPPDATA do —
+  // but the macOS layout derives *everything* from `home`, and Bun's `homedir()`
+  // reads the account record rather than `HOME`. That left macOS with no way to
+  // redirect its storage root from the environment at all: a test that set the
+  // documented variables still resolved the real `~/Library/Application Support`
+  // and wrote the developer's live profile.
+  const home = options.homeDir ?? env.HOME ?? env.USERPROFILE ?? homedir();
   const join = joinerFor(platform);
 
   const dirs = getBaseDirs(platform, env, home);

--- a/packages/storage/test/paths-home-resolution.test.ts
+++ b/packages/storage/test/paths-home-resolution.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import { getKunaiPaths } from "../src/paths";
+
+/**
+ * Home resolution order, which is what makes a sandboxed run possible at all.
+ *
+ * Linux can be redirected with the XDG variables and Windows with
+ * APPDATA/LOCALAPPDATA, but the macOS layout derives *every* root from home. If
+ * home came only from `homedir()` — which reads the account record, not `HOME` —
+ * then macOS had no way to be redirected from the environment, and a test that
+ * set the documented variables still resolved the developer's real
+ * `~/Library/Application Support/kunai` and wrote their live profile.
+ */
+describe("getKunaiPaths home resolution", () => {
+  test("an explicit homeDir still outranks the environment", () => {
+    const paths = getKunaiPaths({
+      platform: "darwin",
+      homeDir: "/Users/explicit",
+      env: { HOME: "/Users/from-env" },
+    });
+
+    expect(paths.configDir).toBe("/Users/explicit/Library/Application Support/kunai");
+  });
+
+  test("macOS takes its roots from HOME when no homeDir is given", () => {
+    const paths = getKunaiPaths({ platform: "darwin", env: { HOME: "/sandbox" } });
+
+    expect(paths.configDir).toBe("/sandbox/Library/Application Support/kunai");
+    expect(paths.dataDir).toBe("/sandbox/Library/Application Support/kunai");
+    expect(paths.cacheDir).toBe("/sandbox/Library/Caches/kunai");
+  });
+
+  test("USERPROFILE stands in for HOME", () => {
+    const paths = getKunaiPaths({ platform: "darwin", env: { USERPROFILE: "/sandbox" } });
+
+    expect(paths.configDir).toBe("/sandbox/Library/Application Support/kunai");
+  });
+
+  test("HOME wins over USERPROFILE when both are set", () => {
+    const paths = getKunaiPaths({
+      platform: "darwin",
+      env: { HOME: "/from-home", USERPROFILE: "/from-userprofile" },
+    });
+
+    expect(paths.configDir).toBe("/from-home/Library/Application Support/kunai");
+  });
+
+  test("Linux still prefers the XDG variables over home", () => {
+    const paths = getKunaiPaths({
+      platform: "linux",
+      env: { HOME: "/sandbox", XDG_CONFIG_HOME: "/xdg/config" },
+    });
+
+    expect(paths.configDir).toBe("/xdg/config/kunai");
+  });
+
+  test("Linux falls back to HOME when XDG is unset", () => {
+    const paths = getKunaiPaths({ platform: "linux", env: { HOME: "/sandbox" } });
+
+    expect(paths.configDir).toBe("/sandbox/.config/kunai");
+  });
+
+  test("Windows still prefers APPDATA over home", () => {
+    const paths = getKunaiPaths({
+      platform: "win32",
+      env: { USERPROFILE: "C:\\sandbox", APPDATA: "C:\\Roaming", LOCALAPPDATA: "C:\\Local" },
+    });
+
+    expect(paths.configDir).toBe("C:\\Roaming\\kunai");
+  });
+
+  test("Windows falls back to the profile layout when APPDATA is unset", () => {
+    const paths = getKunaiPaths({ platform: "win32", env: { USERPROFILE: "C:\\sandbox" } });
+
+    expect(paths.configDir).toBe("C:\\sandbox\\AppData\\Roaming\\kunai");
+  });
+});

--- a/packages/storage/test/paths-home-resolution.test.ts
+++ b/packages/storage/test/paths-home-resolution.test.ts
@@ -46,6 +46,26 @@ describe("getKunaiPaths home resolution", () => {
     expect(paths.configDir).toBe("/from-home/Library/Application Support/kunai");
   });
 
+  test("an empty HOME is treated as unset, not as a root", () => {
+    // `??` treats "" as a value, so `HOME=""` used to survive the fallback chain
+    // and become the storage root — every path joined from it came out relative
+    // to the working directory instead of a profile.
+    const paths = getKunaiPaths({
+      platform: "darwin",
+      env: { HOME: "", USERPROFILE: "/sandbox" },
+    });
+
+    expect(paths.configDir).toBe("/sandbox/Library/Application Support/kunai");
+  });
+
+  test("whitespace-only HOME is also treated as unset", () => {
+    const paths = getKunaiPaths({ platform: "darwin", env: { HOME: "   " } });
+
+    // Falls through to homedir(), so it is at least absolute rather than relative.
+    expect(paths.configDir.startsWith("/")).toBe(true);
+    expect(paths.configDir).not.toStartWith("   ");
+  });
+
   test("Linux still prefers the XDG variables over home", () => {
     const paths = getKunaiPaths({
       platform: "linux",

--- a/packages/storage/test/paths-home-resolution.test.ts
+++ b/packages/storage/test/paths-home-resolution.test.ts
@@ -59,11 +59,17 @@ describe("getKunaiPaths home resolution", () => {
   });
 
   test("whitespace-only HOME is also treated as unset", () => {
-    const paths = getKunaiPaths({ platform: "darwin", env: { HOME: "   " } });
+    // Every other case here supplies the whole environment so the result does
+    // not depend on the host. The first version of this one let HOME fall
+    // through to `homedir()` and asserted the result was absolute — which is
+    // true on POSIX and false on a Windows runner, where `homedir()` is
+    // `C:\Users\...`. Pin the fallback instead of the shape.
+    const paths = getKunaiPaths({
+      platform: "darwin",
+      env: { HOME: "   ", USERPROFILE: "/sandbox" },
+    });
 
-    // Falls through to homedir(), so it is at least absolute rather than relative.
-    expect(paths.configDir.startsWith("/")).toBe(true);
-    expect(paths.configDir).not.toStartWith("   ");
+    expect(paths.configDir).toBe("/sandbox/Library/Application Support/kunai");
   });
 
   test("Linux still prefers the XDG variables over home", () => {


### PR DESCRIPTION
## What changed

Twelve verified bugs across silent failures, a poisoned discovery cache, episode-numbering mismatches, and transport/path handling — each read against the tree before being actioned.

### Silent failures and lost writes

- **`ConfigServiceImpl`** — a debounce that had already fired cleared `savePending` while its store write was still running, so `flushPending()` on the shutdown path (`main.ts:158`) returned early and `process.exit()` could truncate `config.json`. The in-flight write is now tracked and awaited. The existing "store rejection rejects both `save()` and `flushPending()`" test still holds — the `.catch(() => {})` there is unhandled-rejection suppression on a duplicate handle, not error swallowing.
- **`FileStorage`** — `chmod` sat outside the `try`, so a file deleted between the `exists()` check and the chmod rejected with `ENOENT` instead of returning `null`. The corrupt-JSON backup also wrote `""` when the text read failed, destroying the bytes the backup exists to preserve.

### Cache poisoning

`CatalogDiscoveryService` cached whatever a loader resolved for the full 30-minute TTL, and every loader folded failures — including the `AbortError` from navigating away mid-fetch — into `[]`. One offline blip served an empty trending tray until the TTL expired, recoverable only via `clearTrendingCache()`.

Loaders now reject with `DiscoveryUnavailableError`, only a non-empty success is cached, and all seven call sites degrade to an empty tray for display. Failure is visible to the cache layer; the UI still degrades quietly.

### Episode numbering — one rule, four sites

`(entry.season ?? 1) === job.season` normalized only the history side, so absolute-numbered anime compared `1 === undefined` and matched nothing:

- **Retention** — "keep the last 3 watched" retained **zero** for absolute-numbered anime, and cleanup then deleted them.
- **Queue restore** — `sameEpisodeIdentity` returned early when *either* side had an absolute episode, so `13 === undefined` meant an absolute row never matched its own season-relative entry and the resume head was not promoted after a crash.
- Same bug also found in `shouldAutoCleanupOfflineJob` and `isProtectedEpisode`.

All four now share `sameEpisodeNumbering`. The tell was in the existing code: the sort comparator eleven lines below the broken filter *did* normalize the job side.

### Transport and paths

- **Analytics** accepted any scheme from `KUNAI_ANALYTICS_URL` / `analyticsEndpoint`, so `http://` sent `sha256(installId)` in cleartext. Now https-only with a loopback exception, mirroring `normalizeRelayBaseUrl`. A rejected override **stops sending** rather than falling back to the built-in default — rerouting someone's self-hosted telemetry to Kunai's endpoint would be its own consent breach. Contract and user docs updated in the same change set.
- **Relay** used `new URL("/rpc/x", base)`, whose leading slash discards the base's path, so a relay behind a sub-path 404ed into permanent direct fallback — while `normalizeRelayBaseUrl` deliberately *preserves* that path.
- **Download paths** derived a budget in UTF-16 code units and spent it as UTF-8 bytes. Fixing the units exposed that the estimate itself under-corrects (it shares the overrun with a fixed `Season 01` folder that cannot shrink), so the Windows path is now measured and tightened rather than estimated.
- **`merge-timing`** chose on array length, so a degenerate IntroDB `{startMs: 0, endMs: 0}` discarded a valid AniSkip window and the skip prompt never appeared. It now selects on whether a segment can actually drive a skip, matching `normalizeEndSeconds` in `playback-skip.ts`.

### Test isolation (hazard #1)

`FileStorage` built its path map as a **module-level constant**, so `getKunaiPaths()` ran while the module was being imported. Any suite that imported this file — however indirectly — before pointing `HOME`/`XDG_CONFIG_HOME`/`APPDATA` at a sandbox froze the developer's real `config.json` path in, and a later `new FileStorage()` with no explicit paths then wrote the **live profile**.

The map is now built on first use. Explicit paths still win, so existing tests are unaffected; `exists()` keeps answering `false` for an unknown key while read/write/delete keep throwing.

The regression test asserts the condition that used to lose: the module is already imported by the time it runs, and the storage root set afterwards must still decide where the write lands. Verified the write lands in the sandbox and that `~/.config/kunai/config.json` was not touched.

### Tests

25 new assertions; unit suite **5233 → 5258**. Two gaps closed directly rather than through callers: `sameEpisodeNumbering` (now four callers, previously no test of its own) and `offline-sync-policy.ts` (no test file at all, and it decides whether a downloaded file is deleted).

## Seams walked (`AGENTS.md`)

- **Declaration → reader** — every loader that changed from returning `[]` to rejecting has its consumers updated; all seven discovery call sites verified.
- **Both lanes** — the numbering rule is exactly the anime-vs-TMDB split; absolute and season-relative are covered on both sides and a symmetry test pins it.
- **Every platform** — the path fix is Windows-specific and asserted with CJK and astral cases; POSIX keeps the byte cap.
- **Docs** — `.docs/analytics-privacy-contract.md` and `docs/users/reliability-and-privacy.mdx` updated with the analytics change. `verify:doc-paths` passes.
- **Every provider** — no provider-shaped behavior changed; the relay fix is transport-level and applies to all relay-safe providers.

## Not in scope

Deliberately excluded: `PlaybackPhase` / `shell-workflows` decomposition, the 16 baselined layer inversions, and the legacy `tmdb.ts`/`search.ts` cycle — plans **010/011/012/014/015** own those and are dependency-ordered.

Nine reported findings were checked and refuted, producing no change. The notable ones: download naming *is* asserted (`download-service.test.ts:65` pins `Frieren - E03.mp4`), `vidrock` was already migrated off `crypto-js` to `node:crypto`, the reserved-name guard runs on the bare title before any extension exists, and the TMDB season fan-out is bounded by a filter that admits only seasons with no air date.

## Checklist

- [x] Changeset added — patch
- [x] `bun run guard` passes — `@kitsunekode/kunai@0.3.0` in sync
- [x] `bun run fmt && bun run lint && bun run test && bun run typecheck` pass locally (forced, not cache replays: typecheck 14/14 and test 23/23 with `0 cached`)
- [x] `bun run build` passes — host binary written and `--help` smoked
- [x] Live provider / Discord smokes skipped intentionally — no provider or presence behavior changed

## Note for the reviewer

One pre-existing flake seen: `buildDiagnosticsInsight > healthy session` failed once in six `--parallel` runs, then passed 5/5. Clean `main` is green, and it passes in isolation. Unrelated to this branch but worth a look.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shutdown reliability by ensuring pending settings are saved before exit.
  - Discovery and trending sections remain usable when catalog services fail.
  - Fixed episode resume, offline cleanup, and absolute-numbered anime matching.
  - Preserved intro-skip timing when preferred metadata is unusable.
  - Improved Windows filename handling and relay URLs hosted under sub-paths.
  - Improved handling of missing, unreadable, and sandboxed configuration files.
  - Storage locations now respect supported home-directory environment settings.

- **Privacy & Documentation**
  - Analytics overrides require HTTPS, except for local development addresses; unsafe endpoints send nothing.
  - Updated privacy, analytics, and contributor guidance documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->