### PR TITLE
fix(release): wait out npm propagation before failing a publish

### DIFF
--- a/apps/cli/test/unit/scripts/publish-npm-release.test.ts
+++ b/apps/cli/test/unit/scripts/publish-npm-release.test.ts
@@ -469,6 +469,74 @@ describe("resumable npm publication orchestration", () => {
     expect(published.at(-1)).toBe("@kitsunekode/kunai");
   });
 
+  test("waits out registry propagation instead of failing a successful publish", async () => {
+    // What actually happened to 0.3.0: `@kitsunekode/kunai-linux-x64` published
+    // fine, `npm view` answered "not found" seconds later, and the release died
+    // with one of nine packages live. The publish is not retried — only the
+    // read after it.
+    const localCandidates = candidates();
+    const laggard = localCandidates[0]!.name;
+    let publishes = 0;
+    let laggardReads = 0;
+    const waits: number[] = [];
+
+    const result = await reconcileNpmPublication({
+      candidates: localCandidates,
+      confirmed: true,
+      command: async () => {
+        publishes += 1;
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      registry: {
+        queryIntegrity: async () => null,
+        queryMetadata: async (candidate) => {
+          if (candidate.name !== laggard) return metadata(candidate);
+          laggardReads += 1;
+          // Absent for the first two reads, then visible.
+          return laggardReads <= 2 ? null : metadata(candidate);
+        },
+      },
+      wait: async (ms) => {
+        waits.push(ms);
+      },
+    });
+
+    expect(result.every((decision) => decision.action === "publish")).toBe(true);
+    expect(publishes).toBe(localCandidates.length);
+    expect(laggardReads).toBe(3);
+    // Only the laggard waited, and only between its own reads.
+    expect(waits).toEqual([3_000, 3_000]);
+  });
+
+  test("a mismatched artifact fails on the first read rather than being retried", async () => {
+    // Absence is propagation; a wrong integrity is a wrong artifact. Retrying
+    // that would turn a clear failure into a timeout and delay the signal.
+    const localCandidates = candidates();
+    let reads = 0;
+    const waits: number[] = [];
+
+    await expect(
+      reconcileNpmPublication({
+        candidates: localCandidates,
+        confirmed: true,
+        command: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+        registry: {
+          queryIntegrity: async () => null,
+          queryMetadata: async (candidate) => {
+            reads += 1;
+            return { ...metadata(candidate), integrity: "sha512-somethingElseEntirely==" };
+          },
+        },
+        wait: async (ms) => {
+          waits.push(ms);
+        },
+      }),
+    ).rejects.toThrow(/verification failed/i);
+
+    expect(reads).toBe(1);
+    expect(waits).toEqual([]);
+  });
+
   test("fails when post-reconciliation verification does not exactly match", async () => {
     const localCandidates = candidates();
     let launcherQueried = false;

--- a/scripts/publish-npm-release.ts
+++ b/scripts/publish-npm-release.ts
@@ -71,7 +71,26 @@ export interface ReconcileNpmPublicationOptions {
   readonly command: CommandPort;
   readonly registry: RegistryPort;
   readonly log?: (message: string) => void;
+  /**
+   * Injected so a test can exhaust the propagation window without sleeping.
+   * Defaults to a real timer only on the publication path.
+   */
+  readonly wait?: (ms: number) => Promise<void>;
 }
+
+/**
+ * npm's registry is read-after-write eventually consistent: `npm view` can
+ * answer "not found" for a version that was just accepted. The 0.3.0 release
+ * published `@kitsunekode/kunai-linux-x64` successfully and then failed its own
+ * verification a few seconds later on exactly that, leaving one of nine
+ * packages live and the release half-applied.
+ *
+ * Bounded, and only ever for absence — an integrity *mismatch* is a wrong
+ * artifact and must fail on the first read rather than be retried into a
+ * timeout.
+ */
+const PUBLISH_VISIBILITY_ATTEMPTS = 10;
+const PUBLISH_VISIBILITY_DELAY_MS = 3_000;
 
 type JsonObject = Record<string, unknown>;
 
@@ -446,6 +465,29 @@ function assertVerified(
   }
 }
 
+/**
+ * Poll for a just-published version until the registry admits it exists.
+ *
+ * Returns the first non-null metadata, whatever it says: deciding whether it
+ * *matches* stays with `assertVerified`, so a wrong artifact still fails on the
+ * first read instead of being retried. Only absence is waited on.
+ */
+async function awaitPublishedMetadata(
+  candidate: LocalPackageCandidate,
+  options: ReconcileNpmPublicationOptions,
+): Promise<RegistryPackageMetadata | null> {
+  const wait = options.wait ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  let metadata = await options.registry.queryMetadata(candidate);
+  for (let attempt = 1; metadata === null && attempt < PUBLISH_VISIBILITY_ATTEMPTS; attempt += 1) {
+    options.log?.(
+      `[publish] ${candidate.name}@${candidate.version} not visible yet; retry ${attempt}/${PUBLISH_VISIBILITY_ATTEMPTS - 1}`,
+    );
+    await wait(PUBLISH_VISIBILITY_DELAY_MS);
+    metadata = await options.registry.queryMetadata(candidate);
+  }
+  return metadata;
+}
+
 /** Reconcile validated candidates sequentially, preserving launcher-last safety. */
 export async function reconcileNpmPublication(
   options: ReconcileNpmPublicationOptions,
@@ -474,7 +516,11 @@ export async function reconcileNpmPublication(
       };
       const result = await options.command(request);
       if (result.exitCode !== 0) throw commandError("npm publish", request, result);
+      assertVerified(candidate, await awaitPublishedMetadata(candidate, options));
+      continue;
     }
+    // A skipped candidate was already on the registry before this run, so its
+    // metadata is visible now; only the read after our own write can lag.
     assertVerified(candidate, await options.registry.queryMetadata(candidate));
   }
   return decisions;


### PR DESCRIPTION
## What happened

The 0.3.0 publish put `@kitsunekode/kunai-linux-x64@0.3.0` on the registry, then failed its own verification 9.6s later and ended the run with **one of nine packages live**:

```
07:08:12.46  [publish] publish @kitsunekode/kunai-linux-x64@0.3.0 (sha512-WLWic…HQS2dw==)
07:08:22.05  [publish] verification failed …; expected sha512-WLWic…HQS2dw==, received not found.
```

## The publish was correct — verified, not assumed

What is on npm right now carries **exactly** the integrity the run attempted:

```
attempted:   sha512-WLWicFJHn7Hpt6zmlfsW/LeSb+DuXADvB9LXZ6u8XhbehUTgr14STHmpy0X9slqzhQOMcMC7NUJIdJ0IHQS2dw==
on registry: sha512-WLWicFJHn7Hpt6zmlfsW/LeSb+DuXADvB9LXZ6u8XhbehUTgr14STHmpy0X9slqzhQOMcMC7NUJIdJ0IHQS2dw==
```

Same artifact. So this was npm answering a read-after-write before the version had propagated — not a bad credential, not a corrupt tarball, not a wrong artifact.

Notably the **workflow's** later verification already retries ten times with a delay, so this lag was understood at that boundary. The per-package check *inside* the publish script read once and treated absence as failure.

## The fix

Absence is waited out — bounded, ten attempts three seconds apart.

Two deliberate limits:

- **An integrity mismatch still fails on the first read.** That is a wrong artifact; retrying it would convert a clear signal into a timeout and delay the very thing you need to see.
- **Waiting happens only after this run's own publish.** A skipped candidate was already on the registry before the run started and cannot be subject to our write lag.

The wait is injected, so tests exhaust the window without sleeping.

## Recovery needs no special handling

`reconcileCandidate` already skips a version whose registry integrity matches the local candidate. A re-run therefore **skips `linux-x64` and publishes the remaining eight** — no `EPUBLISHCONFLICT`, no manual unpublish.

## Verification

- 26 tests pass in `publish-npm-release.test.ts`.
- Mutation-checked both ways: removing the retry fails the propagation test; the mismatch test is unaffected by it and fails if retrying is applied too broadly.
- Forced `typecheck`, `lint`, `fmt:check` clean.

https://claude.ai/code/session_01RTShUCup4AgfkcaaT4yPPF
