### PR TITLE
test(diagnostics): stop the healthy-verdict test reading host memory

### DIFF
--- a/apps/cli/src/services/diagnostics/diagnostics-insight.ts
+++ b/apps/cli/src/services/diagnostics/diagnostics-insight.ts
@@ -10,7 +10,7 @@ import type { ProviderHealth, ProviderId } from "@kunai/types";
 
 import type { DiagnosticEvent } from "./diagnostic-event";
 import { buildRuntimeHealthSnapshot } from "./runtime-health";
-import type { RuntimeMemorySample } from "./runtime-memory";
+import type { RuntimeMemorySample, RuntimeMemorySnapshot } from "./runtime-memory";
 
 // ---------------------------------------------------------------------------
 // Shared taxonomy
@@ -118,6 +118,8 @@ export type BuildDiagnosticsInsightInput = {
   readonly releaseSummary?: { titleCount: number; episodeCount: number } | null;
   readonly releaseDiagnostics?: ReleaseProgressDiagnosticsSummary | null;
   readonly presenceSnapshot?: PresenceSnapshot | null;
+  /** Defaults to the live process; injected so a verdict can be computed without reading host memory. */
+  readonly memorySnapshot?: RuntimeMemorySnapshot;
   readonly memorySamples?: readonly RuntimeMemorySample[];
   readonly getProviderHealth?: (providerId: ProviderId) => ProviderHealth | undefined;
 };
@@ -216,6 +218,7 @@ export function buildDiagnosticsInsight(input: BuildDiagnosticsInsightInput): Di
   const runtimeHealth = buildRuntimeHealthSnapshot({
     recentEvents: input.recentEvents,
     currentProvider: input.state.provider,
+    memorySnapshot: input.memorySnapshot,
     memorySamples: input.memorySamples,
     persistedProviderHealth: input.getProviderHealth?.(input.state.provider as ProviderId),
   });

--- a/apps/cli/test/unit/services/diagnostics/diagnostics-insight.test.ts
+++ b/apps/cli/test/unit/services/diagnostics/diagnostics-insight.test.ts
@@ -9,6 +9,7 @@ import {
   formatSessionVerdictLabel,
   type RecommendedAction,
 } from "@/services/diagnostics/diagnostics-insight";
+import type { RuntimeMemorySnapshot } from "@/services/diagnostics/runtime-memory";
 import type { PresenceSnapshot } from "@/services/presence/PresenceService";
 
 function baseState() {
@@ -19,6 +20,22 @@ function baseState() {
   });
 }
 
+/**
+ * The memory row defaults to the live process. Under the full unit suite that
+ * process can sit above the warning line or on swap, which turned a pure
+ * verdict test into a host-memory test; a quiet snapshot keeps it about the
+ * session.
+ */
+const quietMemory: RuntimeMemorySnapshot = {
+  appRssBytes: 256 * 1024 ** 2,
+  appHeapUsedBytes: 64 * 1024 ** 2,
+  appHeapTotalBytes: 128 * 1024 ** 2,
+  playbackChildRssBytes: 0,
+  playbackChildSwapBytes: 0,
+  playbackChildCount: 0,
+  appSwapBytes: 0,
+};
+
 describe("buildDiagnosticsInsight", () => {
   test("healthy session reports healthy verdict and none action", () => {
     const state = {
@@ -28,6 +45,7 @@ describe("buildDiagnosticsInsight", () => {
     };
     const insight = buildDiagnosticsInsight({
       state,
+      memorySnapshot: quietMemory,
       recentEvents: [
         {
           timestamp: 1,
@@ -48,6 +66,17 @@ describe("buildDiagnosticsInsight", () => {
     expect(insight.healthRows.find((row) => row.subsystem === "playback")?.severity).toBe(
       "healthy",
     );
+  });
+
+  test("an injected memory snapshot drives the memory row", () => {
+    const insight = buildDiagnosticsInsight({
+      state: baseState(),
+      memorySnapshot: { ...quietMemory, appSwapBytes: 1 },
+      recentEvents: [],
+    });
+
+    expect(insight.healthRows.find((row) => row.subsystem === "memory")?.severity).toBe("degraded");
+    expect(insight.degradedSubsystems).toContain("memory");
   });
 
   test("provider timeout is explainable with fallback-provider action", () => {


### PR DESCRIPTION
## What flipped

`buildDiagnosticsInsight > healthy session reports healthy verdict and none action` failed during a pre-push full-suite run with no related change:

```
Expected: "healthy"
Received: "degraded"
```

It passes in isolation every time. The memory health row defaults to the **live process** — `process.memoryUsage()` plus `/proc` swap — and reports `warning` at RSS ≥ 3 GiB or any swap in use. Under 5,300+ tests in one Bun process on a machine with swap active, that condition is met, so a pure verdict test was asserting on the test runner's own memory.

## The change

- `BuildDiagnosticsInsightInput` gains `memorySnapshot?: RuntimeMemorySnapshot`, passed through to `buildRuntimeHealthSnapshot` exactly like the `memorySamples` it already accepted. Default behaviour is unchanged; production callers pass nothing and still read the live process.
- The healthy-session test injects a quiet snapshot.
- A new case drives the memory row to `degraded` through the same field, so the injection is a pinned seam rather than a way to mute the row.

## Why it matters for releases

The pre-push hook and CI run the whole suite. A test that reads host memory fails on whichever machine happens to be busiest — this one blocked pushing two release fixes today.

## Verification

13 pass in the file; forced `typecheck`, `lint`, `fmt` clean; the pre-push full suite passed on this push.