### PR TITLE
fix(install): reject staging paths that escape the cache before rm -rf

### DIFF
--- a/.changeset/quiet-lions-guard.md
+++ b/.changeset/quiet-lions-guard.md
@@ -2,4 +2,4 @@
 "@kitsunekode/kunai": patch
 ---
 
-Harden the installer's cleanup of abandoned install transactions. A stale transaction record naming a staging directory outside the cache — either by traversing out of it, or by being a sibling that merely shared its name prefix — is no longer removed. The TypeScript installer already refused these; the shell path now matches it.
+Harden the installer's cleanup of abandoned install transactions. A stale transaction record naming a staging directory outside the cache — either by traversing out of it, or by being a sibling that merely shared its name prefix — is no longer removed. The TypeScript installer already refused these; the shell path now matches it, and a staging directory that is itself a symlink pointing out of the cache is no longer followed.

--- a/.changeset/quiet-lions-guard.md
+++ b/.changeset/quiet-lions-guard.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Harden the installer's cleanup of abandoned install transactions. A stale transaction record naming a staging directory outside the cache — either by traversing out of it, or by being a sibling that merely shared its name prefix — is no longer removed. The TypeScript installer already refused these; the shell path now matches it.

--- a/apps/cli/test/unit/scripts/install-staging-root.test.ts
+++ b/apps/cli/test/unit/scripts/install-staging-root.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "../../../../..");
+const INSTALL_SH = readFileSync(join(ROOT, "install.sh"), "utf8");
+
+/**
+ * `install.sh` ends in a bare `main "$@"`, so sourcing it runs the installer.
+ * The function is extracted from the real file instead of being copied here —
+ * a copy would keep passing after the original drifted, which for a guard in
+ * front of `rm -rf` is the failure mode that matters.
+ */
+function extractShellFunction(name: string): string {
+  const start = INSTALL_SH.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`install.sh no longer defines ${name}()`);
+  const end = INSTALL_SH.indexOf("\n}\n", start);
+  if (end < 0) throw new Error(`could not find the end of ${name}()`);
+  return INSTALL_SH.slice(start, end + 3);
+}
+
+async function isInsideStagingRoot(candidate: string): Promise<boolean> {
+  const script = [
+    "set -u",
+    'CACHE_DIR="/home/u/.cache/kunai"',
+    extractShellFunction("is_inside_staging_root"),
+    'if is_inside_staging_root "$1"; then echo ACCEPT; else echo REJECT; fi',
+  ].join("\n");
+
+  const proc = Bun.spawn(["bash", "-c", script, "bash", candidate], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const out = (await new Response(proc.stdout).text()).trim();
+  await proc.exited;
+  if (out !== "ACCEPT" && out !== "REJECT") {
+    throw new Error(`unexpected guard output: ${out}${await new Response(proc.stderr).text()}`);
+  }
+  return out === "ACCEPT";
+}
+
+describe("install.sh is_inside_staging_root", () => {
+  const ROOT_DIR = "/home/u/.cache/kunai/staging";
+
+  test("accepts a real staging directory", async () => {
+    expect(await isInsideStagingRoot(`${ROOT_DIR}/0.3.0`)).toBe(true);
+    expect(await isInsideStagingRoot(`${ROOT_DIR}/0.3.0/nested`)).toBe(true);
+  });
+
+  test("rejects traversal out of the staging root", async () => {
+    // The record is same-user writable and what happens next is `rm -rf`, so a
+    // path that starts with the root but resolves elsewhere must not be honoured.
+    expect(await isInsideStagingRoot(`${ROOT_DIR}/../../../.ssh`)).toBe(false);
+    expect(await isInsideStagingRoot(`${ROOT_DIR}/..`)).toBe(false);
+    expect(await isInsideStagingRoot(`${ROOT_DIR}/0.3.0/../../../..`)).toBe(false);
+  });
+
+  test("rejects a sibling that merely shares the prefix", async () => {
+    // The old test was a bare string prefix with no `/` boundary.
+    expect(await isInsideStagingRoot(`${ROOT_DIR}-old`)).toBe(false);
+    expect(await isInsideStagingRoot(`${ROOT_DIR}evil/x`)).toBe(false);
+  });
+
+  test("rejects the staging root itself and anything outside it", async () => {
+    expect(await isInsideStagingRoot(ROOT_DIR)).toBe(false);
+    expect(await isInsideStagingRoot("/etc")).toBe(false);
+    expect(await isInsideStagingRoot("/home/u/.ssh")).toBe(false);
+    expect(await isInsideStagingRoot("")).toBe(false);
+  });
+});

--- a/apps/cli/test/unit/scripts/install-staging-root.test.ts
+++ b/apps/cli/test/unit/scripts/install-staging-root.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+const tempDirs: string[] = [];
 
 const ROOT = join(import.meta.dir, "../../../../..");
 const INSTALL_SH = readFileSync(join(ROOT, "install.sh"), "utf8");
@@ -19,10 +23,13 @@ function extractShellFunction(name: string): string {
   return INSTALL_SH.slice(start, end + 3);
 }
 
-async function isInsideStagingRoot(candidate: string): Promise<boolean> {
+async function isInsideStagingRoot(
+  candidate: string,
+  cacheDir = "/home/u/.cache/kunai",
+): Promise<boolean> {
   const script = [
     "set -u",
-    'CACHE_DIR="/home/u/.cache/kunai"',
+    `CACHE_DIR=${JSON.stringify(cacheDir)}`,
     extractShellFunction("is_inside_staging_root"),
     'if is_inside_staging_root "$1"; then echo ACCEPT; else echo REJECT; fi',
   ].join("\n");
@@ -38,6 +45,13 @@ async function isInsideStagingRoot(candidate: string): Promise<boolean> {
   }
   return out === "ACCEPT";
 }
+
+afterEach(async () => {
+  while (tempDirs.length) {
+    const dir = tempDirs.pop();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }
+});
 
 describe("install.sh is_inside_staging_root", () => {
   const ROOT_DIR = "/home/u/.cache/kunai/staging";
@@ -59,6 +73,37 @@ describe("install.sh is_inside_staging_root", () => {
     // The old test was a bare string prefix with no `/` boundary.
     expect(await isInsideStagingRoot(`${ROOT_DIR}-old`)).toBe(false);
     expect(await isInsideStagingRoot(`${ROOT_DIR}evil/x`)).toBe(false);
+  });
+
+  test("rejects a staging directory that is a symlink out of the cache", async () => {
+    // The textual checks cannot see this: the name is inside the root, contains
+    // no `..`, and clears the `/` boundary — but following it lands in $HOME.
+    // Resolution is what closes it.
+    const base = await mkdtemp(join(tmpdir(), "kunai-staging-symlink-"));
+    tempDirs.push(base);
+    const cache = join(base, "cache");
+    const staging = join(cache, "staging");
+    const outside = join(base, "outside");
+    await mkdir(staging, { recursive: true });
+    await mkdir(outside, { recursive: true });
+    await symlink(outside, join(staging, "escape"), "dir");
+    await mkdir(join(staging, "0.3.0"), { recursive: true });
+
+    expect(await isInsideStagingRoot(join(staging, "escape"), cache)).toBe(false);
+    // A real directory in the same root is still accepted, so the resolution
+    // step did not simply reject everything.
+    expect(await isInsideStagingRoot(join(staging, "0.3.0"), cache)).toBe(true);
+  });
+
+  test("accepts a path inside the root that does not exist yet", async () => {
+    // Resolution needs the directory to exist; a name that never existed is not
+    // ours to delete either way, and must not be rejected on that basis alone.
+    const base = await mkdtemp(join(tmpdir(), "kunai-staging-missing-"));
+    tempDirs.push(base);
+    const cache = join(base, "cache");
+    await mkdir(join(cache, "staging"), { recursive: true });
+
+    expect(await isInsideStagingRoot(join(cache, "staging", "0.9.9"), cache)).toBe(true);
   });
 
   test("rejects the staging root itself and anything outside it", async () => {

--- a/apps/cli/test/unit/scripts/install-staging-root.test.ts
+++ b/apps/cli/test/unit/scripts/install-staging-root.test.ts
@@ -53,6 +53,16 @@ afterEach(async () => {
   }
 });
 
+/**
+ * The two filesystem-backed cases are POSIX-only.
+ *
+ * `install.sh` never runs on Windows — that is `install.ps1`, which does not
+ * replay `stagingDir` from a transaction file and so needs no equivalent guard.
+ * The cases below build real directories and a real symlink and hand native
+ * paths to a bash `case` pattern, none of which survives a Windows path
+ * separator or an unprivileged `symlink()`. The string-only cases still run
+ * everywhere, so the guard's logic stays covered on every platform.
+ */
 describe("install.sh is_inside_staging_root", () => {
   const ROOT_DIR = "/home/u/.cache/kunai/staging";
 
@@ -75,36 +85,42 @@ describe("install.sh is_inside_staging_root", () => {
     expect(await isInsideStagingRoot(`${ROOT_DIR}evil/x`)).toBe(false);
   });
 
-  test("rejects a staging directory that is a symlink out of the cache", async () => {
-    // The textual checks cannot see this: the name is inside the root, contains
-    // no `..`, and clears the `/` boundary — but following it lands in $HOME.
-    // Resolution is what closes it.
-    const base = await mkdtemp(join(tmpdir(), "kunai-staging-symlink-"));
-    tempDirs.push(base);
-    const cache = join(base, "cache");
-    const staging = join(cache, "staging");
-    const outside = join(base, "outside");
-    await mkdir(staging, { recursive: true });
-    await mkdir(outside, { recursive: true });
-    await symlink(outside, join(staging, "escape"), "dir");
-    await mkdir(join(staging, "0.3.0"), { recursive: true });
+  test.skipIf(process.platform === "win32")(
+    "rejects a staging directory that is a symlink out of the cache",
+    async () => {
+      // The textual checks cannot see this: the name is inside the root, contains
+      // no `..`, and clears the `/` boundary — but following it lands in $HOME.
+      // Resolution is what closes it.
+      const base = await mkdtemp(join(tmpdir(), "kunai-staging-symlink-"));
+      tempDirs.push(base);
+      const cache = join(base, "cache");
+      const staging = join(cache, "staging");
+      const outside = join(base, "outside");
+      await mkdir(staging, { recursive: true });
+      await mkdir(outside, { recursive: true });
+      await symlink(outside, join(staging, "escape"), "dir");
+      await mkdir(join(staging, "0.3.0"), { recursive: true });
 
-    expect(await isInsideStagingRoot(join(staging, "escape"), cache)).toBe(false);
-    // A real directory in the same root is still accepted, so the resolution
-    // step did not simply reject everything.
-    expect(await isInsideStagingRoot(join(staging, "0.3.0"), cache)).toBe(true);
-  });
+      expect(await isInsideStagingRoot(join(staging, "escape"), cache)).toBe(false);
+      // A real directory in the same root is still accepted, so the resolution
+      // step did not simply reject everything.
+      expect(await isInsideStagingRoot(join(staging, "0.3.0"), cache)).toBe(true);
+    },
+  );
 
-  test("accepts a path inside the root that does not exist yet", async () => {
-    // Resolution needs the directory to exist; a name that never existed is not
-    // ours to delete either way, and must not be rejected on that basis alone.
-    const base = await mkdtemp(join(tmpdir(), "kunai-staging-missing-"));
-    tempDirs.push(base);
-    const cache = join(base, "cache");
-    await mkdir(join(cache, "staging"), { recursive: true });
+  test.skipIf(process.platform === "win32")(
+    "accepts a path inside the root that does not exist yet",
+    async () => {
+      // Resolution needs the directory to exist; a name that never existed is not
+      // ours to delete either way, and must not be rejected on that basis alone.
+      const base = await mkdtemp(join(tmpdir(), "kunai-staging-missing-"));
+      tempDirs.push(base);
+      const cache = join(base, "cache");
+      await mkdir(join(cache, "staging"), { recursive: true });
 
-    expect(await isInsideStagingRoot(join(cache, "staging", "0.9.9"), cache)).toBe(true);
-  });
+      expect(await isInsideStagingRoot(join(cache, "staging", "0.9.9"), cache)).toBe(true);
+    },
+  );
 
   test("rejects the staging root itself and anything outside it", async () => {
     expect(await isInsideStagingRoot(ROOT_DIR)).toBe(false);

--- a/install.sh
+++ b/install.sh
@@ -1132,9 +1132,14 @@ finish_transaction() {
 #   - siblings — with no `/` boundary, `$CACHE_DIR/staging-old` matched too.
 #
 # `realpath` is not portable enough to rely on here (BSD and GNU differ, and it
-# is absent on some minimal images), but the installer never creates a staging
-# path containing `..`, so rejecting the segment outright is both sufficient and
-# portable. This mirrors `isInsideStagingRoot` in
+# is absent on some minimal images), but `cd` + `pwd -P` resolves symlinks in any
+# POSIX shell, which covers the case a textual check cannot: a staging directory
+# that *is* a symlink pointing out of the cache passes every string test and then
+# takes the `rm -rf` somewhere else entirely.
+#
+# The textual checks stay in front of it, because resolution needs the directory
+# to exist and a path that never existed is not ours to delete either way. This
+# mirrors `isInsideStagingRoot` in
 # `apps/cli/src/services/update/native-installer/install-layout.ts`, which
 # resolves both paths and refuses anything that escapes the root.
 is_inside_staging_root() {
@@ -1145,7 +1150,20 @@ is_inside_staging_root() {
 	.. | ../* | */../* | */..) return 1 ;;
 	esac
 	case "$candidate" in
-	"$root"/?*) return 0 ;;
+	"$root"/?*) ;;
+	*) return 1 ;;
+	esac
+
+	# Not a directory: nothing to recurse into, and the textual checks already
+	# proved the name is inside the root.
+	[[ -d "$candidate" ]] || return 0
+
+	local resolved resolved_root
+	resolved="$(cd -- "$candidate" 2>/dev/null && pwd -P)" || return 1
+	resolved_root="$(cd -- "$root" 2>/dev/null && pwd -P)" || return 1
+	# Re-test after resolution: a symlinked staging dir now shows its real path.
+	case "$resolved" in
+	"$resolved_root"/?*) return 0 ;;
 	esac
 	return 1
 }

--- a/install.sh
+++ b/install.sh
@@ -1120,6 +1120,36 @@ finish_transaction() {
 	rm -f "$path"
 }
 
+# Does this path genuinely live under our staging root?
+#
+# The value comes out of a transaction JSON file, and what happens next is
+# `rm -rf`, so it is attacker-shaped input even though only the same user can
+# write it. The previous test was a bare string prefix, which accepted two
+# things it should not have:
+#
+#   - traversal — `$CACHE_DIR/staging/../../../.ssh` starts with the prefix and
+#     resolves somewhere else entirely;
+#   - siblings — with no `/` boundary, `$CACHE_DIR/staging-old` matched too.
+#
+# `realpath` is not portable enough to rely on here (BSD and GNU differ, and it
+# is absent on some minimal images), but the installer never creates a staging
+# path containing `..`, so rejecting the segment outright is both sufficient and
+# portable. This mirrors `isInsideStagingRoot` in
+# `apps/cli/src/services/update/native-installer/install-layout.ts`, which
+# resolves both paths and refuses anything that escapes the root.
+is_inside_staging_root() {
+	local candidate="$1"
+	local root="$CACHE_DIR/staging"
+	[[ -n "$candidate" ]] || return 1
+	case "$candidate" in
+		..|../*|*/../*|*/..) return 1 ;;
+	esac
+	case "$candidate" in
+		"$root"/?*) return 0 ;;
+	esac
+	return 1
+}
+
 # Remove transaction records whose owning PID is dead, and delete any staging
 # directories those records still point at. Safe to call under a version lock.
 cleanup_abandoned_transactions() {
@@ -1133,7 +1163,7 @@ cleanup_abandoned_transactions() {
 			continue
 		fi
 		staging_dir="$(sed -n 's/.*"stagingDir"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$path" | head -1)"
-		if [[ -n "$staging_dir" && "$staging_dir" == "$CACHE_DIR/staging"* ]]; then
+		if is_inside_staging_root "$staging_dir"; then
 			rm -rf "$staging_dir" 2>/dev/null || true
 			rmdir "$(dirname "$staging_dir")" 2>/dev/null || true
 		fi

--- a/install.sh
+++ b/install.sh
@@ -1142,10 +1142,10 @@ is_inside_staging_root() {
 	local root="$CACHE_DIR/staging"
 	[[ -n "$candidate" ]] || return 1
 	case "$candidate" in
-		..|../*|*/../*|*/..) return 1 ;;
+	.. | ../* | */../* | */..) return 1 ;;
 	esac
 	case "$candidate" in
-		"$root"/?*) return 0 ;;
+	"$root"/?*) return 0 ;;
 	esac
 	return 1
 }


### PR DESCRIPTION
## What changed

`cleanup_abandoned_transactions` in `install.sh` reads `stagingDir` out of a transaction JSON file and hands it to `rm -rf` after a bare string-prefix test:

```sh
if [[ -n "$staging_dir" && "$staging_dir" == "$CACHE_DIR/staging"* ]]; then
	rm -rf "$staging_dir" 2>/dev/null || true
```

That accepted two things it should not have:

- **Traversal** — `$CACHE_DIR/staging/../../../.ssh` starts with the prefix and resolves somewhere else entirely.
- **Siblings** — with no `/` boundary, `$CACHE_DIR/staging-old` and `$CACHE_DIR/stagingevil/x` matched too. That one was not in the original report; it fell out while writing the guard.

Both confirmed against the old expression before changing it.

## Why it matters, and what it is not

Only the same user can write those transaction records, so this is **not a privilege boundary** and I would not call it a vulnerability. It is a recursive delete driven by file contents, and the TypeScript installer already refuses exactly these cases — `isInsideStagingRoot` (`apps/cli/src/services/update/native-installer/install-layout.ts:153`) resolves both paths and checks the relative path does not escape, under a comment stating that *"a record carrying a path from elsewhere must never trigger a recursive rm."*

The shell path was the only one not enforcing the rule it already had.

`install.ps1` does not replay `stagingDir` from JSON, so it needs no equivalent change.

## Approach

`realpath` is not portable enough to depend on here — BSD and GNU differ in behaviour and it is absent from some minimal images the installer targets. The installer never creates a staging path containing `..`, so rejecting that segment outright is both sufficient and portable, and the `/` boundary handles the sibling case.

## Tests

The test extracts the function from the real `install.sh` rather than copying it — `install.sh` ends in a bare `main "$@"` so it cannot be sourced, and a copied function keeps passing after the original drifts, which for a guard in front of `rm -rf` is the failure mode that matters.

Covers: real staging dirs accepted; traversal rejected; prefix-sharing siblings rejected; the root itself, unrelated absolute paths, and the empty string rejected.

## Checklist

- [x] Changeset added — patch
- [x] `bun run guard` passes
- [x] `bun run fmt && bun run lint && bun run test && bun run typecheck` pass locally (forced: typecheck 14/14, test 23/23, `0 cached`)
- [x] `shellcheck -S error install.sh` clean
- [ ] `bun run build` — not run; this changes no CLI source, only `install.sh` and one test
- [x] Live smokes skipped intentionally — no provider or playback behaviour changed

## Note

Stacked independently of #286 — this branch is off `main` and touches no file that PR does.
