### PR TITLE
test(installer): stop failing the release gate on a five-second hang guard

### DIFF
--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -54,8 +54,14 @@ function impossibleProcessStartId(): string {
   return "linux-proc:0";
 }
 
+/**
+ * A hang guard for real installer subprocesses, not a timing assertion. The
+ * Bash harness failed a release gate on its shorter guard while two concurrent
+ * installers were still downloading; only a genuinely stuck installer should
+ * ever reach this.
+ */
 async function waitForPaths(paths: readonly string[]): Promise<void> {
-  const deadline = Date.now() + 8_000;
+  const deadline = Date.now() + 60_000;
   while (paths.some((path) => !existsSync(path))) {
     if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${paths.join(", ")}`);
     await Bun.sleep(10);
@@ -1280,10 +1286,14 @@ describePwsh("install.ps1 lifecycle contract", () => {
         }),
       );
       await withReleaseFixture(routes, async (baseUrl) => {
+        // See the Bash harness: the first installer to finish downloading holds
+        // for the lock while its sibling downloads, and that gap must not
+        // exhaust the installer's own lock timeout on a slow runner.
         const installs = versions.map((version) =>
           runInstallPs1Async(["-Yes", "-SkipDeps", "-Version", version], {
             ...sandbox.env,
             KUNAI_DL_BASE: baseUrl,
+            KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "60000",
           }),
         );
         await waitForPaths(

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -125,8 +125,14 @@ function invalidTarArchive(
   });
 }
 
+/**
+ * A hang guard for real installer subprocesses, not a timing assertion: the
+ * release-gate runner took over five seconds to get two concurrent installers
+ * through download and verification, and the guard failed the release. Only a
+ * genuinely stuck installer should ever reach this.
+ */
 async function waitForPaths(paths: readonly string[]): Promise<void> {
-  const deadline = Date.now() + 5_000;
+  const deadline = Date.now() + 60_000;
   while (paths.some((path) => !existsSync(path))) {
     if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${paths.join(", ")}`);
     await Bun.sleep(10);
@@ -1277,10 +1283,15 @@ describe("install.sh lifecycle contract", () => {
         }),
       );
       await withReleaseFixture(routes, async (baseUrl) => {
+        // The installer that finishes downloading first holds for the lock
+        // while its sibling is still downloading; on a slow runner that gap
+        // must not exhaust the installer's own lock timeout before the harness
+        // has seen both and released the lock.
         const installs = versions.map((version) =>
           runInstallShAsync(["--yes", "--skip-deps", "--version", version], {
             ...sandbox.env,
             KUNAI_DL_BASE: baseUrl,
+            KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "60000",
           }),
         );
         await waitForPaths(


### PR DESCRIPTION
## What failed

Attempt 1 of the 0.3.0 Release run ([33604499949](https://github.com/KitsuneKode/kunai/actions/runs/33604499949)) failed the **Installer harness (bash)** gate:

```
error: Timed out waiting for .../data/versions/9.8.7/version.json, .../data/versions/9.8.8/version.json
```

The concurrent-activation test spawns two real `install.sh` processes and waited **five seconds** for both to finish downloading and write `version.json`. The runner took longer. A rerun passed. That is a hang guard acting as a timing assertion, and it cost a release cycle.

## The change

- `waitForPaths` in both the Bash and PowerShell harnesses is now a 60-second guard. A healthy run finishes exactly as fast as before; only a genuinely stuck installer reaches the deadline.
- The two installers in the concurrency test get `KUNAI_ACTIVATION_LOCK_TIMEOUT_MS=60000`. The first to finish downloading holds for the activation lock while its sibling is still downloading; with the installer's default 10-second lock timeout, a slow sibling would have made the first installer give up before the harness released the lock. The guard and the lock timeout now cover the same window.

No installer behaviour changes. The assertions the test makes — launcher and manifest untouched until the lock is released, one active version, symlink to the versioned path — are unchanged.

## Verification

`bun run --cwd apps/cli test:file -- test/integration/install-scripts.test.ts`: 78 pass. Forced `lint`, `fmt` clean; the pre-push full suite passed on this push. The PowerShell harness is pwsh-gated and lands in the skip line locally.