### PR TITLE
fix(dist): point the published homepage at the docs site

### DIFF
--- a/.changeset/olive-pugs-smile.md
+++ b/.changeset/olive-pugs-smile.md
@@ -1,0 +1,11 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Point the published `homepage` at the docs site rather than the README anchor.
+
+npm renders `homepage` as the "Homepage" link on the package page, and it is the
+first thing someone evaluating the CLI clicks. `github.com/KitsuneKode/kunai#readme`
+sends them to a raw README anchor; `kunai.kitsunekode.in` is the site that actually
+documents installing and using Kunai. The field propagates from the CLI manifest into
+all eight platform packages, so every published package now points at the same place.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -15,7 +15,7 @@
     "streaming",
     "terminal"
   ],
-  "homepage": "https://github.com/KitsuneKode/kunai#readme",
+  "homepage": "https://kunai.kitsunekode.in",
   "bugs": {
     "url": "https://github.com/KitsuneKode/kunai/issues"
   },


### PR DESCRIPTION
npm renders `homepage` as the **Homepage** link on the package page — the first thing
someone evaluating the CLI clicks. It pointed at a raw README anchor:

```
- "homepage": "https://github.com/KitsuneKode/kunai#readme"
+ "homepage": "https://kunai.kitsunekode.in"
```

`kunai.kitsunekode.in` is the site that actually documents installing and using Kunai,
and it is already what the README and both install one-liners hand out.

The field propagates from the CLI manifest into all eight platform packages through
`build-npm-platform-packages.ts`, so this moves every published package at once.

## Timing is deliberate

A manifest change alters every published tarball — exactly the case `RELEASING.md`
says to hold for the next version:

> *a new `homepage` in `apps/cli/package.json` propagates into all nine manifests, and
> a version already on npm would then halt the release on the integrity rule. Land
> that kind of change in the next version instead.*

That warning was written during the 0.3.0 partial-publish window. 0.3.0 is now fully
published, so this is the safe window and it ships in 0.3.1 with nothing partially
written. Patch changeset included.

## Verification

- both URLs confirmed live: `https://kunai.kitsunekode.in/` → 200, `/docs` → 200
- swept for other references to the old value: the only hit is a **synthetic fixture**
  in `distribution-contract.test.ts` (version `9.8.7`, passed through and echoed back),
  so it pins nothing about real repo state — 57 tests there pass unchanged
- `typecheck --force` 14/14, `lint` 12/12, `fmt:check --force` 26/26 — all **0 cached**

https://claude.ai/code/session_01Qkh3U4cMEM9hRNKMJQmtFd
