### PR TITLE
fix(install): stop the progress bar reporting 100% for a failed download

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -371,6 +371,17 @@ probe_content_length() {
 	[[ "$length" =~ ^[0-9]+$ ]] && printf '%s' "$length"
 }
 
+# Wipe the progress line without leaving a frame behind, so the error that
+# follows starts on a clean row.
+clear_download_progress() {
+	local columns
+	columns="${COLUMNS:-0}"
+	[[ "$columns" -lt 40 ]] && columns="$(tput cols 2>/dev/null || printf 80)"
+	[[ "$columns" -lt 40 ]] && columns=80
+	[[ "$columns" -gt 100 ]] && columns=100
+	printf '\r%*s\r' "$columns" ""
+}
+
 # Sleep between progress frames.
 #
 # POSIX `sleep` takes an integer, and this script already refuses to trust a
@@ -493,14 +504,24 @@ bounded_download() {
 			done
 			curl_rc=0
 			wait "$curl_pid" || curl_rc=$?
-			got=0
-			[[ -f "$dest" ]] && got="$(wc -c <"$dest" 2>/dev/null | tr -d ' ')"
-			render_download_progress "$label" "${got:-0}" "$total_bytes" \
-				"$(($(date +%s) - progress_started))"
-			printf '\n'
 			code="$(cat "$status_file" 2>/dev/null || true)"
 			rm -f "$status_file"
 			[[ -n "$code" ]] || code="000"
+			# Only a download that actually finished earns a final frame. An
+			# error response has a body and a Content-Length of its own, so
+			# drawing one anyway rendered a full bar for a failed transfer --
+			# a 503 whose four-byte body filled the width and printed 100%
+			# immediately above "Download failed". Clear the line instead and
+			# let the error speak.
+			if [[ "$curl_rc" -eq 0 && "$code" =~ ^2[0-9][0-9]$ ]]; then
+				got=0
+				[[ -f "$dest" ]] && got="$(wc -c <"$dest" 2>/dev/null | tr -d ' ')"
+				render_download_progress "$label" "${got:-0}" "$total_bytes" \
+					"$(($(date +%s) - progress_started))"
+				printf '\n'
+			else
+				clear_download_progress
+			fi
 		else
 			code="$(
 				curl -sS -L \


### PR DESCRIPTION
A regression from #316, found by testing the paths that change never exercised.

## The bug

The progress line drew one final frame unconditionally after curl exited. An error
response carries a body *and* a `Content-Length` of its own, so a failed download
rendered a full bar and printed **100%** directly above the error:

```
 kunai-linux-x64.tar.gz       4 B       0 B/s 00:00 [####################] 100%
✗ Download failed for kunai-linux-x64.tar.gz with HTTP 503 after 3 attempts.
```

Those four bytes were the 503's body, measured against the 503's own
`Content-Length` from the `HEAD` probe. A user sees a completed download, then a
failure.

## The fix

The final frame is drawn only when curl exited 0 **and** the status is 2xx.
Otherwise the line is wiped, so the error message starts on a clean row.

## How it was found

#316 shipped having tested only the success path. This PR is the missing half: a
local HTTP server that serves valid checksums and fails every payload download with
a retryable 503, driven through a PTY so the TTY-gated progress code actually runs.

The rest of the error handling was correct, which is worth stating plainly — three
attempts, accurate `HTTP 503` reporting at each, correct final failure and recovery
guidance. The misleading frame was the only defect.

**Before**

```
 kunai-linux-x64.tar.gz       4 B  [####################] 100%
✗ Download failed … with HTTP 503 after 3 attempts.
```

**After**

```
→ Retrying kunai-linux-x64.tar.gz (attempt 3/3) after HTTP 503...
✗ Download failed for kunai-linux-x64.tar.gz with HTTP 503 after 3 attempts.
```

## Verification

- failure path: 503 on every payload download — no false 100%, line cleared, all
  three retries and the final error render correctly
- success path re-verified against the **published 0.3.0**: bar advances to 100%,
  install completes, launcher reports `kunai 0.3.0 (binary)`, and the developer
  profile's mtime is unchanged across the run
- `shellcheck -S warning` clean; `typecheck --force`, `lint`, `fmt:check --force`
  all pass with **0 cached**

## Note on coverage

The progress code is TTY-gated, and the installer test harness spawns with pipes, so
**no automated test exercises it** — both this fix and #316 are covered only by manual
PTY runs. Worth a harness that runs `install.sh` under a pty if this area grows.

https://claude.ai/code/session_01Qkh3U4cMEM9hRNKMJQmtFd
