### PR TITLE
fix(release): give the tag step a committer identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1149,6 +1149,12 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${{ needs.confirmation.outputs.tag }}"
+          # An annotated tag records a tagger, and the runner has no git identity
+          # of its own, so `git tag -a` aborts with "empty ident name" before it
+          # writes anything. Same bot identity the metadata job already commits
+          # under, kept local to this checkout.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "${TAG}" -m "Release ${TAG}"
           git push origin "refs/tags/${TAG}"
 


### PR DESCRIPTION
## What happened

0.3.0's second publish attempt got **four steps further** than the first. npm is now
completely done — all nine packages at 0.3.0, `latest: 0.3.0`:

```
12. Publish platform packages, then the launcher: success
13. Verify npm package and every platform package: success
14. Smoke the published package from the public registry: success   ← #313's fix held
15. Create canonical tag: FAILURE
```

## Why

`git tag -a` creates an **annotated** tag, which records a tagger. A GitHub runner
has no git identity, so it aborts before writing anything:

```
Committer identity unknown
fatal: empty ident name (for <runner@runnervm...internal.cloudapp.net>) not allowed
##[error]Process completed with exit code 128
```

The `metadata` job already configures the bot identity before its commit. The
`publish` job never did — and since this step has never executed in a release, the
gap was invisible.

## The fix

Two lines, the same identity `metadata` uses, set locally rather than globally
because only this step needs it.

## Verification

Reproduced in a scratch repo with no git identity: `git tag -a` fails exactly as
above; with the config lines it succeeds and produces a real annotated tag —

```
$ git cat-file -t v0.3.0
tag
$ git cat-file tag v0.3.0
tagger github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com> ...
```

`fmt:check` 26/26 with **0 cached** (forced, not a turbo replay).

## Why this should be the last one

Rather than fix one step and rediscover the next, I audited every remaining
never-executed step against this run's evidence:

| Step | Verdict | Basis |
|---|---|---|
| 16 Reverify native payload | ✅ | byte-identical to step 10, which passed |
| 17 Verify native provenance | ✅ | byte-identical to step 11, which passed |
| 18 Create draft release | ✅ | `body_path` exists; its 18 `files:` are the set step 10 verified |
| 19 Verify draft assets | ✅ | has `attestations: read` + `GH_TOKEN` |
| 20 Promote to latest | ✅ | has `contents: write` + `GH_TOKEN` |
| 21 Verify public assets | ✅ | same as 19 |
| metadata job | ✅ | already sets git identity |

## Release impact

Touches only a workflow file — nothing inside a published tarball — so per
`RELEASING.md` a fresh dispatch reconciles all nine packages as **skip** on
integrity match and proceeds to tag → draft → promote → metadata.
