### PR TITLE
test(analytics): seed the installs each rollup assertion counts

### DIFF
--- a/apps/analytics-ingest/test/postgres-ingest-lifecycle.test.ts
+++ b/apps/analytics-ingest/test/postgres-ingest-lifecycle.test.ts
@@ -75,7 +75,10 @@ describe.skipIf(!TEST_DATABASE_URL)("postgres ingest lifecycle", () => {
 
   test("dimensions group and round-trip through jsonb", async () => {
     const now = Date.parse(`${DAY}T12:00:00Z`);
-    for (let n = 2; n <= 7; n += 1) await ping(store, n, "0.3.0", now);
+    // Install 1 included deliberately: this asserts a total of 8, so it seeds
+    // all 8 rather than inheriting one from the test above. Re-pinging a day an
+    // install already has is a no-op by the (day, install_hash) primary key.
+    for (let n = 1; n <= 7; n += 1) await ping(store, n, "0.3.0", now);
     // One straggler on an older version: below the floor on its own.
     await ping(store, 8, "0.2.9", now);
 
@@ -112,6 +115,17 @@ describe.skipIf(!TEST_DATABASE_URL)("postgres ingest lifecycle", () => {
 
   test("the same install on a second day is active twice but lifetime once", async () => {
     const oldNow = Date.parse(`${OLD_DAY}T12:00:00Z`);
+    const now = Date.parse(`${DAY}T12:00:00Z`);
+
+    // Seed every install this asserts on, rather than inheriting 2..8 from the
+    // two tests above. Reading counts that earlier tests happened to leave
+    // behind made this fail on main with `Expected: 8, Received: 5` whenever
+    // the file's tests did not all land first -- a property of the run order,
+    // not of the SQL. Re-pinging an install on a day it already has is a no-op
+    // by the (day, install_hash) primary key, so this is safe to repeat.
+    for (let n = 1; n <= 8; n += 1) {
+      await ping(store, n, n === 8 ? "0.2.9" : "0.3.0", now);
+    }
     await ping(store, 1, "0.3.0", oldNow);
 
     const older = await store.rollUpDay(OLD_DAY);


### PR DESCRIPTION
Fixes #323. This is the **only failing job on main** — every other job on the current
tip passes.

## The failure

```
(fail) postgres ingest lifecycle > the same install on a second day is active twice but lifetime once
Expected: 8
Received: 5
```

It alternates across merges that touch nothing near analytics:

| commit | changed | result |
|---|---|---|
| `1ff6933e` (#317) | `release.yml`, shell scripts | **failure** |
| `cae68468` (#318) | two test files | success |
| `ad4408a2` (#311) | diagnostics test | success |
| `9d3ab388` (#316) | `install.sh` | **failure** |

## Why

The file prunes once in `beforeAll` and then **accumulates**. Installs 1–8 are seeded
across two *earlier* tests, and the failing test asserts a total it never created:

```ts
// test 1 seeds install 1
// test 2 seeds installs 2..8
// this test asserts:
expect(newer.lifetimeInstalls).toBe(8);   // ← counts what the others left behind
```

So the assertion is really about **run order**, not about the SQL it claims to test.
`Received: 5` means three installs were not there yet.

## The fix

Both cumulative assertions now seed what they count. Re-pinging an install on a day it
already has is a **no-op** by the `(day, install_hash)` primary key — which is itself
what the file's first test proves — so the added pings cannot change any expected
total.

This keeps what the tests are for. They exist to exercise real SQL: the data-modifying
CTE's two conflict targets, `jsonb` round-tripping, `date`/`timestamptz` casts. None of
that changes; only the seeding stops being someone else's job.

## Not verified locally — stated plainly

`bun run test:pg` needs Docker port publishing, and this machine's kernel is missing
the DNAT module:

```
iptables failed: ... Warning: Extension DNAT revision 0 not supported, missing kernel module?
```

Both the compose stack and a hand-rolled container fail the same way, and the suite
skips without a database rather than running. So the change is argued from the failure
output and the file's own accumulation, and **CI is the first place it actually runs**.

## Also worth recording

While chasing this I confirmed the pwsh installer suite is **healthy**: 69 pass, 0 fail
under CI's real `--timeout=20000`. Earlier local runs showing ~16 failures at exactly
5001ms were my own invocation omitting the flag, so Bun's 5000ms default applied. That
is a local-invocation trap, not a repo problem — worth knowing before anyone else
chases it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved PostgreSQL lifecycle test isolation by explicitly setting up required install data.
  - Enhanced coverage for cross-day activity and lifetime count scenarios across multiple app versions.
  - Reduced reliance on state left behind by earlier tests, improving consistency and reliability of test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->