### PR TITLE
ci(installer-matrix): upload the release companion archives

### DIFF
--- a/.github/workflows/installer-matrix.yml
+++ b/.github/workflows/installer-matrix.yml
@@ -55,10 +55,18 @@ jobs:
         with:
           name: kunai-linux-binaries-matrix
           retention-days: 1
+          # Must match the list in ci.yml's `native-installer` job. The
+          # scenarios' `prepare-fixture` step resolves a release *companion*
+          # archive next to each binary, so uploading the raw binaries alone
+          # makes every cell fail with "release companion not found" — which is
+          # what this matrix did nightly from 2026-08-26 until this was fixed.
           path: |
             apps/cli/dist/bin/kunai-linux-x64
+            apps/cli/dist/bin/kunai-linux-x64.tar.gz
             apps/cli/dist/bin/kunai-linux-x64-musl
+            apps/cli/dist/bin/kunai-linux-x64-musl.tar.gz
             apps/cli/dist/bin/SHA256SUMS
+            apps/cli/dist/bin/SHA256SUMS.archives
 
   matrix:
     name: ${{ matrix.scenario }} / ${{ matrix.variant }}


### PR DESCRIPTION
## What changed

One line list in `installer-matrix.yml`, plus the comment explaining why it must not drift again.

## The failure

The nightly **Installer Docker Matrix** has failed **every run since 2026-08-26** — six consecutive nights. Every cell, both `glibc` and `musl`, all scenarios (`full-lifecycle`, `reinstall-idempotent`, `stale-lock-recovery`, `uninstall-preserves-user-data`, `upgrade-rollback`), while `Validate scenario registry` and `Build linux binaries` passed.

Everything failing identically while the build passes points at setup, not scenarios. It was:

```
prepare-fixture: release companion not found:
  /home/runner/work/kunai/kunai/apps/cli/dist/bin/kunai-linux-x64.tar.gz
```

## Root cause

This workflow's upload list had drifted from the equivalent in `ci.yml:594-599`.

| | `ci.yml` (passing) | `installer-matrix.yml` (failing) |
|---|---|---|
| `kunai-linux-x64` | ✅ | ✅ |
| `kunai-linux-x64.tar.gz` | ✅ | ❌ |
| `kunai-linux-x64-musl` | ✅ | ✅ |
| `kunai-linux-x64-musl.tar.gz` | ✅ | ❌ |
| `SHA256SUMS` | ✅ | ✅ |
| `SHA256SUMS.archives` | ✅ | ❌ |

The scenarios resolve a release **companion archive** next to each binary. With only the raw binaries downloaded, every cell failed at fixture preparation — before running any of the behaviour it exists to test.

## Why nobody noticed

`installer-matrix.yml` is `schedule` (06:15 UTC daily) + `workflow_dispatch` only. **It never runs on a pull request**, so nothing turned red in review while it was broken for six days. The `Native installer *` jobs visible on PRs come from `ci.yml` and were green throughout — they use the correct list, which is exactly why they kept passing while this did not.

## Release relevance

`.docs/release-reliability-gate.md` treats the native installer scenarios as a release gate. A 0.3.0 candidate signed off while this matrix is red would be signing off on a gate that has not actually executed since 26 August.

## Verification

I cannot run the scheduled workflow from here. After merge, trigger it manually:

```sh
gh workflow run installer-matrix.yml
```

and confirm all cells pass. Until that run is green, treat the native-installer gate as unverified rather than passing.

## Checklist

- [ ] Changeset — N/A, CI configuration only, no shipped code
- [x] `bun run fmt` clean
- [ ] typecheck / lint / test — N/A, no source change (the workflow file is not in any package's build)
- [ ] `bun run build` — N/A
- [x] Live smokes skipped intentionally — no provider or playback behaviour changed

Independent of the other open PRs; touches no file any of them do.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release downloads now include x64 and x64-musl companion archives.
  * Added `SHA256SUMS.archives` to verify the integrity of downloaded archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->