### PR TITLE
fix(analytics): unbreak the Postgres retention case and put the suites under CI

### DIFF
--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -299,11 +299,18 @@ way.
 
 Run the storage path against a real Postgres. The local harness needs only
 Docker — it starts a throwaway database plus the Neon HTTP proxy the driver
-requires, migrates, runs, and tears down:
+requires, migrates, runs the whole `test/` directory, and tears down:
 
 ```sh
 bun run --cwd apps/analytics-ingest test:pg
 ```
+
+CI runs this same command in the `Analytics Postgres suites` job whenever
+`apps/analytics-ingest/**` changes, and fails if any case reports `skip` — a
+database that never starts otherwise produces a green run with every Postgres
+case silently skipped. Release signoff still needs a local or Neon run recorded
+against the release commit, but a regression no longer waits for that run to
+surface.
 
 Against an isolated Neon project instead, opt in explicitly. The suites write
 and prune, so they gate on `ANALYTICS_TEST_DATABASE_URL` rather than

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
+      analytics: ${{ steps.filter.outputs.analytics }}
       cli: ${{ steps.filter.outputs.cli }}
       docs: ${{ steps.filter.outputs.docs }}
       doc-coverage: ${{ steps.filter.outputs.doc-coverage }}
@@ -51,6 +52,17 @@ jobs:
         id: filter
         with:
           filters: |
+            # The ingest's Postgres suites are gated on ANALYTICS_TEST_DATABASE_URL
+            # and skip silently without it, so the ordinary `Test` job proves
+            # nothing about them. Anything that can change what that SQL does —
+            # the app, its migrations, or the harness that runs them — has to
+            # reach the analytics-postgres job below.
+            analytics:
+              - 'apps/analytics-ingest/**'
+              - 'package.json'
+              - 'bun.lock'
+              - '.github/workflows/ci.yml'
+              - '.github/actions/setup-bun-monorepo/**'
             cli:
               - 'apps/cli/**'
               - 'packages/**'
@@ -202,6 +214,50 @@ jobs:
       - name: Test (full on main)
         if: github.event_name == 'push'
         run: bunx turbo run test --summarize
+
+  analytics-postgres:
+    name: Analytics Postgres suites
+    needs: changes
+    if: >-
+      github.event_name == 'push' ||
+      needs.changes.outputs.analytics == 'true'
+    runs-on: ubuntu-latest
+    # The whole run is a container start, two migrations and ~110 assertions;
+    # observed well under a minute. This ceiling identifies a wedged container
+    # pull rather than budgeting for slow tests.
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-bun-monorepo
+        with:
+          turbo-cache-prefix: analytics-pg
+
+      # Deliberately the same command a developer runs locally, rather than a
+      # second copy of the compose topology expressed as `services:`. The store
+      # talks to Neon over HTTP, so it needs the proxy as well as Postgres, and
+      # two definitions of that pair would drift — which is the class of bug
+      # this job exists to catch.
+      #
+      # The database is a throwaway container the harness starts and destroys:
+      # loopback-only, tmpfs-backed, seeded credentials, empty every run. No
+      # real project or production URL is ever reachable from this job.
+      #
+      # The skip assertion is the point of the step, not a flourish. Every skip
+      # construct in this suite is `describe.skipIf(!TEST_DATABASE_URL)`, so a
+      # database that never came up produces a *green* run — measured at 82 pass
+      # / 33 skip / 0 fail — against 109 pass / 0 skip when it did. A zero exit
+      # code alone would therefore prove nothing, which is the exact false pass
+      # this job exists to close.
+      - name: Run the Postgres-backed analytics suites
+        run: |
+          set -euo pipefail
+          bun run --cwd apps/analytics-ingest test:pg 2>&1 | tee pg-suites.log
+          if grep -qE '^ *[0-9]+ skip' pg-suites.log; then
+            echo "::error::Postgres cases skipped — the database never came up, so this job proved nothing"
+            exit 1
+          fi
+          echo "Every Postgres-gated case executed against a real database."
 
   windows-cli:
     name: Windows CLI parity

--- a/apps/analytics-ingest/scripts/test-postgres.ts
+++ b/apps/analytics-ingest/scripts/test-postgres.ts
@@ -80,12 +80,14 @@ async function main(): Promise<number> {
     const migrated = await run("bun", ["run", "scripts/migrate.ts"], env);
     if (migrated !== 0) return migrated;
 
+    // The whole directory, not a hand-listed subset. Naming files here meant
+    // postgres-hardening.test.ts was never run by the command documented as
+    // "the Postgres-backed analytics tests", so a case in it stayed red
+    // indefinitely with nothing reporting it. Running the directory picks up
+    // every new postgres-*.test.ts automatically; the suites that need no
+    // database are cheap and pass either way.
     console.log("→ running postgres-backed suites");
-    return await run(
-      "bun",
-      ["test", "test/postgres-store.test.ts", "test/postgres-ingest-lifecycle.test.ts"],
-      env,
-    );
+    return await run("bun", ["test", "test"], env);
   } finally {
     if (!external && !keep) {
       console.log("→ tearing down");

--- a/apps/analytics-ingest/test/postgres-hardening.test.ts
+++ b/apps/analytics-ingest/test/postgres-hardening.test.ts
@@ -126,6 +126,13 @@ describe.skipIf(!TEST_DATABASE_URL)("postgres lifetime accounting", () => {
   });
 
   test("a returning install refreshes last_seen instead of being retired", async () => {
+    // Hermetic on purpose. The rest of this block accumulates state across
+    // tests, and the survivor of the retirement test above still carries
+    // last_seen 1999-05-03 — earlier than this cutoff, so the sweep would
+    // rightly retire it and `retired` would report that unrelated row rather
+    // than anything about the returning install.
+    await resetAnalyticsTables();
+
     const store = storeWith();
     await ping(store, "1999-05-10", 1);
     await ping(store, "1999-06-20", 1);

--- a/apps/analytics-ingest/test/postgres-hardening.test.ts
+++ b/apps/analytics-ingest/test/postgres-hardening.test.ts
@@ -134,10 +134,19 @@ describe.skipIf(!TEST_DATABASE_URL)("postgres lifetime accounting", () => {
     await resetAnalyticsTables();
 
     const store = storeWith();
+    // Two installs, one either side of the cutoff, so the sweep has to
+    // discriminate rather than trivially retire nothing: install 2 is silent
+    // after May, install 1 comes back in June. Asserting only "retired is 0"
+    // against a single install would still pass if the sweep stopped working
+    // altogether.
+    await ping(store, "1999-05-03", 2);
     await ping(store, "1999-05-10", 1);
     await ping(store, "1999-06-20", 1);
-    // Retention cutoff sits between the two visits: the later one saves it.
-    expect((await store.pruneLifetimeBefore("1999-06-01")).retired).toBe(0);
+
+    // Exactly the silent one. Were last_seen not refreshed on the return visit,
+    // install 1 would still read 1999-05-10 and be swept too — retired 2,
+    // nothing left behind.
+    expect((await store.pruneLifetimeBefore("1999-06-01")).retired).toBe(1);
     expect(await tableCount("install_lifetime")).toBe(1);
   });
 });


### PR DESCRIPTION
## What this closes

The `apps/analytics-ingest` Postgres suites had **no CI coverage at all**, and one of their cases had been permanently red without anyone seeing it. Both halves are fixed here, because the second is what let the first hide.

Measured on this tree:

| | pass | skip | fail |
|---|---|---|---|
| no database | 82 | **33** | 0 — *green, proves nothing* |
| real database | **109** | 0 | 0 |

Every skip construct in the suite is `describe.skipIf(!TEST_DATABASE_URL)`, so without a database the job goes green having verified none of the SQL.

## The red test

`a returning install refreshes last_seen instead of being retired` asserts `retired` is 0. Its describe block resets tables once in `beforeAll` and accumulates state, so the survivor of `retiring a silent install` is still in `install_lifetime` carrying `last_seen 1999-05-03` — earlier than this test's `1999-06-01` cutoff. The sweep correctly retires that leftover and `retired` reports it.

**The product behaviour was never wrong.** The returning install does refresh `last_seen` and does survive — the test's own `tableCount` assertion passes and proves it. Only the counter was reading someone else's row. Run against a fresh table, the case passes untouched, so it now resets at its start. It is the last test in its block and the next block resets in its own `beforeAll`, so nothing downstream changes.

## Why nobody caught it

`test:pg` named two test files. `postgres-hardening.test.ts` — the file containing that case — was never run by the command documented as *"the Postgres-backed analytics tests"*. It now runs the whole `test/` directory, so future `postgres-*.test.ts` files are picked up instead of waiting for someone to extend a list.

## The CI job

`Analytics Postgres suites` runs on any `apps/analytics-ingest/**` change. It calls `test:pg` rather than restating the compose topology as GitHub `services:` — the store speaks HTTP to Neon, so it needs the proxy as well as Postgres, and a second definition of that pair would drift, which is precisely the class of bug this job exists to catch.

It then asserts no case reported `skip`. Without that, a database that never started would pass the job green — the same false pass that let the red test survive.

**The database is disposable**: a container the harness creates and destroys, loopback-only, tmpfs-backed, seeded credentials, empty every run. No real project or production URL is reachable from CI.

## Verification

- Unmodified `test:pg` driven through its external-URL path against throwaway containers: **109 pass, 0 fail across 13 files** (was 108/1 before the test fix, and only 2 files before the runner fix).
- Skip assertion confirmed to fire on the 33-skip output and stay quiet on the clean one.
- Forced `typecheck` (14), `lint` (12), `fmt:check` (26), `verify:doc-paths` — all pass.
- Workflow YAML parsed and the job's `needs`, `if`, and filter output asserted.

## Release context

This unblocks the Analytics Deployment Gate's first line of expected evidence — *"all 12 Postgres integration cases run instead of skip"* — which is release-blocking for 0.3.0 while the Kunai-owned endpoint ships as the default. Release signoff still wants a run recorded against the release commit; the difference is that a regression no longer waits for that run to surface.
