### PR TITLE
fix(release): wait once for the platform set, then the launcher — not once per package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -965,11 +965,14 @@ jobs:
     needs: confirmation
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    # Nine packages, each of which may wait out npm indexing before the next is
-    # published. 0.3.0 saw a seven-minute lag on one package, and the publisher
-    # now allows about ten minutes each; 30 would kill the job mid-sequence and
-    # leave a half-applied release, which is the one state worth avoiding.
-    timeout-minutes: 120
+    # The publisher writes all eight platform packages back to back, waits out
+    # one shared visibility window (about ten minutes) for the set, then writes
+    # the launcher and waits once more. Setup, the registry smoke, tagging, and
+    # the draft/promote/verify tail add roughly ten minutes; 0.3.0's worst
+    # observed apply lag was seven minutes. A timeout can only land inside a
+    # wait, which leaves nothing half-written: no launcher before its platform
+    # packages, and a rerun skips whatever already matches.
+    timeout-minutes: 45
     environment: release-production
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -965,7 +965,11 @@ jobs:
     needs: confirmation
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Nine packages, each of which may wait out npm indexing before the next is
+    # published. 0.3.0 saw a seven-minute lag on one package, and the publisher
+    # now allows about ten minutes each; 30 would kill the job mid-sequence and
+    # leave a half-applied release, which is the one state worth avoiding.
+    timeout-minutes: 120
     environment: release-production
     permissions:
       contents: write

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -240,9 +240,17 @@ Job **`publish`** needs `confirmation` and declares `environment: release-produc
 2. Reverifies the exact native directory and all 18 attestations, before npm
    publication, against the
    expected version, release workflow, main-branch ref, and candidate commit
-3. Runs `bun run release`, whose npm publisher reconciles all eight preserved
-   platform-package tarballs first and the exact-version launcher tarball last,
-   refusing integrity or version skew and publishing with npm provenance
+3. Runs `bun run release`, whose npm publisher works in three phases: it
+   decides every preserved platform-package tarball against the registry
+   before writing any (a conflicting version anywhere halts with nothing new
+   published), writes every missing platform package back to back and waits
+   out one shared visibility window for the set, and only once all eight are
+   read back with the expected integrity writes the exact-version launcher and
+   waits for it. Every write uses npm provenance. npm applies a publish
+   asynchronously — 0.3.0 saw one package take seven minutes to become
+   visible — so the window backs off from 3s to 30s for about ten minutes, and
+   a write is reissued only after a whole window still shows nothing (npm's
+   refusal to overwrite then counts as confirmation)
 4. Retries `npm view` for the launcher and all eight platform packages until
    every exact version is visible, then performs a clean registry install and
    launcher smoke
@@ -282,6 +290,17 @@ Do not unpublish, overwrite, hand-increment, or rebuild a partial candidate.
 The launcher stays last so users can never resolve it before its exact-version
 platform packages exist. A rerun is safe only with the preserved artifacts from
 the original candidate job.
+
+Do not cancel the publish job while it is waiting on npm. "Not visible yet"
+lines are the registry applying a write it has already accepted, and the
+publisher will wait about ten minutes for the set before it gives up on its
+own. Cancelling mid-wait costs another candidate build, another
+`release-production` approval, and — because the publish job pins
+`origin/main` — is invalidated anyway by the next merge.
+
+Because the publish job pins `HEAD == origin/main`, merging anything to main
+while a Release run is waiting for approval invalidates that run. Dispatch the
+release when main is quiet, approve once, and let it finish.
 
 ## Metadata push recovery
 

--- a/apps/cli/test/unit/scripts/publish-npm-release.test.ts
+++ b/apps/cli/test/unit/scripts/publish-npm-release.test.ts
@@ -508,6 +508,107 @@ describe("resumable npm publication orchestration", () => {
     expect(waits).toEqual([3_000, 3_000]);
   });
 
+  test("reissues the write when a successful publish never reaches the registry", async () => {
+    // What 0.3.0 hit: `npm publish` exited 0 for kunai-linux-arm64 and the
+    // version was never created — still absent long after the run ended, so
+    // retrying the read could never recover it.
+    const localCandidates = candidates();
+    const dropped = localCandidates[0]!.name;
+    let droppedPublishes = 0;
+    const waits: number[] = [];
+
+    const result = await reconcileNpmPublication({
+      candidates: localCandidates,
+      confirmed: true,
+      command: async (request) => {
+        if (request.args[1] === localCandidates[0]!.tarballPath) droppedPublishes += 1;
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      registry: {
+        queryIntegrity: async () => null,
+        queryMetadata: async (candidate) => {
+          if (candidate.name !== dropped) return metadata(candidate);
+          // The first write is swallowed entirely; the second one sticks.
+          return droppedPublishes >= 2 ? metadata(candidate) : null;
+        },
+      },
+      wait: async (ms) => {
+        waits.push(ms);
+      },
+    });
+
+    expect(result.every((decision) => decision.action === "publish")).toBe(true);
+    expect(droppedPublishes).toBe(2);
+    // The read retries were exhausted once before the write was reissued.
+    // Nine read retries exhausted before the write was reissued.
+    expect(waits.length).toBe(9);
+  });
+
+  test("treats npm refusing to overwrite as proof the write landed", async () => {
+    // A reissue after a drop that was not a drop must not fail the release:
+    // npm rejecting the duplicate is itself confirmation the version exists.
+    const localCandidates = candidates();
+    const target = localCandidates[0]!.name;
+    let attempts = 0;
+
+    const result = await reconcileNpmPublication({
+      candidates: localCandidates,
+      confirmed: true,
+      command: async (request) => {
+        if (request.args[1] !== localCandidates[0]!.tarballPath) {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        attempts += 1;
+        if (attempts === 1) return { exitCode: 0, stdout: "", stderr: "" };
+        return {
+          exitCode: 1,
+          stdout: "",
+          stderr: "npm error 403 You cannot publish over the previously published versions",
+        };
+      },
+      registry: {
+        queryIntegrity: async () => null,
+        queryMetadata: async (candidate) => {
+          if (candidate.name !== target) return metadata(candidate);
+          return attempts >= 2 ? metadata(candidate) : null;
+        },
+      },
+      wait: async () => {},
+    });
+
+    expect(result.every((decision) => decision.action === "publish")).toBe(true);
+    expect(attempts).toBe(2);
+  });
+
+  test("a genuine publish failure still throws instead of being reissued", async () => {
+    // Only the overwrite refusal is benign. Anything else — auth, network,
+    // a rejected tarball — must surface immediately with npm's own output.
+    const localCandidates = candidates();
+    let attempts = 0;
+
+    await expect(
+      reconcileNpmPublication({
+        candidates: localCandidates,
+        confirmed: true,
+        command: async () => {
+          attempts += 1;
+          return {
+            exitCode: 1,
+            stdout: "",
+            stderr: "npm error code ENEEDAUTH\nnpm error need auth",
+          };
+        },
+        registry: {
+          queryIntegrity: async () => null,
+          queryMetadata: async (candidate) => metadata(candidate),
+        },
+        wait: async () => {},
+      }),
+    ).rejects.toThrow(/ENEEDAUTH/);
+
+    expect(attempts).toBe(1);
+  });
+
   test("a mismatched artifact fails on the first read rather than being retried", async () => {
     // Absence is propagation; a wrong integrity is a wrong artifact. Retrying
     // that would turn a clear failure into a timeout and delay the signal.

--- a/apps/cli/test/unit/scripts/publish-npm-release.test.ts
+++ b/apps/cli/test/unit/scripts/publish-npm-release.test.ts
@@ -469,6 +469,92 @@ describe("resumable npm publication orchestration", () => {
     expect(published.at(-1)).toBe("@kitsunekode/kunai");
   });
 
+  test("writes every platform package before waiting on any, then the launcher after all are visible", async () => {
+    // npm's write-apply lag is per package but the lags overlap, so waiting
+    // after each write pays the worst lag up to eight times; waiting once
+    // after all eight pays it once. The launcher still goes last, and only
+    // after every platform package has been read back with the expected bytes.
+    const localCandidates = candidates();
+    const platforms = localCandidates.filter((candidate) => candidate.role === "platform");
+    const launcher = localCandidates.at(-1)!;
+    const readsUntilVisible = new Map(
+      localCandidates.map((candidate, index) => [candidate.name, (index % 3) + 1]),
+    );
+    const reads = new Map<string, number>();
+    const events: string[] = [];
+
+    const result = await reconcileNpmPublication({
+      candidates: localCandidates,
+      confirmed: true,
+      command: async (request) => {
+        const candidate = localCandidates.find((item) => item.tarballPath === request.args[1])!;
+        events.push(`publish ${candidate.name}`);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      registry: {
+        queryIntegrity: async () => null,
+        queryMetadata: async (candidate) => {
+          const count = (reads.get(candidate.name) ?? 0) + 1;
+          reads.set(candidate.name, count);
+          events.push(`read ${candidate.name}`);
+          return count >= readsUntilVisible.get(candidate.name)! ? metadata(candidate) : null;
+        },
+      },
+      wait: async (ms) => {
+        events.push(`wait ${ms}`);
+      },
+    });
+
+    expect(result.every((decision) => decision.action === "publish")).toBe(true);
+    // All eight platform writes happen before the first read-back.
+    expect(events.slice(0, platforms.length)).toEqual(
+      platforms.map((candidate) => `publish ${candidate.name}`),
+    );
+    // The launcher is written only after the last platform package was seen.
+    const launcherWrite = events.indexOf(`publish ${launcher.name}`);
+    const lastPlatformRead = Math.max(
+      ...platforms.map((candidate) => events.lastIndexOf(`read ${candidate.name}`)),
+    );
+    expect(launcherWrite).toBeGreaterThan(lastPlatformRead);
+    // The slowest platform package needs three reads; that costs two waits for
+    // the whole set, not two per laggard. The launcher then waits on its own.
+    expect(events.filter((event) => event.startsWith("wait"))).toEqual([
+      "wait 3000",
+      "wait 6000",
+      "wait 3000",
+      "wait 6000",
+    ]);
+    // A package that was visible on the first read is not read again.
+    expect(reads.get(platforms[0]!.name)).toBe(1);
+  });
+
+  test("halts before writing anything when a platform package already exists with different bytes", async () => {
+    // Every platform decision is made before the first write, so a conflict on
+    // the sixth package cannot leave the first five newly published.
+    const localCandidates = candidates();
+    const conflicting = localCandidates[5]!;
+    let publishes = 0;
+
+    await expect(
+      reconcileNpmPublication({
+        candidates: localCandidates,
+        confirmed: true,
+        command: async () => {
+          publishes += 1;
+          return { exitCode: 0, stdout: "", stderr: "" };
+        },
+        registry: {
+          queryIntegrity: async (candidate) =>
+            candidate.name === conflicting.name ? "sha512-somethingElseEntirely==" : null,
+          queryMetadata: async (candidate) => metadata(candidate),
+        },
+        wait: async () => {},
+      }),
+    ).rejects.toThrow(/different integrity/i);
+
+    expect(publishes).toBe(0);
+  });
+
   test("waits out registry propagation instead of failing a successful publish", async () => {
     // What actually happened to 0.3.0: `@kitsunekode/kunai-linux-x64` published
     // fine, `npm view` answered "not found" seconds later, and the release died
@@ -541,7 +627,6 @@ describe("resumable npm publication orchestration", () => {
 
     expect(result.every((decision) => decision.action === "publish")).toBe(true);
     expect(droppedPublishes).toBe(2);
-    // The read retries were exhausted once before the write was reissued.
     // The full visibility window was exhausted before the write was reissued.
     expect(waits.length).toBe(25);
     // Backoff, not a flat delay: 3s rising to a 30s ceiling.

--- a/apps/cli/test/unit/scripts/publish-npm-release.test.ts
+++ b/apps/cli/test/unit/scripts/publish-npm-release.test.ts
@@ -504,14 +504,16 @@ describe("resumable npm publication orchestration", () => {
     expect(result.every((decision) => decision.action === "publish")).toBe(true);
     expect(publishes).toBe(localCandidates.length);
     expect(laggardReads).toBe(3);
-    // Only the laggard waited, and only between its own reads.
-    expect(waits).toEqual([3_000, 3_000]);
+    // Only the laggard waited, and only between its own reads, backing off.
+    expect(waits).toEqual([3_000, 6_000]);
   });
 
   test("reissues the write when a successful publish never reaches the registry", async () => {
-    // What 0.3.0 hit: `npm publish` exited 0 for kunai-linux-arm64 and the
-    // version was never created — still absent long after the run ended, so
-    // retrying the read could never recover it.
+    // Only after the whole visibility window still shows nothing. A slow
+    // publish is not a dropped one: kunai-linux-arm64 exited 0, read absent for
+    // 27s, and was indexed roughly seven minutes later with the exact expected
+    // integrity. Reissuing early would have raced a version that already
+    // existed.
     const localCandidates = candidates();
     const dropped = localCandidates[0]!.name;
     let droppedPublishes = 0;
@@ -540,8 +542,11 @@ describe("resumable npm publication orchestration", () => {
     expect(result.every((decision) => decision.action === "publish")).toBe(true);
     expect(droppedPublishes).toBe(2);
     // The read retries were exhausted once before the write was reissued.
-    // Nine read retries exhausted before the write was reissued.
-    expect(waits.length).toBe(9);
+    // The full visibility window was exhausted before the write was reissued.
+    expect(waits.length).toBe(25);
+    // Backoff, not a flat delay: 3s rising to a 30s ceiling.
+    expect(waits.slice(0, 3)).toEqual([3_000, 6_000, 9_000]);
+    expect(waits.at(-1)).toBe(30_000);
   });
 
   test("treats npm refusing to overwrite as proof the write landed", async () => {

--- a/scripts/publish-npm-release.ts
+++ b/scripts/publish-npm-release.ts
@@ -89,15 +89,30 @@ export interface ReconcileNpmPublicationOptions {
  * artifact and must fail on the first read rather than be retried into a
  * timeout.
  */
-const PUBLISH_VISIBILITY_ATTEMPTS = 10;
-const PUBLISH_VISIBILITY_DELAY_MS = 3_000;
+/**
+ * Measured, not guessed. During 0.3.0 `kunai-linux-x64-musl` appeared after one
+ * 3s retry, while `kunai-linux-arm64` — published at 08:01 — was not indexed
+ * until 08:08:41Z, roughly seven minutes later. A 27s budget failed the release
+ * on a version npm had already accepted with the exact expected integrity.
+ *
+ * Backs off from 3s to a 30s ceiling, which spends about ten minutes per
+ * package before giving up. Long enough to absorb the worst lag observed;
+ * bounded so a genuinely refused publish still ends the run.
+ */
+const PUBLISH_VISIBILITY_ATTEMPTS = 26;
+const PUBLISH_VISIBILITY_MAX_DELAY_MS = 30_000;
+
+function publishVisibilityDelayMs(attempt: number): number {
+  return Math.min(PUBLISH_VISIBILITY_MAX_DELAY_MS, 3_000 * attempt);
+}
 
 /**
- * How many times the write itself is reissued when the registry never shows the
- * version. Three, because a drop is rare and a fourth attempt would more likely
- * mean npm is refusing for a reason retrying cannot fix.
+ * The write is reissued only after that entire window still shows nothing —
+ * a genuinely dropped write, as distinct from a slow one. Reissuing early is
+ * what a short budget tempts you into, and it is wrong: the version usually
+ * exists and npm simply has not indexed it yet.
  */
-const PUBLISH_WRITE_ATTEMPTS = 3;
+const PUBLISH_WRITE_ATTEMPTS = 2;
 
 type JsonObject = Record<string, unknown>;
 
@@ -486,10 +501,11 @@ async function awaitPublishedMetadata(
   const wait = options.wait ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
   let metadata = await options.registry.queryMetadata(candidate);
   for (let attempt = 1; metadata === null && attempt < PUBLISH_VISIBILITY_ATTEMPTS; attempt += 1) {
+    const delay = publishVisibilityDelayMs(attempt);
     options.log?.(
-      `[publish] ${candidate.name}@${candidate.version} not visible yet; retry ${attempt}/${PUBLISH_VISIBILITY_ATTEMPTS - 1}`,
+      `[publish] ${candidate.name}@${candidate.version} not visible yet; retry ${attempt}/${PUBLISH_VISIBILITY_ATTEMPTS - 1} in ${Math.round(delay / 1000)}s`,
     );
-    await wait(PUBLISH_VISIBILITY_DELAY_MS);
+    await wait(delay);
     metadata = await options.registry.queryMetadata(candidate);
   }
   return metadata;

--- a/scripts/publish-npm-release.ts
+++ b/scripts/publish-npm-release.ts
@@ -79,25 +79,18 @@ export interface ReconcileNpmPublicationOptions {
 }
 
 /**
- * npm's registry is read-after-write eventually consistent: `npm view` can
- * answer "not found" for a version that was just accepted. The 0.3.0 release
- * published `@kitsunekode/kunai-linux-x64` successfully and then failed its own
- * verification a few seconds later on exactly that, leaving one of nine
- * packages live and the release half-applied.
+ * npm applies a publish asynchronously: `npm publish` returns 0 once the write
+ * is accepted, and `npm view` can answer "not found" until the registry has
+ * applied it. Measured during 0.3.0, not guessed: `kunai-linux-x64-musl` was
+ * visible after one 3s retry, while `kunai-linux-arm64` — accepted at 08:01:27Z
+ * — carries a registry `time` of 08:08:41Z, seven minutes later, with the exact
+ * expected integrity. Provenance shows the same run attempt wrote both. A 27s
+ * budget failed the release on a version npm already held.
  *
- * Bounded, and only ever for absence — an integrity *mismatch* is a wrong
- * artifact and must fail on the first read rather than be retried into a
- * timeout.
- */
-/**
- * Measured, not guessed. During 0.3.0 `kunai-linux-x64-musl` appeared after one
- * 3s retry, while `kunai-linux-arm64` — published at 08:01 — was not indexed
- * until 08:08:41Z, roughly seven minutes later. A 27s budget failed the release
- * on a version npm had already accepted with the exact expected integrity.
- *
- * Backs off from 3s to a 30s ceiling, which spends about ten minutes per
- * package before giving up. Long enough to absorb the worst lag observed;
- * bounded so a genuinely refused publish still ends the run.
+ * Backs off from 3s to a 30s ceiling, about ten minutes in total. The window
+ * is shared by every package written in the same phase, so the release pays
+ * the worst lag once, not once per package. Only absence is waited on: an
+ * integrity *mismatch* is a wrong artifact and fails on the first read.
  */
 const PUBLISH_VISIBILITY_ATTEMPTS = 26;
 const PUBLISH_VISIBILITY_MAX_DELAY_MS = 30_000;
@@ -107,10 +100,11 @@ function publishVisibilityDelayMs(attempt: number): number {
 }
 
 /**
- * The write is reissued only after that entire window still shows nothing —
- * a genuinely dropped write, as distinct from a slow one. Reissuing early is
- * what a short budget tempts you into, and it is wrong: the version usually
- * exists and npm simply has not indexed it yet.
+ * A write is reissued only after that entire window still shows nothing — a
+ * genuinely dropped write, as distinct from a slow one. No 0.3.0 write was
+ * actually dropped; this is insurance, and it is safe because npm refuses to
+ * overwrite an existing version, so a reissue that races the first write is
+ * rejected and that rejection is itself the confirmation.
  */
 const PUBLISH_WRITE_ATTEMPTS = 2;
 
@@ -487,28 +481,8 @@ function assertVerified(
   }
 }
 
-/**
- * Poll for a just-published version until the registry admits it exists.
- *
- * Returns the first non-null metadata, whatever it says: deciding whether it
- * *matches* stays with `assertVerified`, so a wrong artifact still fails on the
- * first read instead of being retried. Only absence is waited on.
- */
-async function awaitPublishedMetadata(
-  candidate: LocalPackageCandidate,
-  options: ReconcileNpmPublicationOptions,
-): Promise<RegistryPackageMetadata | null> {
-  const wait = options.wait ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
-  let metadata = await options.registry.queryMetadata(candidate);
-  for (let attempt = 1; metadata === null && attempt < PUBLISH_VISIBILITY_ATTEMPTS; attempt += 1) {
-    const delay = publishVisibilityDelayMs(attempt);
-    options.log?.(
-      `[publish] ${candidate.name}@${candidate.version} not visible yet; retry ${attempt}/${PUBLISH_VISIBILITY_ATTEMPTS - 1} in ${Math.round(delay / 1000)}s`,
-    );
-    await wait(delay);
-    metadata = await options.registry.queryMetadata(candidate);
-  }
-  return metadata;
+function describeSpecs(candidates: readonly LocalPackageCandidate[]): string {
+  return candidates.map((candidate) => `${candidate.name}@${candidate.version}`).join(", ");
 }
 
 /** npm's refusal to overwrite a version, which here means the write did land. */
@@ -518,92 +492,164 @@ function isAlreadyPublished(result: CommandResult): boolean {
   );
 }
 
-/**
- * Publish, then confirm the registry actually holds it — reissuing the write if
- * it does not.
- *
- * `npm publish` exiting 0 is not proof. During the 0.3.0 release
- * `@kitsunekode/kunai-linux-arm64@0.3.0` exited 0 and the version was never
- * created; it was still absent long after the run ended, so this was a dropped
- * write rather than the propagation lag the read retries already handle. npm's
- * own status history records repeated "intermittent Publish Failures".
- *
- * Retrying the read alone cannot recover that. Retrying the write can, and is
- * safe because npm refuses to overwrite an existing version: if the earlier
- * attempt did land after all, the reissue is rejected and that rejection is
- * itself the confirmation.
- */
-async function publishWithRetry(
+/** Issue one `npm publish`; a refusal to overwrite counts as the write existing. */
+async function publishOnce(
   candidate: LocalPackageCandidate,
   options: ReconcileNpmPublicationOptions,
-): Promise<RegistryPackageMetadata | null> {
+): Promise<void> {
   const request: CommandRequest = {
     command: "npm",
     args: ["publish", candidate.tarballPath, "--access", "public", "--provenance"],
     cwd: ROOT,
   };
+  const result = await options.command(request);
 
-  let metadata: RegistryPackageMetadata | null = null;
-  for (let attempt = 1; attempt <= PUBLISH_WRITE_ATTEMPTS; attempt += 1) {
-    const result = await options.command(request);
-
-    // Always surfaced, not only on failure. A dropped write exits 0, so the
-    // run that hit one had npm's output captured and discarded, leaving no
-    // way to tell why the version never appeared.
-    const output = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join("\n");
-    if (output)
-      options.log?.(`[publish] npm output for ${candidate.name}@${candidate.version}:\n${output}`);
-
-    if (result.exitCode !== 0) {
-      // A refusal to overwrite means the version exists; fall through and let
-      // verification compare integrity rather than treating it as a failure.
-      if (!isAlreadyPublished(result)) throw commandError("npm publish", request, result);
-      options.log?.(
-        `[publish] ${candidate.name}@${candidate.version} already on the registry; verifying instead`,
-      );
-    }
-
-    metadata = await awaitPublishedMetadata(candidate, options);
-    if (metadata !== null) return metadata;
-
-    if (attempt < PUBLISH_WRITE_ATTEMPTS) {
-      options.log?.(
-        `[publish] ${candidate.name}@${candidate.version} still absent after a successful publish; reissuing (${attempt}/${PUBLISH_WRITE_ATTEMPTS - 1})`,
-      );
-    }
+  // Always surfaced, not only on failure. A slow publish exits 0, so a run
+  // that hits one otherwise has npm's output captured and discarded, leaving
+  // nothing to diagnose from.
+  const output = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join("\n");
+  if (output) {
+    options.log?.(`[publish] npm output for ${candidate.name}@${candidate.version}:\n${output}`);
   }
-  return metadata;
+
+  if (result.exitCode === 0) return;
+  if (!isAlreadyPublished(result)) throw commandError("npm publish", request, result);
+  options.log?.(
+    `[publish] ${candidate.name}@${candidate.version} already on the registry; verifying instead`,
+  );
 }
 
-/** Reconcile validated candidates sequentially, preserving launcher-last safety. */
+/**
+ * One visibility window for a set of just-written packages: poll every absent
+ * one each round, back off between rounds, and return whatever is still absent
+ * when the window closes. A package that appears is verified on that first
+ * read, so a wrong artifact fails immediately instead of being retried.
+ */
+async function pollVisibilityWindow(
+  candidates: readonly LocalPackageCandidate[],
+  options: ReconcileNpmPublicationOptions,
+): Promise<LocalPackageCandidate[]> {
+  const wait = options.wait ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  let absent = [...candidates];
+  for (let attempt = 1; ; attempt += 1) {
+    const stillAbsent: LocalPackageCandidate[] = [];
+    for (const candidate of absent) {
+      const metadata = await options.registry.queryMetadata(candidate);
+      if (metadata === null) stillAbsent.push(candidate);
+      else assertVerified(candidate, metadata);
+    }
+    if (stillAbsent.length === 0 || attempt >= PUBLISH_VISIBILITY_ATTEMPTS) return stillAbsent;
+
+    const delay = publishVisibilityDelayMs(attempt);
+    options.log?.(
+      `[publish] not visible yet: ${describeSpecs(stillAbsent)}; retry ${attempt}/${PUBLISH_VISIBILITY_ATTEMPTS - 1} in ${Math.round(delay / 1000)}s`,
+    );
+    await wait(delay);
+    absent = stillAbsent;
+  }
+}
+
+/**
+ * Confirm every written package is on the registry with the expected bytes,
+ * reissuing a write only after a whole window still shows nothing for it.
+ */
+async function awaitVisible(
+  candidates: readonly LocalPackageCandidate[],
+  options: ReconcileNpmPublicationOptions,
+): Promise<void> {
+  if (candidates.length === 0) return;
+  let absent = [...candidates];
+  for (let write = 1; ; write += 1) {
+    absent = await pollVisibilityWindow(absent, options);
+    if (absent.length === 0) return;
+    if (write >= PUBLISH_WRITE_ATTEMPTS) {
+      throw new Error(
+        `[publish] verification failed for ${describeSpecs(absent)}; still not found after ` +
+          `${PUBLISH_WRITE_ATTEMPTS} writes and ${PUBLISH_VISIBILITY_ATTEMPTS} reads each.`,
+      );
+    }
+    for (const candidate of absent) {
+      options.log?.(
+        `[publish] ${candidate.name}@${candidate.version} still absent after a successful publish; reissuing (${write}/${PUBLISH_WRITE_ATTEMPTS - 1})`,
+      );
+      await publishOnce(candidate, options);
+    }
+  }
+}
+
+async function decide(
+  candidate: LocalPackageCandidate,
+  options: ReconcileNpmPublicationOptions,
+): Promise<PublicationDecision> {
+  const decision = reconcileCandidate(candidate, await options.registry.queryIntegrity(candidate));
+  options.log?.(
+    `[publish] ${decision.action} ${candidate.name}@${candidate.version} (${candidate.integrity})`,
+  );
+  return decision;
+}
+
+/**
+ * A skipped candidate was already on the registry before this run, so its
+ * metadata is visible now; only the read after our own write can lag.
+ */
+async function verifySkipped(
+  decisions: readonly PublicationDecision[],
+  options: ReconcileNpmPublicationOptions,
+): Promise<void> {
+  for (const decision of decisions) {
+    if (decision.action !== "skip") continue;
+    assertVerified(decision.candidate, await options.registry.queryMetadata(decision.candidate));
+  }
+}
+
+/**
+ * Reconcile validated candidates in three phases, preserving launcher-last
+ * safety:
+ *
+ * 1. decide every platform package before writing any, so a conflicting
+ *    version anywhere in the set halts with nothing new on the registry;
+ * 2. write every missing platform package back to back, then wait out one
+ *    shared visibility window for all of them;
+ * 3. only once all eight are read back with the expected bytes, decide and
+ *    write the launcher and wait for it.
+ *
+ * The launcher is the only package users resolve by name, so what matters is
+ * that it never exists before the exact-version platform packages it pins. A
+ * platform package that is live while its siblings are still being applied is
+ * invisible to users, which is what makes waiting once for the whole set safe.
+ */
 export async function reconcileNpmPublication(
   options: ReconcileNpmPublicationOptions,
 ): Promise<PublicationDecision[]> {
   await validateLocalCandidates(options.candidates);
-  const decisions: PublicationDecision[] = [];
-  for (const candidate of options.candidates) {
-    const registryIntegrity = await options.registry.queryIntegrity(candidate);
-    const decision = reconcileCandidate(candidate, registryIntegrity);
-    decisions.push(decision);
-    options.log?.(
-      `[publish] ${decision.action} ${candidate.name}@${candidate.version} (${candidate.integrity})`,
-    );
+  const platforms = options.candidates.filter((candidate) => candidate.role === "platform");
+  const launcher = options.candidates.find((candidate) => candidate.role === "launcher")!;
 
-    if (!options.confirmed) {
-      if (decision.action === "skip") {
-        assertVerified(candidate, await options.registry.queryMetadata(candidate));
-      }
-      continue;
+  const platformDecisions: PublicationDecision[] = [];
+  for (const candidate of platforms) platformDecisions.push(await decide(candidate, options));
+  await verifySkipped(platformDecisions, options);
+
+  if (options.confirmed) {
+    const pending = platformDecisions
+      .filter((decision) => decision.action === "publish")
+      .map((decision) => decision.candidate);
+    for (const candidate of pending) await publishOnce(candidate, options);
+    if (pending.length > 0) {
+      options.log?.(
+        `[publish] wrote ${pending.length} platform package(s); waiting for the registry to apply them`,
+      );
     }
-    if (decision.action === "publish") {
-      assertVerified(candidate, await publishWithRetry(candidate, options));
-      continue;
-    }
-    // A skipped candidate was already on the registry before this run, so its
-    // metadata is visible now; only the read after our own write can lag.
-    assertVerified(candidate, await options.registry.queryMetadata(candidate));
+    await awaitVisible(pending, options);
   }
-  return decisions;
+
+  const launcherDecision = await decide(launcher, options);
+  if (options.confirmed && launcherDecision.action === "publish") {
+    await publishOnce(launcher, options);
+    await awaitVisible([launcher], options);
+  } else {
+    await verifySkipped([launcherDecision], options);
+  }
+  return [...platformDecisions, launcherDecision];
 }
 
 export function parsePublishArgs(args: readonly string[]): { readonly confirmed: boolean } {

--- a/scripts/publish-npm-release.ts
+++ b/scripts/publish-npm-release.ts
@@ -92,6 +92,13 @@ export interface ReconcileNpmPublicationOptions {
 const PUBLISH_VISIBILITY_ATTEMPTS = 10;
 const PUBLISH_VISIBILITY_DELAY_MS = 3_000;
 
+/**
+ * How many times the write itself is reissued when the registry never shows the
+ * version. Three, because a drop is rare and a fourth attempt would more likely
+ * mean npm is refusing for a reason retrying cannot fix.
+ */
+const PUBLISH_WRITE_ATTEMPTS = 3;
+
 type JsonObject = Record<string, unknown>;
 
 function isJsonObject(value: unknown): value is JsonObject {
@@ -488,6 +495,70 @@ async function awaitPublishedMetadata(
   return metadata;
 }
 
+/** npm's refusal to overwrite a version, which here means the write did land. */
+function isAlreadyPublished(result: CommandResult): boolean {
+  return /cannot publish over|previously published version|EPUBLISHCONFLICT/i.test(
+    `${result.stdout}\n${result.stderr}`,
+  );
+}
+
+/**
+ * Publish, then confirm the registry actually holds it — reissuing the write if
+ * it does not.
+ *
+ * `npm publish` exiting 0 is not proof. During the 0.3.0 release
+ * `@kitsunekode/kunai-linux-arm64@0.3.0` exited 0 and the version was never
+ * created; it was still absent long after the run ended, so this was a dropped
+ * write rather than the propagation lag the read retries already handle. npm's
+ * own status history records repeated "intermittent Publish Failures".
+ *
+ * Retrying the read alone cannot recover that. Retrying the write can, and is
+ * safe because npm refuses to overwrite an existing version: if the earlier
+ * attempt did land after all, the reissue is rejected and that rejection is
+ * itself the confirmation.
+ */
+async function publishWithRetry(
+  candidate: LocalPackageCandidate,
+  options: ReconcileNpmPublicationOptions,
+): Promise<RegistryPackageMetadata | null> {
+  const request: CommandRequest = {
+    command: "npm",
+    args: ["publish", candidate.tarballPath, "--access", "public", "--provenance"],
+    cwd: ROOT,
+  };
+
+  let metadata: RegistryPackageMetadata | null = null;
+  for (let attempt = 1; attempt <= PUBLISH_WRITE_ATTEMPTS; attempt += 1) {
+    const result = await options.command(request);
+
+    // Always surfaced, not only on failure. A dropped write exits 0, so the
+    // run that hit one had npm's output captured and discarded, leaving no
+    // way to tell why the version never appeared.
+    const output = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join("\n");
+    if (output)
+      options.log?.(`[publish] npm output for ${candidate.name}@${candidate.version}:\n${output}`);
+
+    if (result.exitCode !== 0) {
+      // A refusal to overwrite means the version exists; fall through and let
+      // verification compare integrity rather than treating it as a failure.
+      if (!isAlreadyPublished(result)) throw commandError("npm publish", request, result);
+      options.log?.(
+        `[publish] ${candidate.name}@${candidate.version} already on the registry; verifying instead`,
+      );
+    }
+
+    metadata = await awaitPublishedMetadata(candidate, options);
+    if (metadata !== null) return metadata;
+
+    if (attempt < PUBLISH_WRITE_ATTEMPTS) {
+      options.log?.(
+        `[publish] ${candidate.name}@${candidate.version} still absent after a successful publish; reissuing (${attempt}/${PUBLISH_WRITE_ATTEMPTS - 1})`,
+      );
+    }
+  }
+  return metadata;
+}
+
 /** Reconcile validated candidates sequentially, preserving launcher-last safety. */
 export async function reconcileNpmPublication(
   options: ReconcileNpmPublicationOptions,
@@ -509,14 +580,7 @@ export async function reconcileNpmPublication(
       continue;
     }
     if (decision.action === "publish") {
-      const request: CommandRequest = {
-        command: "npm",
-        args: ["publish", candidate.tarballPath, "--access", "public", "--provenance"],
-        cwd: ROOT,
-      };
-      const result = await options.command(request);
-      if (result.exitCode !== 0) throw commandError("npm publish", request, result);
-      assertVerified(candidate, await awaitPublishedMetadata(candidate, options));
+      assertVerified(candidate, await publishWithRetry(candidate, options));
       continue;
     }
     // A skipped candidate was already on the registry before this run, so its


### PR DESCRIPTION
## What actually happened to 0.3.0

`npm publish` exits 0 when the registry *accepts* a write; the registry *applies* it asynchronously. Two facts from the registry itself settle the mechanism:

| | |
|---|---|
| `kunai-linux-arm64@0.3.0` write accepted | 08:01:27Z (attempt 2 log) |
| npm's own `time["0.3.0"]` for that version | **08:08:41Z** |
| Provenance `invocationId` | `runs/33604499949/attempts/2` |

So the same attempt that "failed verification" is the one that published it, and npm took seven minutes to apply. Nothing was dropped; no read path can shortcut a write the server has not applied yet. The 27-second budget in #308 was simply too short.

`kunai-linux-x64-musl`, in the same run, was visible after 3 seconds. The lag is per write and wildly variable.

## Why the first two commits on this branch were not enough

They kept the publisher's shape — **publish one package, wait for it, publish the next** — and made each wait ~10 minutes. Eight platform packages × 10 minutes is why the job timeout went to 120 minutes. That is the wrong shape: the lags overlap, so paying the worst one eight times is waste, and a 120-minute publish job is a release you cannot babysit.

The first commit also called this a dropped write. It was not (see provenance above). The reissue survives only as insurance behind a full window.

## The fix (third commit)

`reconcileNpmPublication` now runs in three phases:

1. **Decide every platform package before writing any.** A conflicting version anywhere in the set halts with nothing new on the registry. (Previously a conflict on package 6 left packages 1–5 newly published.)
2. **Write all eight missing platform packages back to back, then wait out one shared visibility window** (3s → 30s backoff, ~10 min). A package that appears is verified on that first read, so a wrong artifact still fails immediately. Anything still absent after the whole window gets one reissue; npm refusing to overwrite counts as confirmation.
3. **Only after all eight read back with the expected integrity: decide and write the launcher, wait once for it.**

This is safe for the same reason launcher-last was always the invariant: the launcher is the only package users resolve by name. A platform package that is live while its siblings are still being applied is invisible to users.

**Publish job timeout: 120 → 45 minutes.** Setup + eight writes + one window + launcher + one window + smoke/tag/draft/promote ≈ 30 minutes worst plausible. A timeout can now only land inside a wait, which leaves nothing half-written — no launcher before its platform packages, and a rerun skips whatever already matches.

Kept from the earlier commits: npm's stdout/stderr logged on every publish; overwrite refusal read as confirmation.

## Tests

31 pass. Two new cases pin the shape, and both were red against the previous commit:

- *writes every platform package before waiting on any, then the launcher after all are visible* — asserts all eight `publish` events precede the first `read`, the launcher write follows the last platform read, and the whole set costs `[3000, 6000]` of waits for a three-read laggard, not two waits per laggard.
- *halts before writing anything when a platform package already exists with different bytes* — conflict on the sixth candidate, zero publishes.

Every existing case (propagation wait, reissue after a full window, overwrite-as-confirmation, genuine failure throws, mismatch fails on first read, dry-run) passes unchanged. Forced `typecheck`, `lint`, `fmt` clean; `release.yml` parses; pre-push full suite passed.

## Docs

`RELEASING.md` step 4 describes the three phases; the recovery section now says explicitly: do not cancel the publish job while it is waiting on npm, and do not merge to `main` while a Release run is waiting for approval (the publish job pins `HEAD == origin/main`).

## Release state right now

3 of 9 live at 0.3.0 (`linux-x64`, `linux-x64-musl`, `linux-arm64`), all with the expected integrity. No launcher, no tag, no GitHub release, `latest` still 0.2.5 — nothing is user-visible. A new dispatch rebuilds the candidate (SHA pin), skips those three if the compile stays deterministic (already shown for `linux-x64` across two SHAs), writes the other five, waits once, then the launcher.

Companion PRs for the other two things that cost cycles today: #312 (installer harness five-second guard), #311 (diagnostics test reading host memory).