### PR TITLE
test: size two runner-measuring guards to catch hangs, not slow machines

### DIFF
--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -435,6 +435,15 @@ describePwsh("install.ps1 activation identity", () => {
 });
 
 describePwsh("install.ps1 release asset failures", () => {
+  /**
+   * Runs a real install.ps1 that downloads a zip, verifies two digests and
+   * expands the archive. On a Windows runner that is PowerShell start-up plus
+   * Expand-Archive plus disk, none of which this test is asserting anything
+   * about — it asserts the archive path completes and records provenance. The
+   * shared 20s integration budget was close enough to that cost to fail a green
+   * release gate at 20000.70ms, so this one gets a guard sized to catch a stuck
+   * installer instead of a slow one.
+   */
   test("installs the verified zip member and records archive provenance", async () => {
     const target = hostWindowsTarget();
     const body = "MZ-archived-kunai";
@@ -496,7 +505,7 @@ describePwsh("install.ps1 release asset failures", () => {
     } finally {
       sandbox.cleanup();
     }
-  });
+  }, 120_000);
 
   test.each([
     "absolute",

--- a/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
+++ b/apps/cli/test/unit/services/update/native-installer/activation-lock.test.ts
@@ -14,7 +14,20 @@ import {
 } from "@/services/update/native-installer/install-layout";
 
 const made: string[] = [];
-const RECLAIM_TEST_TIMEOUT_MS = process.platform === "win32" ? 1_000 : 100;
+/**
+ * Acquisition budget for tests that assert the lock IS acquired.
+ *
+ * The mirror image of `RETAIN_TEST_TIMEOUT_MS` below, and it has to be read the
+ * other way round: there the deadline firing is the assertion, here it is the
+ * failure. Reclaiming a corrupt lock costs a poll interval plus the corrupt
+ * grace period plus however long the runner takes to stat and read the file,
+ * and `tryAcquireActivationLock` measures that against a real `Date.now()`.
+ * A 100ms budget was therefore an assertion about disk and scheduler speed:
+ * CI failed `reclaims persistently corrupt metadata after the partial-write
+ * grace period` at 285.92ms on a runner where the logic was entirely correct.
+ * This bound only has to catch a lock that never resolves.
+ */
+const RECLAIM_TEST_TIMEOUT_MS = process.platform === "win32" ? 10_000 : 5_000;
 
 /**
  * Acquisition budget for tests that assert the lock is *retained*.


### PR DESCRIPTION
Two CI failures, both measuring the runner rather than the product.

## 1. `activation lock > reclaims persistently corrupt metadata…` (Linux, main)

Lock acquisition had a **100ms** budget. Reclaiming costs a poll interval, the
corrupt grace period, and however long the machine takes to stat and read the file
— measured against a real `Date.now()`. CI failed at **285.92ms** with the logic
entirely correct.

The file already documents this exact lesson for its sibling `RETAIN_TEST_TIMEOUT_MS`,
where a 40ms budget lost to a loaded Windows runner at 50.57ms. The reclaim constant
never got the same treatment, and it reads the *other way round*:

- **retain** tests assert `acquired: false` — the deadline firing **is** the assertion
- **reclaim** tests assert `acquired: true` — the deadline firing **is** the failure

So it needs headroom, not precision. Now 5s / 10s (Windows).

## 2. `install.ps1 … installs the verified zip member` (Windows, this PR)

Runs a real `install.ps1` that downloads a zip, verifies two digests and expands the
archive. On a Windows runner that is PowerShell start-up plus `Expand-Archive` plus
disk — none of which the test asserts anything about.

It failed at **20000.70ms** against the shared 20s integration budget. Seven tenths
of a millisecond over. Given a per-test guard of 120s.

Neither change weakens an assertion. Both still prove what they proved before, and
both still fail on a lock or installer that never resolves.

## Verification

- reclaim test: **10/10 green under saturated CPU and disk** — the point being that
  the budget no longer competes with the machine
- full activation-lock suite: 17 pass, 1 skip, 0 fail
- `typecheck --force` 14/14, `lint` 12/12, `fmt:check --force` 26/26 — all **0 cached**

---

# Why this suite is flaky (the underlying cause)

These two are instances, not the disease. Three consecutive full-suite runs produced
**three different results**, none reproducible in isolation:

```
run A:  (fail) diagnostics-panel-lines > renders sections in cockpit order
run B:  (fail) resolveProviderStreamWithRetries > classifies provider timeouts…
run C:  0 fail
```

Cross-file mocking is **not** the cause — only 2 test files call `mock.module`, and
neither is in the affected areas.

The cause is that a large set of tests assert on **real wall-clock timing with margins
smaller than the scheduling noise of a saturated parallel suite**. The clearest
example, from run B:

```js
timeoutMs: 1,                                   // product must time out in 1ms
resolve: async () => {
  await new Promise((r) => setTimeout(r, 20));  // work takes 20ms
```

A 19ms margin. Starve the event loop past that and the resolve wins, so the expected
timeout never fires. Whichever timing-sensitive test loses the scheduler lottery on a
given run is the one that fails — which is exactly the "different test every time"
signature.

Scale of exposure:

- **32** test files use a real `Bun.sleep`
- **18** build deadlines from `Date.now() + N`
- the repo's own `test-timeout-budget.test.ts` records one storage test measured at
  **6428ms on one run and 16549ms on the next** — a 2.6x spread on the same machine

**The systemic fix is injected clocks / fake timers for anything asserting elapsed
time**, so these become deterministic instead of races. That is a sizeable piece of
work and does not belong in a PR unblocking CI — filing it separately is the right
call, and this PR only sizes the two guards that are red right now.

https://claude.ai/code/session_01Qkh3U4cMEM9hRNKMJQmtFd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased time allowances for installation and lock-acquisition tests to improve reliability on slower or heavily loaded systems.
  * Documented the extended timeout used during PowerShell archive extraction and verification tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->