### PR TITLE
fix(release): resolve the smoke host package the way the launcher does

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1118,9 +1118,22 @@ jobs:
 
           # The host platform package must be physically present: if npm skipped
           # it, the launcher would still install and only fail at runtime.
-          HOST_PACKAGE="${PREFIX}/lib/node_modules/@kitsunekode/kunai-linux-x64"
-          test -x "${HOST_PACKAGE}/bin/kunai" \
-            || { echo "::error::host platform package missing at ${HOST_PACKAGE}"; exit 1; }
+          # Resolve it exactly as the launcher does, with createRequire from the
+          # installed launcher module, rather than assuming a tree shape. npm
+          # nests an optional dependency under the launcher for a global install
+          # and hoists it in other layouts; both are correct as long as Node can
+          # resolve it, and only Node's own resolution answers that question.
+          LAUNCHER_MODULE="${PREFIX}/lib/node_modules/@kitsunekode/kunai/dist/npm-launcher.mjs"
+          HOST_BINARY="$(node -e '
+            const { createRequire } = require("node:module");
+            const { dirname, join } = require("node:path");
+            const req = createRequire(process.argv[1]);
+            const manifest = req.resolve("@kitsunekode/kunai-linux-x64/package.json");
+            console.log(join(dirname(manifest), "bin", "kunai"));
+          ' "${LAUNCHER_MODULE}" 2>/dev/null)" \
+            || { echo "::error::host platform package @kitsunekode/kunai-linux-x64 is not resolvable from the installed launcher"; exit 1; }
+          test -x "${HOST_BINARY}" \
+            || { echo "::error::host platform binary missing at ${HOST_BINARY}"; exit 1; }
 
           LAUNCHER="${PREFIX}/bin/kunai"
           test -x "${LAUNCHER}"


### PR DESCRIPTION
## What happened

0.3.0 published **all nine packages successfully**. `latest` is `0.3.0`, and a real
`npm install -g @kitsunekode/kunai@0.3.0` installs and runs:

```
kunai 0.3.0 (npm-global (detected))
```

The release still failed — at the post-publish smoke, *after* everything was on npm,
which stopped tagging, the GitHub release, and the metadata commit.

## Why

The smoke asserted the host platform package sat at the **hoisted** path:

```sh
HOST_PACKAGE="${PREFIX}/lib/node_modules/@kitsunekode/kunai-linux-x64"
```

npm **nests** an optional dependency under its parent for a global install:

```
lib/node_modules/@kitsunekode/kunai/node_modules/@kitsunekode/kunai-linux-x64/bin/kunai
```

So the check failed against a completely healthy install. The log even says
`added 9 packages` immediately before the error.

This assertion was added in db91addc and has never run against a real registry
install, which is why 0.2.5 released clean.

## The fix

The check is worth keeping — npm treats an unresolvable `optionalDependency` as
success, so a missing binary is invisible until a user runs the CLI. It just has to
ask the question the launcher asks.

`dist/npm-launcher.mjs` resolves its binary layout-agnostically:

```js
const require = createRequire(import.meta.url);
const manifest = require.resolve(`${packageName}/package.json`);
```

The smoke now does the same from the installed launcher module, so it passes whether
npm nests or hoists, and still fails when the package is genuinely absent.

## Verification

Against the **live 0.3.0 on npm**, not in the abstract:

- patched step exits **0** through install → resolve → `--version` → `--help`
- with the platform package removed from the tree, resolution exits **1**
- `fmt:check` 26/26, 0 cached (not a turbo replay)

## Release impact

Nothing here lands inside a published tarball, so per `RELEASING.md` a fresh dispatch
reconciles all nine existing packages as **skip** on integrity match, then proceeds to
smoke → tag → draft → promote → metadata.

https://claude.ai/code/session_01MSUxtYErJBiTZNCJwosgZZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved post-install verification to accurately locate and validate the platform-specific executable after installation.
  - Installation checks now better reflect the launcher’s runtime behavior across supported host platforms.
  - Added clearer failure reporting when the required platform package cannot be found or the executable is not runnable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->