### PR TITLE
fix(download): defer a full disk instead of spending the retry budget

### DIFF
--- a/.docs/download-offline-onboarding.md
+++ b/.docs/download-offline-onboarding.md
@@ -154,6 +154,15 @@ accounts, usage ping, done. Implementation is
   discoveries of the condition wait for space instead of spending attempts.
   Windows (`ERROR_DISK_FULL`) and quota (`EDQUOT`) spellings classify alongside
   POSIX `ENOSPC`.
+- A deferred job resumes on the next queue pass after its `next_retry_at`
+  elapses. Queue passes are event-driven (`kickQueue`: startup, opening
+  downloads, queueing another, offline repair) — there is no periodic tick,
+  and freeing disk space triggers nothing by itself. Paused-job messages
+  therefore state the action to take rather than promising an automatic
+  resume.
+- `resumeEligiblePausedJobs` is not the resume path and is not dead code: it
+  exists solely to heal a corrupt `next_retry_at`, which SQL string-compares
+  into `listPaused` while `selectEligibleQueuedJob` skips it forever.
 - Background queue triggers enter through one supervised seam. An unexpected
   reconciliation, repository, filesystem, or worker failure records a redacted
   download diagnostic and cannot terminate playback or the CLI.

--- a/.docs/download-offline-onboarding.md
+++ b/.docs/download-offline-onboarding.md
@@ -146,6 +146,14 @@ accounts, usage ping, done. Implementation is
 - Abort terminates active download processes (`yt-dlp`), deletes temporary files, and persists an aborted job state.
 - App shutdown pauses active downloads, cleans temporary workers, and leaves jobs retryable.
 - Failed jobs retry with bounded backoff and then surface as failed when retry limits are exhausted.
+- Storage exhaustion is deferred, not retried. The pre-flight reserve check
+  pauses a job whose start would breach the free-space reserve; a volume that
+  fills _during_ a transfer classifies as `disk-full` and enters the same pause
+  lane, with a future `next_retry_at` and the attempt budget untouched. Retrying
+  a full disk only re-downloads the file from zero into the same wall, so both
+  discoveries of the condition wait for space instead of spending attempts.
+  Windows (`ERROR_DISK_FULL`) and quota (`EDQUOT`) spellings classify alongside
+  POSIX `ENOSPC`.
 - Background queue triggers enter through one supervised seam. An unexpected
   reconciliation, repository, filesystem, or worker failure records a redacted
   download diagnostic and cannot terminate playback or the CLI.

--- a/apps/cli/src/services/download/DownloadService.ts
+++ b/apps/cli/src/services/download/DownloadService.ts
@@ -1694,10 +1694,22 @@ export class DownloadService {
   }
 
   /**
-   * Auto-resume on return: a previous quit pauses active jobs with
-   * `next_retry_at = now`, so on the next launch they are immediately eligible —
-   * re-queue them. Disk-space pauses carry a FUTURE retry time and stay paused
-   * until that elapses, so they are not prematurely resumed here.
+   * Repair for an unparseable `next_retry_at`, not the ordinary resume path.
+   *
+   * The ordinary case needs nothing from here: `selectEligibleQueuedJob` scans
+   * `listQueued`, which is unfiltered by retry time, and takes any job whose
+   * `next_retry_at` has elapsed. A shutdown pause (`next_retry_at = now`) is
+   * therefore already eligible on the next pass.
+   *
+   * What it does do is narrow and load-bearing. `listPaused` compares
+   * `next_retry_at` as a *string* in SQL, so a corrupt value like `not-a-date`
+   * sorts greater than any timestamp and is returned here, while
+   * `selectEligibleQueuedJob` requires `Number.isFinite` and skips it forever.
+   * Without this pass such a row is stranded for the life of the install.
+   *
+   * Verified against a real database rather than by reading: a future-dated
+   * pause is returned by `listPaused` and requeued by nobody; a corrupt one is
+   * requeued only here.
    */
   private resumeEligiblePausedJobs(): void {
     const now = Date.now();
@@ -1915,9 +1927,16 @@ export class DownloadService {
    * Deliberately not phrased as a reserve breach: the reserve message names a
    * figure the pre-flight check computed, and there is no such figure once the
    * volume is actually full.
+   *
+   * It also does not promise an automatic resume. Freeing space triggers
+   * nothing on its own — the deferral is time-based, and a queue pass only
+   * happens on a `kickQueue` (startup, opening downloads, queueing another,
+   * offline repair). There is no periodic tick, so an idle session can hold a
+   * due job indefinitely. Stating the action the user can actually take beats
+   * a promise the runtime does not keep.
    */
   private formatDiskExhaustedMessage(): string {
-    return "Download paused because the download volume ran out of space. It resumes automatically once space is free.";
+    return "Download paused because the download volume ran out of space. Free space, then retry it from /downloads.";
   }
 
   private formatInsufficientDiskMessage(requiredBytes: number): string {

--- a/apps/cli/src/services/download/DownloadService.ts
+++ b/apps/cli/src/services/download/DownloadService.ts
@@ -71,6 +71,13 @@ const STALLED_HEARTBEAT_MS = 90_000;
 const STDERR_MAX_BYTES = 64_000;
 const DEFAULT_ABORT_GRACE_MS = 2_500;
 const DEFAULT_INACTIVE_WAIT_MS = 5_000;
+/**
+ * How long a job waits when storage is unusable rather than the download being
+ * wrong — an unavailable folder, a breached reserve, or a volume that filled
+ * mid-transfer. Long enough that a full disk is not re-attempted in a tight
+ * loop, short enough that freeing space is noticed within one sitting.
+ */
+const STORAGE_DEFERRAL_RETRY_MS = 30 * 60 * 1000;
 const FFPROBE_DEADLINE_MS = 30_000;
 const FFPROBE_TERMINATION_GRACE_MS = 2_500;
 const FFPROBE_FORCE_WAIT_MS = 2_500;
@@ -648,7 +655,7 @@ export class DownloadService {
     } catch (error) {
       this.claimedJobIds.delete(next.id);
       const detail = error instanceof Error ? error.message : String(error);
-      const retryAt = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+      const retryAt = new Date(Date.now() + STORAGE_DEFERRAL_RETRY_MS).toISOString();
       this.deps.repo.pause(
         next.id,
         `Download paused because the download folder is unavailable: ${detail}`,
@@ -667,7 +674,7 @@ export class DownloadService {
 
     if (!storage.allowed) {
       this.claimedJobIds.delete(next.id);
-      const retryAt = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+      const retryAt = new Date(Date.now() + STORAGE_DEFERRAL_RETRY_MS).toISOString();
       this.deps.repo.pause(
         next.id,
         this.formatInsufficientDiskMessage(storage.requiredBytes),
@@ -744,7 +751,29 @@ export class DownloadService {
       } else {
         const analysis = analyzeDownloadFailure(message);
         const retriesLeft = next.retryCount + 1 < next.maxAttempts;
-        if (analysis.retryable && retriesLeft) {
+        if (analysis.failureKind === "disk-full") {
+          // The pre-flight reserve check only sees the volume as it was before
+          // the transfer started. A disk that fills underneath a running job —
+          // because the estimate was low, or because something else consumed
+          // the space — used to land in `unknown`, which is retryable: the job
+          // re-downloaded from zero into the same full disk until it had spent
+          // every attempt. Defer it the way the pre-flight check defers, so
+          // both discoveries of the same condition behave the same and the
+          // retry budget survives to be useful once space is freed.
+          this.deps.repo.pause(
+            next.id,
+            this.formatDiskExhaustedMessage(),
+            new Date(Date.now() + STORAGE_DEFERRAL_RETRY_MS).toISOString(),
+            failedAt,
+          );
+          this.deps.diagnostics?.record({
+            category: "download",
+            level: "warn",
+            operation: "download.capacity.midflight",
+            message: "Download paused because the download volume filled during the transfer",
+            context: { jobId: next.id },
+          });
+        } else if (analysis.retryable && retriesLeft) {
           const retryAt = new Date(Date.now() + retryDelayMs(next.retryCount)).toISOString();
           this.deps.repo.scheduleRetry(next.id, message, retryAt, failedAt);
         } else {
@@ -1882,6 +1911,15 @@ export class DownloadService {
     );
   }
 
+  /**
+   * Deliberately not phrased as a reserve breach: the reserve message names a
+   * figure the pre-flight check computed, and there is no such figure once the
+   * volume is actually full.
+   */
+  private formatDiskExhaustedMessage(): string {
+    return "Download paused because the download volume ran out of space. It resumes automatically once space is free.";
+  }
+
   private formatInsufficientDiskMessage(requiredBytes: number): string {
     const requiredGB = requiredBytes / (1024 * 1024 * 1024);
     return `Download paused because the offline safety reserve needs ${requiredGB.toFixed(1)}GB available on the download volume.`;
@@ -2036,6 +2074,14 @@ function redactDownloadQueueAggregateText(value: string, maxStringLength: number
 
 export function analyzeDownloadFailure(message: string): DownloadFailureAnalysis {
   const normalized = message.toLowerCase();
+  // First, and never `retryable`: a retry re-downloads the whole file from
+  // zero and fails at the same byte, spending a provider request per attempt
+  // against a disk that is still full. `processNextQueued` defers this kind
+  // into the same pause lane the pre-flight reserve check uses, so a volume
+  // that fills mid-transfer ends up where one that was already full does.
+  if (isDiskExhaustionMessage(normalized)) {
+    return { failureKind: "disk-full", retryable: false };
+  }
   if (normalized.includes("artifact-validation-timeout")) {
     return { failureKind: "artifact-timeout", retryable: false };
   }
@@ -2095,6 +2141,25 @@ export function analyzeDownloadFailure(message: string): DownloadFailureAnalysis
     return { failureKind: "network", retryable: true };
   }
   return { failureKind: "unknown", retryable: true };
+}
+
+/**
+ * Every spelling of "the volume is full" that can reach us.
+ *
+ * Matched on phrases rather than the bare words "disk" or "space" so an
+ * upstream message like `HTTP Error 500: disk backend unavailable` is not
+ * claimed as a local storage failure.
+ */
+function isDiskExhaustionMessage(normalized: string): boolean {
+  return (
+    // POSIX ENOSPC as yt-dlp, ffmpeg and node:fs each render it.
+    normalized.includes("no space left on device") ||
+    normalized.includes("enospc") ||
+    // Windows ERROR_DISK_FULL never uses the POSIX wording.
+    normalized.includes("not enough space on the disk") ||
+    // EDQUOT is a full disk from the writer's side: same cause and remedy.
+    normalized.includes("disk quota exceeded")
+  );
 }
 
 function resolveThumbnailArtifactPath(outputPath: string): string {

--- a/apps/cli/src/services/download/DownloadService.ts
+++ b/apps/cli/src/services/download/DownloadService.ts
@@ -2074,19 +2074,29 @@ function redactDownloadQueueAggregateText(value: string, maxStringLength: number
 
 export function analyzeDownloadFailure(message: string): DownloadFailureAnalysis {
   const normalized = message.toLowerCase();
-  // First, and never `retryable`: a retry re-downloads the whole file from
-  // zero and fails at the same byte, spending a provider request per attempt
-  // against a disk that is still full. `processNextQueued` defers this kind
-  // into the same pause lane the pre-flight reserve check uses, so a volume
-  // that fills mid-transfer ends up where one that was already full does.
-  if (isDiskExhaustionMessage(normalized)) {
-    return { failureKind: "disk-full", retryable: false };
-  }
   if (normalized.includes("artifact-validation-timeout")) {
     return { failureKind: "artifact-timeout", retryable: false };
   }
   if (normalized.includes("artifact-invalid")) {
     return { failureKind: "artifact-invalid", retryable: false };
+  }
+
+  // After the two `artifact-*` branches and before everything else.
+  //
+  // Those two prefixes are markers this file constructs itself, with terminal
+  // semantics chosen deliberately; the disk phrases below are unstructured
+  // vendor text scraped from yt-dlp, ffmpeg or the OS. A structured marker we
+  // wrote outranks a substring we found — otherwise a stray "no space left on
+  // device" anywhere in an artifact-validation message silently re-routes our
+  // own classification.
+  //
+  // Never `retryable`: a retry re-downloads the whole file from zero and fails
+  // at the same byte, spending a provider request per attempt against a disk
+  // that is still full. `processNextQueued` defers this kind into the same
+  // pause lane the pre-flight reserve check uses, so a volume that fills
+  // mid-transfer ends up where one that was already full does.
+  if (isDiskExhaustionMessage(normalized)) {
+    return { failureKind: "disk-full", retryable: false };
   }
   if (normalized.includes("download aborted") || normalized.includes("aborted")) {
     return { failureKind: "aborted", retryable: false };

--- a/apps/cli/test/unit/services/download/download-disk-exhaustion.test.ts
+++ b/apps/cli/test/unit/services/download/download-disk-exhaustion.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { DownloadService } from "@/services/download/DownloadService";
+import type { ConfigService } from "@/services/persistence/ConfigService";
+import { DownloadJobsRepository, openKunaiDatabase, runMigrations } from "@kunai/storage";
+
+/**
+ * The pre-flight reserve check in `processNextQueued` only sees the volume as
+ * it was before the transfer began. When the disk fills *underneath* a running
+ * job, the failure arrives as yt-dlp stderr instead — and it used to classify
+ * as `unknown`, which is `retryable: true`. The job then re-downloaded the
+ * whole file from zero into the same full disk, once per attempt, until the
+ * budget was gone: several full transfers spent, several provider requests
+ * spent, and a terminal `unknown` failure at the end of it with no indication
+ * that the remedy was to free space.
+ *
+ * The seam here is `resolveDownloadStream`, which is the injectable dependency
+ * that reaches the same catch block a failing yt-dlp reaches. The classifier
+ * reads a message either way, and `runYtDlpProcess` keeps the tail of stderr
+ * (`appendBoundedText` slices `-maxBytes`), so the real fatal write error is
+ * present in the string production classifies.
+ */
+let tempDir: string;
+let db: ReturnType<typeof openKunaiDatabase>;
+let repo: DownloadJobsRepository;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "kunai-download-space-"));
+  db = openKunaiDatabase(join(tempDir, "data.sqlite"));
+  runMigrations(db, "data");
+  repo = new DownloadJobsRepository(db);
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(tempDir, { recursive: true, force: true });
+  mock.restore();
+});
+
+function buildService(failure: string): DownloadService {
+  return new DownloadService({
+    repo,
+    titleAliases: { upsertAliases() {} },
+    config: {
+      downloadsEnabled: true,
+      downloadPath: join(tempDir, "downloads"),
+      offlineArtworkCacheEnabled: false,
+      // Zero reserve and a one-byte estimate keep the *pre-flight* check
+      // passing, so the test exercises the mid-transfer discovery rather than
+      // the admission one it is meant to complement.
+      offlineFreeSpaceReserveBytes: 0,
+      offlineUnknownEpisodeEstimateBytes: 1,
+    } as ConfigService,
+    ytDlpAvailable: true,
+    ffprobeAvailable: false,
+    resolveDownloadStream: () => {
+      throw new Error(failure);
+    },
+    logger: {
+      debug() {},
+      info() {},
+      warn() {},
+      error() {},
+      fatal() {},
+      child() {
+        return this;
+      },
+    },
+  });
+}
+
+test("a volume that fills mid-transfer defers the job instead of spending its retries", async () => {
+  const service = buildService("ERROR: unable to write data: [Errno 28] No space left on device");
+  const job = await service.enqueue({
+    title: { id: "tmdb:1", type: "series", name: "Frieren" },
+    episode: { season: 1, episode: 3, name: "Episode 3" },
+    providerId: "allanime",
+    mode: "anime",
+  });
+
+  await service.processNextQueued();
+
+  const after = repo.get(job.id);
+  // `repo.pause` keeps the row queued and defers it through next_retry_at, so
+  // the retry window is the signal — the same one the pre-flight reserve pause
+  // and the unavailable-folder pause produce.
+  expect(after?.status).toBe("queued");
+  expect(after?.errorMessage).toContain("ran out of space");
+
+  // The whole point: the attempt budget is untouched, so it is still there
+  // once space is freed. Before the fix this was 1 and climbing.
+  expect(after?.retryCount).toBe(0);
+
+  // Deferred into the future, not immediately eligible — otherwise the queue
+  // would spin on a disk that is still full.
+  const retryAt = after?.nextRetryAt ? Date.parse(after.nextRetryAt) : Number.NaN;
+  expect(Number.isFinite(retryAt)).toBe(true);
+  expect(retryAt).toBeGreaterThan(Date.now());
+});
+
+test("an ordinary transient failure still consumes an attempt", async () => {
+  // The complement: proving disk-full is deferred is only meaningful if the
+  // normal retry lane is untouched by the new branch.
+  const service = buildService("Unable to download webpage: connection reset");
+  const job = await service.enqueue({
+    title: { id: "tmdb:2", type: "series", name: "Frieren" },
+    episode: { season: 1, episode: 4, name: "Episode 4" },
+    providerId: "allanime",
+    mode: "anime",
+  });
+
+  await service.processNextQueued();
+
+  const after = repo.get(job.id);
+  expect(after?.retryCount).toBe(1);
+});

--- a/apps/cli/test/unit/services/download/download-failure-classification.test.ts
+++ b/apps/cli/test/unit/services/download/download-failure-classification.test.ts
@@ -42,3 +42,56 @@ describe("download failure classification", () => {
     });
   });
 });
+
+/**
+ * A full disk is the one failure where retrying is actively harmful: every
+ * attempt re-downloads the whole file from zero, fails at the same byte, and
+ * spends a provider request to do it. Before this classification it landed in
+ * the `unknown` bucket, which is `retryable: true`, so it burned the entire
+ * `maxAttempts` budget against a disk that was still full.
+ *
+ * yt-dlp's stderr reaches `analyzeDownloadFailure` verbatim —
+ * `runYtDlpProcess` keeps the *tail* of the stream (`appendBoundedText` slices
+ * `-maxBytes`), which is where a fatal write error lands — so these are the
+ * real strings, not paraphrases.
+ */
+describe("disk exhaustion", () => {
+  test("classifies the POSIX write failure yt-dlp and ffmpeg emit", () => {
+    expect(
+      analyzeDownloadFailure("ERROR: unable to write data: [Errno 28] No space left on device"),
+    ).toEqual({ failureKind: "disk-full", retryable: false });
+    expect(analyzeDownloadFailure("av_interleaved_write_frame(): No space left on device")).toEqual(
+      { failureKind: "disk-full", retryable: false },
+    );
+  });
+
+  test("classifies the Node and Windows spellings", () => {
+    // Sidecar and artwork writes go through node:fs, which prefixes the code.
+    expect(analyzeDownloadFailure("ENOSPC: no space left on device, write")).toEqual({
+      failureKind: "disk-full",
+      retryable: false,
+    });
+    // Windows never says "No space left on device"; a Windows-only spelling is
+    // the difference between this working on one platform and on three.
+    expect(analyzeDownloadFailure("[WinError 112] There is not enough space on the disk")).toEqual({
+      failureKind: "disk-full",
+      retryable: false,
+    });
+  });
+
+  test("classifies an exhausted quota as the same condition", () => {
+    // EDQUOT is a full disk from the writer's point of view: same cause, same
+    // remedy, and the same reason not to retry.
+    expect(analyzeDownloadFailure("OSError: [Errno 122] Disk quota exceeded")).toEqual({
+      failureKind: "disk-full",
+      retryable: false,
+    });
+  });
+
+  test("does not claim unrelated failures that merely mention space or disk", () => {
+    expect(analyzeDownloadFailure("HTTP Error 500: disk backend unavailable")).toEqual({
+      failureKind: "http-server",
+      retryable: true,
+    });
+  });
+});

--- a/apps/cli/test/unit/services/download/download-failure-classification.test.ts
+++ b/apps/cli/test/unit/services/download/download-failure-classification.test.ts
@@ -88,6 +88,35 @@ describe("disk exhaustion", () => {
     });
   });
 
+  test("our own artifact markers outrank scraped vendor text", () => {
+    // The `artifact-*` prefixes are constructed in DownloadService itself and
+    // carry deliberate terminal semantics. The disk phrases are unstructured
+    // text scraped from yt-dlp, ffmpeg or the OS. If a stray "no space left on
+    // device" rode along in an artifact-validation message, letting it win
+    // would silently re-route our own classification into the pause lane and
+    // make a corrupt artifact look like a recoverable storage condition.
+    expect(
+      analyzeDownloadFailure("artifact-invalid: ffprobe rejected output; No space left on device"),
+    ).toEqual({ failureKind: "artifact-invalid", retryable: false });
+    expect(
+      analyzeDownloadFailure(
+        "artifact-validation-timeout: ffprobe exceeded 30000ms; no space left on device",
+      ),
+    ).toEqual({ failureKind: "artifact-timeout", retryable: false });
+  });
+
+  test("a self-abort caused by the disk filling is classified as the disk", () => {
+    // A user-initiated cancel never reaches the classifier — `processNextQueued`
+    // checks `activeProcesses`/`cancellationRequests` first — so this string
+    // only arises when yt-dlp aborts itself over the write failure. The cause
+    // is the disk, and the disk is what the user has to act on.
+    expect(
+      analyzeDownloadFailure(
+        "ERROR: unable to write data; download aborted: [Errno 28] No space left on device",
+      ),
+    ).toEqual({ failureKind: "disk-full", retryable: false });
+  });
+
   test("does not claim unrelated failures that merely mention space or disk", () => {
     expect(analyzeDownloadFailure("HTTP Error 500: disk backend unavailable")).toEqual({
       failureKind: "http-server",

--- a/apps/cli/test/unit/services/download/download-paused-job-recovery.test.ts
+++ b/apps/cli/test/unit/services/download/download-paused-job-recovery.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { DownloadService } from "@/services/download/DownloadService";
+import type { ConfigService } from "@/services/persistence/ConfigService";
+import { DownloadJobsRepository, openKunaiDatabase, runMigrations } from "@kunai/storage";
+
+/**
+ * `resumeEligiblePausedJobs` reads as dead code and is not.
+ *
+ * Its requeue looks unreachable: `listPaused` selects `next_retry_at > now`,
+ * and the loop then requeues only when `retryAt <= now`. Those are disjoint for
+ * every well-formed timestamp, so a reviewer reasonably concludes the function
+ * never fires and deletes it.
+ *
+ * The reachable case is a *corrupt* `next_retry_at`. SQL compares that column
+ * as a string, so `not-a-date` sorts above any ISO timestamp and is returned;
+ * `Date.parse` then yields NaN, the `!Number.isFinite` arm fires, and the row
+ * is healed. `selectEligibleQueuedJob` cannot do this — it requires a finite,
+ * elapsed timestamp, so it skips such a row for the life of the install.
+ *
+ * This test exists so the deletion fails loudly instead of quietly stranding
+ * every job that ever gets a bad timestamp written to it.
+ */
+let tempDir: string;
+let db: ReturnType<typeof openKunaiDatabase>;
+let repo: DownloadJobsRepository;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "kunai-paused-recovery-"));
+  db = openKunaiDatabase(join(tempDir, "data.sqlite"));
+  runMigrations(db, "data");
+  repo = new DownloadJobsRepository(db);
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(tempDir, { recursive: true, force: true });
+  mock.restore();
+});
+
+function buildService(): DownloadService {
+  return new DownloadService({
+    repo,
+    titleAliases: { upsertAliases() {} },
+    config: {
+      downloadsEnabled: true,
+      downloadPath: join(tempDir, "downloads"),
+      offlineArtworkCacheEnabled: false,
+      offlineFreeSpaceReserveBytes: 0,
+      offlineUnknownEpisodeEstimateBytes: 1,
+    } as ConfigService,
+    ytDlpAvailable: true,
+    ffprobeAvailable: false,
+    // Fail the transfer immediately: this test is about job selection, and a
+    // resolver that throws keeps it off the network entirely.
+    resolveDownloadStream: () => {
+      throw new Error("resolver unavailable for this test");
+    },
+    logger: {
+      debug() {},
+      info() {},
+      warn() {},
+      error() {},
+      fatal() {},
+      child() {
+        return this;
+      },
+    },
+  });
+}
+
+test("a corrupt next_retry_at is healed instead of stranding the job forever", async () => {
+  const service = buildService();
+  const job = await service.enqueue({
+    title: { id: "tmdb:1", type: "series", name: "Frieren" },
+    episode: { season: 1, episode: 3, name: "Episode 3" },
+    providerId: "allanime",
+    mode: "anime",
+  });
+
+  db.query(
+    "UPDATE download_jobs SET status = 'queued', next_retry_at = 'not-a-date' WHERE id = ?",
+  ).run(job.id);
+  expect(repo.get(job.id)?.nextRetryAt).toBe("not-a-date");
+
+  await service.processQueue();
+
+  const healed = repo.get(job.id);
+  // The corrupt window is gone. It is not `undefined`: the heal requeues the
+  // row, the same pass then selects and attempts it, and the failing resolver
+  // schedules a fresh retry — which is the proof it became reachable at all.
+  expect(healed?.nextRetryAt).not.toBe("not-a-date");
+  expect(Number.isFinite(Date.parse(healed?.nextRetryAt ?? ""))).toBe(true);
+  // Attempted, not merely re-timestamped. Without the heal this stays 0
+  // forever because `selectEligibleQueuedJob` can never pick the row.
+  expect(healed?.retryCount).toBe(1);
+});
+
+test("a genuinely deferred job keeps its retry window", async () => {
+  // The complement, and the reason the heal cannot simply requeue everything
+  // `listPaused` returns: a disk-full or unavailable-folder pause must stay
+  // deferred, not be resumed on the next queue pass.
+  const service = buildService();
+  const job = await service.enqueue({
+    title: { id: "tmdb:2", type: "series", name: "Frieren" },
+    episode: { season: 1, episode: 4, name: "Episode 4" },
+    providerId: "allanime",
+    mode: "anime",
+  });
+
+  const retryAt = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+  repo.pause(job.id, "deferred", retryAt, new Date().toISOString());
+
+  await service.processQueue();
+
+  expect(repo.get(job.id)?.nextRetryAt).toBe(retryAt);
+});


### PR DESCRIPTION
## What this is

An audit of relay, analytics, player, downloads and provider-resolve was handed
to me to verify and act on. I applied
[`.docs/agents/audit-findings-bar.md`](.docs/agents/audit-findings-bar.md) to
each item. **Four of the five dissolved on inspection. One was real, and this PR
fixes it.**

## The real one: a full disk burned the retry budget

`analyzeDownloadFailure` had no disk-space branch, so a volume that filled
*during* a transfer fell through to `unknown` — and `unknown` is `retryable`.
The job re-downloaded the whole file from zero into the same full disk, once per
attempt, until the budget was gone: several complete transfers, a provider
request each, ending in a terminal `unknown` failure that never told the user
the remedy was to free space.

The pre-flight reserve check already pauses a job it can see will not fit
(`processNextQueued`, `!storage.allowed`). The pause machinery, the future
`next_retry_at`, and the `resumeEligiblePausedJobs` comment that explicitly
reasons about "disk-space pauses" were all already there — **only the mid-flight
discovery never reached them.** This routes it into that same lane.

- `disk-full` classifies as non-retryable and pauses with a future
  `next_retry_at`; `repo.pause` does not increment `retry_count`, so the budget
  survives for when space is actually freed.
- Phrase matching, not the bare words "disk"/"space", so an upstream
  `HTTP Error 500: disk backend unavailable` is not claimed as a local storage
  failure. Covered by a test.
- The 30-minute deferral both existing storage pauses had inline is now the
  shared, named `STORAGE_DEFERRAL_RETRY_MS`.

**Every platform** (an AGENTS.md seam, and the main risk here): POSIX `ENOSPC` as
yt-dlp, ffmpeg and `node:fs` each render it; Windows `ERROR_DISK_FULL`, which
never uses the POSIX wording; and `EDQUOT`. Tests assert all three spellings
without pinning an OS.

### The check that mattered

Classification is worthless if the text never arrives. `throw new Error(stderr.trim())`
passes yt-dlp's stderr verbatim, and `runYtDlpProcess` keeps the **tail**
(`appendBoundedText` → `next.slice(-maxBytes)`) — which is exactly where a fatal
write error lands. Had it kept the head, this fix would not fire in production.

## The four that dissolved

| Finding | Verdict |
|---|---|
| Analytics endpoint not `https`-normalized like relay | **Already fixed.** `isTransportSafeAnalyticsEndpoint` + `acceptOverride` reject non-https and return `""` (stop sending) rather than silently redirecting to Kunai's endpoint. Landed in #286, with tests at `usage-analytics-service.test.ts:243-261`. |
| Relay CORS `*` could be abused | **Not reachable.** The deployed path is fail-closed — no `RELAY_TOKEN` → 503 — and the dev server refuses `local-loopback` on a non-loopback host. With a required bearer and no `Allow-Credentials`, a browser cannot mint a call. README already states user-owned/not-a-public-proxy. |
| IPv6 `2000::/3` allow-shape too strict | **No action, and correct as written.** Verified the allow-shape plus IPv4-mapped handling and the exhaustive v4 non-public table (incl. 198.18/15, 192.88.99/24, 203.0.113/24, AS112). |
| `CI` / `DO_NOT_TRACK` env handling | Already marked done in the report; confirmed. |

I also re-checked two claims the audit asserted as safe rather than taking them
on trust: the mpv `tls-verify` bypass is genuinely scoped to `mp4upload.com` and
valid subdomains over https with control characters rejected, and the relay's
three SSRF layers (pre-DNS literal reject, post-DNS pre-connect filter, re-check
per redirect) are intact.

## Verification

Run in a clean worktree off `origin/main`, `--force` throughout so no result is
a turbo cache replay:

- `bun run typecheck --force` — 14/14
- `bun run lint` — 0 warnings, 0 errors
- `bun run fmt`, `bun run verify:doc-paths` — 51 docs, 2110 sources, all resolve
- `bun run test --force` — 23/23 tasks, **0 fail** (relay 116, providers 544, storage 184, core 104, integration 239 pass / 25 skip)
- `bun run build` — 10/10, host binary compiles

The new behavioral test was written after the fix, so I proved it bites: with
the routing branch disabled it fails (`expected "queued", received "failed"`),
and the classification tests were red first (`unknown` / `retryable: true`),
which is the defect stated exactly.

## Seams walked

`Declaration → reader` (the `disk-full` kind is read by the new routing branch)
· `Reverse states` (in = pause, out = `resumeEligiblePausedJobs` once
`next_retry_at` elapses, plus manual `retry`; visible via `errorMessage` and the
`download.capacity.midflight` diagnostic) · `Every platform` (three spellings) ·
`Docs` (`.docs/download-offline-onboarding.md` updated in the same change set).

Not applicable: `Both lanes` and `Every provider` — classification is
message-based and identity-independent. One known wart left alone: `repo.pause`
hardcodes `failure_kind = 'interrupted'`, so a paused disk-full job stores that
kind rather than `disk-full`. Behavior keys off `next_retry_at`, not the kind,
and `failureKind` has no UI reader today — changing the repo signature for an
unread field looked like scope creep. Happy to do it if you'd rather.

## Release readiness

No release blocker found. The four hazards hold: relay `baseUrl` is empty by
default, analytics needs an explicit keystroke, `KUNAI_CONFIG_DIR` is still not
an override, and no shared relay host is baked in. What remains before calling
analytics "privacy-preserving in prod" is operational, not code — Vercel
firewall rate limits, DB budget alerts, and `ANALYTICS_HASH_SECRET` stability —
and `.plans/usage-analytics-redesign.md` already owns that row.

https://claude.ai/code/session_01EV1oGFvwNTDBRV8uw5cWWQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Downloads that run out of disk space are now paused instead of repeatedly restarting.
  * Full-disk and quota-exhaustion errors are recognized across supported operating systems.
  * Paused downloads wait for storage to become available before retrying, without consuming retry attempts.
  * Transient download failures continue to follow the existing retry behavior.

* **Documentation**
  * Added guidance explaining how storage exhaustion and deferred retries are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->