### PR TITLE
fix(anidb): tolerate reindexed ids, extra languages, and 404 drift

### DIFF
--- a/.docs/provider-dossiers/anidb-runtime-contract.md
+++ b/.docs/provider-dossiers/anidb-runtime-contract.md
@@ -1,6 +1,6 @@
 ---
 status: current
-lastReviewed: "2026-08-26"
+lastReviewed: "2026-09-01"
 ---
 
 # Provider: AniDB — runtime contract
@@ -52,7 +52,9 @@ instead of pretending those fields came from `anidb.app`.
 
 - `anidb.app` language evidence is per episode: `jpn` is the sub/original embed and `eng` is the
   dub embed when present. Search does not advertise both modes blindly; availability is confirmed
-  only by the episode languages response.
+  only by the episode languages response. Live `2026-09` also returns `kor` (e.g. Solo
+  Leveling S1 E1 `16704` → `eng,jpn,kor`); `kor` is ignored — `collectAnidbAvailableAudioModes`
+  remains `sub/dub` only (`jpn`/`eng` case-insensitive, exact).
 - A missing requested language is an exhausted AniDB attempt. It must not fall back to the other
   language and label the stream incorrectly.
 - Only exact `jpn` (sub/original) and `eng` (dub) catalog evidence is accepted.
@@ -92,7 +94,10 @@ AniDB models each season as its own title, so `routeAnidbSeason()` in
 - Season 1 retains the base title.
 - Season 2+ searches `<normalized base> Season N` and requires both a matching parsed season and
   exact/prefix normalized base-title evidence. An ambiguous best score fails closed with a
-  structured `not-found` rather than resolving the wrong title.
+  structured `not-found` rather than resolving the wrong title. A suffixed title such as
+  `Solo Leveling Season 2: Arise from the Shadow` (live `4884`, was `19837`) leaves
+  `solo leveling arise from the shadow` and matches via `prefix` (score 1) — covered by
+  `anidb-season-routing.test.ts` prefix test.
 - If no numbered sibling matches, a standalone `Final Season` may route to the ordinal immediately
   after the show's highest explicitly numbered sibling. Movie cards, final-season parts, and
   prefixed spin-off seasons provide no ordinal evidence; ambiguous or arc-named runs fail closed.

--- a/.docs/provider-dossiers/anidb-runtime-contract.md
+++ b/.docs/provider-dossiers/anidb-runtime-contract.md
@@ -57,6 +57,18 @@ instead of pretending those fields came from `anidb.app`.
   remains `sub/dub` only (`jpn`/`eng` case-insensitive, exact).
 - A missing requested language is an exhausted AniDB attempt. It must not fall back to the other
   language and label the stream incorrectly.
+- A reindexed show id (`19413` → `4883`) is repaired, but only on proof. `fetchAnidbEpisodeCatalog`
+  reports `missing: true` for an HTTP 404 and `missing: false` for a catalogue that is merely empty
+  or unparseable; `resolveAnidbShow` re-searches on the first and never on the second, because an
+  announced season with no episodes listed is not a stale id. The repair also requires real title
+  evidence (`chooseAnidbSearchMatch(..., { requireTitleEvidence: true })`) — the ordinary
+  "best guess is the top card" fallback is disabled there, since substituting a search result for a
+  _persisted_ id would silently swap the show the user chose.
+- The 404 has to be asked for. `anidb.app` is fetched with `curl -sL`, which has no `--fail`, so a
+  missing id returns the error page with exit 0 and is otherwise indistinguishable from a body that
+  failed to parse. Reads that branch on the status pass `reportStatus: true`, which appends
+  `-w '\n%{http_code}'` and raises `AnidbHttpStatusError`. A caller that reads the status out of a
+  message string is reading prose, not a status.
 - Only exact `jpn` (sub/original) and `eng` (dub) catalog evidence is accepted.
   The requested mode resolves first; the alternate starts concurrently but is
   skipped for `fast`, bounded to 1 second for `balanced`, and bounded to 4

--- a/packages/providers/src/anidb/browse-parser.ts
+++ b/packages/providers/src/anidb/browse-parser.ts
@@ -102,10 +102,23 @@ export function parseAnidbBrowseHtml(html: string): readonly AnidbSearchResult[]
 export function chooseAnidbSearchMatch(
   query: string,
   results: readonly AnidbSearchResult[],
+  options: {
+    /**
+     * Drop the "best guess is the first card" fallback and return `null` when
+     * no title actually matches.
+     *
+     * A user who typed a query is well served by the top card even on a weak
+     * match — they can see what they got. Code repairing a *persisted* id has
+     * no such reader: substituting the first search result there swaps the show
+     * the user previously chose for an unrelated one, silently.
+     */
+    readonly requireTitleEvidence?: boolean;
+  } = {},
 ): AnidbSearchResult | null {
-  const first = results[0] ?? null;
+  const strict = options.requireTitleEvidence === true;
+  const fallback = strict ? null : (results[0] ?? null);
   const normalizedQuery = normalizeTitle(query);
-  if (!first || !normalizedQuery) return first;
+  if (results.length === 0 || !normalizedQuery) return fallback;
 
   const exact = results.find((result) => normalizeTitle(result.title) === normalizedQuery);
   if (exact) return exact;
@@ -117,7 +130,7 @@ export function chooseAnidbSearchMatch(
       normalizedQuery.startsWith(`${normalizedTitle} `)
     );
   });
-  return prefixed ?? first;
+  return prefixed ?? fallback;
 }
 
 /**

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -41,7 +41,9 @@ export const ANIDB_HTTP_API_CLIENT_VERSION = "1";
 export const ANIDB_USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
-const episodeCache = new TTLCache<string, readonly AnidbEpisodeEntry[]>(1_800_000);
+const episodeCache = new TTLCache<string, AnidbEpisodeCatalog>(1_800_000);
+/** A miss is cached far shorter than a hit: reindexes are permanent, 404s from a hiccup are not. */
+const ANIDB_MISSING_CATALOG_TTL_MS = 120_000;
 const languageCache = new TTLCache<string, readonly AnidbLanguageEntry[]>(300_000);
 const malCache = new TTLCache<string, number | null>(3_600_000);
 const externalIdsCache = new TTLCache<
@@ -127,12 +129,48 @@ export function resolveAnidbCurl(environment: Partial<CurlEnvironment> = {}): Cu
  * and is frequently still challenged, since Cloudflare fingerprints the TLS
  * handshake rather than trusting the User-Agent.
  */
+/**
+ * An AniDB HTTP status a caller is allowed to branch on.
+ *
+ * `anidb.app` reindexes slugs, so "this id is gone" (404) and "this id is
+ * blocked right now" (403 / Cloudflare) demand opposite responses: re-search
+ * for the first, keep the id and surface a retryable error for the second.
+ * Reading that distinction back out of a message string is how it gets lost,
+ * so the status rides on the error.
+ */
+export class AnidbHttpStatusError extends Error {
+  readonly status: number;
+
+  constructor(status: number) {
+    // Message shape preserved from the untyped throw this replaces.
+    super(`anidb fetch HTTP ${status}`);
+    this.name = "AnidbHttpStatusError";
+    this.status = status;
+  }
+}
+
+/** curl reports the final status after redirects; the body keeps the rest. */
+const ANIDB_STATUS_WRITE_OUT = ["-w", "\n%{http_code}"] as const;
+
+function splitAnidbStatus(stdout: string): { readonly body: string; readonly status: number } {
+  const cut = stdout.lastIndexOf("\n");
+  if (cut < 0) return { body: "", status: Number.parseInt(stdout, 10) || 0 };
+  const status = Number.parseInt(stdout.slice(cut + 1), 10);
+  return { body: stdout.slice(0, cut), status: Number.isFinite(status) ? status : 0 };
+}
+
 export async function anidbFetchText(
   url: string,
   options: {
     readonly context?: ProviderRuntimeContext;
     readonly signal?: AbortSignal;
     readonly maxTimeSec?: number;
+    /**
+     * Turn an HTTP error status into an {@link AnidbHttpStatusError} instead of
+     * an opaque failure. Only the JSON API reads need it; HTML scrapes are
+     * happier with the existing best-effort behaviour.
+     */
+    readonly reportStatus?: boolean;
   } = {},
 ): Promise<string> {
   if (options.context?.fetch) {
@@ -146,8 +184,15 @@ export async function anidbFetchText(
         if (!isCloudflareChallengeText(text)) {
           return text;
         }
+      } else if (options.reportStatus === true && response.status === 404) {
+        // Falling through to curl exists so a Cloudflare challenge gets a
+        // second chance with a better TLS fingerprint. A 404 is not a
+        // fingerprint problem — curl would spend a request to be told the same
+        // thing — so it is answered here.
+        throw new AnidbHttpStatusError(404);
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof AnidbHttpStatusError) throw error;
       // Fallback to local curl/impersonate
     }
   }
@@ -159,7 +204,7 @@ export async function anidbFetchText(
       signal: createTimeoutSignal(options.signal, 15_000),
     });
     if (!response.ok) {
-      throw new Error(`anidb fetch HTTP ${response.status}`);
+      throw new AnidbHttpStatusError(response.status);
     }
     const text = await response.text();
     if (isCloudflareChallengeText(text)) {
@@ -179,9 +224,22 @@ export async function anidbFetchText(
     "--max-time",
     maxTime,
     ...anidbCipherArgs(curl.impersonates),
+    ...(options.reportStatus === true ? ANIDB_STATUS_WRITE_OUT : []),
     url,
   ];
   const stdout = await runAnidbCurlWithRetry(args, options.signal);
+  // `-sL` has no `--fail`, so curl exits 0 and hands back the error page for a
+  // 404. Without asking for the status explicitly the miss is indistinguishable
+  // from a body that merely failed to parse, which is how a reindexed id used
+  // to look exactly like an empty catalogue.
+  if (options.reportStatus === true) {
+    const { body, status } = splitAnidbStatus(stdout);
+    if (status >= 400) throw new AnidbHttpStatusError(status);
+    if (isCloudflareChallengeText(body)) {
+      throw new Error("anidb blocked by Cloudflare (try curl-impersonate)");
+    }
+    return body;
+  }
   if (isCloudflareChallengeText(stdout)) {
     throw new Error("anidb blocked by Cloudflare (try curl-impersonate)");
   }
@@ -420,32 +478,54 @@ function readMetaContent(html: string, property: string): string | undefined {
   return propertyFirst.exec(html)?.[1] ?? contentFirst.exec(html)?.[1];
 }
 
-export async function fetchAnidbEpisodes(
+/**
+ * An episode list, plus whether the show id itself resolved.
+ *
+ * `episodes: []` alone cannot carry this: a season announced but not yet
+ * listed is legitimately empty, and treating that the same as a reindexed id
+ * sends the caller off to search and hand back a *different show*. The two
+ * need separate answers, so they get separate fields.
+ */
+export type AnidbEpisodeCatalog = {
+  readonly episodes: readonly AnidbEpisodeEntry[];
+  /** The id is gone (HTTP 404) — not merely empty. */
+  readonly missing: boolean;
+};
+
+const ANIDB_EMPTY_CATALOG: AnidbEpisodeCatalog = { episodes: [], missing: false };
+const ANIDB_MISSING_CATALOG: AnidbEpisodeCatalog = { episodes: [], missing: true };
+
+export async function fetchAnidbEpisodeCatalog(
   showId: string,
   signal?: AbortSignal,
   context?: ProviderRuntimeContext,
-): Promise<readonly AnidbEpisodeEntry[]> {
+): Promise<AnidbEpisodeCatalog> {
   const numericId = anidbNumericId(showId);
-  if (!numericId) return [];
+  if (!numericId) return ANIDB_EMPTY_CATALOG;
   const cached = episodeCache.get(showId);
   if (cached) return cached;
 
   const url = `${ANIDB_BASE}/api/frontend/anime/${numericId}/episodes`;
   let text: string;
   try {
-    text = await anidbFetchText(url, { signal, context });
+    text = await anidbFetchText(url, { signal, context, reportStatus: true });
   } catch (error) {
-    // A reindexed slug (e.g. Solo Leveling 19413 → 4883) 404s forever.
-    // Treat as empty catalog so resolve surfaces `catalog-unavailable`
-    // rather than a retryable `network-error` that would loop.
-    if (error instanceof Error && /HTTP 404/.test(error.message)) return [];
+    // A reindexed slug (Solo Leveling 19413 → 4883) 404s permanently. Record
+    // it as a miss so the caller can re-search, and cache it briefly so a dead
+    // id is not re-requested once per call site on the same resolve.
+    if (error instanceof AnidbHttpStatusError && error.status === 404) {
+      episodeCache.set(showId, ANIDB_MISSING_CATALOG, ANIDB_MISSING_CATALOG_TTL_MS);
+      return ANIDB_MISSING_CATALOG;
+    }
     throw error;
   }
   let parsed: { episodes?: readonly Record<string, unknown>[] };
   try {
     parsed = JSON.parse(text) as { episodes?: readonly Record<string, unknown>[] };
   } catch {
-    return [];
+    // Unparseable is not the same as absent: the id may be fine and the body
+    // mangled, so this must not be reported as a miss.
+    return ANIDB_EMPTY_CATALOG;
   }
   const episodes = (parsed.episodes ?? [])
     .flatMap((entry) => {
@@ -461,8 +541,18 @@ export async function fetchAnidbEpisodes(
     })
     .sort((left, right) => left.number - right.number);
 
-  episodeCache.set(showId, episodes);
-  return episodes;
+  const catalog: AnidbEpisodeCatalog = { episodes, missing: false };
+  episodeCache.set(showId, catalog);
+  return catalog;
+}
+
+/** Episode list only, for the callers that cannot act on a missing id. */
+export async function fetchAnidbEpisodes(
+  showId: string,
+  signal?: AbortSignal,
+  context?: ProviderRuntimeContext,
+): Promise<readonly AnidbEpisodeEntry[]> {
+  return (await fetchAnidbEpisodeCatalog(showId, signal, context)).episodes;
 }
 
 export async function fetchAnidbLanguages(
@@ -477,9 +567,10 @@ export async function fetchAnidbLanguages(
   const url = `${ANIDB_BASE}/api/frontend/episode/${episodeId}/languages`;
   let text: string;
   try {
-    text = await anidbFetchText(url, { signal, context });
+    text = await anidbFetchText(url, { signal, context, reportStatus: true });
   } catch (error) {
-    if (error instanceof Error && /HTTP 404/.test(error.message)) return [];
+    // No languages row for this episode is a real answer, not a failure.
+    if (error instanceof AnidbHttpStatusError && error.status === 404) return [];
     throw error;
   }
   let parsed: { languages?: readonly Record<string, unknown>[] };

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -193,6 +193,12 @@ export async function anidbFetchText(
       }
     } catch (error) {
       if (error instanceof AnidbHttpStatusError) throw error;
+      // A cancelled caller is not a fingerprint problem either. Without this
+      // an abort during the context fetch is swallowed and the fallback spends
+      // a whole curl request on work nobody is waiting for. Checked against
+      // `options.signal` rather than the error shape, so the 15s internal
+      // timeout still earns its second chance through curl.
+      if (options.signal?.aborted === true) throw error;
       // Fallback to local curl/impersonate
     }
   }
@@ -525,6 +531,13 @@ export async function fetchAnidbEpisodeCatalog(
   } catch {
     // Unparseable is not the same as absent: the id may be fine and the body
     // mangled, so this must not be reported as a miss.
+    return ANIDB_EMPTY_CATALOG;
+  }
+  // `?? []` only covers null and undefined. A body like `{"episodes":{}}`
+  // parses cleanly and then throws on `.flatMap`, turning malformed upstream
+  // data into a crash rather than an empty listing. A non-array field is
+  // empty-but-present, the same as an unparseable body: not a missing id.
+  if (parsed.episodes !== undefined && !Array.isArray(parsed.episodes)) {
     return ANIDB_EMPTY_CATALOG;
   }
   const episodes = (parsed.episodes ?? [])

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -431,7 +431,16 @@ export async function fetchAnidbEpisodes(
   if (cached) return cached;
 
   const url = `${ANIDB_BASE}/api/frontend/anime/${numericId}/episodes`;
-  const text = await anidbFetchText(url, { signal, context });
+  let text: string;
+  try {
+    text = await anidbFetchText(url, { signal, context });
+  } catch (error) {
+    // A reindexed slug (e.g. Solo Leveling 19413 → 4883) 404s forever.
+    // Treat as empty catalog so resolve surfaces `catalog-unavailable`
+    // rather than a retryable `network-error` that would loop.
+    if (error instanceof Error && /HTTP 404/.test(error.message)) return [];
+    throw error;
+  }
   let parsed: { episodes?: readonly Record<string, unknown>[] };
   try {
     parsed = JSON.parse(text) as { episodes?: readonly Record<string, unknown>[] };
@@ -466,7 +475,13 @@ export async function fetchAnidbLanguages(
   if (cached) return cached;
 
   const url = `${ANIDB_BASE}/api/frontend/episode/${episodeId}/languages`;
-  const text = await anidbFetchText(url, { signal, context });
+  let text: string;
+  try {
+    text = await anidbFetchText(url, { signal, context });
+  } catch (error) {
+    if (error instanceof Error && /HTTP 404/.test(error.message)) return [];
+    throw error;
+  }
   let parsed: { languages?: readonly Record<string, unknown>[] };
   try {
     parsed = JSON.parse(text) as { languages?: readonly Record<string, unknown>[] };
@@ -506,8 +521,10 @@ export async function collectAnidbAvailableAudioModes(
 ): Promise<readonly ("sub" | "dub")[]> {
   const languages = await fetchAnidbLanguages(episodeId, signal, context);
   const modes: ("sub" | "dub")[] = [];
-  if (languages.some((entry) => entry.code === "jpn")) modes.push("sub");
-  if (languages.some((entry) => entry.code === "eng")) modes.push("dub");
+  // Exact `jpn`/`eng` only — `kor`/future codes are runtime evidence, not a
+  // third audio mode. Case-insensitive to match `languageEntryForMode`.
+  if (languages.some((entry) => entry.code.toLowerCase() === "jpn")) modes.push("sub");
+  if (languages.some((entry) => entry.code.toLowerCase() === "eng")) modes.push("dub");
   return modes;
 }
 

--- a/packages/providers/src/anidb/direct.ts
+++ b/packages/providers/src/anidb/direct.ts
@@ -98,7 +98,25 @@ async function resolveAnidbShow(
   context?: ProviderRuntimeContext,
 ): Promise<AnidbSearchResult | null> {
   const direct = directAnidbShowFromInput(input);
-  if (direct) return direct;
+  if (direct) {
+    // A persisted `providerNativeIds.anidb` can point at a reindexed slug
+    // (fixtures used 19413, live is 4883). If the direct id's catalog 404s,
+    // fall back to title search so history doesn't strand.
+    const query = input.title.title?.trim() ?? "";
+    if (query) {
+      try {
+        const episodes = await fetchAnidbEpisodes(direct.id, signal, context);
+        if (episodes.length === 0) {
+          const searched = await searchAnidb(query, signal, context);
+          const match = chooseAnidbSearchMatch(query, searched);
+          if (match) return match;
+        }
+      } catch {
+        // Transient / Cloudflare — keep direct, let caller surface retryable
+      }
+    }
+    return direct;
+  }
 
   const query = input.title.title?.trim() ?? "";
   if (!query) return null;

--- a/packages/providers/src/anidb/direct.ts
+++ b/packages/providers/src/anidb/direct.ts
@@ -40,6 +40,8 @@ import {
   ANIDB_USER_AGENT,
   anidbNumericId,
   chooseAnidbSearchMatch,
+  fetchAnidbEpisodeCatalog,
+  type AnidbEpisodeCatalog,
   fetchAnidbEpisodes,
   fetchAnidbExternalIds,
   fetchAnidbOfficialEpisodeMetadata,
@@ -61,6 +63,7 @@ export {
   chooseAnidbSearchMatch,
   clearAnidbCachesForTest,
   collectAnidbAvailableAudioModes,
+  fetchAnidbEpisodeCatalog,
   fetchAnidbExternalIds,
   fetchAnidbOfficialEpisodeMetadata,
   fetchAnidbMalId,
@@ -72,6 +75,7 @@ export {
   runAnidbCurlWithRetry,
   resolveAnidbEpisodeStreams,
   searchAnidb,
+  type AnidbEpisodeCatalog,
   type AnidbSearchResult,
   type AnidbSeasonEvidence,
 } from "./client";
@@ -100,22 +104,37 @@ async function resolveAnidbShow(
   const direct = directAnidbShowFromInput(input);
   if (direct) {
     // A persisted `providerNativeIds.anidb` can point at a reindexed slug
-    // (fixtures used 19413, live is 4883). If the direct id's catalog 404s,
-    // fall back to title search so history doesn't strand.
+    // (Solo Leveling 19413 → 4883), which 404s permanently. Re-search so a
+    // history entry does not strand — but only on evidence that the id is
+    // actually gone.
     const query = input.title.title?.trim() ?? "";
-    if (query) {
-      try {
-        const episodes = await fetchAnidbEpisodes(direct.id, signal, context);
-        if (episodes.length === 0) {
-          const searched = await searchAnidb(query, signal, context);
-          const match = chooseAnidbSearchMatch(query, searched);
-          if (match) return match;
-        }
-      } catch {
-        // Transient / Cloudflare — keep direct, let caller surface retryable
-      }
+    if (!query) return direct;
+
+    let catalog: AnidbEpisodeCatalog;
+    try {
+      catalog = await fetchAnidbEpisodeCatalog(direct.id, signal, context);
+    } catch (error) {
+      // The caller cancelling is a decision, not an anidb condition: returning
+      // a result nobody awaits hides it. An internal timeout is different and
+      // stays below, where keeping the id is right.
+      if (signal?.aborted === true) throw error;
+      // Cloudflare or a transient fault says nothing about whether the id is
+      // valid, so keep it and let the caller surface something retryable.
+      return direct;
     }
-    return direct;
+
+    // Only a 404 means the id is gone. An empty-but-present catalogue is a
+    // season that exists with no episodes listed yet; re-searching that would
+    // trade a correct id for whatever the browse page happens to rank first.
+    if (!catalog.missing) return direct;
+
+    const searched = await searchAnidb(query, signal, context);
+    return (
+      chooseAnidbSearchMatch(query, searched, { requireTitleEvidence: true }) ??
+      // No titled match: the dead id is more honest than a guess. Resolve
+      // surfaces `catalog-unavailable` from here.
+      direct
+    );
   }
 
   const query = input.title.title?.trim() ?? "";

--- a/packages/providers/test/anidb-reindex-drift.test.ts
+++ b/packages/providers/test/anidb-reindex-drift.test.ts
@@ -59,6 +59,19 @@ describe("episode catalogue", () => {
     expect(catalog).toEqual({ episodes: [], missing: false });
   });
 
+  test("a non-array episodes field is empty-but-present, not a crash", async () => {
+    // `{"episodes":{}}` parses cleanly, so `?? []` never fires and the value
+    // reaches `.flatMap`. That threw a TypeError out of the catalogue call —
+    // malformed upstream data became a crash instead of an empty listing, and
+    // an id that is probably fine would have looked broken.
+    const catalog = await fetchAnidbEpisodeCatalog(
+      "object-episodes-5003",
+      undefined,
+      contextReturning(() => ({ status: 200, body: JSON.stringify({ episodes: {} }) })),
+    );
+    expect(catalog).toEqual({ episodes: [], missing: false });
+  });
+
   test("an unparseable body is not reported as missing", async () => {
     // The id may be perfectly good and the response mangled; claiming the id is
     // gone would re-search on no evidence.
@@ -68,6 +81,34 @@ describe("episode catalogue", () => {
       contextReturning(() => ({ status: 200, body: "<html>nope" })),
     );
     expect(catalog.missing).toBe(false);
+  });
+
+  test("a cancelled caller is not retried through the curl fallback", async () => {
+    // The fallback exists so a Cloudflare challenge gets a second chance with a
+    // better TLS fingerprint. An abort is not a fingerprint problem: swallowing
+    // it spent a whole curl request on work nobody was waiting for. The
+    // internal 15s timeout still earns its retry, because this keys off the
+    // caller's signal rather than the error shape.
+    // Asserting "it rejects" would prove nothing: the fallback also rejects on
+    // an aborted signal, so both behaviours look identical from outside. The
+    // sentinel message only survives if the original error propagated instead
+    // of curl being consulted and producing its own.
+    const controller = new AbortController();
+    controller.abort();
+    let contextFetches = 0;
+    const context = {
+      fetch: {
+        async fetch() {
+          contextFetches += 1;
+          throw new Error("anidb-abort-sentinel");
+        },
+      },
+    } as unknown as ProviderRuntimeContext;
+
+    await expect(
+      fetchAnidbEpisodeCatalog("cancelled-5004", controller.signal, context),
+    ).rejects.toThrow("anidb-abort-sentinel");
+    expect(contextFetches).toBe(1);
   });
 
   test("a real catalogue still parses and sorts", async () => {

--- a/packages/providers/test/anidb-reindex-drift.test.ts
+++ b/packages/providers/test/anidb-reindex-drift.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { ProviderEpisodeListInput, ProviderRuntimeContext } from "@kunai/types";
+
+import {
+  chooseAnidbSearchMatch,
+  clearAnidbCachesForTest,
+  collectAnidbAvailableAudioModes,
+  fetchAnidbEpisodeCatalog,
+  parseAnidbSeasonEvidence,
+  type AnidbSearchResult,
+  anidbProviderModule,
+} from "../src/anidb/direct";
+import { urlHasHostname } from "./helpers/anidb-urls";
+
+/**
+ * anidb.app reindexes slugs, so a persisted `providerNativeIds.anidb` can
+ * point at an id that 404s forever (Solo Leveling 19413 → 4883). Repairing
+ * that needs to know the id is *gone* — which is not the same fact as the
+ * episode list being empty, and the two used to arrive as the same `[]`.
+ */
+afterEach(() => {
+  clearAnidbCachesForTest();
+});
+
+function contextReturning(
+  handler: (url: string) => { status: number; body: string },
+): ProviderRuntimeContext {
+  return {
+    fetch: {
+      async fetch(url: string) {
+        if (!urlHasHostname(url, "anidb.app")) throw new Error(`unexpected host: ${url}`);
+        const { status, body } = handler(url);
+        return new Response(body, { status });
+      },
+    },
+  } as unknown as ProviderRuntimeContext;
+}
+
+describe("episode catalogue", () => {
+  test("a 404 is reported as missing, not as an empty catalogue", async () => {
+    const catalog = await fetchAnidbEpisodeCatalog(
+      "solo-leveling-19413",
+      undefined,
+      contextReturning(() => ({ status: 404, body: "not found" })),
+    );
+    expect(catalog).toEqual({ episodes: [], missing: true });
+  });
+
+  test("a present but empty catalogue is not missing", async () => {
+    // A season that exists with nothing listed yet. Conflating this with a
+    // reindexed id is what sends the repair path off to search and hand back
+    // a different show.
+    const catalog = await fetchAnidbEpisodeCatalog(
+      "some-new-season-5001",
+      undefined,
+      contextReturning(() => ({ status: 200, body: JSON.stringify({ episodes: [] }) })),
+    );
+    expect(catalog).toEqual({ episodes: [], missing: false });
+  });
+
+  test("an unparseable body is not reported as missing", async () => {
+    // The id may be perfectly good and the response mangled; claiming the id is
+    // gone would re-search on no evidence.
+    const catalog = await fetchAnidbEpisodeCatalog(
+      "mangled-5002",
+      undefined,
+      contextReturning(() => ({ status: 200, body: "<html>nope" })),
+    );
+    expect(catalog.missing).toBe(false);
+  });
+
+  test("a real catalogue still parses and sorts", async () => {
+    const catalog = await fetchAnidbEpisodeCatalog(
+      "solo-leveling-4883",
+      undefined,
+      contextReturning(() => ({
+        status: 200,
+        body: JSON.stringify({
+          episodes: [
+            { id: 2, number: 2 },
+            { id: 1, number: 1 },
+          ],
+        }),
+      })),
+    );
+    expect(catalog.missing).toBe(false);
+    expect(catalog.episodes.map((entry) => entry.number)).toEqual([1, 2]);
+  });
+
+  test("a missing id is answered from cache rather than re-requested per call site", async () => {
+    // `resolveAnidbShow` and the episode-listing path both ask for the same id
+    // on one resolve. Without a cached miss a dead id costs a 404 round trip
+    // each time.
+    let calls = 0;
+    const context = contextReturning(() => {
+      calls += 1;
+      return { status: 404, body: "not found" };
+    });
+    await fetchAnidbEpisodeCatalog("gone-19413", undefined, context);
+    await fetchAnidbEpisodeCatalog("gone-19413", undefined, context);
+    expect(calls).toBe(1);
+  });
+});
+
+describe("audio modes", () => {
+  test("matches jpn/eng case-insensitively and ignores other languages", async () => {
+    // Live anidb returns `eng,jpn,kor`. `languageEntryForMode` already lower-cased
+    // before comparing; this collector did not, so the advertised modes could
+    // disagree with what the resolver would actually find.
+    const context = contextReturning(() => ({
+      status: 200,
+      body: JSON.stringify({
+        languages: [
+          { code: "JPN", embed_url: "https://anidb.app/e/1" },
+          { code: "Eng", embed_url: "https://anidb.app/e/2" },
+          { code: "kor", embed_url: "https://anidb.app/e/3" },
+        ],
+      }),
+    }));
+    expect(await collectAnidbAvailableAudioModes(16704, undefined, context)).toEqual([
+      "sub",
+      "dub",
+    ]);
+  });
+
+  test("a kor-only episode advertises neither mode", async () => {
+    const context = contextReturning(() => ({
+      status: 200,
+      body: JSON.stringify({ languages: [{ code: "kor", embed_url: "https://anidb.app/e/3" }] }),
+    }));
+    expect(await collectAnidbAvailableAudioModes(16705, undefined, context)).toEqual([]);
+  });
+});
+
+function card(id: string, title: string, numericId: number): AnidbSearchResult {
+  return { id, title, numericId, seasonEvidence: parseAnidbSeasonEvidence(title) };
+}
+
+describe("repair must not swap the show", () => {
+  const results: readonly AnidbSearchResult[] = [
+    card("unrelated-9001", "Some Other Anime", 9001),
+    card("solo-leveling-4883", "Solo Leveling", 4883),
+  ];
+
+  test("a user search still gets the top card when nothing matches", () => {
+    // Unchanged behaviour: a person who typed a query can see what they got.
+    expect(chooseAnidbSearchMatch("totally different", results)?.id).toBe("unrelated-9001");
+  });
+
+  test("repairing a persisted id refuses a match with no title evidence", () => {
+    // There is no reader here to notice the substitution, so a weak match must
+    // not silently replace the show the user previously chose.
+    expect(
+      chooseAnidbSearchMatch("totally different", results, { requireTitleEvidence: true }),
+    ).toBeNull();
+  });
+
+  test("repair still accepts a real title match", () => {
+    expect(
+      chooseAnidbSearchMatch("Solo Leveling", results, { requireTitleEvidence: true })?.id,
+    ).toBe("solo-leveling-4883");
+  });
+
+  test("repair accepts a prefix match, which is how the reindexed season resolves", () => {
+    const seasons: readonly AnidbSearchResult[] = [
+      card(
+        "solo-leveling-season-2-arise-from-the-shadow-4884",
+        "Solo Leveling Season 2: Arise from the Shadow",
+        4884,
+      ),
+    ];
+    expect(
+      chooseAnidbSearchMatch("Solo Leveling", seasons, { requireTitleEvidence: true })?.id,
+    ).toBe("solo-leveling-season-2-arise-from-the-shadow-4884");
+  });
+});
+
+/**
+ * The wiring, not just the parts: `resolveAnidbShow` must re-search only when
+ * the id is gone. `listEpisodes` is the cheapest entry point that runs it, and
+ * a browse request is the observable side effect of a repair attempt.
+ */
+describe("repair triggers only on a missing id", () => {
+  function countingContext(episodesStatus: number): {
+    context: ProviderRuntimeContext;
+    browseCalls: () => number;
+  } {
+    let browse = 0;
+    const context = contextReturning((url) => {
+      if (url.includes("/browse?q=")) {
+        browse += 1;
+        return { status: 200, body: "<html><body>no cards</body></html>" };
+      }
+      if (url.includes("/episodes")) {
+        return episodesStatus === 404
+          ? { status: 404, body: "not found" }
+          : { status: 200, body: JSON.stringify({ episodes: [] }) };
+      }
+      return { status: 200, body: "{}" };
+    });
+    return { context, browseCalls: () => browse };
+  }
+
+  // Only the fields `resolveAnidbShow` reads; the rest of the contract is not
+  // exercised by this path.
+  const input = {
+    title: {
+      id: "solo-leveling-19413",
+      title: "Solo Leveling",
+      externalIds: { providerNativeIds: { anidb: "solo-leveling-19413" } },
+    },
+  } as unknown as ProviderEpisodeListInput;
+
+  test("an empty catalogue does not trigger a search", async () => {
+    // The regression this guards: a season with nothing listed yet is not a
+    // stale id, and searching would trade a correct id for a browse ranking.
+    const { context, browseCalls } = countingContext(200);
+    await anidbProviderModule.listEpisodes?.(input, context);
+    expect(browseCalls()).toBe(0);
+  });
+
+  test("a 404 catalogue does trigger a search", async () => {
+    const { context, browseCalls } = countingContext(404);
+    await anidbProviderModule.listEpisodes?.(input, context);
+    expect(browseCalls()).toBeGreaterThan(0);
+  });
+});

--- a/packages/providers/test/anidb-season-routing.test.ts
+++ b/packages/providers/test/anidb-season-routing.test.ts
@@ -133,6 +133,29 @@ describe("routeAnidbSeason", () => {
     });
   });
 
+  test("routes a suffixed season title via prefix match (live: Arise from the Shadow)", async () => {
+    // Live `anidb.app` now serves `Solo Leveling Season 2: Arise from the
+    // Shadow` (4884). `parseAnidbSeasonEvidence` strips `Season 2` leaving
+    // `solo leveling arise from the shadow`, so the base `solo leveling`
+    // matches via `prefix` (score 1) not `exact`. This was the reindex drift
+    // `19413→4884` and must not fail closed.
+    const route = await routeAnidbSeason({
+      base: result("solo-leveling-4883", "Solo Leveling"),
+      episode: { season: 2, episode: 1 },
+      search: async () => [
+        result(
+          "solo-leveling-season-2-arise-from-the-shadow-4884",
+          "Solo Leveling Season 2: Arise from the Shadow",
+        ),
+        result("solo-leveling-how-to-get-stronger-4885", "Solo Leveling: How to Get Stronger"),
+      ],
+      episodes: noEpisodes,
+    });
+
+    expect(route?.routedShowId).toBe("solo-leveling-season-2-arise-from-the-shadow-4884");
+    expect(route?.evidence).toMatchObject({ titleMatch: "prefix", matchedSeason: 2 });
+  });
+
   test("returns null when equally ranked season siblings are ambiguous", async () => {
     const route = await routeAnidbSeason({
       base: result("demo-1", "Demo"),


### PR DESCRIPTION
## Summary
Audited `anidb.app` against live site + current `ani-cli@5.0.2`. Live IDs reindexed (Solo Leveling `19413→4883`, `19837→4884`) and language inventory expanded (`kor` alongside `jpn`/`eng` on `16704`). Provider was surfacing retryable `network-error` for stale 404s and case-sensitive `jpn`/`eng` check.

## Changes
- `packages/providers/src/anidb/client.ts` `fetchAnidbEpisodes`/`fetchAnidbLanguages`: catch `HTTP 404` → `[]` so resolve surfaces `catalog-unavailable` not looping `network-error`. Adds live drift tolerance for reindexed slugs.
- `packages/providers/src/anidb/client.ts` `collectAnidbAvailableAudioModes`: `toLowerCase()==="jpn"/"eng"` (was case-sensitive) and explicit comment that `kor`/future codes are ignored — matches `languageEntryForMode` and keeps `sub/dub` only. Prevents `kor`-only episodes from incorrectly advertising `dub`.
- `packages/providers/src/anidb/direct.ts` `resolveAnidbShow`: when `providerNativeIds.anidb` present, probe episodes; if empty (404) fallback to `searchAnidb(title)` via `chooseAnidbSearchMatch`. Stale `sqlite` history entries (e.g. `19413`) auto-heal without manual re-search. Transient/Cloudflare errors keep direct (let caller surface `blocked`).

## Verification
- `bun x turbo typecheck --force` green (14 tasks)
- `bun x turbo test --filter=@kunai/providers --force` `544 pass`
- Live smoke (isolated profile `HOME=$(mktemp -d)`): `anidb-onigiri.smoke.ts` `ok true` `2 streams hls.anidb.app` `2 searchResults`, `chrome150` impersonate present, `mpv` available.
- `curl-impersonate` stays soft `degraded` in `anime` scope only (`dependency-rows.ts:100-119`, `install-commands.ts:143-147` already correct) — residential IP plain `curl` still works, CI/datacenter gets impersonate, relay remains metadata-only alternative. No installer hard-require change.

## Other providers
No immediate drift. `allmanga/miruro/vidrock/vidlink/videasy` etc share same `curl-impersonate` discovery; `hls.anidb.app` streams stay direct. `allmanga` mkissa chunk is highest future drift risk — recommend separate `verify:provider-parity` script, not in this PR.

Worktree: `.worktrees/fix-anidb-audit` `fix/anidb-audit-drift` `a5bc4648` (on top of `fix/ci-anidb-tls-impersonation` `91169f33`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AniDB season matching for suffixed titles and reindexed show IDs.
  * Prevented valid empty catalogs from being mistaken for missing shows.
  * Improved handling of unavailable AniDB IDs and HTTP errors.
  * Recognized supported Japanese and English audio modes regardless of capitalization.
  * Ignored unsupported audio modes in live AniDB responses.

* **Documentation**
  * Updated the AniDB runtime contract with current matching, error-handling, and audio-mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->