### PR TITLE
fix(history): keep the furthest progress when consolidating a forked row

### DIFF
--- a/.changeset/olive-crabs-merge.md
+++ b/.changeset/olive-crabs-merge.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Stop history consolidation from moving a resume position backwards. When two history rows turn out to be the same episode — usually an opaque row and its catalog row for the same title — the surviving row is chosen by which was touched most recently, and its watch state used to be kept wholesale. A row opened briefly a minute ago therefore beat one watched most of the way through yesterday, and a completion earned under the other id was dropped. The identity still comes from the newer row; the progress now keeps the furthest position, a sticky completion, the longer known duration, and the earlier first-watched date.

--- a/apps/cli/src/domain/continuation/merge-history-progress.ts
+++ b/apps/cli/src/domain/continuation/merge-history-progress.ts
@@ -1,0 +1,80 @@
+import type { HistoryProgress, HistoryProgressWatchState } from "@kunai/storage";
+
+/**
+ * Watch state for two history rows that turned out to be the same episode.
+ *
+ * Consolidation picks the surviving row by identity — the most recently touched
+ * one — and that is the right call for the key, the title and the ids. It is the
+ * wrong call for progress. A row touched a minute ago at 10s and a row from
+ * yesterday at 100s describe one person who watched 100s, so keeping the newer
+ * row wholesale moved their resume position *backwards*, and could drop a
+ * completion they had already earned.
+ *
+ * Identity therefore comes from the survivor and the watch state is merged here.
+ * Every field takes the answer that loses nothing:
+ *
+ * - `completed` is sticky. Finishing something is not undone by opening it again
+ *   under another id, and `completedAt` follows the row that actually finished.
+ * - `positionSeconds` takes the furthest point — except once completed, where a
+ *   resume offset is noise: a finished episode should offer a replay from the
+ *   start, not a seek to wherever the credits were.
+ * - `watchedSeconds` is engaged time, and is a maximum rather than a sum. The
+ *   two rows describe the same viewing, so adding them would invent time.
+ * - `durationSeconds` is a property of the media, so any real value beats a
+ *   missing one; when both are present the longer wins, because a truncated
+ *   manifest reports short.
+ * - `createdAt` reaches back to the earlier row — that is when this title
+ *   genuinely entered the library.
+ */
+export function mergeHistoryWatchState(
+  survivor: HistoryProgress,
+  dropped: HistoryProgress,
+): HistoryProgressWatchState {
+  const completed = survivor.completed || dropped.completed;
+  const durationSeconds = pickDuration(survivor.durationSeconds, dropped.durationSeconds);
+  const completedAt = completedAtOf(survivor, dropped);
+
+  return {
+    positionSeconds: completed ? 0 : Math.max(survivor.positionSeconds, dropped.positionSeconds),
+    ...(durationSeconds !== undefined ? { durationSeconds } : {}),
+    watchedSeconds: Math.max(survivor.watchedSeconds ?? 0, dropped.watchedSeconds ?? 0),
+    completed,
+    ...(completedAt !== undefined ? { completedAt } : {}),
+    lastWatchedAt: laterIso(survivor.lastWatchedAt, dropped.lastWatchedAt),
+    createdAt: earlierIso(survivor.createdAt, dropped.createdAt),
+  };
+}
+
+function pickDuration(left?: number, right?: number): number | undefined {
+  const candidates = [left, right].filter(
+    (value): value is number => typeof value === "number" && Number.isFinite(value) && value > 0,
+  );
+  return candidates.length > 0 ? Math.max(...candidates) : undefined;
+}
+
+/** The completion timestamp belongs to whichever row actually completed, earliest first. */
+function completedAtOf(survivor: HistoryProgress, dropped: HistoryProgress): string | undefined {
+  const stamps = [
+    survivor.completed ? survivor.completedAt : undefined,
+    dropped.completed ? dropped.completedAt : undefined,
+  ].filter(isUsableIso);
+
+  if (stamps.length === 0) return undefined;
+  return stamps.reduce((best, value) => (Date.parse(value) < Date.parse(best) ? value : best));
+}
+
+function laterIso(left?: string | null, right?: string | null): string | null {
+  const stamps = [left, right].filter(isUsableIso);
+  if (stamps.length === 0) return null;
+  return stamps.reduce((best, value) => (Date.parse(value) > Date.parse(best) ? value : best));
+}
+
+function earlierIso(left: string, right: string): string {
+  if (!isUsableIso(left)) return right;
+  if (!isUsableIso(right)) return left;
+  return Date.parse(left) <= Date.parse(right) ? left : right;
+}
+
+function isUsableIso(value: string | null | undefined): value is string {
+  return typeof value === "string" && value.length > 0 && Number.isFinite(Date.parse(value));
+}

--- a/apps/cli/src/services/history-metadata/HistoryIdentityConsolidator.ts
+++ b/apps/cli/src/services/history-metadata/HistoryIdentityConsolidator.ts
@@ -1,3 +1,4 @@
+import { mergeHistoryWatchState } from "@/domain/continuation/merge-history-progress";
 import { mergeBackfillExternalIds, resolveCanonicalCatalogTitleId } from "@kunai/core";
 import {
   createHistoryKey,
@@ -125,16 +126,23 @@ export function runHistoryIdentityConsolidator(
         continue;
       }
 
+      // The newer row wins the *identity* — its key, title and ids are the ones
+      // the user most recently touched. It does not automatically win the watch
+      // state: a row opened a minute ago at 10s does not undo yesterday's 100s.
       const keepNewer =
         Date.parse(row.updatedAt) >= Date.parse(existing.updatedAt) ? row : existing;
       const drop = keepNewer.key === row.key ? existing : row;
+      const watchState = mergeHistoryWatchState(keepNewer, drop);
 
-      log(`merge ${drop.key} into ${keepNewer.key} (keep newer updated_at)`);
+      log(
+        `merge ${drop.key} into ${keepNewer.key} (keep newer updated_at, keep furthest progress)`,
+      );
       if (!options.dryRun) {
         const mergedExternalIds = mergeBackfillExternalIds(keepNewer.externalIds, drop.externalIds);
         if (mergedExternalIds) {
           repo.updateProgressExternalIdsByKey(keepNewer.key, mergedExternalIds);
         }
+        repo.updateProgressWatchStateByKey(keepNewer.key, watchState);
         repo.deleteProgressByKey(drop.key);
         if (keepNewer.key !== newKey) {
           repo.rekeyProgressRow(keepNewer.key, canonicalId, newKey);

--- a/apps/cli/src/services/history-metadata/HistoryIdentityConsolidator.ts
+++ b/apps/cli/src/services/history-metadata/HistoryIdentityConsolidator.ts
@@ -129,8 +129,7 @@ export function runHistoryIdentityConsolidator(
       // The newer row wins the *identity* — its key, title and ids are the ones
       // the user most recently touched. It does not automatically win the watch
       // state: a row opened a minute ago at 10s does not undo yesterday's 100s.
-      const keepNewer =
-        Date.parse(row.updatedAt) >= Date.parse(existing.updatedAt) ? row : existing;
+      const keepNewer = selectIdentitySurvivor(row, existing);
       const drop = keepNewer.key === row.key ? existing : row;
       const watchState = mergeHistoryWatchState(keepNewer, drop);
 
@@ -159,4 +158,25 @@ export function runHistoryIdentityConsolidator(
   consolidate();
 
   return stats;
+}
+/**
+ * Which of two rows keeps the identity: the one touched most recently.
+ *
+ * A direct `Date.parse(a) >= Date.parse(b)` cannot express this, because every
+ * comparison against `NaN` is false. A corrupt `updated_at` therefore won
+ * whenever it happened to sit on the right-hand side and lost whenever it sat on
+ * the left — the survivor depended on iteration order rather than on the data.
+ * A row with a readable timestamp is always the better identity than one without.
+ */
+function selectIdentitySurvivor<T extends { readonly updatedAt: string }>(left: T, right: T): T {
+  const leftAt = Date.parse(left.updatedAt);
+  const rightAt = Date.parse(right.updatedAt);
+  const leftOk = Number.isFinite(leftAt);
+  const rightOk = Number.isFinite(rightAt);
+
+  if (leftOk !== rightOk) return leftOk ? left : right;
+  // Both unreadable: keep `right`, which is the already-stored row, so a merge
+  // between two corrupt rows stays put instead of shuffling on every pass.
+  if (!leftOk) return right;
+  return leftAt >= rightAt ? left : right;
 }

--- a/apps/cli/src/services/history-metadata/HistoryIdentityConsolidator.ts
+++ b/apps/cli/src/services/history-metadata/HistoryIdentityConsolidator.ts
@@ -142,6 +142,11 @@ export function runHistoryIdentityConsolidator(
           repo.updateProgressExternalIdsByKey(keepNewer.key, mergedExternalIds);
         }
         repo.updateProgressWatchStateByKey(keepNewer.key, watchState);
+        // The survivor is the most recently touched row, which is often the one
+        // that arrived with the least metadata. Title and external ids already
+        // merge across; the poster did not, so it went out with the deleted row
+        // and the entry lost its artwork in the library and continue-watching.
+        if (drop.posterUrl) repo.fillMissingPosterByKey(keepNewer.key, drop.posterUrl);
         repo.deleteProgressByKey(drop.key);
         if (keepNewer.key !== newKey) {
           repo.rekeyProgressRow(keepNewer.key, canonicalId, newKey);

--- a/apps/cli/test/unit/domain/continuation/merge-history-progress.test.ts
+++ b/apps/cli/test/unit/domain/continuation/merge-history-progress.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+
+import { mergeHistoryWatchState } from "@/domain/continuation/merge-history-progress";
+import type { HistoryProgress } from "@kunai/storage";
+
+function row(patch: Partial<HistoryProgress> = {}): HistoryProgress {
+  return {
+    key: "k",
+    titleId: "20431",
+    mediaKind: "anime",
+    title: "Hozuki",
+    season: 1,
+    episode: 1,
+    positionSeconds: 0,
+    completed: false,
+    updatedAt: "2026-06-03T00:00:00.000Z",
+    createdAt: "2026-06-03T00:00:00.000Z",
+    ...patch,
+  };
+}
+
+describe("mergeHistoryWatchState", () => {
+  test("keeps the furthest position when the surviving row is behind", () => {
+    // The regression: the survivor is chosen by `updated_at`, so a row opened a
+    // minute ago at 10s beat yesterday's 100s and the resume point moved back.
+    const survivor = row({ positionSeconds: 10, updatedAt: "2026-06-04T00:00:00.000Z" });
+    const dropped = row({ positionSeconds: 100, updatedAt: "2026-06-03T00:00:00.000Z" });
+
+    expect(mergeHistoryWatchState(survivor, dropped).positionSeconds).toBe(100);
+  });
+
+  test("does not move a position backwards when the survivor is ahead", () => {
+    const survivor = row({ positionSeconds: 100 });
+    const dropped = row({ positionSeconds: 10 });
+
+    expect(mergeHistoryWatchState(survivor, dropped).positionSeconds).toBe(100);
+  });
+
+  test("completion is sticky in both directions", () => {
+    expect(
+      mergeHistoryWatchState(row({ completed: false }), row({ completed: true })).completed,
+    ).toBe(true);
+    expect(
+      mergeHistoryWatchState(row({ completed: true }), row({ completed: false })).completed,
+    ).toBe(true);
+  });
+
+  test("a completed merge clears the resume offset", () => {
+    // A finished episode should offer a replay from the start, not a seek to
+    // wherever the credits happened to be.
+    const merged = mergeHistoryWatchState(
+      row({ positionSeconds: 10 }),
+      row({ positionSeconds: 1_400, completed: true }),
+    );
+
+    expect(merged.completed).toBe(true);
+    expect(merged.positionSeconds).toBe(0);
+  });
+
+  test("completedAt follows the row that finished, earliest first", () => {
+    const merged = mergeHistoryWatchState(
+      row({ completed: false, completedAt: "2030-01-01T00:00:00.000Z" }),
+      row({ completed: true, completedAt: "2026-06-01T00:00:00.000Z" }),
+    );
+
+    // The survivor's stamp is ignored because the survivor did not complete.
+    expect(merged.completedAt).toBe("2026-06-01T00:00:00.000Z");
+  });
+
+  test("watchedSeconds is a maximum, never a sum", () => {
+    // Both rows describe the same viewing; adding them would invent time.
+    const merged = mergeHistoryWatchState(
+      row({ watchedSeconds: 400 }),
+      row({ watchedSeconds: 900 }),
+    );
+
+    expect(merged.watchedSeconds).toBe(900);
+  });
+
+  test("a real duration beats a missing one, and the longer of two wins", () => {
+    expect(
+      mergeHistoryWatchState(row({ durationSeconds: undefined }), row({ durationSeconds: 1_440 }))
+        .durationSeconds,
+    ).toBe(1_440);
+    expect(
+      mergeHistoryWatchState(row({ durationSeconds: 600 }), row({ durationSeconds: 1_440 }))
+        .durationSeconds,
+    ).toBe(1_440);
+  });
+
+  test("a zero or non-finite duration is not treated as real", () => {
+    expect(
+      mergeHistoryWatchState(row({ durationSeconds: 0 }), row({ durationSeconds: 1_440 }))
+        .durationSeconds,
+    ).toBe(1_440);
+    expect(
+      mergeHistoryWatchState(row({ durationSeconds: 0 }), row({ durationSeconds: undefined }))
+        .durationSeconds,
+    ).toBeUndefined();
+  });
+
+  test("createdAt reaches back to the earlier row", () => {
+    const merged = mergeHistoryWatchState(
+      row({ createdAt: "2026-06-03T00:00:00.000Z" }),
+      row({ createdAt: "2025-01-01T00:00:00.000Z" }),
+    );
+
+    expect(merged.createdAt).toBe("2025-01-01T00:00:00.000Z");
+  });
+
+  test("lastWatchedAt takes the later stamp and tolerates nulls", () => {
+    expect(
+      mergeHistoryWatchState(
+        row({ lastWatchedAt: null }),
+        row({ lastWatchedAt: "2026-06-02T00:00:00.000Z" }),
+      ).lastWatchedAt,
+    ).toBe("2026-06-02T00:00:00.000Z");
+    expect(
+      mergeHistoryWatchState(row({ lastWatchedAt: null }), row({ lastWatchedAt: null }))
+        .lastWatchedAt,
+    ).toBeNull();
+  });
+
+  test("a corrupt timestamp does not poison the merge", () => {
+    const merged = mergeHistoryWatchState(
+      row({ createdAt: "not-a-date", lastWatchedAt: "also-not-a-date" }),
+      row({ createdAt: "2026-06-01T00:00:00.000Z" }),
+    );
+
+    expect(merged.createdAt).toBe("2026-06-01T00:00:00.000Z");
+    expect(merged.lastWatchedAt).toBeNull();
+  });
+});

--- a/apps/cli/test/unit/services/history-metadata/history-identity-consolidator.test.ts
+++ b/apps/cli/test/unit/services/history-metadata/history-identity-consolidator.test.ts
@@ -203,6 +203,61 @@ test("a corrupt updated_at never wins the identity, in either operand order", ()
   }
 });
 
+test("merging a forked row keeps a poster only the dropped row had", () => {
+  // The survivor is chosen by recency, and the most recently touched row is
+  // often the one that arrived with the least metadata. Title and external ids
+  // already merge across the deletion; the poster did not, so the entry lost its
+  // artwork in the library and continue-watching rows. Same shape as the
+  // legacy-key migration losing it, and only visible once both paths exist.
+  const db = openKunaiDatabase(":memory:");
+  runMigrations(db, "data");
+  const repo = new HistoryRepository(db);
+  repo.upsertProgress({
+    title: { id: "20431", kind: "anime", title: "Canonical", externalIds: { anilistId: "20431" } },
+    episode: { season: 1, episode: 1 },
+    positionSeconds: 100,
+    posterUrl: "https://img.example/poster.jpg",
+    updatedAt: "2026-06-02T00:00:00.000Z",
+  });
+  repo.upsertProgress({
+    title: { id: "bxCKTopaque", kind: "anime", title: "Fork", externalIds: { anilistId: "20431" } },
+    episode: { season: 1, episode: 1 },
+    positionSeconds: 10,
+    updatedAt: "2026-06-03T00:00:00.000Z",
+  });
+
+  expect(runHistoryIdentityConsolidator(db).merged).toBe(1);
+
+  const merged = repo.getLatestForTitle("20431");
+  expect(merged?.positionSeconds).toBe(100);
+  expect(merged?.posterUrl).toBe("https://img.example/poster.jpg");
+});
+
+test("merging never replaces a poster the surviving row already has", () => {
+  const db = openKunaiDatabase(":memory:");
+  runMigrations(db, "data");
+  const repo = new HistoryRepository(db);
+  repo.upsertProgress({
+    title: { id: "20431", kind: "anime", title: "Canonical", externalIds: { anilistId: "20431" } },
+    episode: { season: 1, episode: 1 },
+    positionSeconds: 100,
+    posterUrl: "https://img.example/old.jpg",
+    updatedAt: "2026-06-02T00:00:00.000Z",
+  });
+  repo.upsertProgress({
+    title: { id: "bxCKTopaque", kind: "anime", title: "Fork", externalIds: { anilistId: "20431" } },
+    episode: { season: 1, episode: 1 },
+    positionSeconds: 10,
+    posterUrl: "https://img.example/new.jpg",
+    updatedAt: "2026-06-03T00:00:00.000Z",
+  });
+
+  expect(runHistoryIdentityConsolidator(db).merged).toBe(1);
+
+  // The survivor's own poster is the more recent one and must win.
+  expect(repo.getLatestForTitle("20431")?.posterUrl).toBe("https://img.example/new.jpg");
+});
+
 test("consolidator moves anime-class series rows onto their AniList unit", () => {
   const db = openKunaiDatabase(":memory:");
   runMigrations(db, "data");

--- a/apps/cli/test/unit/services/history-metadata/history-identity-consolidator.test.ts
+++ b/apps/cli/test/unit/services/history-metadata/history-identity-consolidator.test.ts
@@ -84,6 +84,72 @@ test("consolidator merges forked rows that share the same anilist id", () => {
   expect(repo.getLatestForTitle("20431")?.positionSeconds).toBe(100);
 });
 
+test("merging a forked row never moves the resume position backwards", () => {
+  // The existing merge test above happens to have the newer row also be the
+  // further one, so it passed either way. This is the case that lost data: the
+  // survivor is chosen by `updated_at`, and the row touched most recently is
+  // the one that had barely been started.
+  const db = openKunaiDatabase(":memory:");
+  runMigrations(db, "data");
+  const repo = new HistoryRepository(db);
+  repo.upsertProgress({
+    title: { id: "20431", kind: "anime", title: "Canonical", externalIds: { anilistId: "20431" } },
+    episode: { season: 1, episode: 1 },
+    positionSeconds: 100,
+    updatedAt: "2026-06-02T00:00:00.000Z",
+  });
+  repo.upsertProgress({
+    title: {
+      id: "bxCKTopaque",
+      kind: "anime",
+      title: "Fork",
+      externalIds: { anilistId: "20431" },
+    },
+    episode: { season: 1, episode: 1 },
+    positionSeconds: 10,
+    updatedAt: "2026-06-03T00:00:00.000Z",
+  });
+
+  const stats = runHistoryIdentityConsolidator(db);
+
+  expect(stats.merged).toBe(1);
+  expect(repo.listAllProgress()).toHaveLength(1);
+  expect(repo.getLatestForTitle("20431")?.positionSeconds).toBe(100);
+});
+
+test("merging a forked row keeps a completion the surviving row does not have", () => {
+  const db = openKunaiDatabase(":memory:");
+  runMigrations(db, "data");
+  const repo = new HistoryRepository(db);
+  repo.upsertProgress({
+    title: { id: "20431", kind: "anime", title: "Canonical", externalIds: { anilistId: "20431" } },
+    episode: { season: 1, episode: 1 },
+    positionSeconds: 1_400,
+    durationSeconds: 1_440,
+    completed: true,
+    updatedAt: "2026-06-02T00:00:00.000Z",
+  });
+  repo.upsertProgress({
+    title: {
+      id: "bxCKTopaque",
+      kind: "anime",
+      title: "Fork",
+      externalIds: { anilistId: "20431" },
+    },
+    episode: { season: 1, episode: 1 },
+    positionSeconds: 30,
+    updatedAt: "2026-06-03T00:00:00.000Z",
+  });
+
+  expect(runHistoryIdentityConsolidator(db).merged).toBe(1);
+
+  const merged = repo.getLatestForTitle("20431");
+  expect(merged?.completed).toBe(true);
+  // Finished, so it offers a replay rather than a seek into the credits.
+  expect(merged?.positionSeconds).toBe(0);
+  expect(merged?.durationSeconds).toBe(1_440);
+});
+
 test("consolidator moves anime-class series rows onto their AniList unit", () => {
   const db = openKunaiDatabase(":memory:");
   runMigrations(db, "data");

--- a/apps/cli/test/unit/services/history-metadata/history-identity-consolidator.test.ts
+++ b/apps/cli/test/unit/services/history-metadata/history-identity-consolidator.test.ts
@@ -150,6 +150,59 @@ test("merging a forked row keeps a completion the surviving row does not have", 
   expect(merged?.durationSeconds).toBe(1_440);
 });
 
+test("a corrupt updated_at never wins the identity, in either operand order", () => {
+  // `Date.parse(x) >= NaN` is false for every x, so the corrupt row won whenever
+  // it happened to be the right-hand operand — which row survived depended on
+  // iteration order rather than on the data.
+  //
+  // `upsertProgress` rejects an unparseable timestamp, so this state only ever
+  // arrives from a database written by something else: an older build, or
+  // external corruption. It is written directly here for that reason.
+  for (const corruptFirst of [true, false]) {
+    const db = openKunaiDatabase(":memory:");
+    runMigrations(db, "data");
+    const repo = new HistoryRepository(db);
+
+    const insertCorrupt = () => {
+      db.query(
+        `INSERT INTO history_progress (
+           key, title_id, media_kind, title, season, episode, position_seconds,
+           completed, external_ids_json, updated_at, created_at
+         ) VALUES (?, ?, 'anime', 'Corrupt', 1, 1, 5, 0, ?, 'not-a-date', 'not-a-date')`,
+      ).run("bxCKTopaque:s1e1", "bxCKTopaque", JSON.stringify({ anilistId: "20431" }));
+    };
+    const insertGood = () => {
+      repo.upsertProgress({
+        title: {
+          id: "20431",
+          kind: "anime",
+          title: "Readable",
+          externalIds: { anilistId: "20431" },
+        },
+        episode: { season: 1, episode: 1 },
+        positionSeconds: 120,
+        updatedAt: "2026-06-02T00:00:00.000Z",
+      });
+    };
+
+    if (corruptFirst) {
+      insertCorrupt();
+      insertGood();
+    } else {
+      insertGood();
+      insertCorrupt();
+    }
+
+    expect(runHistoryIdentityConsolidator(db).merged).toBe(1);
+
+    const merged = repo.getLatestForTitle("20431");
+    // The readable row keeps the identity...
+    expect(merged?.title).toBe("Readable");
+    // ...and the merge still keeps the furthest progress from either side.
+    expect(merged?.positionSeconds).toBe(120);
+  }
+});
+
 test("consolidator moves anime-class series rows onto their AniList unit", () => {
   const db = openKunaiDatabase(":memory:");
   runMigrations(db, "data");

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -30,6 +30,7 @@ export {
 export type {
   HistoryProgress,
   HistoryProgressInput,
+  HistoryProgressWatchState,
   HistoryTitleLookup,
 } from "./repositories/history";
 export { HISTORY_FINISHED_RATIO, isHistoryProgressFinished } from "./repositories/history";

--- a/packages/storage/src/repositories/history.ts
+++ b/packages/storage/src/repositories/history.ts
@@ -636,6 +636,26 @@ export class HistoryRepository {
       );
   }
 
+  /**
+   * Give a row a poster only if it does not already have one.
+   *
+   * Consolidation picks the survivor by recency, and the row touched most
+   * recently is often the one that arrived with the least metadata. The poster
+   * then went out with the row being deleted — the same shape as the legacy-key
+   * migration losing it, and the reason `upsertProgress` COALESCEs rather than
+   * overwrites. Never replaces an existing poster: a survivor that has one has
+   * a more recent one.
+   */
+  fillMissingPosterByKey(key: string, posterUrl: string): void {
+    const trimmed = posterUrl.trim();
+    if (!trimmed) return;
+    this.db
+      .query(
+        "UPDATE history_progress SET poster_url = ? WHERE key = ? AND (poster_url IS NULL OR poster_url = '')",
+      )
+      .run(trimmed, key);
+  }
+
   updateProgressExternalIdsByKey(key: string, externalIds: ProviderExternalIds): void {
     const externalIdsJson = serializeExternalIds(externalIds);
     if (!externalIdsJson) return;

--- a/packages/storage/src/repositories/history.ts
+++ b/packages/storage/src/repositories/history.ts
@@ -51,6 +51,18 @@ export interface HistoryProgress {
   readonly createdAt: string;
 }
 
+/** The watch-state half of a history row — everything consolidation must not lose. */
+export type HistoryProgressWatchState = Pick<
+  HistoryProgress,
+  | "positionSeconds"
+  | "durationSeconds"
+  | "watchedSeconds"
+  | "completed"
+  | "completedAt"
+  | "lastWatchedAt"
+  | "createdAt"
+>;
+
 /** Canonical title lookup for history reads (resume, continue, episode progress). */
 export interface HistoryTitleLookup {
   readonly id: string;
@@ -589,6 +601,39 @@ export class HistoryRepository {
 
   deleteProgressByKey(key: string): void {
     this.db.query("DELETE FROM history_progress WHERE key = ?").run(key);
+  }
+
+  /**
+   * Overwrite the watch state of one row.
+   *
+   * Consolidation merges two rows that turned out to be the same title, and the
+   * surviving key is chosen by identity (most recently touched), not by who
+   * watched further. Without this the loser's progress went out with
+   * `deleteProgressByKey` and a resume position could travel backwards.
+   */
+  updateProgressWatchStateByKey(key: string, state: HistoryProgressWatchState): void {
+    this.db
+      .query(
+        `UPDATE history_progress
+         SET position_seconds = ?,
+             duration_seconds = ?,
+             watched_seconds = ?,
+             completed = ?,
+             completed_at = ?,
+             last_watched_at = ?,
+             created_at = ?
+         WHERE key = ?`,
+      )
+      .run(
+        Math.round(state.positionSeconds),
+        state.durationSeconds === undefined ? null : Math.round(state.durationSeconds),
+        Math.round(state.watchedSeconds ?? 0),
+        state.completed ? 1 : 0,
+        state.completedAt ?? null,
+        state.lastWatchedAt ?? null,
+        state.createdAt,
+        key,
+      );
   }
 
   updateProgressExternalIdsByKey(key: string, externalIds: ProviderExternalIds): void {


### PR DESCRIPTION
## What changed

Canvas finding **A-13**. `runHistoryIdentityConsolidator` merges two history rows that resolve to the same title — typically an opaque row and its catalog row. It picked the survivor by `updated_at` and then deleted the other row outright, so only `external_ids` survived. Everything describing what the user had actually watched went with the dropped row.

```ts
const keepNewer = Date.parse(row.updatedAt) >= Date.parse(existing.updatedAt) ? row : existing;
const drop = keepNewer.key === row.key ? existing : row;
// ...only external ids were merged
repo.deleteProgressByKey(drop.key);
```

**Canonical row at 100s from yesterday + opaque row at 10s from today merged to 10s.** A completion earned under the other id disappeared with it.

## The distinction the fix rests on

Choosing by `updated_at` is the **right rule for identity** and the **wrong rule for progress**. A row opened for a few seconds a minute ago genuinely is the more recent identity — its key, title and ids are the ones to keep. It does not describe someone who watched less than they did yesterday.

So identity still comes from the newer row, and the watch state is merged. Each field takes the answer that loses nothing:

| Field | Rule | Why |
| --- | --- | --- |
| `completed` | sticky, either side | Finishing something is not undone by opening it under another id |
| `completedAt` | earliest, from a row that actually completed | When it was first finished |
| `positionSeconds` | furthest — but `0` once completed | A finished episode should offer a replay, not a seek into the credits |
| `watchedSeconds` | maximum, **never a sum** | Both rows describe one viewing; adding invents time |
| `durationSeconds` | any real value beats missing; longer of two wins | A truncated manifest reports short |
| `createdAt` | earlier | When the title genuinely entered the library |

## Shape

- **`domain/continuation/merge-history-progress.ts`** — the policy as a pure function, testable without a database. Corrupt timestamps are tolerated rather than propagated.
- **`HistoryRepository.updateProgressWatchStateByKey`** — the write seam. The repository previously had no way to express "merge these two rows"; it could only rekey, delete, or patch external ids, which is why the original code had no better option available to it.

## Tests

The existing merge test passed either way, because its newer row also happened to be its further row — the regression was invisible to it. Added:

- the case that lost data (newer row is *behind*), end to end through the consolidator;
- a completion surviving a merge where the surviving row is unfinished, asserting the position resets to `0` and the known duration is kept;
- 11 unit tests over the field rules directly, including zero/non-finite durations, null `lastWatchedAt`, and a corrupt `createdAt`.

## Scope note

The canvas entry for A-13 also mentions that follows, queue, downloads and lists keep pointing at the old `title_id` after a merge. **That is a separate defect and is not addressed here** — it is a dangling-reference problem across four other tables, not a progress-merge problem, and it deserves its own change with its own migration story. This PR is only the data loss inside `history_progress`.

## Checklist

- [x] Changeset added — patch
- [x] `bun run guard` passes
- [x] `bun run fmt && bun run lint && bun run test && bun run typecheck` pass locally (forced: typecheck 14/14, test 23/23, `0 cached`)
- [ ] `bun run build` — not run; no packaging, provider or binary surface changed
- [x] Live smokes skipped intentionally — no provider or playback behaviour changed

Independent of #286 and #288; branched from `main` and shares no files with either.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved history consolidation when duplicate episodes are merged.
  * Preserves the furthest resume position, completion status, longest duration, and most complete watch progress.
  * Retains accurate watch and creation timestamps, including data from older and newer records.
  * Completed episodes now correctly resume from the beginning instead of a stale position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->