### PR TITLE
fix(release): stop the metadata push running the suite, and unpin its versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,12 @@ env:
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_SCM_BASE: ""
+  # Git hooks are a developer convenience; CI has already run these suites as
+  # dedicated jobs. Leaving them armed made every `git push` in this workflow —
+  # the canonical tag and the metadata commit — re-run the entire monorepo test
+  # suite from inside a release job, where a failure is discovered after npm and
+  # the GitHub release are already public.
+  HUSKY: "0"
   CANDIDATE_ARTIFACT: kunai-release-candidate
   NPM_TARBALL_NAME: kunai-npm.tgz
   RELEASE_NODE_VERSION: "22.14.0"

--- a/.release/kunai-v0.3.0.json
+++ b/.release/kunai-v0.3.0.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
-  "status": "staged",
-  "publishedAt": null,
+  "status": "published",
+  "publishedAt": "2026-09-02T11:23:27Z",
   "packageName": "@kitsunekode/kunai",
   "version": "0.3.0",
   "tag": "v0.3.0",

--- a/apps/docs/lib/generated-release-notes.json
+++ b/apps/docs/lib/generated-release-notes.json
@@ -1,8 +1,8 @@
 [
   {
     "schemaVersion": 2,
-    "status": "staged",
-    "publishedAt": null,
+    "status": "published",
+    "publishedAt": "2026-09-02T11:23:27Z",
     "packageName": "@kitsunekode/kunai",
     "version": "0.3.0",
     "tag": "v0.3.0",

--- a/apps/docs/test/release-doc-contract.test.ts
+++ b/apps/docs/test/release-doc-contract.test.ts
@@ -26,6 +26,7 @@ import {
   getReleaseByTag,
   latestReleaseNotesArtifact,
   publishedReleaseNotesArtifacts,
+  releaseNotesArtifacts,
 } from "../lib/release-notes";
 
 const ROOT = path.resolve(import.meta.dir, "../../..");
@@ -181,20 +182,23 @@ describe("0.3.0 public truth contract", () => {
   });
 
   /**
-   * A staged candidate must never read as shipped. This used to name a fixed
-   * version whose artifact has since been removed; the invariant outlived the
-   * example, so it follows the current staged candidate instead.
+   * A staged candidate must never read as shipped. Naming the version made this
+   * assert the calendar rather than the invariant: pinned to "0.3.0" it passed
+   * only while 0.3.0 was unshipped, so the release job that flipped that status
+   * to `published` — the last step of shipping it — failed this test as its
+   * direct result, after npm and the GitHub release were already public. Read
+   * whatever is staged now, and assert the rule about it.
    */
-  test("the staged candidate is not latest or published", () => {
-    const staged = getReleaseByTag("0.3.0");
-    expect(staged).toBeDefined();
-    expect(staged?.status).toBe("staged");
-    expect(staged?.publishedAt).toBeNull();
+  test("a staged candidate is never latest or published", () => {
+    const staged = releaseNotesArtifacts.filter((release) => release.status === "staged");
+    const latest = latestReleaseNotesArtifact();
+    const published = publishedReleaseNotesArtifacts();
 
-    expect(latestReleaseNotesArtifact()?.version).not.toBe("0.3.0");
-    expect(publishedReleaseNotesArtifacts().some((release) => release.version === "0.3.0")).toBe(
-      false,
-    );
+    for (const candidate of staged) {
+      expect(candidate.publishedAt).toBeNull();
+      expect(latest?.version).not.toBe(candidate.version);
+      expect(published.some((release) => release.version === candidate.version)).toBe(false);
+    }
   });
 
   test("no unpublished version is advertised anywhere public", () => {

--- a/apps/docs/test/release-notes.test.ts
+++ b/apps/docs/test/release-notes.test.ts
@@ -34,12 +34,14 @@ describe("release notes artifacts", () => {
    */
   test("latest public release ignores any staged candidate", () => {
     const published = publishedReleaseNotesArtifacts();
-    const stagedVersions = releaseNotesArtifacts
-      .filter((release) => release.status === "staged")
-      .map((release) => release.version);
+    const stagedVersions = new Set(
+      releaseNotesArtifacts
+        .filter((release) => release.status === "staged")
+        .map((release) => release.version),
+    );
 
     expect(published.every((release) => release.status === "published")).toBe(true);
-    expect(published.some((release) => stagedVersions.includes(release.version))).toBe(false);
+    expect(published.some((release) => stagedVersions.has(release.version))).toBe(false);
 
     const newestPublished = [...published]
       .map((release) => release.version)

--- a/apps/docs/test/release-notes.test.ts
+++ b/apps/docs/test/release-notes.test.ts
@@ -25,14 +25,26 @@ describe("release notes artifacts", () => {
     expect(latest?.summary.trim().length).toBeGreaterThan(0);
   });
 
-  test("latest public release ignores the staged candidate", () => {
-    expect(latestReleaseNotesArtifact()?.version).toBe("0.2.5");
-    expect(
-      publishedReleaseNotesArtifacts().every((release) => release.status === "published"),
-    ).toBe(true);
-    expect(publishedReleaseNotesArtifacts().some((release) => release.version === "0.3.0")).toBe(
-      false,
-    );
+  /**
+   * Naming the two versions turned this into a time bomb of the same shape as
+   * the census below: "0.2.5" stopped being latest the moment 0.3.0 shipped, so
+   * the release job that published it failed here as a direct consequence of
+   * succeeding. The rule is that `latest` is the newest *published* artifact and
+   * nothing staged is ever counted as published — both derivable from the data.
+   */
+  test("latest public release ignores any staged candidate", () => {
+    const published = publishedReleaseNotesArtifacts();
+    const stagedVersions = releaseNotesArtifacts
+      .filter((release) => release.status === "staged")
+      .map((release) => release.version);
+
+    expect(published.every((release) => release.status === "published")).toBe(true);
+    expect(published.some((release) => stagedVersions.includes(release.version))).toBe(false);
+
+    const newestPublished = [...published]
+      .map((release) => release.version)
+      .sort((left, right) => compareVersions(right, left))[0];
+    expect(latestReleaseNotesArtifact()?.version).toBe(newestPublished);
   });
 
   /**
@@ -76,13 +88,14 @@ describe("release notes artifacts", () => {
   });
 
   test("staged releases have no GitHub URL or visible assets", () => {
-    const staged = getReleaseByTag("0.3.0");
-    expect(staged).toBeDefined();
-    if (!staged) return;
+    // Whatever is staged right now, not a version that was staged when this was
+    // written — the same pin that made shipping 0.3.0 fail its own release job.
+    const staged = releaseNotesArtifacts.filter((release) => release.status === "staged");
 
-    expect(staged.status).toBe("staged");
-    expect(githubReleaseUrl(staged)).toBeNull();
-    expect(releaseAssetsForDisplay(staged)).toEqual([]);
+    for (const candidate of staged) {
+      expect(githubReleaseUrl(candidate)).toBeNull();
+      expect(releaseAssetsForDisplay(candidate)).toEqual([]);
+    }
   });
 
   test("looks up releases by tag and builds detail paths", () => {


### PR DESCRIPTION
## What happened

0.3.0 published to npm, tagged `v0.3.0`, and shipped a **public GitHub release with
all 18 assets** — then failed its own `metadata` job, the step that records the
release as published. `.release/kunai-v0.3.0.json` was left at `staged`, so the docs
site still advertised 0.2.5 as latest.

## Two causes, both in code that only runs at the very end of a release

**1. The push ran the whole monorepo suite.** `.husky/pre-push` is `bun run test`, so
the metadata job's `git push` ran every suite from inside a release job:

```
husky - pre-push script failed (code 1)
error: failed to push some refs
```

Hooks are a developer convenience; CI already runs these as dedicated jobs. The
workflow now sets `HUSKY: "0"`. The canonical tag push was paying the same cost.

**2. Three docs tests pinned the version they were written beside.**

```js
expect(staged?.status).toBe("staged");                       // "0.3.0"
expect(latestReleaseNotesArtifact()?.version).toBe("0.2.5");
```

These assert the calendar, not an invariant. They pass **only while 0.3.0 is
unshipped** — so the job that flipped that status to `published`, which is the act of
shipping it, failed them *as a direct consequence of succeeding*.

### Why CI could not have caught it

Every pre-merge run sees the staged state the tests expect, so they pass. The failure
only exists after the flip, and the flip only happens in the release job. This is not
a flaky test or a missing CI job — it is a state-dependent assertion that is
unreachable before the moment it breaks.

## The fix

The tests now read whatever is staged *now* and assert the rule about it, so they
hold before and after any flip:

```js
const staged = releaseNotesArtifacts.filter((r) => r.status === "staged");
for (const candidate of staged) {
  expect(latest?.version).not.toBe(candidate.version);
  expect(published.some((r) => r.version === candidate.version)).toBe(false);
}
```

## This shape has bitten the repo before

The census check sitting directly below these carries its own scar:

> *"Pinning the exact list made this fail on any version above 0.3.0 — a
> release-blocking time bomb that fired the first time a patch changeset produced
> 0.3.1."*

Same bug, three assertions it had not reached yet.

## Sweep

Checked the whole tree, not just docs. Every other test that reads real release state
(`.release/`, `package.json`, `CHANGELOG.md`, the generated artifacts) derives its
versions rather than pinning them. The remaining `"0.3.0"` literals in `apps/cli` are
synthetic fixtures — `currentVersion`, `appVersion`, parser inputs — which cannot rot
because nothing compares them to repo state.

## Verification

- 215 docs tests pass with 0.3.0 **staged** *and* with it **published** — the property
  that was missing
- `bun run test --force` 23/23, **0 cached**
- `typecheck --force` 14/14, `lint` 12/12, `fmt:check --force` 26/26, all 0 cached
- `verify:doc-paths` 51 docs / 2113 files

## Also carries

The metadata the failed job could not push: 0.3.0 marked `published` at its real
GitHub release timestamp (`2026-09-02T11:23:27Z`), with the docs' generated release
notes regenerated to match. Merging this completes the 0.3.0 release.

https://claude.ai/code/session_01UkcBkkHKhdVPRiqdGSc3mW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Published Kunai 0.3.0, including its publication timestamp and release documentation.

* **Bug Fixes**
  * Improved release validation to dynamically handle all staged and published releases, ensuring staged releases are excluded from latest-release results and public assets.

* **Chores**
  * Prevented Git hooks from rerunning automated checks during release publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->