### PR TITLE
fix(install): show the command and ask, instead of sudo-installing packages

### DIFF
--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -13,7 +13,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, delimiter, dirname, join } from "node:path";
 
 import type { InstallManifest } from "@/services/update/install-manifest";
 import { verifyStoredVersion } from "@/services/update/native-installer/version-metadata";
@@ -339,10 +339,29 @@ describePwsh("install.ps1 dry-run", () => {
     try {
       // Deliberately no -SkipDeps: this case exists to prove the dependency plan
       // is reached. -DryRun keeps it a plan, so no winget process is spawned.
-      const result = runInstallPs1(
-        ["-DryRun", "-Yes", "-Version", "9.8.7"],
-        withCommandPath(sandbox.env, sandbox.root),
+      //
+      // The PATH is the shim directory ALONE. `withCommandPath` prepends to the
+      // inherited PATH, which leaves the developer's real mpv and yt-dlp
+      // visible -- and the installer now checks before it offers, so on such a
+      // machine there is correctly nothing to plan and this test saw only the
+      // curl branch. Isolating the PATH is what makes "missing" true here.
+      // pwsh still has to be resolvable, so its own directory stays -- but
+      // nothing else does, which is what keeps a developer's real mpv out of
+      // the run.
+      const pwshDir = dirname(
+        spawnSync("pwsh", ["-NoProfile", "-Command", "(Get-Process -Id $PID).Path"], {
+          encoding: "utf8",
+        }).stdout.trim(),
       );
+      const shimOnlyEnv: NodeJS.ProcessEnv = { ...sandbox.env };
+      for (const key of Object.keys(shimOnlyEnv)) {
+        if (key.toLowerCase() === "path") delete shimOnlyEnv[key];
+      }
+      shimOnlyEnv[process.platform === "win32" ? "Path" : "PATH"] = [sandbox.root, pwshDir].join(
+        delimiter,
+      );
+
+      const result = runInstallPs1(["-DryRun", "-Yes", "-Version", "9.8.7"], shimOnlyEnv);
 
       expect(result.status).toBe(0);
       // mpv.net ships mpvnet.exe; Kunai probes for `mpv`. See the winget id note

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -1956,3 +1956,101 @@ if (!pwshAvailable()) {
     });
   });
 }
+
+/**
+ * Windows parity for the optional-dependency consent rules. install.ps1 had the
+ * same shape as the bash flow: a prompt defaulting to yes, `-Yes` treated as
+ * consent for everything, and `--accept-package-agreements
+ * --accept-source-agreements` accepting a third party's licence terms on the
+ * user's behalf.
+ */
+describePwsh("install.ps1 optional dependency consent", () => {
+  function evalInstallPs1(body: string, testCmd: string): string {
+    const script = [
+      `$src = Get-Content -Raw ${JSON.stringify(INSTALL_PS1)}`,
+      'function Write-Info { param($m) Write-Host "> $m" }',
+      'function Write-Warn { param($m) Write-Host "! $m" }',
+      'function Invoke-OptionalStep { param($d,$a) Write-Host "[RAN] $d" }',
+      testCmd,
+      "foreach ($fn in 'Get-PackageInstallCommand','Request-OptionalInstall') {",
+      '  Invoke-Expression ([regex]::Match($src, "(?ms)^function $fn \\{.*?^\\}").Value)',
+      "}",
+      body,
+    ].join("\n");
+    const result = spawnSync("pwsh", ["-NoProfile", "-Command", script], { encoding: "utf8" });
+    expect(result.stderr, result.stderr).not.toContain("ParserError");
+    return `${result.stdout}${result.stderr}`;
+  }
+
+  /**
+   * One pwsh process for the whole mapping table. Five separate spawns were
+   * flaky under a loaded suite -- pwsh start-up dominates, and a starved one
+   * returned empty output -- and the table is what is being asserted, not the
+   * process boundary.
+   */
+  test("each Windows package manager maps to its own install command", () => {
+    const probe = [
+      "foreach ($mgr in 'winget','scoop','choco') {",
+      "  Invoke-Expression \"function Test-Cmd { param(`$n) return `$n -eq '$mgr' }\"",
+      "  foreach ($pkg in 'mpv','yt-dlp','curl') {",
+      '    Write-Output "$mgr|$pkg|$(Get-PackageInstallCommand $pkg)"',
+      "  }",
+      "}",
+      "function Test-Cmd { param($n) return $false }",
+      "Write-Output \"none|mpv|$(Get-PackageInstallCommand 'mpv')\"",
+    ].join("\n");
+
+    const rows = evalInstallPs1(probe, "function Test-Cmd { param($n) return $false }")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.includes("|"));
+    const table = Object.fromEntries(
+      rows.map((row) => {
+        const [manager, pkg, ...rest] = row.split("|");
+        return [`${manager}/${pkg}`, rest.join("|")];
+      }),
+    );
+
+    // The winget ids are load-bearing: mpv.net ships mpvnet.exe, which Kunai
+    // cannot drive over mpv's IPC socket.
+    expect(table["winget/mpv"]).toBe("winget install --id mpv-player.mpv-CI.MSVC -e");
+    expect(table["winget/curl"]).toBe("winget install --id cURL.cURL -e");
+    expect(table["winget/yt-dlp"]).toBe("winget install yt-dlp");
+    expect(table["scoop/mpv"]).toBe("scoop install mpv");
+    expect(table["choco/mpv"]).toBe("choco install mpv -y");
+    // No recognised manager must yield no command, so the caller falls through
+    // to the manual guidance rather than inventing one.
+    expect(table["none/mpv"]).toBe("");
+  });
+
+  test("no command auto-accepts a package or source agreement", () => {
+    for (const pkg of ["mpv", "yt-dlp", "curl"]) {
+      const command = evalInstallPs1(
+        `Get-PackageInstallCommand ${JSON.stringify(pkg)}`,
+        "function Test-Cmd { param($n) return $n -eq 'winget' }",
+      );
+      expect(command).not.toContain("--accept-package-agreements");
+      expect(command).not.toContain("--accept-source-agreements");
+    }
+  });
+
+  test("-Yes prints the command instead of installing", () => {
+    const output = evalInstallPs1(
+      "$Yes = $true; $DryRun = $false; Request-OptionalInstall @('mpv','yt-dlp')",
+      "function Test-Cmd { param($n) return $n -eq 'winget' }",
+    );
+    // -Yes is consent to install Kunai, not to accept a third party's terms.
+    expect(output).not.toContain("[RAN]");
+    expect(output).toContain("winget install --id mpv-player.mpv-CI.MSVC -e");
+  });
+
+  test("an unrecognised host still gets manual guidance", () => {
+    const output = evalInstallPs1(
+      "$Yes = $false; $DryRun = $false; Request-OptionalInstall @('mpv')",
+      "function Test-Cmd { param($n) return $false }",
+    );
+    expect(output).toContain("No supported package manager found");
+    expect(output).toContain("https://mpv.io/installation/");
+    expect(output).not.toContain("[RAN]");
+  });
+});

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -2192,3 +2192,82 @@ describe("install.sh PATH conflict remediation", () => {
     expect(remedyFor("/some/unknown/place/kunai")).not.toBe("");
   });
 });
+
+/**
+ * Optional dependencies are offered, never imposed. The previous flow ran
+ * `sudo pacman -S --noconfirm` / `sudo apt-get install -y` from a prompt that
+ * defaulted to yes, so a script piped from the internet became root and
+ * installed packages without the user or the package manager confirming
+ * anything. These pin the three properties that replaced it.
+ */
+describe("install.sh optional dependency consent", () => {
+  function evalInstallSh(body: string, extraDefs = ""): string {
+    const script = [
+      "set -euo pipefail",
+      "info() { printf '> %s\\n' \"$*\"; }",
+      "warn() { printf '! %s\\n' \"$*\"; }",
+      "run() { printf '[RAN] %s\\n' \"$*\"; }",
+      `eval "$(sed -n '/^dependency_install_command() {/,/^}/p' ${JSON.stringify(INSTALL_SH)})"`,
+      `eval "$(sed -n '/^missing_dependencies() {/,/^}/p' ${JSON.stringify(INSTALL_SH)})"`,
+      `eval "$(sed -n '/^install_optional_deps() {/,/^}/p' ${JSON.stringify(INSTALL_SH)})"`,
+      extraDefs,
+      body,
+    ].join("\n");
+    const result = spawnSync("bash", ["-c", script], { encoding: "utf8" });
+    expect(result.stderr, result.stderr).not.toContain("syntax error");
+    return `${result.stdout}${result.stderr}`;
+  }
+
+  test("each supported package manager maps to its own install command", () => {
+    const seen: Record<string, string> = {};
+    for (const manager of ["brew", "port", "pacman", "apt-get", "dnf", "zypper", "apk"]) {
+      seen[manager] = evalInstallSh(
+        "dependency_install_command mpv yt-dlp",
+        `have() { [[ "$1" == ${JSON.stringify(manager)} ]]; }`,
+      ).trim();
+    }
+
+    expect(seen["brew"]).toBe("brew install mpv yt-dlp");
+    expect(seen["port"]).toBe("sudo port install mpv yt-dlp");
+    expect(seen["pacman"]).toBe("sudo pacman -S --needed mpv yt-dlp");
+    expect(seen["apt-get"]).toBe("sudo apt-get install mpv yt-dlp");
+    expect(seen["dnf"]).toBe("sudo dnf install mpv yt-dlp");
+    expect(seen["zypper"]).toBe("sudo zypper install mpv yt-dlp");
+    expect(seen["apk"]).toBe("sudo apk add mpv yt-dlp");
+  });
+
+  test("no command silences the package manager's own confirmation", () => {
+    // `--noconfirm` / `-y` are what turned one keystroke into an unattended
+    // root install. The accepted path must still be gated by the manager.
+    for (const manager of ["pacman", "apt-get", "dnf", "zypper"]) {
+      const command = evalInstallSh(
+        "dependency_install_command mpv",
+        `have() { [[ "$1" == ${JSON.stringify(manager)} ]]; }`,
+      );
+      expect(command).not.toContain("--noconfirm");
+      expect(command).not.toMatch(/\s-y(\s|$)/);
+    }
+  });
+
+  test("an already-installed dependency is neither offered nor reported missing", () => {
+    const output = evalInstallSh(
+      "SKIP_DEPS=0; DRY=0; YES=0; install_optional_deps",
+      'have() { case "$1" in mpv|yt-dlp|pacman) return 0;; *) return 1;; esac; }',
+    );
+    expect(output).toContain("already installed");
+    expect(output).not.toContain("This will run");
+    expect(output).not.toContain("[RAN]");
+  });
+
+  test("--yes and a run with no terminal print the command instead of escalating", () => {
+    for (const setup of ["YES=1", "YES=0"]) {
+      const output = evalInstallSh(
+        `SKIP_DEPS=0; DRY=0; ${setup}; install_optional_deps </dev/null`,
+        'have() { [[ "$1" == pacman ]]; }',
+      );
+      // Consent to install Kunai is not consent to become root.
+      expect(output).not.toContain("[RAN]");
+      expect(output).toContain("sudo pacman -S --needed mpv yt-dlp");
+    }
+  });
+});

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "9399f4e19c122a598078ee554d5ef0659a4c62985eef9ea2a9a7b0aa8ac691de",
-  "docsContentFingerprint": "dc3be99f79521b1e7ec8190302e01d5980bab2e5065f943aa602a4d12a066523",
+  "docsContentFingerprint": "bcc585a7ec859046e067b3672813a918d73a50bced1f036a95a3bb765aa2e18b",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/docs/users/install-and-update.mdx
+++ b/docs/users/install-and-update.mdx
@@ -154,14 +154,46 @@ what a Dockerfile or CI step usually wants.
 
 | `install.sh` | `install.ps1` | Environment | Effect |
 | --- | --- | --- | --- |
-| `--yes` | `-Yes` | `KUNAI_INSTALL_YES=1` | Accept every optional prompt. This is the **only** thing that answers on your behalf. |
-| `--skip-deps` | `-SkipDeps` | `KUNAI_SKIP_DEPS=1` | Never offer to install optional dependencies (`mpv`, `ffmpeg`). |
+| `--yes` | `-Yes` | `KUNAI_INSTALL_YES=1` | Accept Kunai's own optional prompts. It does **not** install system packages — see below. |
+| `--skip-deps` | `-SkipDeps` | `KUNAI_SKIP_DEPS=1` | Say nothing at all about optional dependencies (`mpv`, `yt-dlp`). |
 | `--skip-path-update` | `-SkipPathUpdate` | `KUNAI_SKIP_PATH_UPDATE=1` | Leave PATH alone — see [PATH](#path). |
 
 Without a terminal — `curl … | bash` in CI, a container, or a sandbox — optional
 prompts are **skipped, not accepted**, and the installer says which step it
 skipped. Before 0.3.0 a missing terminal defaulted to yes and could run
 `sudo apt-get`/`pacman`/`dnf install` unattended.
+
+### Optional dependencies are never installed for you
+
+Kunai needs `mpv` to play anything, and `yt-dlp` for YouTube. The installer
+checks whether they are already present, and if they are not it prints the exact
+command for your package manager:
+
+```
+! mpv is not installed — Kunai needs it to play anything.
+
+  This will run:
+    sudo pacman -S --needed mpv yt-dlp
+
+Run it now? [y/N]
+```
+
+Three rules hold on every platform:
+
+- **The command is always shown**, before it is offered and again if you decline,
+  so nothing is hidden either way.
+- **The prompt defaults to no.** Pressing Enter never escalates.
+- **`--yes` does not answer this one.** It is consent to install Kunai, not
+  consent to become root or to accept a third party's licence agreements. A run
+  with no terminal prints the command instead of running it.
+
+Saying yes runs the command as shown, without `--noconfirm`, `-y`, or
+`--accept-package-agreements` — so your package manager still confirms too.
+`--skip-deps` silences the section entirely.
+
+Recognised managers: `pacman`, `apt`, `dnf`, `zypper`, `apk` on Linux; `brew`
+and `port` on macOS; `winget`, `scoop` and `choco` on Windows. Anything else
+gets a link to [mpv's install guide](https://mpv.io/installation/).
 
 ## Unsigned binaries (beta)
 

--- a/install.ps1
+++ b/install.ps1
@@ -1405,17 +1405,79 @@ function Write-KunaiPathDiagnostic {
 # anyway, so `irm … | iex` in CI or a container silently acquired system
 # package installs. Decline instead, and say which step was skipped so the
 # run stays useful and the gap is visible.
-function Confirm-OptionalInstall {
-  param([Parameter(Mandatory)][string]$Question)
+# The exact command that installs one package on this machine, or '' when no
+# supported manager is present.
+#
+# Returned as a string rather than run, so the prompt can show precisely what is
+# being agreed to and the decline path can print the same text. winget resolves
+# by package id, so the mapping is per package rather than one command for the
+# set.
+function Get-PackageInstallCommand {
+  param([Parameter(Mandatory)][string]$Package)
 
-  if ($Yes) { return $true }
-  if ($DryRun) { return $true }
-  if ([Console]::IsInputRedirected) {
-    Write-Warn "No console for: $Question - skipping (pass -Yes to accept, -SkipDeps to silence)"
-    return $false
+  if (Test-Cmd 'winget') {
+    switch ($Package) {
+      # mpv.net ships mpvnet.exe, but Kunai probes for `mpv` and drives playback
+      # over mpv's IPC socket + Lua bridge. mpv-player.mpv-CI.MSVC is the winget
+      # package that provides a real mpv.exe (same upstream build CI pins).
+      'mpv' { return 'winget install --id mpv-player.mpv-CI.MSVC -e' }
+      'curl' { return 'winget install --id cURL.cURL -e' }
+      default { return "winget install $Package" }
+    }
   }
-  $reply = Read-Host "$Question [Y/n]"
-  return -not ($reply -match '^[Nn]')
+  if (Test-Cmd 'scoop') { return "scoop install $Package" }
+  if (Test-Cmd 'choco') { return "choco install $Package -y" }
+  return ''
+}
+
+# Offer a set of packages, and never install without a deliberate yes.
+#
+# This replaces a prompt that defaulted to yes and passed
+# --accept-package-agreements --accept-source-agreements, so a `irm … | iex`
+# accepted third-party licence agreements on the user's behalf. Parity with
+# install.sh: show the exact command, default to no, print instead of installing
+# when there is no console or when -Yes was passed, and let the package manager
+# confirm on the accepted path.
+function Request-OptionalInstall {
+  param([Parameter(Mandatory)][string[]]$Packages)
+
+  $commands = @()
+  foreach ($package in $Packages) {
+    $command = Get-PackageInstallCommand $package
+    if ([string]::IsNullOrWhiteSpace($command)) { continue }
+    $commands += $command
+  }
+
+  if ($commands.Count -eq 0) {
+    Write-Info "No supported package manager found (winget, scoop, choco). Install manually: $($Packages -join ', ')"
+    Write-Info 'mpv: https://mpv.io/installation/'
+    return
+  }
+
+  Write-Host ''
+  Write-Host '  This will run:'
+  foreach ($command in $commands) { Write-Host "    $command" }
+  Write-Host ''
+
+  # -Yes is consent to install Kunai, not consent to accept a third party's
+  # licence agreements. Redirected input takes the same path, so `irm … | iex`
+  # in CI reports what is missing rather than installing it.
+  if ($Yes -or $DryRun -or [Console]::IsInputRedirected) {
+    Write-Info 'Install them with:'
+    foreach ($command in $commands) { Write-Host "    $command" }
+    return
+  }
+
+  $reply = Read-Host 'Run it now? [y/N]'
+  if ($reply -notmatch '^[Yy]') {
+    Write-Info 'Skipped. Install them later with:'
+    foreach ($command in $commands) { Write-Host "    $command" }
+    return
+  }
+
+  foreach ($command in $commands) {
+    Invoke-OptionalStep $command { Invoke-Expression $command }.GetNewClosure()
+  }
 }
 
 function Install-OptionalDeps {
@@ -1423,37 +1485,21 @@ function Install-OptionalDeps {
     Write-Info 'Skipping optional dependencies (mpv, yt-dlp, curl).'
     return
   }
-  $installMpv = Confirm-OptionalInstall 'Install mpv (required for playback)?'
-  if ($installMpv) {
-    if (Test-Cmd 'winget') {
-      # mpv.net ships mpvnet.exe, but Kunai probes for `mpv` and drives playback
-      # over mpv's IPC socket + Lua bridge. mpv-player.mpv-CI.MSVC is the winget
-      # package that provides a real mpv.exe (same upstream build CI pins).
-      Invoke-OptionalStep 'winget install --id mpv-player.mpv-CI.MSVC -e' { winget install --id mpv-player.mpv-CI.MSVC -e --accept-package-agreements --accept-source-agreements }
-    }
-    elseif (Test-Cmd 'scoop') {
-      Invoke-OptionalStep 'scoop install mpv' { scoop install mpv }
-    }
-    else {
-      Write-Warn 'No winget/scoop found. Install mpv manually: https://mpv.io/installation/'
-    }
-  }
 
-  $installYtDlp = Confirm-OptionalInstall 'Install yt-dlp (YouTube playback and downloads)?'
-  if ($installYtDlp) {
-    if (Test-Cmd 'winget') {
-      Invoke-OptionalStep 'winget install yt-dlp' { winget install yt-dlp --accept-package-agreements --accept-source-agreements }
-    }
-    elseif (Test-Cmd 'scoop') {
-      Invoke-OptionalStep 'scoop install yt-dlp' { scoop install yt-dlp }
-    }
-    else {
-      Write-Warn 'No winget/scoop found. Install yt-dlp manually: https://github.com/yt-dlp/yt-dlp#installation'
-    }
+  # Checked before anything is offered: the previous flow prompted -- and with
+  # -Yes installed -- even when mpv was already on PATH.
+  $missing = @()
+  if (-not (Test-Cmd 'mpv')) {
+    Write-Warn 'mpv is not installed - Kunai needs it to play anything.'
+    $missing += 'mpv'
+  }
+  if (-not (Test-Cmd 'yt-dlp')) {
+    Write-Warn 'yt-dlp is not installed - YouTube playback and downloads need it.'
+    $missing += 'yt-dlp'
   }
 
   # Windows 10+ ships curl.exe in System32, so "is curl present" is the wrong
-  # question here — the bundled build uses Schannel with no nghttp2, so it
+  # question here - the bundled build uses Schannel with no nghttp2, so it
   # reports no HTTP2 feature. Providers that negotiate HTTP/2 fall back or fail
   # against that build, so offer the full winget/scoop curl when the one on PATH
   # cannot do HTTP/2.
@@ -1470,19 +1516,15 @@ function Install-OptionalDeps {
   }
   if ($curlNeedsUpgrade) {
     Write-Warn 'The curl on PATH has no HTTP/2 support (Windows ships a Schannel build).'
-    $installCurl = Confirm-OptionalInstall 'Install full curl with HTTP/2 (recommended for providers)?'
-    if ($installCurl) {
-      if (Test-Cmd 'winget') {
-        Invoke-OptionalStep 'winget install curl' { winget install --id cURL.cURL -e --accept-package-agreements --accept-source-agreements }
-      }
-      elseif (Test-Cmd 'scoop') {
-        Invoke-OptionalStep 'scoop install curl' { scoop install curl }
-      }
-      else {
-        Write-Warn 'No winget/scoop found. Install curl manually: https://curl.se/windows/'
-      }
-    }
+    $missing += 'curl'
   }
+
+  if ($missing.Count -eq 0) {
+    Write-Info 'mpv, yt-dlp and curl are already installed.'
+    return
+  }
+
+  Request-OptionalInstall $missing
 
   # No poster dependency to install: every renderer consumes one natively
   # prepared image, and half-block is the universal in-process floor.

--- a/install.sh
+++ b/install.sh
@@ -2075,27 +2075,110 @@ install_source() {
 	[[ "$DRY" == 1 ]] || trap - EXIT
 }
 
-install_optional_deps() {
-	[[ "$SKIP_DEPS" == 1 || "$DRY" == 1 ]] && return
-	local pkgs=()
-	ask "Install mpv (required for playback)?" y && pkgs+=(mpv)
-	ask "Install yt-dlp (YouTube playback and downloads)?" y && pkgs+=(yt-dlp)
-	# No poster dependency to offer: every renderer consumes one natively
-	# prepared image, and half-block is the universal in-process floor.
-	((${#pkgs[@]} == 0)) && return
-
+# The exact command that installs the named packages on this machine.
+#
+# Returns a string rather than running anything, so the prompt can show the user
+# precisely what they are agreeing to and the decline path can print the same
+# text. Empty means no supported manager was found.
+dependency_install_command() {
+	local pkgs="$*"
 	if have brew; then
-		run brew install "${pkgs[@]}"
+		printf 'brew install %s' "$pkgs"
+	elif have port; then
+		printf 'sudo port install %s' "$pkgs"
 	elif have pacman; then
-		run sudo pacman -S --needed --noconfirm "${pkgs[@]}"
+		printf 'sudo pacman -S --needed %s' "$pkgs"
 	elif have apt-get; then
-		run sudo apt-get update
-		run sudo apt-get install -y "${pkgs[@]}"
+		printf 'sudo apt-get install %s' "$pkgs"
 	elif have dnf; then
-		run sudo dnf install -y "${pkgs[@]}"
-	else
-		warn "No supported package manager found. Install manually: ${pkgs[*]}"
+		printf 'sudo dnf install %s' "$pkgs"
+	elif have zypper; then
+		printf 'sudo zypper install %s' "$pkgs"
+	elif have apk; then
+		printf 'sudo apk add %s' "$pkgs"
 	fi
+}
+
+# Which of the optional dependencies this machine is actually missing.
+#
+# Checked before anything is offered: the previous flow prompted — and
+# sudo-installed — even when mpv was already present.
+missing_dependencies() {
+	local missing=()
+	have mpv || missing+=(mpv)
+	have yt-dlp || missing+=(yt-dlp)
+	# `printf '%s\n'` with no arguments still emits one empty line, which the
+	# caller's `mapfile` would read as a single blank dependency.
+	[[ "${#missing[@]}" -eq 0 ]] && return 0
+	printf '%s\n' "${missing[@]}"
+}
+
+# Offer the missing dependencies, and never escalate without a deliberate yes.
+#
+# This used to run `sudo pacman -S --noconfirm` / `sudo apt-get install -y` off a
+# prompt that defaulted to yes. A script piped from the internet became root and
+# installed packages without the user, or the package manager, confirming
+# anything. Three rules now hold:
+#
+#   - the exact command is shown before it is offered, and printed again if
+#     declined, so nothing is hidden either way;
+#   - the prompt defaults to no, because Enter must never escalate;
+#   - `--yes` covers this installer, not a system package manager, and a run
+#     with no terminal prints instead of installing.
+#
+# `--noconfirm` / `-y` are gone from the commands as well: on the accepted path
+# the package manager gets to confirm too, so there are two gates rather than
+# none.
+install_optional_deps() {
+	[[ "$SKIP_DEPS" == 1 || "$DRY" == 1 ]] && return 0
+
+	local missing command
+	mapfile -t missing < <(missing_dependencies)
+	if [[ "${#missing[@]}" -eq 0 ]]; then
+		info "mpv and yt-dlp are already installed."
+		return 0
+	fi
+
+	printf '\n'
+	if [[ " ${missing[*]} " == *" mpv "* ]]; then
+		warn "mpv is not installed — Kunai needs it to play anything."
+	fi
+	if [[ " ${missing[*]} " == *" yt-dlp "* ]]; then
+		warn "yt-dlp is not installed — YouTube playback and downloads need it."
+	fi
+
+	command="$(dependency_install_command "${missing[@]}")"
+	if [[ -z "$command" ]]; then
+		info "No supported package manager found. Install manually: ${missing[*]}"
+		info "mpv: https://mpv.io/installation/"
+		return 0
+	fi
+
+	printf '\n  This will run:\n    %s\n\n' "$command"
+
+	# `--yes` is consent to install Kunai, not consent to become root. A
+	# non-interactive run takes the same path, so `curl … | bash` in a container
+	# reports what is missing instead of quietly acquiring system packages.
+	if [[ "$YES" == 1 ]] || ! : 2>/dev/null </dev/tty; then
+		info "Install them with:"
+		printf '    %s\n' "$command"
+		return 0
+	fi
+
+	local reply=""
+	if ! read -r -p "Run it now? [y/N] " reply </dev/tty; then
+		reply=""
+	fi
+	if [[ "$reply" =~ ^([yY]|[yY][eE][sS])$ ]]; then
+		# Word splitting is deliberate: the command is built from this script's
+		# own literals, never from anything a user or a server supplied.
+		# shellcheck disable=SC2086
+		run $command
+		return 0
+	fi
+
+	info "Skipped. Install them later with:"
+	printf '    %s\n' "$command"
 }
 
 usage() {


### PR DESCRIPTION
> Stacked on #322 (`fix/installer-progress-failure-frame`). Merge that first.

## The problem

Both installers escalated off a prompt that defaulted to **yes**.

```bash
ask "Install mpv (required for playback)?" y && pkgs+=(mpv)
...
run sudo pacman -S --needed --noconfirm "${pkgs[@]}"
run sudo apt-get install -y "${pkgs[@]}"
```

`--noconfirm` / `-y` mean pacman and apt do not get to ask either. A script piped
from the internet became root and installed packages with **zero** confirmations.

`install.ps1` had the same shape in a different costume — no sudo, but
`--accept-package-agreements --accept-source-agreements` accepted a third party's
licence terms on the user's behalf, from a prompt that also defaulted to yes.

Neither installer checked whether `mpv` was **already installed** before offering to
install it.

## The flow now

```
! mpv is not installed — Kunai needs it to play anything.
! yt-dlp is not installed — YouTube playback and downloads need it.

  This will run:
    sudo pacman -S --needed mpv yt-dlp

Run it now? [y/N]
```

Three rules, identical on every platform:

- **The command is always shown** — before it is offered, and again if declined.
- **The prompt defaults to no.** Enter never escalates.
- **`--yes` / `-Yes` does not answer this one.** It is consent to install Kunai, not
  consent to become root or accept someone's licence terms. No terminal → print,
  never run.

`--noconfirm`, `-y` and `--accept-*-agreements` are gone from the commands, so the
accepted path still lets the package manager confirm — two gates rather than none.
`--skip-deps` silences the section entirely.

## Coverage: 4 managers → 10

| | |
|---|---|
| Linux | `pacman` · `apt` · `dnf` · `zypper` · `apk` |
| macOS | `brew` · `port` |
| Windows | `winget` · `scoop` · `choco` |
| fallback | link to mpv's install guide |

The winget package ids are preserved — `mpv-player.mpv-CI.MSVC` is load-bearing,
since mpv.net ships `mpvnet.exe`, which Kunai cannot drive over mpv's IPC socket.

## Verification

Run, not reasoned about — and `pwsh` is available locally, so the Windows half was
exercised rather than shipped blind:

- the mapping table for all ten managers, both installers
- already-installed → no prompt, no command
- `--yes` **and** a closed stdin → prints, never escalates (both installers)
- interactive under a real pty: Enter declines and prints, `y` runs
- no supported manager → manual guidance, never a fabricated command

**Two defects testing caught.** `printf '%s\n'` with no arguments still emits one
empty line, so the "nothing missing" case read as a single blank dependency. And the
pwsh mapping test spawned five processes and went flaky under load — it is one
process now, which is the table it was asserting anyway.

8 new tests (4 bash, 4 pwsh). `lint`, `fmt:check --force`, `typecheck --force` and
`verify:doc-paths` all pass.

## Docs

`docs/users/install-and-update.mdx` owned the claim that `--yes` *"accepts every
optional prompt"* — no longer true — and now documents the flow, the ten managers,
and why `--yes` stops at the package manager.

## Scope

Both installers, their two test files, and the doc. Nothing under `apps/cli/src/` or
`packages/`, so no change to compiled binary bytes.

Covers the dependency half of #321; the silent Windows download and npm-only PATH
remediation follow in a separate PR on top of this one.
