### PR TITLE
fix(release): upload the candidate from its dot-prefixed staging directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,6 +296,12 @@ jobs:
           name: ${{ env.CANDIDATE_ARTIFACT }}-${{ steps.ver.outputs.version }}-${{ github.sha }}
           retention-days: 14
           if-no-files-found: error
+          # upload-artifact excludes hidden paths by default from v4.4 onward,
+          # and every candidate file lives under the dot-prefixed staging
+          # directory. Without this the action reports "No files were found"
+          # and fails the release *after* staging, reverification, and
+          # attestation have all already passed against those same bytes.
+          include-hidden-files: true
           path: .candidate-upload/
 
       - name: Upload repository gate evidence
@@ -339,6 +345,11 @@ jobs:
         with:
           name: gate-releaseAssets-${{ steps.ver.outputs.version }}-${{ github.sha }}
           if-no-files-found: error
+          # Same hidden-path exclusion as the candidate upload: this evidence
+          # set spans a visible gate document and a checksum manifest under the
+          # dot-prefixed staging directory, so the manifest is dropped without
+          # this and the gate ships incomplete.
+          include-hidden-files: true
           path: |
             artifacts/gates/releaseAssets.json
             .candidate-upload/native/SHA256SUMS


### PR DESCRIPTION
## The failure

The 0.3.0 dispatch (run `33485665416`) failed at **Upload candidate artifacts**:

```
##[error] No files were found with the provided path: .candidate-upload/.
          No artifacts will be uploaded.
```

Everything before it passed — including `Stage candidate upload directory`, `Reverify exact staged native candidate`, and `Attest exact native candidate`, which reads `.candidate-upload/native/*`. The files demonstrably existed a step earlier.

## The cause

`actions/upload-artifact` **excludes hidden paths by default from v4.4 onward**. The pin here is `ea165f8d…` = **v4.6.2**, where `include-hidden-files` has `default: 'false'` (verified against `action.yml` at that exact SHA). Every candidate file lives under the dot-prefixed `.candidate-upload/`, so the entire tree is a hidden segment and the action filtered all of it.

Nothing was published and no tag was cut — the pipeline failed closed, and all twelve downstream jobs skipped.

## The fix

Two steps needed it, not one:

| Step | Hidden path |
|---|---|
| `Upload candidate artifacts` | `.candidate-upload/` |
| `Upload release assets gate evidence` | `.candidate-upload/native/SHA256SUMS` |

Fixing only the first would have failed at the second with the identical cause.

## Why this is deliberately minimal

The Node 20 deprecation on the artifact actions is real, and a version sweep across all workflows is worth doing — `upload-artifact` is at v7.0.1, `download-artifact` at v8.0.1, `checkout` at v7.0.1. I confirmed `artifact-ids` still exists on the latest `download-artifact`, so this pipeline's ID-passing would survive that upgrade.

But **`release.yml`'s jobs never run in PR CI** — they only execute on dispatch. An action upgrade there ships untested, in the path of the release it is meant to unblock. That belongs in its own change, landed after 0.3.0. Note also that the version bump alone would *not* have fixed this: `include-hidden-files` still defaults to `false` on v7.

## Verification

- `include-hidden-files` confirmed present at the pinned SHA with `default: 'false'`.
- Workflow parses; both hidden-path uploads assert as carrying the flag.
- No other upload step in `release.yml` references a dot-prefixed path.
- `fmt:check` (26 tasks) and `verify:doc-paths` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release candidate artifacts now include hidden staging files and checksum manifests.
  * Release evidence uploads are more complete and reliable with newer artifact-upload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->