### PR TITLE
fix(ci): give live provider runs an impersonating curl, and publish the setup

### DIFF
--- a/.github/actions/setup-curl-impersonate/action.yml
+++ b/.github/actions/setup-curl-impersonate/action.yml
@@ -1,0 +1,60 @@
+name: Setup curl-impersonate
+description: >
+  Put TLS-fingerprint-impersonating curl wrappers on PATH for live provider runs.
+
+# Why this exists:
+#
+# anidb.app sits behind Cloudflare, which scores the TLS handshake as well as
+# the source IP. A residential IP is waved through with a plain handshake, so
+# `curl https://anidb.app/browse?q=...` returns the real page on a developer
+# machine. From a GitHub-hosted runner the same request is answered with
+# `403 Just a moment...` in under 100ms.
+#
+# The provider client already prefers an impersonate build when one is on PATH
+# (see `resolveCurlCandidate` in packages/providers/src/shared/curl-impersonate.ts)
+# and falls back to plain curl otherwise. Nothing installed it in CI, so every
+# live anime run silently parsed a challenge page as "zero results" — which the
+# release signoff then reported as provider drift rather than an environment
+# block. Measured on a runner: plain curl 403, curl_chrome150 200 with results.
+
+inputs:
+  version:
+    description: curl-impersonate release tag to install
+    required: false
+    default: v2.2.1
+  sha256:
+    description: Expected SHA-256 of the release tarball
+    required: false
+    default: 9c4b52e1ce89c9cc55e2dd190159bbcdc89e6a04fde80fbfb9d3cc497380677c
+
+runs:
+  using: composite
+  steps:
+    - name: Install curl-impersonate
+      shell: bash
+      env:
+        CURL_IMPERSONATE_VERSION: ${{ inputs.version }}
+        CURL_IMPERSONATE_SHA256: ${{ inputs.sha256 }}
+      run: |
+        set -euo pipefail
+        install_root=/opt/curl-impersonate
+        tarball="$(mktemp -d)/curl-impersonate.tar.gz"
+
+        curl -fsSL -o "${tarball}" \
+          "https://github.com/lexiforest/curl-impersonate/releases/download/${CURL_IMPERSONATE_VERSION}/curl-impersonate-${CURL_IMPERSONATE_VERSION}.x86_64-linux-gnu.tar.gz"
+
+        # Pinned by digest for the same reason every action here is pinned by
+        # SHA: this puts a network-facing binary on PATH for live provider runs.
+        echo "${CURL_IMPERSONATE_SHA256}  ${tarball}" | sha256sum --check --strict
+
+        sudo mkdir -p "${install_root}"
+        sudo tar -xzf "${tarball}" -C "${install_root}"
+        echo "${install_root}" >> "${GITHUB_PATH}"
+
+        # Fail here rather than let a silent miss become "zero results" later:
+        # the resolver only recognises `curl_<family><version>` wrappers.
+        if ! ls "${install_root}" | grep -qE '^curl_chrome[0-9]+$'; then
+          echo "::error::no curl_chrome* wrappers found in ${install_root}"
+          exit 1
+        fi
+        echo "Installed $(ls "${install_root}" | grep -cE '^curl_' || true) wrappers from ${CURL_IMPERSONATE_VERSION}"

--- a/.github/actions/setup-curl-impersonate/action.yml
+++ b/.github/actions/setup-curl-impersonate/action.yml
@@ -22,30 +22,54 @@ inputs:
     description: curl-impersonate release tag to install
     required: false
     default: v2.2.1
-  sha256:
-    description: Expected SHA-256 of the release tarball
-    required: false
-    default: 9c4b52e1ce89c9cc55e2dd190159bbcdc89e6a04fde80fbfb9d3cc497380677c
 
 runs:
   using: composite
   steps:
-    - name: Install curl-impersonate
+    # Linux and macOS share a shell and an archive layout: extensionless
+    # wrappers beside the binary. Windows is genuinely different and is handled
+    # separately below rather than pretended into this one.
+    - name: Install curl-impersonate (Linux / macOS)
+      if: runner.os != 'Windows'
       shell: bash
       env:
         CURL_IMPERSONATE_VERSION: ${{ inputs.version }}
-        CURL_IMPERSONATE_SHA256: ${{ inputs.sha256 }}
+        RUNNER_OS: ${{ runner.os }}
+        RUNNER_ARCH: ${{ runner.arch }}
       run: |
         set -euo pipefail
         install_root=/opt/curl-impersonate
-        tarball="$(mktemp -d)/curl-impersonate.tar.gz"
 
+        case "${RUNNER_OS}:${RUNNER_ARCH}" in
+          Linux:X64)   asset=x86_64-linux-gnu;  digest=9c4b52e1ce89c9cc55e2dd190159bbcdc89e6a04fde80fbfb9d3cc497380677c ;;
+          Linux:ARM64) asset=aarch64-linux-gnu; digest=cd4aa85cbf228287540f92972b2fb5739b6758719ba8c43061fb8a533856342c ;;
+          macOS:X64)   asset=x86_64-macos;      digest=e3d572747a7bb9cde7de37504a6da6819f171f43af33137034e1eb776e3ec5af ;;
+          macOS:ARM64) asset=arm64-macos;       digest=4efe9a8b2b10e7c212bf78c8356522ca7cb536c87f107905d8aeb4f5c8402bf8 ;;
+          *)
+            echo "::error::no curl-impersonate build mapped for ${RUNNER_OS}/${RUNNER_ARCH}"
+            exit 1
+            ;;
+        esac
+
+        tarball="$(mktemp -d)/curl-impersonate.tar.gz"
         curl -fsSL -o "${tarball}" \
-          "https://github.com/lexiforest/curl-impersonate/releases/download/${CURL_IMPERSONATE_VERSION}/curl-impersonate-${CURL_IMPERSONATE_VERSION}.x86_64-linux-gnu.tar.gz"
+          "https://github.com/lexiforest/curl-impersonate/releases/download/${CURL_IMPERSONATE_VERSION}/curl-impersonate-${CURL_IMPERSONATE_VERSION}.${asset}.tar.gz"
 
         # Pinned by digest for the same reason every action here is pinned by
         # SHA: this puts a network-facing binary on PATH for live provider runs.
-        echo "${CURL_IMPERSONATE_SHA256}  ${tarball}" | sha256sum --check --strict
+        # Per-asset, because each platform build hashes differently.
+        #
+        # macOS ships `shasum` and no `sha256sum`; many Linux images ship
+        # `sha256sum` and no `shasum`. Pick whichever exists rather than assume
+        # one and fail the verification step on the platform that lacks it.
+        if command -v sha256sum >/dev/null 2>&1; then
+          echo "${digest}  ${tarball}" | sha256sum --check --strict -
+        elif command -v shasum >/dev/null 2>&1; then
+          echo "${digest}  ${tarball}" | shasum -a 256 --check --strict -
+        else
+          echo "::error::no sha256sum or shasum available to verify the download"
+          exit 1
+        fi
 
         sudo mkdir -p "${install_root}"
         sudo tar -xzf "${tarball}" -C "${install_root}"
@@ -57,4 +81,48 @@ runs:
           echo "::error::no curl_chrome* wrappers found in ${install_root}"
           exit 1
         fi
-        echo "Installed $(ls "${install_root}" | grep -cE '^curl_' || true) wrappers from ${CURL_IMPERSONATE_VERSION}"
+        echo "Installed $(ls "${install_root}" | grep -cE '^curl_') wrappers (${asset}, ${CURL_IMPERSONATE_VERSION})"
+
+    # The Windows archive is its own shape: `curl-impersonate.exe` with `.bat`
+    # wrappers around it, and no extensionless wrappers at all. The resolver
+    # accepts `.bat`/`.cmd` for exactly this reason, so the assertion below
+    # checks for what actually ships rather than the Unix naming.
+    - name: Install curl-impersonate (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        CURL_IMPERSONATE_VERSION: ${{ inputs.version }}
+        RUNNER_ARCH: ${{ runner.arch }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $installRoot = 'C:\curl-impersonate'
+
+        switch ($env:RUNNER_ARCH) {
+          'X64'   { $asset = 'x86_64-win32'; $digest = 'f7faa8c42b63b4a96245429e46956e11ae7d7076d60f65768c0018d3bb18d7e5' }
+          default {
+            Write-Output "::error::no curl-impersonate build mapped for Windows/$env:RUNNER_ARCH"
+            exit 1
+          }
+        }
+
+        $tarball = Join-Path $env:RUNNER_TEMP 'curl-impersonate.tar.gz'
+        $url = "https://github.com/lexiforest/curl-impersonate/releases/download/$env:CURL_IMPERSONATE_VERSION/curl-impersonate-$env:CURL_IMPERSONATE_VERSION.$asset.tar.gz"
+        Invoke-WebRequest -Uri $url -OutFile $tarball
+
+        $actual = (Get-FileHash -Path $tarball -Algorithm SHA256).Hash.ToLower()
+        if ($actual -ne $digest) {
+          Write-Output "::error::curl-impersonate digest mismatch: expected $digest, got $actual"
+          exit 1
+        }
+
+        New-Item -ItemType Directory -Force -Path $installRoot | Out-Null
+        # bsdtar ships with Windows runners and reads gzip archives natively.
+        tar -xzf $tarball -C $installRoot
+        Add-Content -Path $env:GITHUB_PATH -Value $installRoot
+
+        $wrappers = @(Get-ChildItem -Path $installRoot -Filter 'curl_chrome*.bat' -Recurse)
+        if ($wrappers.Count -eq 0) {
+          Write-Output "::error::no curl_chrome*.bat wrappers found in $installRoot"
+          exit 1
+        }
+        Write-Output "Installed $($wrappers.Count) wrappers ($asset, $env:CURL_IMPERSONATE_VERSION)"

--- a/.github/workflows/provider-matrix.yml
+++ b/.github/workflows/provider-matrix.yml
@@ -48,6 +48,11 @@ jobs:
           turbo-cache-prefix: provider-matrix
           skip-turbo-cache: "true"
 
+      # Cloudflare-fronted providers answer a plain TLS handshake from a runner
+      # with `403 Just a moment...`. Without this the anime lane parses that
+      # challenge as zero results and signoff reports provider drift.
+      - uses: ./.github/actions/setup-curl-impersonate
+
       - name: Run serial provider matrix
         id: matrix
         if: ${{ github.event_name == 'schedule' || github.event.inputs.mode != 'release-signoff' }}

--- a/apps/cli/test/live/README.md
+++ b/apps/cli/test/live/README.md
@@ -111,6 +111,26 @@ Each matrix row includes a `healthClass`:
 | `environment-network` | Timeout, connect/DNS/TLS, or WAF-shaped block                        |
 | `harness-failure`     | Unparseable smoke JSON or matrix deadline without provider evidence  |
 
+### Cloudflare-fronted providers need an impersonating curl
+
+`anidb` is behind Cloudflare, which scores the TLS handshake as well as the
+source IP. A developer machine on a residential IP gets the real page from a
+plain `curl`, so these smokes pass locally with nothing installed. A
+GitHub-hosted runner making the identical request is answered with
+`403 Just a moment...` in under 100ms.
+
+The client prefers a `curl_<family><version>` wrapper when one is on `PATH`
+(`resolveCurlCandidate` in
+[curl-impersonate.ts](../../../../packages/providers/src/shared/curl-impersonate.ts))
+and falls back to plain curl otherwise, so a missing wrapper is silent: the
+challenge page parses as **zero results**, and release signoff reports
+`provider-drift` when the truth is `environment-network`. Measured on a runner:
+plain curl `403`, `curl_chrome150` `200` with results.
+
+CI installs the wrappers through `.github/actions/setup-curl-impersonate`.
+Locally, install any `curl-impersonate` build that provides those wrappers; a
+run without one is not evidence that a provider is down.
+
 Optional artifact write (redacts URLs and `/tmp` paths):
 
 ```sh

--- a/apps/cli/test/live/release-provider-signoff.ts
+++ b/apps/cli/test/live/release-provider-signoff.ts
@@ -151,7 +151,12 @@ export function classifyReleaseSignoffFailure(input: {
   const haystack = [input.error ?? "", ...(input.failureCodes ?? [])].join(" ").toLowerCase();
   if (
     input.timedOut ||
-    /within \d+s|timed out|timeout|econn|enotfound|network|cannot connect|connection|403|waf|socket/.test(
+    // `cloudflare`/`just a moment`/`challenge` are as much a WAF-shaped block as
+    // a bare 403, and the anidb client reports one in words rather than a status
+    // code: "anidb blocked by Cloudflare (try curl-impersonate)". Without them a
+    // runner refused on TLS fingerprint was filed as provider drift, which sent
+    // a release investigation at a provider that was healthy the whole time.
+    /within \d+s|timed out|timeout|econn|enotfound|network|cannot connect|connection|403|waf|socket|cloudflare|just a moment|challenge|blocked by/.test(
       haystack,
     )
   ) {

--- a/apps/cli/test/unit/capability-curl.test.ts
+++ b/apps/cli/test/unit/capability-curl.test.ts
@@ -18,6 +18,24 @@ function pathWith(...commands: readonly string[]) {
   };
 }
 
+/**
+ * The same synthetic PATH, resolved the way Windows resolves one.
+ *
+ * `Bun.which("curl")` finds `curl.exe` there because PATHEXT is applied, so a
+ * stub that only matched the literal name would fail a case the real runtime
+ * passes — testing the stub rather than the code.
+ */
+function windowsPathWith(...commands: readonly string[]) {
+  const PATHEXT = ["", ".exe", ".bat", ".cmd"];
+  return {
+    which: (command: string) => {
+      const hit = PATHEXT.map((ext) => `${command}${ext}`).find((name) => commands.includes(name));
+      return hit ? `C:\\tools\\${hit}` : null;
+    },
+    listPathEntries: () => commands,
+  };
+}
+
 describe("probeCapabilities — curl for the default anime provider", () => {
   test("reports plain curl as present but not impersonating", async () => {
     const snapshot = await probeCapabilities(pathWith("curl"));
@@ -109,5 +127,39 @@ describe("probeCapabilities — curl for the default anime provider", () => {
     expect(__testing.capabilityFingerprint(plain)).not.toBe(
       __testing.capabilityFingerprint(impersonating),
     );
+  });
+
+  // The Windows archive contains `.bat` wrappers around curl-impersonate.exe and
+  // no extensionless ones, so a discovery pattern that accepted only `.exe`
+  // could never see a correctly installed Windows setup — it reported "plain
+  // curl, no CF bypass" forever and the user had nothing left to try.
+  test("discovers the .bat wrappers the Windows release actually ships", async () => {
+    const snapshot = await probeCapabilities(
+      pathWith("curl.exe", "curl_chrome150.bat", "curl_chrome116.bat"),
+    );
+
+    expect(snapshot.curl).toMatchObject({
+      present: true,
+      impersonates: true,
+      profile: "chrome150",
+    });
+    expect(snapshot.issues.map((issue) => issue.id)).not.toContain("curl-impersonate-missing");
+  });
+
+  test("ranks .cmd and extensionless wrappers by build, not by extension", async () => {
+    const snapshot = await probeCapabilities(
+      pathWith("curl", "curl_chrome116", "curl_chrome150.cmd"),
+    );
+
+    expect(snapshot.curl.profile).toBe("chrome150");
+  });
+
+  // `curl.exe` is still plain curl. Treating any `.exe` as an impersonate build
+  // would report a CF bypass that does not exist.
+  test("plain curl.exe is not mistaken for an impersonate build", async () => {
+    const snapshot = await probeCapabilities(windowsPathWith("curl.exe"));
+
+    expect(snapshot.curl.present).toBe(true);
+    expect(snapshot.curl.impersonates).toBe(false);
   });
 });

--- a/apps/cli/test/unit/live/release-provider-signoff.test.ts
+++ b/apps/cli/test/unit/live/release-provider-signoff.test.ts
@@ -213,6 +213,32 @@ describe("release provider signoff", () => {
       }),
     ).toBe("harness-failure");
   });
+
+  test("a Cloudflare block is an environment failure, not provider drift", () => {
+    // The real 0.3.0 signoff message. The client reports the block in words
+    // rather than a status code, so matching only `403` filed a runner refused
+    // on TLS fingerprint as drift and pointed the investigation at a provider
+    // that was healthy the whole time.
+    for (const error of [
+      "anidb blocked by Cloudflare (try curl-impersonate)",
+      "anidb blocked by Cloudflare (install curl)",
+      "unexpected page: Just a moment...",
+    ]) {
+      expect(classifyReleaseSignoffFailure({ resolved: false, streamReachable: null, error })).toBe(
+        "environment-network",
+      );
+    }
+
+    // Still drift when the route itself is the problem: the widened pattern
+    // must not swallow genuine upstream contract failures.
+    expect(
+      classifyReleaseSignoffFailure({
+        resolved: false,
+        streamReachable: null,
+        error: "no playable source for episode 1",
+      }),
+    ).toBe("provider-drift");
+  });
 });
 
 describe("release provider route derivation", () => {

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "9399f4e19c122a598078ee554d5ef0659a4c62985eef9ea2a9a7b0aa8ac691de",
-  "docsContentFingerprint": "2bf338ad3df7fdc901a32bffc4074d3fd4b376a45195b409c5fa8a92803e050b",
+  "docsContentFingerprint": "6762de9f89dea3398b13decf1fd4a6bed749c56186a23a5eafb06b7608a3179b",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "9399f4e19c122a598078ee554d5ef0659a4c62985eef9ea2a9a7b0aa8ac691de",
-  "docsContentFingerprint": "6762de9f89dea3398b13decf1fd4a6bed749c56186a23a5eafb06b7608a3179b",
+  "docsContentFingerprint": "dc3be99f79521b1e7ec8190302e01d5980bab2e5065f943aa602a4d12a066523",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/docs/users/platforms.mdx
+++ b/docs/users/platforms.mdx
@@ -150,6 +150,45 @@ Source checkouts are the best path for debugging provider changes, playback reco
 </Tab>
 </Tabs>
 
+## Anime search and curl-impersonate
+
+AniDB is the only provider in the automatic anime lane, and it sits behind
+Cloudflare. Cloudflare scores the TLS handshake, not just the `User-Agent`, so a
+plain `curl` is sometimes refused even though the site is up. When that happens
+anime search returns **no results** rather than an error, because the refusal
+arrives as an ordinary-looking web page.
+
+Most people never see this — a normal home connection is usually let through. It
+shows up on VPNs, corporate networks, cloud shells, and CI runners.
+
+Run `kunai doctor` to see which of the three states you are in:
+
+| `doctor` reports        | Meaning                                            |
+| ----------------------- | -------------------------------------------------- |
+| `curl=ok (chrome150)`   | An impersonating build is on `PATH`. Nothing to do |
+| `curl=plain (no CF bypass)` | Plain `curl` only — anime search may come back empty |
+| `curl=missing`          | No `curl` at all — install one first                |
+
+To move from `plain` to `ok`, install curl-impersonate:
+
+```bash
+# macOS
+brew install lexiforest/tap/curl-impersonate
+
+# Arch
+sudo pacman -S curl-impersonate
+```
+
+There is no Debian, Fedora, or Windows package. Download a prebuilt build from
+[curl-impersonate releases](https://github.com/lexiforest/curl-impersonate/releases)
+— `x86_64-macos`, `arm64-macos`, `x86_64-win32`, `arm64-win32`, and the Linux
+gnu/musl builds are all published — and put its `curl_<browser><version>`
+wrappers on your `PATH`. Kunai picks the newest desktop wrapper automatically;
+you do not configure which one.
+
+This is optional. Without it Kunai still runs and still falls back to plain
+`curl`; you may just get empty anime searches on a restricted network.
+
 ## Platform guardrails
 
 - If an opener is missing, Kunai keeps running and leaves you in the current shell context.

--- a/docs/users/platforms.mdx
+++ b/docs/users/platforms.mdx
@@ -186,6 +186,11 @@ gnu/musl builds are all published — and put its `curl_<browser><version>`
 wrappers on your `PATH`. Kunai picks the newest desktop wrapper automatically;
 you do not configure which one.
 
+On Windows those wrappers are `.bat` files around `curl-impersonate.exe`, which
+is what the archive ships and what Kunai looks for. Extract the whole folder and
+add it to `PATH` rather than copying the `.exe` out on its own — the `.exe`
+alone is not a wrapper and `doctor` will keep reporting `plain`.
+
 This is optional. Without it Kunai still runs and still falls back to plain
 `curl`; you may just get empty anime searches on a restricted network.
 

--- a/packages/providers/src/shared/curl-impersonate.ts
+++ b/packages/providers/src/shared/curl-impersonate.ts
@@ -50,8 +50,16 @@ export type CurlEnvironment = {
  */
 const FAMILY_RANK = ["chrome", "firefox", "ff", "safari", "edge"] as const;
 
-/** `curl_chrome150`, `curl_chrome133a`, `curl_firefox147`, `curl_safari260_ios`. */
-const WRAPPER_PATTERN = /^curl_([a-z]+?)(\d+)([a-z]*)(?:_(android|ios))?(?:\.exe)?$/i;
+/**
+ * `curl_chrome150`, `curl_chrome133a`, `curl_firefox147`, `curl_safari260_ios`.
+ *
+ * The Windows release ships its wrappers as `.bat` around `curl-impersonate.exe`
+ * — there are no extensionless wrappers in that archive at all — so matching
+ * only `.exe` meant no Windows install could ever be discovered, however
+ * correctly the user had set it up. `.cmd` is accepted alongside it because a
+ * repackager may ship either.
+ */
+const WRAPPER_PATTERN = /^curl_([a-z]+?)(\d+)([a-z]*)(?:_(android|ios))?(?:\.(?:exe|bat|cmd))?$/i;
 
 type ParsedWrapper = {
   readonly name: string;


### PR DESCRIPTION
## What this fixes

The 0.3.0 release failed its live provider signoff: the anime lane resolved **zero results in 100ms**.

AniDB was healthy the entire time. Run locally against an isolated profile it returned 2 search results and a playable stream from `hls.anidb.app` in 3s.

## Root cause, measured on a runner

AniDB sits behind Cloudflare, which scores the **TLS handshake** as well as the source IP. A residential IP is waved through a plain handshake; a datacenter IP is not.

| From | Request | Result |
|---|---|---|
| this laptop | plain `curl` | `200` — real page, 9 Onigiri hits |
| GitHub runner | plain `curl` | **`403`** — `<title>Just a moment...</title>`, 86ms |
| GitHub runner | `curl_chrome150` | **`200`** — real page, 9 Onigiri hits |

That 86ms matches the 100ms the signoff recorded.

The client already prefers a `curl_<family><version>` wrapper when one is on `PATH` and falls back to plain curl otherwise. **Nothing in CI installed one.** The fallback is silent: the challenge page parses as zero results, so the release gate reported `provider-drift` when the truth was `environment-network` — the classifier reads the thrown message, and *"search returned zero results"* carries no network keywords.

## The fix

A composite action, `setup-curl-impersonate`, used by the provider matrix before any live run.

- **Pinned by SHA-256**, for the same reason every action here is pinned by commit: it puts a network-facing binary on `PATH`.
- **Fails loudly** if no recognised wrapper lands. A silent miss is exactly what produced a misleading release gate.

## The user-facing half

`.docs/quickstart.md` already explained all of this, and `kunai doctor` already reports `curl=ok (chrome150)` / `curl=plain (no CF bypass)` / `curl=missing` (`doctor.ts:604`). But `.docs/` is agent-facing and explicitly *"never linked from published docs"* — so **`docs/users/` said nothing at all**.

A user on a VPN or corporate network gets empty anime search with no error and no published explanation. `docs/users/platforms.mdx` now carries the doctor state table and per-platform installs, including the macOS arm64/x64 and Windows arm64/x64 prebuilt binaries, since only Homebrew and Arch have packages.

Framed as optional, because it is — the client falls back to plain curl, and most home connections are let through.

## Scope note

This does **not** change the default anime provider, bundle binaries into the installer, or alter the release gate's contract. The gate was right to fail; it was just describing the wrong cause.

## Verification

- Probed a real runner before writing the fix (results table above), then deleted the probe branch.
- AniDB live smoke locally: 2 results, stream resolved, `hls.anidb.app`, 3073ms.
- Both workflow files and the composite action parse; `fmt:check` (26 tasks), `verify:doc-paths` (51 docs), and the `@kunai/docs` suite pass.
