### PR TITLE
ci: move the artifact and docker actions onto Node 24

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -60,7 +60,7 @@ jobs:
             --expected-version "${VERSION}"
 
       - name: Upload binaries artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: kunai-release-binaries
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,7 +642,7 @@ jobs:
 
       - name: Upload linux binaries for installer job
         if: needs.changes.outputs.installer == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: kunai-linux-binaries
           retention-days: 1
@@ -672,13 +672,13 @@ jobs:
         run: bash apps/cli/test/docker/native-installer/run-local.sh --list-scenarios >/dev/null
 
       - name: Download linux binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8
         with:
           name: kunai-linux-binaries
           path: apps/cli/dist/bin
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # docker/setup-buildx-action@v4
 
       - name: Cache installer smoke images
         uses: actions/cache@v5
@@ -690,7 +690,7 @@ jobs:
 
       - name: Build glibc smoke image
         if: matrix.variant == 'glibc'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # docker/build-push-action@v7
         with:
           context: apps/cli/test/docker/native-installer
           file: apps/cli/test/docker/native-installer/Dockerfile
@@ -702,7 +702,7 @@ jobs:
 
       - name: Build musl smoke image
         if: matrix.variant == 'musl'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # docker/build-push-action@v7
         with:
           context: apps/cli/test/docker/native-installer
           file: apps/cli/test/docker/native-installer/Dockerfile

--- a/.github/workflows/installer-matrix.yml
+++ b/.github/workflows/installer-matrix.yml
@@ -72,7 +72,7 @@ jobs:
           done
           [ "$missing" -eq 0 ] || exit 1
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: kunai-linux-binaries-matrix
           retention-days: 1
@@ -109,14 +109,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Download linux binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8
         with:
           name: kunai-linux-binaries-matrix
           path: apps/cli/dist/bin
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # docker/setup-buildx-action@v4
       - name: Build smoke image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # docker/build-push-action@v7
         with:
           context: apps/cli/test/docker/native-installer
           file: apps/cli/test/docker/native-installer/Dockerfile

--- a/.github/workflows/provider-matrix.yml
+++ b/.github/workflows/provider-matrix.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: Upload redacted matrix artifact
         if: ${{ always() && (github.event_name == 'schedule' || github.event.inputs.mode != 'release-signoff') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: provider-matrix-${{ github.run_id }}
           path: artifacts/provider-matrix.json
@@ -159,7 +159,7 @@ jobs:
 
       - name: Upload release provider signoff artifact
         if: ${{ always() && github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'release-signoff' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: release-provider-signoff-${{ github.run_id }}
           path: artifacts/release-provider-signoff.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,7 +291,7 @@ jobs:
 
       - name: Upload candidate artifacts
         id: upload-candidate
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: ${{ env.CANDIDATE_ARTIFACT }}-${{ steps.ver.outputs.version }}-${{ github.sha }}
           retention-days: 14
@@ -305,7 +305,7 @@ jobs:
           path: .candidate-upload/
 
       - name: Upload repository gate evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: gate-repository-${{ steps.ver.outputs.version }}-${{ github.sha }}
           if-no-files-found: error
@@ -314,7 +314,7 @@ jobs:
             artifacts/gates/repository.log
 
       - name: Upload package gate evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: gate-package-${{ steps.ver.outputs.version }}-${{ github.sha }}
           if-no-files-found: error
@@ -323,7 +323,7 @@ jobs:
             artifacts/gates/package.log
 
       - name: Upload npm global install gate evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: gate-npmGlobalInstall-${{ steps.ver.outputs.version }}-${{ github.sha }}
           if-no-files-found: error
@@ -332,7 +332,7 @@ jobs:
             artifacts/gates/npmGlobalInstall.log
 
       - name: Upload compiled playback gate evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: gate-compiledPlayback-${{ steps.ver.outputs.version }}-${{ github.sha }}
           if-no-files-found: error
@@ -341,7 +341,7 @@ jobs:
             artifacts/gates/compiledPlayback.log
 
       - name: Upload release assets gate evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: gate-releaseAssets-${{ steps.ver.outputs.version }}-${{ github.sha }}
           if-no-files-found: error
@@ -376,7 +376,7 @@ jobs:
           skip-turbo-cache: "true"
 
       - name: Download preserved native candidate
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8
         with:
           artifact-ids: ${{ needs.candidate.outputs.candidate_artifact_id }}
           path: .release-download
@@ -459,7 +459,7 @@ jobs:
           skip-turbo-cache: "true"
 
       - name: Download exact preserved candidate
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8
         with:
           artifact-ids: ${{ needs.candidate.outputs.candidate_artifact_id }}
           path: .release-download
@@ -570,7 +570,7 @@ jobs:
           $help | Tee-Object -FilePath "artifacts/native-${{ matrix.id }}.log" -Append
 
       - name: Upload native smoke log
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: native-smoke-${{ needs.candidate.outputs.version }}-${{ github.sha }}-${{ matrix.id }}
           retention-days: 14
@@ -594,7 +594,7 @@ jobs:
           skip-turbo-cache: "true"
 
       - name: Download every native smoke log
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8
         with:
           pattern: native-smoke-${{ needs.candidate.outputs.version }}-${{ github.sha }}-*
           path: artifacts/native-logs
@@ -621,7 +621,7 @@ jobs:
             --output artifacts/nativePlatforms.json
 
       - name: Upload native platform gate evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: gate-nativePlatforms-${{ needs.candidate.outputs.version }}-${{ github.sha }}
           retention-days: 14
@@ -673,7 +673,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Upload installer harness log
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: installer-smoke-${{ needs.candidate.outputs.version }}-${{ github.sha }}-${{ matrix.id }}
           if-no-files-found: error
@@ -694,7 +694,7 @@ jobs:
         with:
           turbo-cache-prefix: release-installer-aggregate
           skip-turbo-cache: "true"
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8
         with:
           pattern: installer-smoke-${{ needs.candidate.outputs.version }}-${{ github.sha }}-*
           path: artifacts/installer-logs
@@ -719,7 +719,7 @@ jobs:
             --output artifacts/installer.json
 
       - name: Upload installer gate evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: gate-installer-${{ needs.candidate.outputs.version }}-${{ github.sha }}
           if-no-files-found: error
@@ -742,7 +742,7 @@ jobs:
         with:
           turbo-cache-prefix: release-readme-commands
           skip-turbo-cache: "true"
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8
         with:
           artifact-ids: ${{ needs.candidate.outputs.candidate_artifact_id }}
           path: .release-download
@@ -774,7 +774,7 @@ jobs:
             --output artifacts/readmeCommands.json
 
       - name: Upload README commands gate evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: gate-readmeCommands-${{ needs.candidate.outputs.version }}-${{ github.sha }}
           if-no-files-found: error
@@ -826,7 +826,7 @@ jobs:
             --output artifacts/liveProviders.json
 
       - name: Upload live provider gate evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: gate-liveProviders-${{ needs.candidate.outputs.version }}-${{ github.sha }}
           if-no-files-found: error
@@ -865,14 +865,14 @@ jobs:
           skip-turbo-cache: "true"
 
       - name: Download candidate artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8
         with:
           artifact-ids: ${{ needs.candidate.outputs.candidate_artifact_id }}
           path: .release-download
           merge-multiple: "true"
 
       - name: Download every gate evidence document and hashed artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8
         with:
           pattern: gate-*-${{ needs.candidate.outputs.version }}-${{ github.sha }}
           path: artifacts/gates
@@ -935,7 +935,7 @@ jobs:
           echo "binary_artifact=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Upload confirmation evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
         with:
           name: release-confirmation-${{ needs.candidate.outputs.version }}
           retention-days: 14
@@ -995,7 +995,7 @@ jobs:
           npm --version
 
       - name: Download candidate artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8
         with:
           artifact-ids: ${{ needs.confirmation.outputs.candidate_artifact_id }}
           path: .release-download


### PR DESCRIPTION
## What this closes

Every 0.3.0 release run carried **13 Node 20 deprecation warnings**. Four actions declared Node 20 and were being *forced* onto Node 24 by the runner — and the forcing is what goes away.

| Action | From | To | Runtime |
|---|---|---|---|
| `actions/upload-artifact` | v4.6.2 | **v7.0.1** | `node24` |
| `actions/download-artifact` | v4 | **v8.0.1** | `node24` |
| `docker/build-push-action` | v6 | **v7.3.0** | `node24` |
| `docker/setup-buildx-action` | v3 | **v4.3.0** | `node24` |

Each SHA was resolved from its tag ref and **verified to match** rather than copied off a release page, and each pinned `action.yml` was read to confirm it declares `using: node24`.

## Two things this had to not break

**`include-hidden-files` still exists on upload-artifact v7**, and still defaults to `false`. That input is the only reason the release candidate uploads at all from its dot-prefixed staging directory (#300). A rename would have re-broken the release the same week it was fixed — checked at the pinned SHA, not assumed.

**download-artifact v8 is the one real behaviour change.** It migrates to ESM, errors on digest mismatches by default, and reads `Content-Type` before unzipping rather than unzipping unconditionally.

- The unzip change is **inert here**: nothing sets `archive: false`, so our uploads stay zipped.
- Enforced digests are a **gain** for a pipeline that attests its candidate and re-verifies it at four boundaries.
- Every input `release.yml` passes — `artifact-ids`, `merge-multiple`, `path`, `pattern` — is present at the pinned SHA. `artifact-ids` in particular carries the candidate between jobs, so losing it would have broken publication.

## Convention

Tag-style call sites are now SHA-pinned with a major-version comment, matching what `release.yml` already did, so the mixed convention is gone. The comment format is major-only (`@v7`, not `@v7.0.1`) because `distribution-contract.test.ts:658` enforces exactly that — my first attempt used full versions and the contract test caught it.

## How this gets exercised

`release.yml` jobs never run in PR CI, so an upgrade there is untested until a dispatch. That is not the whole story though:

- **PR CI** exercises both artifact actions (`Build linux binaries` uploads, the native-installer cells download) and both docker actions in the installer PR-gate cells.
- **The installer matrix** exercises all four together and can be dispatched on `main` before the next release dispatch.

I'd suggest dispatching `Installer Docker Matrix` on `main` after this merges — it is the cheapest way to prove all four actions on real runners before the release pipeline depends on them.

## Verification

- All four SHA↔tag mappings confirmed, all four `using: node24`.
- `include-hidden-files` and every `download-artifact` input in use confirmed at the pinned SHAs.
- `distribution-contract.test.ts` — 57 pass; forced `fmt:check`; full suite green via the pre-push hook.
