### PR TITLE
fix(release): keep the releaseAssets evidence in one upload root

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,6 +277,12 @@ jobs:
             --artifact-path .candidate-upload/native/SHA256SUMS \
             --output artifacts/gates/releaseAssets.json
 
+          # The manifest is hashed above from its staged location, then copied
+          # beside the document that references it so the upload spans a single
+          # non-hidden root. Copied rather than moved: the candidate artifact
+          # and the exact-directory verifier both still read the original.
+          cp .candidate-upload/native/SHA256SUMS artifacts/gates/SHA256SUMS
+
       - name: Reverify exact staged native candidate
         run: |
           set -euo pipefail
@@ -345,14 +351,22 @@ jobs:
         with:
           name: gate-releaseAssets-${{ steps.ver.outputs.version }}-${{ github.sha }}
           if-no-files-found: error
-          # Same hidden-path exclusion as the candidate upload: this evidence
-          # set spans a visible gate document and a checksum manifest under the
-          # dot-prefixed staging directory, so the manifest is dropped without
-          # this and the gate ships incomplete.
-          include-hidden-files: true
+          # Both paths deliberately sit under `artifacts/gates`, and neither is
+          # hidden. upload-artifact roots an artifact at the least common
+          # ancestor of its paths, so pairing this document with the manifest
+          # at `.candidate-upload/native/SHA256SUMS` moved that root to the
+          # workspace and nested both a level deeper. The confirmation gate
+          # downloads every `gate-*` artifact with `merge-multiple` into
+          # `artifacts/gates`, so it then looked for `releaseAssets.json` and
+          # found `artifacts/gates/releaseAssets.json` instead.
+          #
+          # `include-hidden-files` on the candidate upload is still required —
+          # that whole tree is dot-prefixed. Here the fix is to not span two
+          # roots in the first place, which is sturdier than depending on where
+          # the LCA happens to land.
           path: |
             artifacts/gates/releaseAssets.json
-            .candidate-upload/native/SHA256SUMS
+            artifacts/gates/SHA256SUMS
 
   # ---------------------------------------------------------------------------
   # Verify the preserved candidate's bytes and provenance before any downstream


### PR DESCRIPTION
## The failure

The 0.3.0 dispatch (run `33510395101`) cleared **all fifteen gates** — candidate build, provenance, live provider signoff, both installer harnesses, README commands, and all six native smokes — then failed at the confirmation gate:

```
[release-evidence] evidence path is not readable:
  artifacts/gates/releaseAssets.json: ENOENT
```

Publish skipped. Nothing tagged, nothing published.

## The cause — a second-order effect of the hidden-files fix

`upload-artifact` roots an artifact at the **least common ancestor** of its paths. The `gate-releaseAssets` upload pairs two paths:

```
artifacts/gates/releaseAssets.json
.candidate-upload/native/SHA256SUMS      ← hidden
```

While the hidden path was being silently dropped (the pre-#300 behaviour), the LCA was `artifacts/gates` and the document sat at the artifact root. Adding `include-hidden-files: true` pulled the second path back in, moved the LCA to the workspace, and nested both a level deeper.

Confirmation downloads every `gate-*` artifact with `merge-multiple: true` into `artifacts/gates`, so it looked for `releaseAssets.json` and the file had become `artifacts/gates/releaseAssets.json`.

Verified by downloading the artifact from the failed run, not inferred:

```
./artifacts/gates/releaseAssets.json
./.candidate-upload/native/SHA256SUMS
```

## The fix

Copy the manifest beside the document that references it, so the upload spans **one non-hidden root** and the artifact is flat again.

- **Copied, not moved** — the candidate artifact and the exact-directory verifier both still read the staged original.
- The evidence document still hashes the manifest from its staged path, so what confirmation actually checks is unchanged.
- The **candidate upload keeps `include-hidden-files`**: that tree is entirely dot-prefixed and has a single root, so it has no ambiguity to hit.

Not spanning two roots is sturdier than depending on where the ancestor happens to land.

## Seam check

Audited every `upload-artifact` step in the workflow for this shape — **no other upload spans more than one root, and no hidden path is unflagged.**

## Verification

- Artifact from the failed run downloaded and its layout confirmed.
- Workflow parses; `distribution-contract.test.ts` 57 pass; forced `fmt:check` clean.
- The one thing PR CI cannot prove is `release.yml` itself, so the real test is the next dispatch — which now has fifteen green gates behind it and one changed step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation by ensuring checksum evidence is included with release asset evidence.
  * Corrected evidence file placement so automated confirmation checks can locate release information reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->