### PR TITLE
docs(plans): route the two CLI surface findings into plan 023

### DIFF
--- a/.plans/023-cli-surface-honesty.md
+++ b/.plans/023-cli-surface-honesty.md
@@ -83,6 +83,25 @@ that installs with **no Bun on PATH** and asserts the install succeeds and
 - **Dropped values warn nowhere.** `--jump abc` / `--jump 0` fail validation and are
   discarded silently (`cli-args.ts:341-344`) while every other malformed input pushes
   to `warnings`.
+- **`--jump` is not scoped to `-S`.** Help states "Auto-pick the n-th search result
+  (1-based, with -S)" (`cli-args.ts:66`), but `resolveAutoPickIndex`
+  (`app/bootstrap/bootstrap-intent.ts:49-55`) returns `args.jump` unconditionally,
+  while the sibling `quick` branch on the next line does require
+  `args.search?.trim()`. So `kunai --jump 2 --discover` silently plays discover
+  result #2, and the index is not cleared until `SearchPhase` returns, so typing
+  `/discover` after launching with `--jump 2` does the same. **Fix:** decide whether
+  `--jump` means "auto-pick from whatever list opens" or "auto-pick from a search",
+  then make the help and the code agree. If it stays search-scoped, gate it on a
+  query the way `quick` already is; if it widens, the help line is the bug.
+  (Canvas audit A-10, verified at `ec2e90e6`.)
+- **`--download` outranks `--history`, opposite to what the dry-run announces.**
+  `resolveLaunchSurfaceName` (`bootstrap-intent.ts:67-72`) ranks `history` above
+  `download`, but `runCli` runs `maybeRunDownloadMode` and returns
+  (`main.ts:1143-1148`) before the history branch at `:1152`. `kunai --history
+--download` therefore prints "watch history" and opens download mode. **Fix:**
+  one precedence order, applied in both places — the announced surface and the
+  executed surface must come from the same list, not two hand-maintained ones.
+  (Canvas audit A-11, verified at `ec2e90e6`.)
 
 ---
 


### PR DESCRIPTION
## What changed

Canvas audit findings **A-10** and **A-11** added to `023.2 — Flags that lie`. No code.

## Why 023 and not a new plan

Both are "the flag does not do what the help says", which is the subject 023.2 already owns. It pins adjacent lines in the same two files and already carries a `--jump` entry. Filing these as new plans would split one subject across three boards.

## A-10 — `--jump` is not scoped to `-S`

`cli-args.ts:66` documents it as *"Auto-pick the n-th search result (1-based, with -S)"*, but:

```ts
if (args.jump !== undefined) return args.jump;
return args.quick && args.search?.trim() ? 1 : undefined;
```

`jump` returns unconditionally while the sibling `quick` branch on the very next line **does** require a query. So `kunai --jump 2 --discover` silently plays discover result #2, and the index is not cleared until `SearchPhase` returns, so typing `/discover` after launching with `--jump 2` does the same thing.

Recorded as a decision rather than a patch: `--jump` may reasonably mean "auto-pick from whatever list opens", in which case **the help line is the bug**, not the code. That is a product call, not a mechanical fix.

## A-11 — `--download` outranks `--history`, opposite to what the dry-run announces

`resolveLaunchSurfaceName` (`bootstrap-intent.ts:67-72`) ranks `history` above `download`. `runCli` runs `maybeRunDownloadMode` and returns (`main.ts:1143-1148`) before reaching the history branch at `:1152`.

`kunai --history --download` prints **"watch history"** and opens **download mode**.

The fix is one precedence order applied in both places. Two hand-maintained lists that must agree is the defect, not the ordering itself.

## Verification

Both read against the tree at `ec2e90e6` rather than taken from the audit report. A-11 I had verified earlier in this sweep; A-10 I verified while writing this — including the help string, which is the half that makes it a contradiction rather than a preference.

## Checklist

- [ ] Changeset — N/A, planning docs only
- [x] `bun run verify:doc-paths` passes — 50 docs, all paths resolve
- [x] Plan is already indexed in `.plans/roadmap.md` (no new row needed — 023 exists)
- [ ] build / live smokes — N/A, no code
