### PR TITLE
test(docs): assert the release gap, not the exact artifact list

### DIFF
--- a/apps/docs/test/release-notes.test.ts
+++ b/apps/docs/test/release-notes.test.ts
@@ -46,7 +46,33 @@ describe("release notes artifacts", () => {
    */
   test("no release artifact sits between 0.2.5 and 0.3.0", () => {
     expect(getReleaseByTag("0.2.6")).toBeNull();
-    expect(releaseNotesArtifacts.map((release) => release.version)).toEqual(["0.3.0", "0.2.5"]);
+
+    // The invariant is the *gap*, not the census. Pinning the exact list made
+    // this fail on any version above 0.3.0 — a release-blocking time bomb that
+    // fired the first time a patch changeset produced 0.3.1, and would have
+    // fired on whatever came next regardless. Assert what the comment above
+    // actually describes: nothing strictly between the two anchors.
+    const between = releaseNotesArtifacts
+      .map((release) => release.version)
+      .filter(
+        (version) => compareVersions(version, "0.2.5") > 0 && compareVersions(version, "0.3.0") < 0,
+      );
+    expect(between).toEqual([]);
+
+    // Both anchors are still present, so the filter above is testing a real
+    // range rather than passing because the list emptied out.
+    const versions = releaseNotesArtifacts.map((release) => release.version);
+    expect(versions).toContain("0.2.5");
+    expect(versions).toContain("0.3.0");
+  });
+
+  test("artifacts are ordered newest first", () => {
+    // The exact-list assertion used to cover ordering as a side effect. It is
+    // worth keeping on its own: `latestReleaseNotesArtifact` reads position, so
+    // an out-of-order artifact would silently advertise the wrong release.
+    const versions = releaseNotesArtifacts.map((release) => release.version);
+    const sorted = [...versions].sort((left, right) => compareVersions(right, left));
+    expect(versions).toEqual(sorted);
   });
 
   test("staged releases have no GitHub URL or visible assets", () => {
@@ -153,3 +179,16 @@ test("a summary already represented by a section is not duplicated", () => {
 
   expect(sections.map((section) => section.title)).toEqual(["Privacy"]);
 });
+
+/** Numeric semver-ish compare, enough for the `major.minor.patch` tags shipped here. */
+function compareVersions(left: string, right: string): number {
+  const parse = (value: string): number[] =>
+    value.split(".").map((part) => Number.parseInt(part, 10) || 0);
+  const a = parse(left);
+  const b = parse(right);
+  for (let index = 0; index < Math.max(a.length, b.length); index += 1) {
+    const diff = (a[index] ?? 0) - (b[index] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}


### PR DESCRIPTION
## What changed

One assertion in `apps/docs/test/release-notes.test.ts`, plus an ordering test the old assertion was covering by accident.

## The failure

The **Release** workflow's "Open or update version PR" job has failed on every push to `main` since 21:33 today. Main's own CI is green — this fails *inside* the version-PR job, where `changeset version` produces 0.3.1 and husky's pre-push then runs the suite against the versioned tree:

```
  [
+   "0.3.1",
    "0.3.0",
    "0.2.5",
  ]
```

So the version PR can never be opened, and the release path is blocked.

## Root cause: the test did not test what its comment says

The test is named `no release artifact sits between 0.2.5 and 0.3.0`, and its comment explains a real rule — a versioned-but-unreleasable 0.2.6 once had to be withdrawn, and nothing should sit in that gap again.

The assertion did not check that. It pinned the **entire list**:

```ts
expect(releaseNotesArtifacts.map((r) => r.version)).toEqual(["0.3.0", "0.2.5"]);
```

Which means **any version above 0.3.0 fails it**. This is a release-blocking time bomb that happened to fire on the first patch changeset after 0.3.0; it would have fired on whatever came next regardless of which change triggered it.

## The fix

Filter for versions strictly between the two anchors, assert that set is empty, then assert both anchors are still present — so the filter is testing a real range rather than passing because the list emptied out.

Ordering was covered by the old assertion as a side effect, so it gets its own test: `latestReleaseNotesArtifact` reads position, and an out-of-order artifact would advertise the wrong release.

## Verification

Injected a synthetic 0.3.1 artifact into `generated-release-notes.json` and re-ran: **the gap test passes where it previously failed**. (The only failure under that simulation was `release notes match .release/`, because I hand-edited the generated file without its source — CI regenerates both together.)

Gates forced, `0 cached`: typecheck 14/14, lint clean, test 23/23, docs 215 pass.

## ⚠️ A release decision this does NOT settle

Unblocking the version PR is not the same as deciding what version to ship, and there is a real problem waiting:

**0.3.0 has never been released.** The latest tag is `v0.2.5`; 0.3.0 is versioned in `package.json` and `CHANGELOG.md` and carries release notes with status `staged`. If the next release goes out as **0.3.1**, then 0.3.0 becomes a second phantom version — versioned, documented, never installable. That is *exactly* the situation this test's comment says was cleaned up for 0.2.6.

Two options, and this is a maintainer call:

1. **Fold the pending fixes into 0.3.0** (recommended). They are bug fixes to an unreleased candidate, which is what a candidate is for. Requires consuming the pending changesets into the existing 0.3.0 CHANGELOG section rather than letting them bump.
2. **Release 0.3.0 first, then 0.3.1.** Keeps changesets untouched, but ships a release that omits fixes already merged to main.

I have not done either — published versions are a one-way door.

## Checklist

- [ ] Changeset — N/A, test-only change with no user-facing behaviour
- [x] `bun run fmt && bun run lint && bun run test && bun run typecheck` pass locally (forced, `0 cached`)
- [ ] `bun run build` — N/A, no source change
- [x] Live smokes skipped intentionally — no provider or playback behaviour changed
