### PR TITLE
ci(release): make the tag idempotent and smoke the published install.sh

### DIFF
--- a/.github/scripts/create-canonical-tag.sh
+++ b/.github/scripts/create-canonical-tag.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Create and push the canonical release tag, idempotently.
+#
+# RELEASING.md ("npm publication recovery") tells you to re-dispatch the same
+# version after a partial failure. Everything after this step — draft creation,
+# draft asset verification, promotion, public verification — is reached only
+# once the tag exists, so a failure there is exactly the case that recovery
+# path is for. `git tag -a` exits 128 on an existing tag, which made the
+# unconditional form fail every such re-dispatch before it could retry
+# anything.
+#
+# Re-creating a tag that already points at the commit being released is a
+# no-op, so skip it. A tag pointing anywhere else is a conflict and must stop
+# the release: `git tag -f` or a force push would move a tag whose old commit
+# is already baked into published checksums, sigstore attestations, and
+# `.../releases/download/vX.Y.Z/...` URLs. This script never rewrites a ref.
+set -euo pipefail
+
+TAG="${1:?usage: create-canonical-tag.sh <tag> <release-sha>}"
+RELEASE_SHA="${2:?usage: create-canonical-tag.sh <tag> <release-sha>}"
+
+[[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+	echo "::error::refusing to publish a non-canonical release tag: $TAG"
+	exit 1
+}
+[[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+	echo "::error::refusing to tag a non-canonical commit sha: $RELEASE_SHA"
+	exit 1
+}
+
+# Peel a ref to the commit it releases. An annotated tag's `refs/tags/X` names
+# the tag object, not the commit, so a raw comparison against a release SHA
+# never matches; `^{}` (from ls-remote) and `rev-list -n 1` (locally) are the
+# two ways to ask for the commit underneath.
+remote_tag_commit() {
+	local refs peeled
+	refs="$(git ls-remote --tags origin "refs/tags/$TAG" "refs/tags/$TAG^{}")"
+	peeled="$(awk -v want="refs/tags/$TAG^{}" '$2 == want { print $1 }' <<<"$refs")"
+	if [[ -n "$peeled" ]]; then
+		printf '%s\n' "$peeled"
+		return 0
+	fi
+	awk -v want="refs/tags/$TAG" '$2 == want { print $1 }' <<<"$refs"
+}
+
+# The remote is the authority on whether this release is already tagged. The
+# publish job checks out with `fetch-depth: 0`, which does fetch tags, but that
+# says what origin looked like when the job started, and a rerun of a job whose
+# push already landed is precisely the case this handles.
+EXISTING_REMOTE="$(remote_tag_commit)"
+if [[ -n "$EXISTING_REMOTE" ]]; then
+	if [[ "$EXISTING_REMOTE" == "$RELEASE_SHA" ]]; then
+		echo "tag $TAG already exists on origin at $RELEASE_SHA — nothing to do"
+		exit 0
+	fi
+	echo "::error::tag $TAG already exists on origin at $EXISTING_REMOTE, but this run releases $RELEASE_SHA"
+	echo "::error::A published release tag is never moved. Investigate which commit v${TAG#v} shipped from; release the fix as the next version."
+	exit 1
+fi
+
+# Origin has no such tag, so anything local is stale — from an earlier attempt
+# in this same checkout, say. Left alone it would fail `git tag -a` with the
+# same exit 128 this script exists to remove.
+EXISTING_LOCAL="$(git rev-list -n 1 "refs/tags/$TAG" 2>/dev/null || true)"
+if [[ -n "$EXISTING_LOCAL" && "$EXISTING_LOCAL" != "$RELEASE_SHA" ]]; then
+	echo "::error::local tag $TAG points at $EXISTING_LOCAL, but this run releases $RELEASE_SHA"
+	exit 1
+fi
+
+# An annotated tag records a tagger, and the runner has no git identity of its
+# own, so `git tag -a` aborts with "empty ident name" before it writes
+# anything. Same bot identity the metadata job already commits under, kept
+# local to this checkout.
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+if [[ -z "$EXISTING_LOCAL" ]]; then
+	git tag -a "$TAG" -m "Release $TAG" "$RELEASE_SHA"
+fi
+git push origin "refs/tags/$TAG"
+echo "pushed $TAG at $RELEASE_SHA"

--- a/.github/scripts/smoke-published-installer.sh
+++ b/.github/scripts/smoke-published-installer.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Install the public release through production install.sh, the way the README
+# tells a user to, and prove the binary it activates reports <version>.
+#
+# The `installer-smoke` jobs run `needs: candidate` — against artifacts that
+# have not been published yet — and the registry smoke in the publish job
+# covers only the npm route. Nothing exercised the recommended route against
+# the real release, and that route has a step the candidate harness structurally
+# cannot reach: install.sh resolves `latest` from
+# api.github.com/repos/KitsuneKode/kunai/releases/latest, and that endpoint
+# excludes drafts. Until `gh release edit --draft=false --latest` runs, the
+# route resolves to the *previous* release. So this must run after promotion,
+# and it must let install.sh resolve `latest` itself — pinning `--version`
+# would skip the one thing only a post-promote run can prove.
+set -euo pipefail
+
+VERSION="${1:?usage: smoke-published-installer.sh <version> [install-script]}"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+	echo "::error::invalid release version: $VERSION"
+	exit 1
+}
+TAG="v$VERSION"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
+INSTALLER="${2:-$REPO_ROOT/install.sh}"
+[[ -f "$INSTALLER" ]] || {
+	echo "::error::installer not found: $INSTALLER"
+	exit 1
+}
+
+RELEASES_API="${KUNAI_RELEASES_API:-https://api.github.com/repos/KitsuneKode/kunai/releases/latest}"
+
+# `gh release edit --draft=false --latest` returns before the REST API has
+# caught up, and an unauthenticated api.github.com call can also be rate
+# limited on a shared runner IP. Wait for the endpoint to name this tag before
+# handing the job to install.sh, so a slow promotion reports itself here
+# instead of surfacing as an opaque installer failure that installed the
+# previous release.
+resolve_latest_tag() {
+	curl -fsSL -H "user-agent: kunai-installer" "$RELEASES_API" |
+		sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
+		head -1
+}
+
+observed_tag=""
+for attempt in 1 2 3 4 5 6 7 8 9 10; do
+	observed_tag="$(resolve_latest_tag || true)"
+	[[ "$observed_tag" == "$TAG" ]] && break
+	echo "attempt $attempt: releases/latest reports '${observed_tag:-<none>}', waiting for $TAG"
+	observed_tag=""
+	sleep 15
+done
+if [[ "$observed_tag" != "$TAG" ]]; then
+	echo "::error::$RELEASES_API never reported $TAG — the recommended install route would install the previous release"
+	exit 1
+fi
+echo "releases/latest reports $TAG"
+
+# A full profile sandbox. KUNAI_CONFIG_DIR alone is not isolation: install.sh
+# derives DATA_DIR and CACHE_DIR from HOME/XDG independently, so a partial
+# override writes a real profile on any machine that has one.
+SANDBOX="$(mktemp -d)"
+cleanup() {
+	rm -rf "$SANDBOX"
+}
+trap cleanup EXIT
+
+export HOME="$SANDBOX/home"
+export XDG_CONFIG_HOME="$SANDBOX/config"
+export XDG_DATA_HOME="$SANDBOX/data"
+export XDG_CACHE_HOME="$SANDBOX/cache"
+export APPDATA="$SANDBOX/appdata"
+export KUNAI_BIN_DIR="$SANDBOX/bin"
+export KUNAI_SOURCE_DIR="$SANDBOX/src"
+# Parity with the musl smoke: nothing here owns a shell rc file worth writing.
+export KUNAI_SKIP_PATH_UPDATE=1
+mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$APPDATA" "$KUNAI_BIN_DIR"
+
+# `--yes --skip-deps` is what makes this non-interactive, and both halves
+# matter. `--skip-deps` returns from install_optional_deps before its two mpv
+# and yt-dlp prompts; `--yes` short-circuits ask() without touching /dev/tty at
+# all. Getting that wrong is not a hang — install.sh's ask() opens /dev/tty and
+# declines when the open fails — it is `--yes` alone answering "install mpv?"
+# with a silent sudo. `</dev/null` closes the last way stdin could be read.
+bash "$INSTALLER" \
+	--method binary \
+	--yes \
+	--skip-deps \
+	--skip-path-update </dev/null
+
+MANIFEST="$XDG_CONFIG_HOME/kunai/install.json"
+[[ -f "$MANIFEST" ]] || {
+	echo "::error::install.sh wrote no ownership manifest at $MANIFEST"
+	exit 1
+}
+grep -F "\"activeVersion\": \"$VERSION\"" "$MANIFEST" || {
+	echo "::error::install manifest does not record $VERSION as the active version"
+	cat "$MANIFEST"
+	exit 1
+}
+
+LAUNCHER="$KUNAI_BIN_DIR/kunai"
+[[ -x "$LAUNCHER" ]] || {
+	echo "::error::no executable launcher at $LAUNCHER after a successful install"
+	exit 1
+}
+
+OBSERVED="$("$LAUNCHER" --version 2>&1)"
+echo "install.sh route reports: $OBSERVED"
+case "$OBSERVED" in
+*"$VERSION"*) ;;
+*)
+	echo "::error::install.sh route reported '$OBSERVED', expected $VERSION"
+	exit 1
+	;;
+esac
+"$LAUNCHER" --help >/dev/null
+echo "published install.sh route verified for $TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1151,18 +1151,20 @@ jobs:
           esac
           "${LAUNCHER}" --help >/dev/null
 
+      # Idempotent by necessity: everything below this step is reached only once
+      # the tag exists, so a failure below is exactly the case RELEASING.md's
+      # recovery path covers — re-dispatch the same version. Bare `git tag -a`
+      # exits 128 on an existing tag, which made that re-dispatch fail here
+      # every time. The script skips a tag already on the released commit and
+      # refuses one on any other commit; it never moves a ref. HEAD is the SHA
+      # to compare against because it is the commit being tagged, and the
+      # recheck step above has already proven it equals origin/main.
       - name: Create canonical tag
         run: |
           set -euo pipefail
-          TAG="${{ needs.confirmation.outputs.tag }}"
-          # An annotated tag records a tagger, and the runner has no git identity
-          # of its own, so `git tag -a` aborts with "empty ident name" before it
-          # writes anything. Same bot identity the metadata job already commits
-          # under, kept local to this checkout.
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${TAG}" -m "Release ${TAG}"
-          git push origin "refs/tags/${TAG}"
+          .github/scripts/create-canonical-tag.sh \
+            "${{ needs.confirmation.outputs.tag }}" \
+            "$(git rev-parse HEAD)"
 
       - name: Reverify exact native payload before draft upload
         run: |
@@ -1238,6 +1240,26 @@ jobs:
             --attestation-source-digest "${GITHUB_SHA}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # The README's recommended route, proven against the real release.
+      #
+      # The `installer-smoke` jobs run `needs: candidate`, against artifacts that
+      # are not published yet, and the registry smoke above covers only npm.
+      # Neither can reach the step that actually breaks: install.sh resolves the
+      # version from api.github.com/…/releases/latest, and that endpoint excludes
+      # drafts — before promotion it names the *previous* release. So this runs
+      # after promotion, and lets install.sh resolve `latest` itself rather than
+      # pinning --version, which would skip the one thing only a post-promote run
+      # can prove.
+      #
+      # Placed after asset verification on purpose: that check is fast and reads
+      # metadata, so a malformed release fails there rather than after this step
+      # has spent a 38MB download reaching the same conclusion.
+      - name: Smoke the published install.sh route
+        timeout-minutes: 10
+        run: |
+          .github/scripts/smoke-published-installer.sh \
+            "${{ needs.confirmation.outputs.version }}"
 
   # ---------------------------------------------------------------------------
   # Post-release: mark .release metadata published after public verification.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -254,7 +254,9 @@ Job **`publish`** needs `confirmation` and declares `environment: release-produc
 4. Retries `npm view` for the launcher and all eight platform packages until
    every exact version is visible, then performs a clean registry install and
    launcher smoke
-5. Creates annotated tag `v<version>` and pushes it
+5. Creates annotated tag `v<version>` and pushes it, via
+   `.github/scripts/create-canonical-tag.sh` — idempotent for a re-dispatch of
+   the same version, and refusing to move a tag that points elsewhere
 6. Reverifies the same downloaded native directory and provenance again,
    immediately before creating a **draft** GitHub release (`make_latest: false`)
    with its 18 files
@@ -264,6 +266,11 @@ Job **`publish`** needs `confirmation` and declares `environment: release-produc
    `gh release edit <tag> --draft=false --latest`
 9. Proves the release is public, then downloads and verifies its bytes and
    attestations again
+10. Installs through the published `install.sh` in a sandboxed profile and
+    asserts the activated binary reports `<version>`. This runs last because
+    `install.sh` resolves the version from `releases/latest`, which excludes
+    drafts — before promotion it would install the _previous_ release, so no
+    earlier job can cover the recommended route
 
 ### 5. Metadata after public verification
 
@@ -289,6 +296,16 @@ preserved candidate against npm in canonical order:
 Do not unpublish, overwrite, or hand-increment a partial candidate. The launcher
 stays last so users can never resolve it before its exact-version platform
 packages exist.
+
+Recovery works past the tag, too. Everything after the canonical tag — draft
+creation, draft asset verification, promotion, public verification, the
+published `install.sh` smoke — is reached only once `v<version>` exists, so a
+failure there is exactly what this path is for. `.github/scripts/create-canonical-tag.sh`
+skips a tag already on the released commit and refuses one pointing anywhere
+else; it never moves a ref, because a published tag's commit is already baked
+into checksums, attestations, and `releases/download/v<version>/…` URLs. A
+conflict there means the tag shipped from a different commit: investigate, then
+release the fix as the next version.
 
 Rerunning the failed job reuses the preserved candidate and is always safe. A
 fresh dispatch rebuilds the candidate, which is also safe **provided nothing


### PR DESCRIPTION
Two latent bugs of the same shape as the three that broke 0.3.0 today: code at the
end of the `publish` job that no release had ever executed. 0.2.5 never reached
these steps, so they ran for the first time during a real publication.

## 1. The canonical tag step is not idempotent

`git tag -a` exits 128 on an existing tag.

Everything after that step — draft creation, draft asset verification, promotion,
public verification — is reached **only once the tag exists**. So a failure in any
of them is exactly the case `RELEASING.md`'s "npm publication recovery" covers,
and re-dispatching the same version would have failed at the tag before it could
retry anything. 0.3.0 escaped this only by failing one step *earlier*.

The step now delegates to `.github/scripts/create-canonical-tag.sh`, which:

- creates and pushes when the tag is absent
- **skips** when the tag already points at the commit being released
- **refuses** when it points anywhere else, with an error naming both commits

It never moves a ref. A published tag's commit is already baked into checksums,
sigstore attestations and `releases/download/v<version>/…` URLs, so `git tag -f`
or a force push would invalidate artifacts people have already downloaded. A
conflict means the tag shipped from a different commit — investigate, then release
the fix as the next version.

Annotated tags are peeled (`refs/tags/X^{}`) before comparing, since `refs/tags/X`
names the tag object rather than the commit.

## 2. Nothing smoke-tested the recommended install route

The `Installer harness` jobs run `needs: candidate` — against artifacts that are
not published yet. The registry smoke in `publish` covers only the npm route.
Neither can reach what actually breaks.

`install.sh` resolves its version from
`api.github.com/repos/KitsuneKode/kunai/releases/latest`, and **that endpoint
excludes drafts**. Before `gh release edit --draft=false --latest` runs, the
recommended route resolves to the *previous* release. That is structurally
unreachable from any pre-publication job.

The new step runs after promotion and lets `install.sh` resolve `latest` itself —
pinning `--version` would skip the one thing only a post-promote run can prove. It
waits for the endpoint to name the tag first, so a slow promotion reports itself
plainly instead of surfacing as an installer that silently fetched the previous
release.

**Placement:** after `Verify public release assets`. That check is fast and reads
metadata, so a malformed release fails there rather than after this step has spent
a 38MB download reaching the same conclusion.

**Isolation:** full profile sandbox — `HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`,
`XDG_CACHE_HOME`, `APPDATA`, `KUNAI_BIN_DIR`. `KUNAI_CONFIG_DIR` alone is not
isolation: `install.sh` derives its data and cache dirs from HOME/XDG
independently, so a partial override writes a real profile on any machine that has
one.

**Non-interactive:** `--yes --skip-deps`, plus `</dev/null`. Both halves matter —
`--skip-deps` returns before the mpv/yt-dlp prompts, and `--yes` short-circuits
`ask()` without touching `/dev/tty`. Getting this wrong is not a hang (`ask()`
opens `/dev/tty` and declines when the open fails); it is `--yes` alone answering
"install mpv?" with a silent `sudo`.

## Verification — both scripts were run, not reviewed

**Tag script, four cases** against a scratch repo with a bare remote:

| Case | Result |
|---|---|
| tag absent | creates + pushes, exit 0 |
| tag at the released commit | `already exists on origin … nothing to do`, exit 0 |
| tag at a **different** commit | exit 1, and `ls-remote` confirmed the tag **unmoved** |
| malformed tag (`0.3.0`) | rejected before touching the remote |

**Installer smoke** against the live published 0.3.0:

```
releases/latest reports v0.3.0
  "activeVersion": "0.3.0",
install.sh route reports: kunai 0.3.0 (binary)
published install.sh route verified for v0.3.0
SMOKE EXIT CODE: 0
```

The developer profile's mtime was **unchanged** across the run — the isolation this
script exists to get right, checked rather than assumed.

**Gates:** `shellcheck -S warning` clean on both scripts; `bun run test --force`
23/23, `typecheck --force` 14/14, `lint` 12/12, `fmt:check --force` 26/26 — all
**0 cached**; `verify:doc-paths` 51 docs / 2112 files.

## Docs

`RELEASING.md` owns this subject: the recovery section now states that recovery
works past the tag and why a published tag is never moved, and the publish-job
sequence documents both the idempotent tag and the new step 10.

## Scope

Workflow, two new scripts, and the doc. Nothing under `apps/cli/src/` or
`packages/`, so no change to compiled binary bytes.

https://claude.ai/code/session_01Qkh3U4cMEM9hRNKMJQmtFd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Improved release publishing to safely handle repeated runs and prevent release tags from being moved to a different commit.
  - Added a post-release check confirming the public installation route is available and installs the expected version.

- **Documentation**
  - Updated release guidance with the revised tag workflow, installation verification, and recovery steps for interrupted releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->