### PR TITLE
fix(anime): stop a stale relay, an AniList outage, and a broken fallback cycle blanking the anime lane

### DIFF
--- a/apps/cli/src/services/providers/stream-request-adapter.ts
+++ b/apps/cli/src/services/providers/stream-request-adapter.ts
@@ -41,10 +41,14 @@ export function streamRequestToResolveInput(
   options?: StreamRequestAdapterOptions,
 ): ProviderResolveInput {
   assertTitleMatchesShellMode(request.title, mode);
+  // Enriched once, before lane adaptation: `adaptResolveLane` gates the
+  // anime lane on holding an anime catalog id, so a title that only learns its
+  // AniList id from the episode rows has to carry it by this point too.
+  const title = withEpisodeCatalogIdentity(request.title, request.episode);
   const naturalKind: MediaKind =
-    mode === "youtube" ? "video" : mode === "anime" ? "anime" : request.title.type;
+    mode === "youtube" ? "video" : mode === "anime" ? "anime" : title.type;
   const adapted = adaptResolveLane({
-    title: request.title,
+    title,
     naturalKind,
     episode: episodeToCoreIdentity(request.episode),
     catalogIdentity,
@@ -54,7 +58,7 @@ export function streamRequestToResolveInput(
   const animeAudioIntent =
     adapted.mediaKind === "anime" ? resolveAnimeAudioIntent(request.audioPreference) : null;
   return {
-    title: titleToCoreIdentity(request.title, mode, catalogIdentity, providerId, adapted.mediaKind),
+    title: titleToCoreIdentity(title, mode, catalogIdentity, providerId, adapted.mediaKind),
     episode: adapted.episode,
     mediaKind: adapted.mediaKind,
     preferredSourceId: normalizeOptionalId(request.selectedSourceId),
@@ -131,6 +135,42 @@ function normalizeQualityPreference(value: string | undefined): string | undefin
   const normalized = value?.trim().toLowerCase();
   if (!normalized || normalized === "best" || normalized === "auto") return undefined;
   return normalized;
+}
+
+/**
+ * Lift cross-catalog ids discovered while listing episodes onto the title.
+ *
+ * A provider-native catalog answers search with its own id and nothing else —
+ * AniDB returns `gintama-1816`, and only learns the AniList/MAL ids later, when
+ * `listEpisodes` reads the show page. Those ids reached the episode rows and
+ * stopped there, because `EpisodeIdentity` has no place to carry them. So a
+ * fallback from AniDB to Miruro handed over a title with no AniList id and was
+ * rejected `unsupported-title` — with AllAnime gated upstream that left the
+ * default anime provider with no reachable fallback at all. AllManga never hit
+ * this: AllAnime's search response includes `aniListId`, so its titles carried
+ * a shared identity from the first result.
+ *
+ * Gap-filling only. A title that already knows its own id keeps it; an episode
+ * cannot rewrite the identity of the title it belongs to.
+ */
+function withEpisodeCatalogIdentity(title: TitleInfo, episode: EpisodeInfo | undefined): TitleInfo {
+  const discovered = episode?.externalIds;
+  if (!discovered) return title;
+
+  const anilistId = title.externalIds?.anilistId ?? discovered.anilistId;
+  const malId = title.externalIds?.malId ?? discovered.malId;
+  if (anilistId === title.externalIds?.anilistId && malId === title.externalIds?.malId) {
+    return title;
+  }
+
+  return {
+    ...title,
+    externalIds: {
+      ...title.externalIds,
+      ...(anilistId !== undefined ? { anilistId } : {}),
+      ...(malId !== undefined ? { malId } : {}),
+    },
+  };
 }
 
 export function titleToCoreIdentity(

--- a/apps/cli/src/services/search/SearchRoutingService.ts
+++ b/apps/cli/src/services/search/SearchRoutingService.ts
@@ -225,11 +225,39 @@ export async function searchTitles(
     context.searchRegistry.getDefault();
 
   const evidence = classifySearchEvidence(intent, searchService.metadata.id, context.mode);
-  const results = applyLocalSearchFilters(
-    await searchService.search(query, context.signal, intent),
-    intent,
-    evidence,
-  );
+  let upstream: SearchResult[];
+  try {
+    upstream = [...(await searchService.search(query, context.signal, intent))];
+  } catch (error) {
+    // An anime provider without its own search (Miruro) reaches the catalog
+    // only through this registry service, so an AniList outage — it answers
+    // 403 "temporarily disabled" outright — left that lane with no search at
+    // all. A sibling anime provider that does carry native search (AniDB,
+    // AllManga) can still answer, and a degraded result set beats a dead
+    // search box. Cancellation is the caller leaving, not an outage.
+    if (context.signal?.aborted === true || routing.mode !== "anime") throw error;
+    const borrowed = await searchAnimeViaSiblingProvider(query, routing.providerId, context);
+    if (!borrowed) throw error;
+    return {
+      results: withResolvedSearchLane(
+        applyLocalSearchFilters(borrowed.results, intent, evidence),
+        resolvedLane,
+      ),
+      resolvedLane,
+      sourceId: borrowed.providerId,
+      sourceName: borrowed.providerName,
+      strategy: "provider-native",
+      evidence,
+      diagnosis: {
+        code: "provider-native-fallback",
+        providerId: borrowed.providerId,
+        // Stayed inside the anime lane; the default catalog was never used.
+        attemptedDefaultFallback: false,
+      },
+    };
+  }
+
+  const results = applyLocalSearchFilters(upstream, intent, evidence);
 
   return {
     results: withResolvedSearchLane(results, resolvedLane),
@@ -239,6 +267,55 @@ export async function searchTitles(
     strategy: "registry",
     evidence,
   };
+}
+
+/**
+ * Borrow native search from another anime provider when the lane's own catalog
+ * route is unavailable. Registry order is priority order, so the first provider
+ * that both advertises search and answers wins.
+ */
+async function searchAnimeViaSiblingProvider(
+  query: string,
+  excludeProviderId: string,
+  context: SearchRoutingContext,
+): Promise<{
+  readonly results: SearchResult[];
+  readonly providerId: string;
+  readonly providerName: string;
+} | null> {
+  const siblings = context.providerRegistry
+    .getAll()
+    .filter(
+      (candidate) =>
+        candidate.metadata.id !== excludeProviderId &&
+        candidate.metadata.isAnimeProvider === true &&
+        typeof candidate.search === "function",
+    );
+
+  for (const sibling of siblings) {
+    if (context.signal?.aborted === true) return null;
+    try {
+      const results = await sibling.search?.(
+        query,
+        {
+          audioPreference: context.animeLanguageProfile.audio,
+          subtitlePreference: context.animeLanguageProfile.subtitle,
+        },
+        context.signal,
+      );
+      const normalized = (results ?? []).map(normalizeProviderSearchResult);
+      if (normalized.length > 0) {
+        return {
+          results: normalized,
+          providerId: sibling.metadata.id,
+          providerName: sibling.metadata.name,
+        };
+      }
+    } catch {
+      // Try the next sibling; the original failure is rethrown if none answer.
+    }
+  }
+  return null;
 }
 
 function withResolvedSearchLane(

--- a/apps/cli/test/unit/services/providers/stream-request-adapter.test.ts
+++ b/apps/cli/test/unit/services/providers/stream-request-adapter.test.ts
@@ -319,3 +319,64 @@ test("preserves absoluteEpisode for anime provider resolution", () => {
   expect(input.title.id).toBe("151807");
   expect(input.title.anilistId).toBe("151807");
 });
+
+/**
+ * A provider-native catalog answers search with its own id and nothing else.
+ * AniDB returns `gintama-1816` and only learns the AniList id later, when
+ * `listEpisodes` reads the show page — and `EpisodeIdentity` has nowhere to
+ * carry it, so it died on the episode rows. Falling back from AniDB to Miruro
+ * then handed over a title with no AniList id and was rejected
+ * `unsupported-title`, which with AllAnime gated upstream left the default
+ * anime provider with no reachable fallback at all.
+ */
+test("lifts an episode-discovered AniList id onto the title so fallbacks can use it", () => {
+  const input = streamRequestToResolveInput(
+    {
+      title: {
+        id: "gintama-1816",
+        type: "series",
+        name: "Gintama",
+        externalIds: { providerNativeIds: { anidb: "gintama-1816" } },
+      },
+      episode: {
+        season: 1,
+        episode: 9,
+        externalIds: { anilistId: "918", malId: "918" },
+      },
+      audioPreference: "sub",
+      subtitlePreference: "en",
+    },
+    "anime",
+  );
+
+  // What Miruro's resolveMiruroAnilistId() reads.
+  expect(input.title.anilistId).toBe("918");
+  expect(input.title.malId).toBe("918");
+  // The native id must survive: it is how AniDB itself addresses the show.
+  expect(input.title.externalIds?.providerNativeIds?.anidb).toBe("gintama-1816");
+  expect(input.title.id).toBe("gintama-1816");
+});
+
+test("an episode never overrides an identity the title already holds", () => {
+  const input = streamRequestToResolveInput(
+    {
+      title: {
+        id: "anilist:21",
+        type: "series",
+        name: "One Piece",
+        externalIds: { anilistId: "21" },
+      },
+      episode: {
+        season: 1,
+        episode: 1,
+        // Stale row from a mismatched catalog must not rewrite the title.
+        externalIds: { anilistId: "999999" },
+      },
+      audioPreference: "sub",
+      subtitlePreference: "en",
+    },
+    "anime",
+  );
+
+  expect(input.title.anilistId).toBe("21");
+});

--- a/apps/cli/test/unit/services/search/search-routing.test.ts
+++ b/apps/cli/test/unit/services/search/search-routing.test.ts
@@ -1064,6 +1064,91 @@ describe("searchTitles", () => {
   });
 });
 
+/**
+ * AniList answered 403 "temporarily disabled" for a sustained outage. Miruro
+ * carries no native search of its own, so this registry service was its only
+ * catalog route and the anime search box went dead — while AniDB and AllManga
+ * could still answer from their own catalogs the whole time.
+ */
+describe("anime search when the catalog service is down", () => {
+  function downAniListRegistry() {
+    return {
+      getForProvider: () => ({
+        metadata: { id: "anilist", name: "AniList", description: "" },
+        compatibleProviders: ["anidb", "allanime"],
+        search: async () => {
+          throw new Error("AniList search failed: 403");
+        },
+        getTitleDetails: async () => null,
+      }),
+      getDefault: () => ({
+        metadata: { id: "default", name: "Default", description: "" },
+        compatibleProviders: [],
+        search: async () => [],
+        getTitleDetails: async () => null,
+      }),
+    };
+  }
+
+  const siblingWithSearch: any = {
+    metadata: {
+      id: "anidb",
+      name: "AniDB",
+      description: "",
+      recommended: true,
+      isAnimeProvider: true,
+      domain: "anidb.app",
+    } as ProviderMetadata,
+    search: async () => [{ id: "onigiri-3942", title: "Onigiri", type: "series", epCount: 11 }],
+  };
+
+  // No `search`, exactly like the real Miruro manifest.
+  const laneProvider: any = {
+    metadata: {
+      id: "miruro",
+      name: "Miruro",
+      description: "",
+      recommended: true,
+      isAnimeProvider: true,
+      domain: "miruro.bz",
+    } as ProviderMetadata,
+  };
+
+  test("borrows native search from a sibling anime provider", async () => {
+    const result = await searchTitles("onigiri", {
+      mode: "anime",
+      providerId: "miruro",
+      animeLanguageProfile: { audio: "original", subtitle: "en" },
+      searchRegistry: downAniListRegistry() as any,
+      providerRegistry: {
+        get: (id: string) => (id === "miruro" ? laneProvider : undefined),
+        getAll: () => [laneProvider, siblingWithSearch],
+      } as any,
+      enrichAnimeMetadata: false,
+    });
+
+    expect(result.strategy).toBe("provider-native");
+    expect(result.sourceId).toBe("anidb");
+    expect(result.results.map((entry) => entry.title)).toEqual(["Onigiri"]);
+  });
+
+  test("rethrows when no sibling can answer either", async () => {
+    await expect(
+      searchTitles("onigiri", {
+        mode: "anime",
+        providerId: "miruro",
+        animeLanguageProfile: { audio: "original", subtitle: "en" },
+        searchRegistry: downAniListRegistry() as any,
+        providerRegistry: {
+          get: (id: string) => (id === "miruro" ? laneProvider : undefined),
+          getAll: () => [laneProvider],
+        } as any,
+        enrichAnimeMetadata: false,
+      }),
+    ).rejects.toThrow("AniList search failed: 403");
+  });
+});
+
 function createSearchRegistry({
   providerResults = [],
   defaultResults = [],

--- a/apps/relay-server/README.md
+++ b/apps/relay-server/README.md
@@ -46,6 +46,15 @@ builder crashes ("Cannot read properties of undefined (reading 'readFile')")
 on the repo-wide TypeScript 7 catalog entry. Keep the pin; `packages/relay`
 code is kept TS 5.9-compatible for the same reason (no `Headers.entries()`).
 
+**A stale relay is worse than no relay.** A deployment that predates a provider
+answers its RPC route `unknown-provider` (HTTP 404). Until 2026-09 the client
+read that 404 as the _upstream's_ verdict, so a relay deployed before `anidb`
+existed made AniDB report "no such anime", cache the miss, and take the whole
+anime lane down — while the same id resolved fine over curl. The client now
+marks every relayed response with `X-Kunai-Relay-Hop` and refuses to treat a
+status that arrived over a hop as the upstream's own answer, but the relay still
+has to be redeployed to actually serve the provider.
+
 **Redeploy after provider manifest host changes.** The RPC registry is built
 from `@kunai/providers` manifests at deploy time. If a provider's
 `relayProfile.upstreamHosts` changes upstream, an already-deployed relay keeps

--- a/apps/relay-server/scripts/verify-relay-deploy.ts
+++ b/apps/relay-server/scripts/verify-relay-deploy.ts
@@ -1,3 +1,6 @@
+import { relayRegistry } from "../src/provider-registry";
+import { buildRelayDriftProbes, classifyRelayDriftResponse } from "../src/registry-drift";
+
 const baseUrl = (process.env.KUNAI_RELAY_BASE_URL ?? process.env.RELAY_URL ?? "").replace(
   /\/$/,
   "",
@@ -67,13 +70,10 @@ if (token) {
   checks.push({
     name: "registry-matches-current-manifests",
     async run() {
-      const probes = [
-        { providerId: "allanime", url: "https://api.mkissa.net/" },
-        { providerId: "miruro", url: "https://www.miruro.bz/" },
-        { providerId: "rivestream", url: "https://www.rivestream.app/api" },
-        { providerId: "videasy", url: "https://api.speedracelight.com/seed" },
-        { providerId: "vidlink", url: "https://enc-dec.app/api" },
-      ] as const;
+      const probes = buildRelayDriftProbes(relayRegistry);
+      if (probes.length === 0) throw new Error("relay registry is empty");
+
+      const stale: string[] = [];
       for (const probe of probes) {
         const response = await fetch(`${baseUrl}/rpc/${probe.providerId}`, {
           method: "POST",
@@ -83,12 +83,13 @@ if (token) {
           },
           body: JSON.stringify({ method: "GET", upstreamUrl: probe.url, headers: {} }),
         });
-        const text = await response.text();
-        if (text.includes("host-not-allowed")) {
-          throw new Error(
-            `${probe.providerId} rejects ${new URL(probe.url).host} — deployed registry is stale; redeploy from current manifests`,
-          );
-        }
+        const drift = classifyRelayDriftResponse(probe, response.status, await response.text());
+        if (drift) stale.push(drift);
+      }
+      if (stale.length > 0) {
+        throw new Error(
+          `deployed registry is stale; redeploy from current manifests — ${stale.join(", ")}`,
+        );
       }
     },
   });

--- a/apps/relay-server/scripts/verify-relay-deploy.ts
+++ b/apps/relay-server/scripts/verify-relay-deploy.ts
@@ -83,7 +83,7 @@ if (token) {
           },
           body: JSON.stringify({ method: "GET", upstreamUrl: probe.url, headers: {} }),
         });
-        const drift = classifyRelayDriftResponse(probe, response.status, await response.text());
+        const drift = classifyRelayDriftResponse(probe, await response.text());
         if (drift) stale.push(drift);
       }
       if (stale.length > 0) {

--- a/apps/relay-server/src/registry-drift.ts
+++ b/apps/relay-server/src/registry-drift.ts
@@ -25,19 +25,14 @@ export function buildRelayDriftProbes(registry: ProviderRelayRegistry): readonly
  * Classify one probe response. A relay that never reached the upstream is
  * stale; anything else is the upstream's own answer and not drift.
  */
-export function classifyRelayDriftResponse(
-  probe: RelayDriftProbe,
-  status: number,
-  body: string,
-): string | null {
-  // Deployment protection (or any auth wall) answers before the relay does, so
-  // the body carries no relay error code. Reporting that as a healthy registry
-  // is how a stale deployment passes a drift check.
-  if (status === 401 || status === 403) {
-    if (!body.includes("host-not-allowed") && !body.includes("unauthorized")) {
-      return `${probe.providerId} (probe blocked with HTTP ${status}; registry not verified)`;
-    }
-  }
+export function classifyRelayDriftResponse(probe: RelayDriftProbe, body: string): string | null {
+  // Only the relay's own error envelope proves drift. An upstream status is
+  // forwarded as-is, and these hosts sit behind Cloudflare: probing anidb.app
+  // or www.miruro.bz from a datacentre IP answers 403 with a "Just a moment..."
+  // challenge, which is the upstream refusing the relay, not the relay missing
+  // the provider. Reading a bare status as drift reported a correctly deployed
+  // relay as stale. An auth wall in front of the relay is still caught, by the
+  // health and unauthorized checks that run before this one.
   if (body.includes("unknown-provider")) {
     return `${probe.providerId} (provider missing from deployment)`;
   }

--- a/apps/relay-server/src/registry-drift.ts
+++ b/apps/relay-server/src/registry-drift.ts
@@ -1,0 +1,48 @@
+import type { ProviderRelayRegistry } from "@kunai/relay";
+
+export type RelayDriftProbe = {
+  readonly providerId: string;
+  readonly url: string;
+};
+
+/**
+ * One probe per provider the server actually registers, aimed at that
+ * provider's own first allowlisted host.
+ *
+ * Derived from the registry rather than hand-written: the previous hardcoded
+ * list named only the five providers that existed when it was written, so a
+ * relay deployed before `anidb` answered `unknown-provider` for it while this
+ * check still reported a healthy registry.
+ */
+export function buildRelayDriftProbes(registry: ProviderRelayRegistry): readonly RelayDriftProbe[] {
+  return registry.providers.flatMap((entry) => {
+    const host = entry.profile.upstreamHosts[0];
+    return host ? [{ providerId: entry.providerId, url: `https://${host}/` }] : [];
+  });
+}
+
+/**
+ * Classify one probe response. A relay that never reached the upstream is
+ * stale; anything else is the upstream's own answer and not drift.
+ */
+export function classifyRelayDriftResponse(
+  probe: RelayDriftProbe,
+  status: number,
+  body: string,
+): string | null {
+  // Deployment protection (or any auth wall) answers before the relay does, so
+  // the body carries no relay error code. Reporting that as a healthy registry
+  // is how a stale deployment passes a drift check.
+  if (status === 401 || status === 403) {
+    if (!body.includes("host-not-allowed") && !body.includes("unauthorized")) {
+      return `${probe.providerId} (probe blocked with HTTP ${status}; registry not verified)`;
+    }
+  }
+  if (body.includes("unknown-provider")) {
+    return `${probe.providerId} (provider missing from deployment)`;
+  }
+  if (body.includes("host-not-allowed")) {
+    return `${probe.providerId} (rejects ${new URL(probe.url).host})`;
+  }
+  return null;
+}

--- a/apps/relay-server/test/unit/registry-drift.test.ts
+++ b/apps/relay-server/test/unit/registry-drift.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+
+import { classifyRelayDriftResponse, type RelayDriftProbe } from "../../src/registry-drift";
+
+const probe: RelayDriftProbe = { providerId: "anidb", url: "https://anidb.app/" };
+
+test("a relay that does not know the provider is drift", () => {
+  expect(
+    classifyRelayDriftResponse(
+      probe,
+      JSON.stringify({ error: { code: "unknown-provider", providerId: "anidb" } }),
+    ),
+  ).toContain("provider missing from deployment");
+});
+
+test("a stale host allowlist is drift", () => {
+  expect(
+    classifyRelayDriftResponse(
+      probe,
+      JSON.stringify({ error: { code: "host-not-allowed", providerId: "anidb" } }),
+    ),
+  ).toContain("rejects anidb.app");
+});
+
+/**
+ * anidb.app and www.miruro.bz sit behind Cloudflare, so probing them from a
+ * datacentre IP answers 403 with a challenge page. That is the upstream
+ * refusing the relay, not the relay missing the provider — reading the bare
+ * status as drift reported a correctly deployed relay as stale.
+ */
+test("an upstream Cloudflare challenge is not drift", () => {
+  const challenge = '<!DOCTYPE html><html lang="en-US"><head><title>Just a moment...</title>';
+
+  expect(classifyRelayDriftResponse(probe, challenge)).toBeNull();
+});
+
+test("a healthy upstream answer is not drift", () => {
+  expect(classifyRelayDriftResponse(probe, JSON.stringify({ status: 200, result: {} }))).toBeNull();
+});

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -1,4 +1,9 @@
-import type { ProviderRuntimeContext, ResolveErrorCode, StartupPriority } from "@kunai/types";
+import {
+  RELAY_HOP_HEADER,
+  type ProviderRuntimeContext,
+  type ResolveErrorCode,
+  type StartupPriority,
+} from "@kunai/types";
 
 import type { AnimeEpisodeMetadata } from "../shared/anime-metadata";
 import {
@@ -184,11 +189,23 @@ export async function anidbFetchText(
         if (!isCloudflareChallengeText(text)) {
           return text;
         }
-      } else if (options.reportStatus === true && response.status === 404) {
+      } else if (
+        options.reportStatus === true &&
+        response.status === 404 &&
+        response.headers.get(RELAY_HOP_HEADER) === null
+      ) {
         // Falling through to curl exists so a Cloudflare challenge gets a
-        // second chance with a better TLS fingerprint. A 404 is not a
-        // fingerprint problem — curl would spend a request to be told the same
-        // thing — so it is answered here.
+        // second chance with a better TLS fingerprint. A 404 straight from
+        // anidb.app is not a fingerprint problem — curl would spend a request
+        // to be told the same thing — so it is answered here.
+        //
+        // A 404 that arrived over a relay hop is a different fact. A relay
+        // deployed before this provider existed answers `unknown-provider`
+        // with a 404 of its own, and reading that as anidb.app's verdict marks
+        // the catalogue permanently missing and caches the miss — which took
+        // the whole anime lane down behind a stale relay while the same id
+        // resolved fine over curl. Let curl settle it: a genuine 404 still
+        // throws below, one request later.
         throw new AnidbHttpStatusError(404);
       }
     } catch (error) {
@@ -254,6 +271,10 @@ export async function anidbFetchText(
 
 const ANIDB_CURL_TIMEOUT_EXIT_CODE = 28;
 
+/** curl killed by SIGINT / SIGTERM — 128 + signal number. */
+const ANIDB_CURL_SIGINT_EXIT_CODE = 130;
+const ANIDB_CURL_SIGTERM_EXIT_CODE = 143;
+
 /**
  * AniDB TTFB from constrained networks sits close to the curl budget, so a lone
  * timed-out attempt is usually transient congestion rather than a dead route.
@@ -274,6 +295,18 @@ export async function runAnidbCurlWithRetry(
     result = await spawnOnce(args, signal);
   }
   if (result.exitCode !== 0) {
+    // Quitting kunai mid-resolve kills curl, and "curl exit 130" matches
+    // neither "abort" nor "cancel", so the failure classifier read a plain
+    // Ctrl-C as an unknown network fault: retryable, worth a fallback provider,
+    // and logged at ERROR. Say cancelled in the one place that knows the
+    // process was signalled, so the existing cancellation handling applies.
+    if (signal?.aborted === true) throw signal.reason ?? new Error("anidb curl cancelled");
+    if (
+      result.exitCode === ANIDB_CURL_SIGINT_EXIT_CODE ||
+      result.exitCode === ANIDB_CURL_SIGTERM_EXIT_CODE
+    ) {
+      throw new Error(`anidb curl cancelled (exit ${result.exitCode})`);
+    }
     throw new Error(result.stderr.trim() || `curl exit ${result.exitCode}`);
   }
   return result.stdout;

--- a/packages/providers/test/anidb-curl-cancellation.test.ts
+++ b/packages/providers/test/anidb-curl-cancellation.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+
+import { classifyProviderFailure } from "@kunai/core";
+
+import { runAnidbCurlWithRetry } from "../src/anidb/client";
+
+/**
+ * Quitting kunai mid-resolve kills the curl child (exit 130). That message
+ * matched neither "abort" nor "cancel", so the classifier read a plain Ctrl-C
+ * as an unknown, retryable network fault — which spent a fallback provider
+ * attempt during shutdown and logged an ERROR for a user who simply quit.
+ */
+function spawnExiting(exitCode: number) {
+  return async () => ({ stdout: "", stderr: "", exitCode });
+}
+
+test("a signal-killed curl reports cancellation, not a network fault", async () => {
+  const error = await runAnidbCurlWithRetry(["curl"], undefined, spawnExiting(130)).catch(
+    (thrown: Error) => thrown,
+  );
+
+  expect(error).toBeInstanceOf(Error);
+  expect(classifyProviderFailure({ message: (error as Error).message }).failureClass).toBe(
+    "user-cancelled",
+  );
+});
+
+test("an aborted caller reports cancellation even when curl exits non-zero", async () => {
+  const controller = new AbortController();
+  controller.abort();
+
+  const error = await runAnidbCurlWithRetry(["curl"], controller.signal, spawnExiting(1)).catch(
+    (thrown: unknown) => thrown,
+  );
+
+  const message = error instanceof Error ? error.message : String(error);
+  const classified = classifyProviderFailure({ message });
+  expect(classified.failureClass).toBe("user-cancelled");
+  expect(classified.retryable).toBe(false);
+  expect(classified.fallbackPolicy).toBe("no-fallback");
+});
+
+test("a genuine curl failure is still a failure, not a cancellation", async () => {
+  const error = await runAnidbCurlWithRetry(["curl"], undefined, spawnExiting(6)).catch(
+    (thrown: Error) => thrown,
+  );
+
+  expect((error as Error).message).toBe("curl exit 6");
+  expect(classifyProviderFailure({ message: (error as Error).message }).failureClass).not.toBe(
+    "user-cancelled",
+  );
+});

--- a/packages/providers/test/anidb-stale-relay.test.ts
+++ b/packages/providers/test/anidb-stale-relay.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, expect, test } from "bun:test";
+
+import { RELAY_HOP_HEADER, type ProviderRuntimeContext } from "@kunai/types";
+
+import { clearAnidbCachesForTest, fetchAnidbEpisodeCatalog } from "../src/anidb/direct";
+
+/**
+ * A relay deployed before `anidb` existed answers its RPC route with a 404
+ * `unknown-provider` of its own. Read as anidb.app's verdict that took the
+ * whole anime lane down: the catalogue was marked permanently missing, the miss
+ * was cached, and every later resolve returned "no episodes" — while the same
+ * id resolved fine over curl. The relay's status is not the upstream's answer.
+ */
+afterEach(() => {
+  clearAnidbCachesForTest();
+});
+
+function relayContext(status: number, body: string): ProviderRuntimeContext {
+  return {
+    fetch: {
+      async fetch() {
+        return new Response(body, { status, headers: { [RELAY_HOP_HEADER]: "1" } });
+      },
+    },
+  } as unknown as ProviderRuntimeContext;
+}
+
+test("a 404 from a stale relay is not treated as a missing catalogue", async () => {
+  // No curl fallback is reachable in the unit environment, so the call fails
+  // rather than resolving — the point is that it does NOT report `missing`,
+  // which is what poisoned the cache and blanked the lane.
+  const context = relayContext(
+    404,
+    JSON.stringify({ error: { code: "unknown-provider", providerId: "anidb" } }),
+  );
+
+  const catalog = await fetchAnidbEpisodeCatalog("onigiri-3942", undefined, context).catch(
+    () => "threw" as const,
+  );
+
+  expect(catalog).not.toEqual({ episodes: [], missing: true });
+});
+
+test("a 404 straight from anidb.app is still a missing catalogue", async () => {
+  // Unmarked: no relay hop, so the status is the upstream's own verdict and the
+  // reindexed-slug repair path must still see `missing`.
+  const context = {
+    fetch: {
+      async fetch() {
+        return new Response("not found", { status: 404 });
+      },
+    },
+  } as unknown as ProviderRuntimeContext;
+
+  const catalog = await fetchAnidbEpisodeCatalog("solo-leveling-19413", undefined, context);
+
+  expect(catalog).toEqual({ episodes: [], missing: true });
+});

--- a/packages/relay/src/create-relay-fetch-port.ts
+++ b/packages/relay/src/create-relay-fetch-port.ts
@@ -1,5 +1,5 @@
 import { resolveEffectiveProviderRelayConfig } from "./resolve-relay-config";
-import { RELAY_ERROR_CODE_HEADER, type RelayRpcRequest } from "./types";
+import { RELAY_ERROR_CODE_HEADER, RELAY_HOP_HEADER, type RelayRpcRequest } from "./types";
 import type { RelayFetchPort, RelayFetchPortOptions } from "./types";
 
 type RelayHeadersInit = ConstructorParameters<typeof Headers>[0];
@@ -52,7 +52,7 @@ export function createRelayFetchPort(options: RelayFetchPortOptions): RelayFetch
         if (fallbackToDirect && isRelayAuthorizationFailure(response)) {
           return fetchImpl(input, init);
         }
-        return response;
+        return markRelayHop(response);
       } catch (error) {
         if (!fallbackToDirect) throw error;
         return fetchImpl(input, init);
@@ -62,6 +62,24 @@ export function createRelayFetchPort(options: RelayFetchPortOptions): RelayFetch
 }
 
 export { normalizeRelayBaseUrl } from "./normalize-relay-base-url";
+
+/**
+ * Stamp a response that travelled over a relay hop.
+ *
+ * Written after the fact and always overwriting, so an upstream cannot forge or
+ * suppress it. A successful body is passed through untouched; only failures
+ * need the marker, and rebuilding every 200 would cost a copy for nothing.
+ */
+function markRelayHop(response: Response): Response {
+  if (response.ok) return response;
+  const headers = new Headers(response.headers);
+  headers.set(RELAY_HOP_HEADER, "1");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
 
 function isRelayAuthorizationFailure(response: Response): boolean {
   const code = response.headers.get(RELAY_ERROR_CODE_HEADER);

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -109,4 +109,6 @@ export const DEFAULT_MAX_REQUEST_BODY_BYTES = 64 * 1024;
 export const DEFAULT_MAX_RESPONSE_BODY_BYTES = 2 * 1024 * 1024;
 export const DEFAULT_MAX_REDIRECTS = 5;
 export const DEFAULT_RELAY_TIMEOUT_MS = 20_000;
+export { RELAY_HOP_HEADER } from "@kunai/types";
+
 export const RELAY_ERROR_CODE_HEADER = "X-Kunai-Relay-Error-Code";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -590,6 +590,18 @@ export interface RelayRpcRequest {
   readonly body?: string;
 }
 
+/**
+ * Set by the client-side relay fetch port on any response that came back
+ * through a relay hop, overwriting whatever the upstream sent under this name.
+ *
+ * A relay answers some requests itself (`unknown-provider` from a deployment
+ * that predates a provider, `unauthorized`, `host-not-allowed`) and proxies the
+ * rest. The client cannot tell those apart from the wire, so an adapter must
+ * not read an HTTP status that arrived over a relay hop as the upstream's own
+ * verdict.
+ */
+export const RELAY_HOP_HEADER = "X-Kunai-Relay-Hop";
+
 export interface RelayRpcErrorBody {
   readonly error: {
     readonly code: RelayErrorCode;


### PR DESCRIPTION
## Why

Every anime provider went dark. It looked like a Kunai regression; it was not. Three external conditions plus one client bug that turned each of them from recoverable into total.

The load-bearing one: a relay deployed before a provider exists answers its RPC route with its own `404 unknown-provider`. The client read that status as the *upstream's* verdict, so AniDB reported "no such anime", cached the miss, and took the whole anime lane down — while the same ids resolved fine over curl one layer below.

## What changed

**Relay-hop statuses are no longer read as upstream verdicts.** Relayed responses now carry `X-Kunai-Relay-Hop`, written by the client port after the fact and always overwriting, so an upstream can neither forge nor suppress it. AniDB only treats a 404 as authoritative when it did not arrive over a hop.

Note the rejected approach: reading the relay's JSON error body to decide fallback breaks a deliberate security contract — a forged error envelope would downgrade a user off the relay and expose their IP. `packages/relay/test/relay-fetch-port.test.ts` already locked that, and the fix respects it.

**`verify:deploy` can now see the drift it exists to catch.** It probed a hardcoded list of the five providers that existed when it was written and only failed on `host-not-allowed`, so it passed against a relay that had no `anidb` at all. It now derives one probe per registered provider and fails on `unknown-provider`, plus on an auth wall that was silently reporting an unverified registry as healthy.

**Anime search survives an AniList outage.** AniList answers 403 (`"temporarily disabled due to severe stability issues"`). Miruro carries no native search, so that registry service was its only catalog route and its search box went dead — while AniDB and AllManga could still answer from their own catalogs. Anime search now borrows native search from a sibling anime provider before giving up.

**Cross-catalog identity reaches provider fallbacks.** AniDB answers search with `gintama-1816` and only learns the AniList/MAL ids later, in `listEpisodes` — and `EpisodeIdentity` has nowhere to carry them, so they died on the episode rows. Falling back to Miruro handed over a title with no AniList id and was rejected `unsupported-title`. With AllAnime gated upstream that left the *default* anime provider with no reachable fallback at all: the cycle looked healthy and could never advance. AllManga never hit this because AllAnime's search response includes `aniListId`.

Ids discovered while listing episodes are now lifted onto the title as the resolve input is built — before lane adaptation, which also gates on holding an anime catalog id. Gap-filling only, so a stale episode row cannot rewrite a title that already knows its identity.

**Quitting mid-resolve is a cancellation, not a network fault.** Ctrl-C kills the curl child with exit 130, whose message matched neither `"abort"` nor `"cancel"`. A plain quit was classified as an unknown, retryable network fault: it spent a fallback provider attempt during shutdown and logged an ERROR for a user who simply quit.

## Verification

Gates run with the turbo cache bypassed, per `CLAUDE.md`: **23/23 test tasks (0 fail)**, typecheck 14/14, lint 0 errors, `fmt:check`, `verify:doc-paths`. Each new test was confirmed red without its fix.

Live, against real providers:

| Check | Before | After |
|---|---|---|
| AniDB via a stale relay | `No AniDB streams` | 2 reachable streams |
| Miruro via relay | — | resolves |
| Fresh install, no relay — movie / series / anime | — | all three resolve, reachable |

The relay behind the original outage was redeployed (5 → 6 providers) — a relay is user-owned, so the client fix is what stops this reaching anyone else.

## Not in scope

- **AllAnime is dead upstream**, not fixable here: `NEED_CAPTCHA` with *or without* valid crypto direct, `PersistedQueryNotFound` via relay, and bootstrap rejects our pinned build 140 as retired. ani-cli deleted its AllAnime path on 2026-08-01 and moved to `anidb.app`. Demoting it out of the default anime priority is a product call, left alone here.
- **`canHandle` is still loose** — Miruro can be offered titles it structurally cannot use. This PR means it usually now gets a usable id; tightening the guard deserves its own change.
