### PR TITLE
docs(release): make trusted publishing a preflight, not a discovery

### DIFF
--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -479,6 +479,58 @@ bun run test:live:youtube
 
 Expected: `ok: true`, `streamResolved: true`, `streamHost` contains `youtube.com`. When yt-dlp is intentionally absent on the runner, `skipped: true` is acceptable.
 
+## npm Trusted Publishing Preflight
+
+Publication is OIDC-only. `release.yml` carries no `NODE_AUTH_TOKEN` — a
+contract test asserts its absence — so every package authenticates through npm
+Trusted Publishing against the workflow's `id-token: write` claim.
+
+That trust is configured **per package on npmjs.com**, not in this repository,
+so nothing in CI can prove it before a dispatch reaches the publish job. Check
+it before dispatching, because the failure lands after the protected
+environment approval, on the far side of every other gate.
+
+All **nine** packages need an identical entry: the launcher
+`@kitsunekode/kunai` plus the eight platform packages
+(`@kitsunekode/kunai-{linux,darwin,windows}-{x64,arm64}` and the two musl
+variants).
+
+| Field       | Value                |
+| ----------- | -------------------- |
+| Repository  | `KitsuneKode/kunai`  |
+| Workflow    | `release.yml`        |
+| Environment | `release-production` |
+| Permission  | `npm publish`        |
+
+**The repository field is case-sensitive.** GitHub's OIDC `repository` claim is
+the canonical `owner.login`, exactly `KitsuneKode/kunai`. A stored
+`Kitsunekode/kunai` does not match it, and npm reports the mismatch as
+`ENEEDAUTH — need auth This command requires you to be logged in`, which reads
+like a missing credential rather than a wrong one. The 0.3.0 dispatch lost a
+full release run to that single character: the launcher was correct and the
+platform packages were not, and because platform packages publish first, the
+correct entry was never reached.
+
+Verify each package, which needs a 2FA prompt per call:
+
+```sh
+npm trust list @kitsunekode/kunai
+npm trust list @kitsunekode/kunai-linux-x64
+```
+
+Repair one with the canonical casing:
+
+```sh
+npm trust github @kitsunekode/kunai-linux-x64 \
+  --file release.yml --repo KitsuneKode/kunai --env release-production -y
+```
+
+A `for` loop over the eight without `-y` silently answers `n` to every prompt
+and changes nothing while looking like it ran.
+
+Expected evidence: `npm trust list` reports the same repository, workflow, and
+environment for all nine, with `KitsuneKode` capitalised as GitHub spells it.
+
 ## Withdrawing a Released Version
 
 Every gate above exists to stop a bad release shipping. This section is for when


### PR DESCRIPTION
## Why

The 0.3.0 dispatch cleared **all sixteen gates**, took the protected environment approval, and then failed on the first `npm publish`:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to
                    https://registry.npmjs.org/
```

The cause was one character. The platform packages had their trusted publisher stored as `Kitsunekode/kunai`; GitHub's OIDC `repository` claim is the canonical `KitsuneKode/kunai`. npm surfaces that mismatch as a *missing* credential rather than a *wrong* one, so it reads like the publisher was never configured at all.

The launcher was correct the whole time — but platform packages publish first by design, so the correct entry was never reached.

## Why it belongs in the gate doc

Nothing in this repository can prove that configuration. It lives on npmjs.com, per package, and the only thing that exercises it is the publish job — which sits on the far side of every other gate and behind a human approval. That is the most expensive possible place to discover it, and it cost a full release run.

## What it records

- All **nine** packages need an identical entry, and which nine.
- The repository field is **case-sensitive**, with the canonical spelling.
- The `ENEEDAUTH` symptom, so the next reader recognises it rather than re-deriving it.
- That a `for` loop over `npm trust github` without `-y` silently answers `n` to every prompt and changes nothing while appearing to run — which is how the first repair attempt went by unnoticed.

## Verification

`verify:doc-paths` (51 docs, 2113 source files) and `verify:doc-frontmatter` (67 docs) pass; forced `fmt:check` clean.

https://claude.ai/code/session_01RTShUCup4AgfkcaaT4yPPF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release guidance for verifying npm Trusted Publishing configuration.
  * Documented required repository, workflow, environment, and permission settings for all published packages.
  * Added verification and repair commands, along with troubleshooting notes for case sensitivity and interactive prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->