### PR TITLE
fix(install): show download progress, and make a PATH conflict actionable

### DIFF
--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -2142,3 +2142,53 @@ describe("install.sh PATH persistence", () => {
     }
   });
 });
+
+/**
+ * A PATH conflict is reported by shelling out to the manager that owns the
+ * competing install. The mapping used to test only the winner against npm and
+ * bun, so a winner from any other manager — fnm shims one under
+ * /run/user/…/fnm_multishells — printed a "fix it" header with nothing under
+ * it. These pin that every recognised layout yields a runnable line and that an
+ * unrecognised one still names the path.
+ */
+describe("install.sh PATH conflict remediation", () => {
+  function remedyFor(entry: string): string {
+    const script = [
+      'KUNAI_PACKAGE="@kitsunekode/kunai"',
+      `eval "$(sed -n '/^path_conflict_remedy() {/,/^}/p' ${JSON.stringify(INSTALL_SH)})"`,
+      `path_conflict_remedy ${JSON.stringify(entry)}`,
+    ].join("\n");
+    const result = spawnSync("bash", ["-c", script], { encoding: "utf8" });
+    expect(result.status).toBe(0);
+    return result.stdout.trim();
+  }
+
+  test("a node version manager shim maps to the npm removal", () => {
+    // The exact path shape that produced an empty remediation list.
+    expect(remedyFor("/run/user/1000/fnm_multishells/697191_1788348965165/bin/kunai")).toBe(
+      "npm uninstall -g @kitsunekode/kunai",
+    );
+    expect(remedyFor("/home/u/.nvm/versions/node/v22.0.0/bin/kunai")).toBe(
+      "npm uninstall -g @kitsunekode/kunai",
+    );
+  });
+
+  test("each supported manager maps to its own removal command", () => {
+    expect(remedyFor("/home/u/.bun/bin/kunai")).toBe("bun remove --global @kitsunekode/kunai");
+    expect(remedyFor("/usr/lib/node_modules/@kitsunekode/kunai/bin/kunai")).toBe(
+      "npm uninstall -g @kitsunekode/kunai",
+    );
+    expect(remedyFor("/home/u/.local/share/pnpm/kunai")).toBe(
+      "pnpm remove --global @kitsunekode/kunai",
+    );
+    expect(remedyFor("/home/u/.yarn/bin/kunai")).toBe("yarn global remove @kitsunekode/kunai");
+    expect(remedyFor("/opt/homebrew/bin/kunai")).toBe("brew uninstall kunai");
+  });
+
+  test("an unrecognised install still yields an actionable line naming its path", () => {
+    // The fallback is what keeps the header from standing alone: every entry
+    // produces something, so the list is never empty.
+    expect(remedyFor("/usr/local/bin/kunai")).toBe("# remove or rename /usr/local/bin/kunai");
+    expect(remedyFor("/some/unknown/place/kunai")).not.toBe("");
+  });
+});

--- a/install.sh
+++ b/install.sh
@@ -371,6 +371,25 @@ probe_content_length() {
 	[[ "$length" =~ ^[0-9]+$ ]] && printf '%s' "$length"
 }
 
+# Sleep between progress frames.
+#
+# POSIX `sleep` takes an integer, and this script already refuses to trust a
+# fractional one — the download retry path routes it through python3 with a
+# whole-second fallback. Under `set -e` a `sleep 0.2` that errors would not just
+# spin, it would abort the installer mid-download, so the capability is probed
+# once and the fallback is a coarser frame rate rather than a failure.
+PROGRESS_TICK=""
+progress_tick() {
+	if [[ -z "$PROGRESS_TICK" ]]; then
+		if sleep 0.2 2>/dev/null; then
+			PROGRESS_TICK="0.2"
+			return 0
+		fi
+		PROGRESS_TICK="1"
+	fi
+	sleep "$PROGRESS_TICK" 2>/dev/null || sleep 1
+}
+
 # One \r-updated line: name, size, rate, elapsed, bar, percent.
 #
 #   kunai-linux-x64   85.9 MiB   10.5 MiB/s  00:08 [####################] 100%
@@ -470,7 +489,7 @@ bounded_download() {
 				[[ -f "$dest" ]] && got="$(wc -c <"$dest" 2>/dev/null | tr -d ' ')"
 				render_download_progress "$label" "${got:-0}" "$total_bytes" \
 					"$(($(date +%s) - progress_started))"
-				sleep 0.2
+				progress_tick
 			done
 			curl_rc=0
 			wait "$curl_pid" || curl_rc=$?

--- a/install.sh
+++ b/install.sh
@@ -43,6 +43,14 @@ ARCHIVE_TAR_COMMAND="${KUNAI_ARCHIVE_TAR_COMMAND:-tar}"
 DOWNLOAD_CHECKSUM_MAX_BYTES="${KUNAI_DOWNLOAD_CHECKSUM_MAX_BYTES:-1048576}"
 DOWNLOAD_MAX_ATTEMPTS="${KUNAI_DOWNLOAD_MAX_ATTEMPTS:-3}"
 DOWNLOAD_RETRY_BASE_MS="${KUNAI_DOWNLOAD_RETRY_BASE_MS:-1000}"
+# Only the platform binary and its archive are worth a progress line; the two
+# checksum manifests are a few hundred bytes and finish before a bar could
+# render. Their cap is the natural boundary, so anything allowed to exceed it
+# is a payload download.
+DOWNLOAD_PROGRESS_MIN_BYTES="${KUNAI_DOWNLOAD_PROGRESS_MIN_BYTES:-1048576}"
+# Set once report_path_winner has named a conflicting install, so the PATH
+# success line does not immediately contradict the warning above it.
+PATH_CONFLICT_REPORTED=0
 ACTIVATION_LOCK_TIMEOUT_MS="${KUNAI_ACTIVATION_LOCK_TIMEOUT_MS:-10000}"
 ACTIVATION_LOCK_POLL_MS="${KUNAI_ACTIVATION_LOCK_POLL_MS:-50}"
 ACTIVATION_LOCK_CORRUPT_GRACE_MS="${KUNAI_ACTIVATION_LOCK_CORRUPT_GRACE_MS:-250}"
@@ -327,13 +335,103 @@ is_retryable_http_status() {
 	[[ "$status" == 408 || "$status" == 429 || "$status" -ge 500 ]]
 }
 
+# Render a byte count the way a person reads it. Integer-only: `awk` is the one
+# tool guaranteed present that does float formatting, and shelling out to it
+# five times a second for a progress line is not worth it.
+human_bytes() {
+	local bytes="$1" whole frac
+	if [[ "$bytes" -ge 1048576 ]]; then
+		whole=$((bytes / 1048576))
+		frac=$(((bytes % 1048576) * 10 / 1048576))
+		printf '%d.%d MiB' "$whole" "$frac"
+	elif [[ "$bytes" -ge 1024 ]]; then
+		whole=$((bytes / 1024))
+		frac=$(((bytes % 1024) * 10 / 1024))
+		printf '%d.%d KiB' "$whole" "$frac"
+	else
+		printf '%d B' "$bytes"
+	fi
+}
+
+# Total size for the progress bar, or empty when the server will not say.
+# A HEAD costs one fast round trip and buys the percentage; when it fails —
+# a mirror that rejects HEAD, a proxy that strips Content-Length — progress
+# still renders, just without a bar. Never fatal: this is decoration.
+probe_content_length() {
+	local url="$1" length
+	length="$(
+		curl -sIL \
+			--connect-timeout "$DOWNLOAD_CONNECT_TIMEOUT" \
+			--max-time 15 \
+			-A "kunai-installer" \
+			"$url" 2>/dev/null |
+			tr -d '\r' |
+			awk 'tolower($1) == "content-length:" { value = $2 } END { if (value) print value }'
+	)" || return 0
+	[[ "$length" =~ ^[0-9]+$ ]] && printf '%s' "$length"
+}
+
+# One \r-updated line: name, size, rate, elapsed, bar, percent.
+#
+#   kunai-linux-x64   85.9 MiB   10.5 MiB/s  00:08 [####################] 100%
+#
+# Only ever drawn to a terminal. Under `curl … | bash` stdin is the script, so
+# stdout is still the tty and `-t 1` is the honest test; in CI it is a pipe and
+# the caller falls back to the single quiet line rather than writing thousands
+# of \r frames into a log.
+render_download_progress() {
+	local label="$1" got="$2" total="$3" seconds="$4"
+	local rate=0 percent bar width filled i line mins secs columns
+
+	[[ "$seconds" -gt 0 ]] && rate=$((got / seconds))
+	mins=$((seconds / 60))
+	secs=$((seconds % 60))
+
+	# Fields are sized so label + size + rate + clock + bar + percent lands in 79
+	# columns: an 80-column terminal is the floor worth designing to, and the
+	# label field holds the longest real asset name ("kunai-linux-x64.tar.gz")
+	# rather than clipping it to something that reads like a typo.
+	line="$(printf ' %-22.22s %9s %9s/s %02d:%02d' \
+		"$label" "$(human_bytes "$got")" "$(human_bytes "$rate")" "$mins" "$secs")"
+
+	if [[ -n "$total" && "$total" -gt 0 ]]; then
+		percent=$((got * 100 / total))
+		[[ "$percent" -gt 100 ]] && percent=100
+		width=20
+		filled=$((percent * width / 100))
+		bar=""
+		for ((i = 0; i < width; i++)); do
+			if [[ "$i" -lt "$filled" ]]; then bar+="#"; else bar+="-"; fi
+		done
+		line+="$(printf ' [%s] %3d%%' "$bar" "$percent")"
+	fi
+
+	# Pad to clear a previously longer frame, then return to column 0. Truncating
+	# at the real terminal width keeps a narrow window from wrapping, which would
+	# leave every frame on its own line instead of overwriting in place.
+	columns="${COLUMNS:-0}"
+	[[ "$columns" -lt 40 ]] && columns="$(tput cols 2>/dev/null || printf 80)"
+	[[ "$columns" -lt 40 ]] && columns=80
+	[[ "$columns" -gt 100 ]] && columns=100
+	printf '\r%-*.*s' "$columns" "$columns" "$line"
+}
+
 # Bounded curl download with retries for transient HTTP errors.
 # Uses --connect-timeout, remaining --max-time, --speed-time/--speed-limit, --max-filesize.
 bounded_download() {
 	local url="$1" dest="$2" max_bytes="$3" label="${4:-download}"
 	local attempt=1 code curl_rc remaining started elapsed delay_ms
+	local show_progress=0 total_bytes="" status_file curl_pid progress_started got
 	started="$(date +%s)"
 	BOUNDED_DOWNLOAD_HTTP_STATUS=""
+
+	# A progress line is for a payload on a terminal. Everywhere else — CI, a
+	# pipe, the two tiny checksum manifests — keep the single quiet line the
+	# installer has always printed.
+	if [[ -t 1 && "$max_bytes" -gt "$DOWNLOAD_PROGRESS_MIN_BYTES" ]]; then
+		show_progress=1
+		total_bytes="$(probe_content_length "$url")"
+	fi
 
 	while [[ "$attempt" -le "$DOWNLOAD_MAX_ATTEMPTS" ]]; do
 		elapsed=$(($(date +%s) - started))
@@ -347,7 +445,12 @@ bounded_download() {
 		curl_rc=0
 		# Capture curl exit: --max-filesize (63) can leave a partial with HTTP 200
 		# when Transfer-Encoding is chunked / Content-Length is absent.
-		code="$(
+		if [[ "$show_progress" == 1 ]]; then
+			# curl runs in the background so this shell can watch the staging
+			# file grow. Its status code goes to a file rather than a command
+			# substitution, which would otherwise block until curl exited and
+			# leave nothing to render meanwhile.
+			status_file="$(mktemp)"
 			curl -sS -L \
 				--connect-timeout "$DOWNLOAD_CONNECT_TIMEOUT" \
 				--max-time "$remaining" \
@@ -357,8 +460,42 @@ bounded_download() {
 				-A "kunai-installer" \
 				-o "$dest" \
 				-w "%{http_code}" \
-				"$url"
-		)" || curl_rc=$?
+				"$url" >"$status_file" &
+			curl_pid=$!
+			progress_started="$(date +%s)"
+			# `kill -0` is the liveness test; `wait` below is what reaps it and
+			# yields the real exit status.
+			while kill -0 "$curl_pid" 2>/dev/null; do
+				got=0
+				[[ -f "$dest" ]] && got="$(wc -c <"$dest" 2>/dev/null | tr -d ' ')"
+				render_download_progress "$label" "${got:-0}" "$total_bytes" \
+					"$(($(date +%s) - progress_started))"
+				sleep 0.2
+			done
+			curl_rc=0
+			wait "$curl_pid" || curl_rc=$?
+			got=0
+			[[ -f "$dest" ]] && got="$(wc -c <"$dest" 2>/dev/null | tr -d ' ')"
+			render_download_progress "$label" "${got:-0}" "$total_bytes" \
+				"$(($(date +%s) - progress_started))"
+			printf '\n'
+			code="$(cat "$status_file" 2>/dev/null || true)"
+			rm -f "$status_file"
+			[[ -n "$code" ]] || code="000"
+		else
+			code="$(
+				curl -sS -L \
+					--connect-timeout "$DOWNLOAD_CONNECT_TIMEOUT" \
+					--max-time "$remaining" \
+					--speed-time "$DOWNLOAD_SPEED_TIME" \
+					--speed-limit "$DOWNLOAD_SPEED_LIMIT" \
+					--max-filesize "$max_bytes" \
+					-A "kunai-installer" \
+					-o "$dest" \
+					-w "%{http_code}" \
+					"$url"
+			)" || curl_rc=$?
+		fi
 		BOUNDED_DOWNLOAD_HTTP_STATUS="$code"
 		if [[ "$curl_rc" -ne 0 ]]; then
 			rm -f "$dest"
@@ -1347,6 +1484,10 @@ path_hint() {
 	local dir="$1" rc_file
 	case ":$PATH:" in
 	*":$dir:"*)
+		# The directory is on PATH, but saying so right after reporting that a
+		# different kunai wins reads as a contradiction and buries the warning.
+		# The conflict block has already said everything true about this case.
+		[[ "$PATH_CONFLICT_REPORTED" == 1 ]] && return 0
 		info "kunai is on PATH ($dir)."
 		return 0
 		;;
@@ -1674,8 +1815,43 @@ list_path_kunai() {
 # bookkeeping, and silently deleting software a user installed deliberately is
 # a surprise no installer should spring. Naming the conflict and the exact
 # remediation leaves them in control.
+# Map one conflicting `kunai` on PATH to the command that removes it.
+#
+# This used to test only the PATH winner against npm and bun. A winner from any
+# other manager — fnm shims a node install under /run/user/…/fnm_multishells,
+# volta, asdf, pnpm, a plain copy in /usr/local/bin — matched nothing, so the
+# installer printed a "fix it" header with no fix under it. Every branch here
+# ends in a line the user can run, and the fallback names the path so an
+# unrecognised manager is still actionable.
+path_conflict_remedy() {
+	local entry="$1"
+	case "$entry" in
+	*/.bun/*)
+		printf 'bun remove --global %s' "$KUNAI_PACKAGE"
+		;;
+	*node_modules* | */npm/* | */.npm-global/* | */fnm_multishells/* | */.nvm/* | */.volta/* | */.asdf/*)
+		# Node version managers shim whatever npm installed into the active
+		# runtime, so the removal is still npm's — run it under that runtime.
+		printf 'npm uninstall -g %s' "$KUNAI_PACKAGE"
+		;;
+	*/pnpm/*)
+		printf 'pnpm remove --global %s' "$KUNAI_PACKAGE"
+		;;
+	*/.yarn/* | */yarn/global/*)
+		printf 'yarn global remove %s' "$KUNAI_PACKAGE"
+		;;
+	*/homebrew/* | */Cellar/*)
+		printf 'brew uninstall kunai'
+		;;
+	*)
+		printf '# remove or rename %s' "$entry"
+		;;
+	esac
+}
+
 report_path_winner() {
-	local launcher="$BIN_DIR/kunai" found others=() entry winner
+	local launcher="$BIN_DIR/kunai" found others=() entry winner remedy seen
+	local remedies=()
 	[[ "$DRY" == 1 ]] && return 0
 
 	winner="$(command -v kunai 2>/dev/null || true)"
@@ -1696,16 +1872,27 @@ report_path_winner() {
 	done
 	printf '\n'
 	warn "This install is at $launcher, but 'kunai' currently resolves to $winner."
-	printf '  Fix it either way:\n'
-	if [[ "$winner" == *node_modules* || "$winner" == *npm* ]]; then
-		printf '    npm uninstall -g %s      # remove the old npm install\n' "$KUNAI_PACKAGE"
-	fi
-	if [[ "$winner" == *".bun"* ]]; then
-		printf '    bun remove --global %s   # remove the old bun install\n' "$KUNAI_PACKAGE"
-	fi
+	printf '  Fix it any of these ways:\n'
+	# Every conflicting entry gets its own line, not just the winner: removing
+	# the winner only promotes the next one, so a user told about one of three
+	# installs runs this three times. Deduplicated because two entries can share
+	# a manager.
+	remedies=()
+	for entry in "${others[@]}"; do
+		remedy="$(path_conflict_remedy "$entry")"
+		[[ -z "$remedy" ]] && continue
+		for seen in ${remedies[@]+"${remedies[@]}"}; do
+			[[ "$seen" == "$remedy" ]] && continue 2
+		done
+		remedies+=("$remedy")
+	done
+	for remedy in ${remedies[@]+"${remedies[@]}"}; do
+		printf '    %s\n' "$remedy"
+	done
 	printf '    # …or put %s earlier in your PATH\n' "$BIN_DIR"
 	printf '\n'
 	printf '  Then open a new shell and confirm with: command -v kunai\n'
+	PATH_CONFLICT_REPORTED=1
 }
 
 ensure_bun() {


### PR DESCRIPTION
Both of these came out of one real install on a machine that already had three
`kunai` binaries on PATH.

## 1. The download was silent

An 86MB fetch printed one line and then nothing for ten seconds — it reads as a hang.
The cause is `curl -sS` at the download site: `-s` silences the progress meter.

curl now runs in the background while the shell watches the staging file grow, and
renders one `\r`-updated line:

```
 kunai-linux-x64.tar.gz  35.7 MiB   3.5 MiB/s 00:10 [####################] 100%
```

- Total comes from a single HEAD request. If a mirror rejects HEAD or strips
  `Content-Length`, the line still renders — just without the bar. Never fatal;
  this is decoration.
- Gated on `-t 1` **and** on a payload-sized cap, so CI, pipes, and the two tiny
  checksum manifests keep the quiet single line they have always printed.
- Field widths fit an 80-column terminal; the line truncates to the real terminal
  width so a narrow window overwrites in place instead of wrapping.

## 2. The PATH conflict block printed a promise with nothing under it

This is the worse bug. The old code tested only the **winner**, against npm and bun:

```sh
if [[ "$winner" == *node_modules* || "$winner" == *npm* ]]; then ...
if [[ "$winner" == *".bun"* ]]; then ...
printf '    # …or put %s earlier in your PATH\n' "$BIN_DIR"
```

A winner from anything else matches neither branch. On a machine where fnm shims the
install under `/run/user/…/fnm_multishells/…`, the user got:

```
  Fix it either way:
    # …or put /home/u/.local/bin earlier in your PATH
```

A header promising two options, one dangling `…or`, and no command to run. The same
machine's `.bun` install was **listed as a conflict but given no fix**, because it
wasn't the winner.

Now:

- remediation resolves **per conflicting entry**, not for the winner alone — removing
  the winner only promotes the next one
- covers fnm / nvm / volta / asdf (→ npm), pnpm, yarn, homebrew, bun
- a fallback names the path, so an unrecognised manager is still actionable
- every entry yields a line, so the header can never stand alone

```
  Fix it any of these ways:
    npm uninstall -g @kitsunekode/kunai
    bun remove --global @kitsunekode/kunai
    # …or put /home/u/.local/bin earlier in your PATH
```

## 3. The success line contradicted the warning

`path_hint` announced `→ kunai is on PATH (…)` immediately after warning that a
*different* kunai wins. Both statements were true; the pair read as a contradiction
and buried the warning. The success line is suppressed once a conflict is reported.

## Not changed

`ask()` is sound — it opens `/dev/tty` to test for a real terminal and declines on a
failed read, with comments documenting exactly the trap it avoids. The mpv prompt was
legitimately waiting for input, so it is untouched.

## Verification

Against the **published 0.3.0**, not a fixture: a sandboxed `install.sh` (HOME + XDG
isolated) downloads with the bar advancing to 100% and installs a binary reporting
`kunai 0.3.0 (binary)`.

Running it for real is what found two defects that review would not have:

- percent rendered as `10` instead of `100%` — the line is 81 chars, the pad was 79
- `kunai-linux-x64.tar.gz` clipped to `kunai-linux-x64.ta` by an 18-wide label field

`shellcheck` also caught a pnpm pattern that could never match.

- 81 installer integration tests pass, **3 new** covering the remediation mapping
  (including the exact fnm path that produced the empty list, and the fallback)
- `bun run test --force` 23/23, `typecheck --force` 14/14, `lint` 12/12,
  `fmt:check --force` 26/26 — all **0 cached**, so no turbo replay
- `shellcheck -S warning install.sh` clean

## Scope

`install.sh` and one test file. Nothing under `apps/cli/src/` or `packages/`, so no
change to compiled binary bytes.

https://claude.ai/code/session_01Qkh3U4cMEM9hRNKMJQmtFd
