### PR TITLE
docs(agents): prune dated and duplicated text from the agent context

### DIFF
--- a/.docs/agents/issue-tracker.md
+++ b/.docs/agents/issue-tracker.md
@@ -1,6 +1,6 @@
 ---
 status: current
-lastReviewed: "2026-07-25"
+lastReviewed: "2026-09-03"
 ---
 
 # Issue tracker: GitHub

--- a/.docs/agents/issue-tracker.md
+++ b/.docs/agents/issue-tracker.md
@@ -32,14 +32,6 @@ When set to `yes`, PRs run through the same labels and states as issues, using t
 
 GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
 
-## When a skill says "publish to the issue tracker"
-
-Create a GitHub issue.
-
-## When a skill says "fetch the relevant ticket"
-
-Run `gh issue view <number> --comments`.
-
 ## Wayfinding operations
 
 Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.

--- a/.docs/agents/triage-labels.md
+++ b/.docs/agents/triage-labels.md
@@ -9,14 +9,12 @@ lastReviewed: "2026-07-25"
 
 The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
 
-| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
-| -------------------------- | -------------------- | ---------------------------------------- |
-| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
-| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
-| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
-| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
-| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+| Canonical role    | Label in this tracker | Meaning                                  |
+| ----------------- | --------------------- | ---------------------------------------- |
+| `needs-triage`    | `needs-triage`        | Maintainer needs to evaluate this issue  |
+| `needs-info`      | `needs-info`          | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent`     | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | `ready-for-human`     | Requires human implementation            |
+| `wontfix`         | `wontfix`             | Will not be actioned                     |
 
-When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
-
-Edit the right-hand column to match whatever vocabulary you actually use.
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table. Every role maps to a label of the same name here; verified against `gh label list` on 2026-09-03.

--- a/.docs/agents/triage-labels.md
+++ b/.docs/agents/triage-labels.md
@@ -1,6 +1,6 @@
 ---
 status: current
-lastReviewed: "2026-07-25"
+lastReviewed: "2026-09-03"
 ---
 
 # Triage Labels

--- a/.reference/experiments/scratchpads/skill-headless-scraper/SKILL.md
+++ b/.reference/experiments/scratchpads/skill-headless-scraper/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: headless-scraper-pro
-description: Guides the agent through reverse-engineering streaming websites and building 0-RAM headless scrapers (like ani-cli). Use this skill whenever the user wants to "scrape a provider", "reverse engineer a streaming site", "build a scraper for", "bypass obfuscation", or "crack a streaming API". It provides a step-by-step methodology for sniffing network traffic, deobfuscating JS/WASM, and writing pure HTTP fetch scripts to extract m3u8 streams without launching heavy headless browsers.
+description: Reverse-engineer a streaming site's stream-resolution path and port it to a pure-fetch extractor — sniff the hidden backend API, deobfuscate the JS/WASM that hides it, and reimplement the key derivation and payload decryption in TypeScript so the shipped scraper needs no headless browser. Use when adding a provider, or when an existing one breaks because the site changed its obfuscation.
 ---
 
 # Headless Scraper Pro
 
-This skill provides the ultimate playbook for reverse-engineering obfuscated streaming websites (like Vidking, Rivestream, HDToday, etc.) to build lightning-fast, 0-RAM, headless scrapers. The goal is to always extract the direct `.m3u8` or `.mp4` stream links using pure `fetch` and `cheerio`, bypassing the need for RAM-heavy headless browsers (like Playwright, Puppeteer, or JSDOM) in the final implementation.
+This skill is the playbook for reverse-engineering obfuscated streaming websites (like Vidking, Rivestream, HDToday, etc.) to build lightning-fast, 0-RAM, headless scrapers. The goal is to always extract the direct `.m3u8` or `.mp4` stream links using pure `fetch` and `cheerio`, bypassing the need for RAM-heavy headless browsers (like Playwright, Puppeteer, or JSDOM) in the final implementation.
 
 ## The 4 Phases of Cracking a Provider
 
@@ -21,6 +21,9 @@ import { chromium } from "playwright";
 (async () => {
   const browser = await chromium.launch({ headless: true });
   const context = await browser.newContext({
+    // Bump to a current desktop Chrome build before running this. A UA several
+    // majors behind is itself a bot signal on the strict-TLS sites in
+    // "Common Pitfalls" below.
     userAgent:
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
   });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,8 @@ Each of these is enforced by a test or is expensive to get wrong.
 **The house failure mode is the silent no-op** — a flag parsed and dropped, a
 setting persisted and ignored, a capability declared and never read.
 `apps/cli/test/unit/architecture/contract-conformance.test.ts` catches some of
-it; the rest is this list. Before calling work done, walk it and say which
-entries applied.
+it; the rest is this list. On a change that adds or alters behaviour, walk it
+before calling the work done and say which entries applied.
 
 - **Declaration → reader.** If you add a flag, config key, capability, or
   contract field, name the code that consumes it. If nothing does, you shipped
@@ -126,41 +126,24 @@ what gives mpv IPC its cancellable deadlines. Do not change APIs for style alone
 
 ## Deep docs
 
-Read one when your change lands in its subject. Not before. Full index with the
-rest of `.docs/`: [.docs/README.md](.docs/README.md).
+`.docs/` holds how the system works and why. Read one when your change lands in
+its subject — not before, and never the directory end to end.
 
-| Changing…                                                        | Read                                                                                                                                                 |
-| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Where feature X lives                                            | [feature-map.md](.docs/feature-map.md)                                                                                                               |
-| Playback flow, provider orchestration, persistence, recovery     | [architecture.md](.docs/architecture.md)                                                                                                             |
-| Which layer or package work belongs in                           | [runtime-boundary-map.md](.docs/runtime-boundary-map.md)                                                                                             |
-| Broad refactors, service extraction, caching                     | [engineering-guide.md](.docs/engineering-guide.md)                                                                                                   |
-| Shell flow, hotkeys, overlays, setup UX                          | [ux-architecture.md](.docs/ux-architecture.md) · [keybindings.md](.docs/keybindings.md)                                                              |
-| Terminal styling and interaction patterns                        | [design-system.md](.docs/design-system.md) · [ui-redesign-playbook.md](.docs/ui-redesign-playbook.md)                                                |
-| Poster previews, Kitty/iTerm2/Sixel output, capability detection | [poster-image-rendering.md](.docs/poster-image-rendering.md)                                                                                         |
-| Adding or hardening a provider                                   | [providers.md](.docs/providers.md) · [provider-intake.md](.docs/provider-intake.md) · [provider-agent-workflow.md](.docs/provider-agent-workflow.md) |
-| A provider shape from scratch                                    | [provider-examples.md](.docs/provider-examples.md)                                                                                                   |
-| Source, quality, audio, subtitle inventory                       | [playback-source-inventory-contract.md](.docs/playback-source-inventory-contract.md)                                                                 |
-| IntroDB/AniSkip, MAL resolution, auto-skip metadata              | [playback-timing-and-aniskip.md](.docs/playback-timing-and-aniskip.md)                                                                               |
-| mpv reconnect on the persistent session path                     | [mpv-in-process-reconnect.md](.docs/mpv-in-process-reconnect.md)                                                                                     |
-| Debug logs, diagnostics panels, provider tracing                 | [diagnostics-guide.md](.docs/diagnostics-guide.md)                                                                                                   |
-| Broad reliability or debugging sweeps                            | [debugging-map.md](.docs/debugging-map.md)                                                                                                           |
-| Provider health, cache layers, reset behavior                    | [title-provider-health-and-cache-reset.md](.docs/title-provider-health-and-cache-reset.md)                                                           |
-| `/discover` and recommendations                                  | [recommendations-and-discover.md](.docs/recommendations-and-discover.md)                                                                             |
-| Share URLs, `/share`, `/watch`, `kunai --open`                   | [share-links.md](.docs/share-links.md)                                                                                                               |
-| Discord presence and social status                               | [presence-integrations.md](.docs/presence-integrations.md)                                                                                           |
-| Download, offline library, setup, onboarding                     | [download-offline-onboarding.md](.docs/download-offline-onboarding.md)                                                                               |
-| AniList/TMDB sync, the outbox, tracker auth                      | [tracker-sync.md](.docs/tracker-sync.md)                                                                                                             |
-| Tests, test seams, new runtime behaviors                         | [testing-strategy.md](.docs/testing-strategy.md)                                                                                                     |
-| CI, Husky, lint-staged, issue and PR templates                   | [repo-infrastructure.md](.docs/repo-infrastructure.md) · [lint-policy.md](.docs/lint-policy.md)                                                      |
-| Release gating                                                   | [release-reliability-gate.md](.docs/release-reliability-gate.md)                                                                                     |
-| Setup, local run flow, troubleshooting                           | [quickstart.md](.docs/quickstart.md)                                                                                                                 |
-| Product vocabulary (Watchlist / Playlists / Up Next / …)         | [adr/0001-personal-media-vocabulary.md](.docs/adr/0001-personal-media-vocabulary.md)                                                                 |
-| Parked surfaces — web, desktop, daemon, cache direction          | [architecture-v2.md](.docs/architecture-v2.md)                                                                                                       |
+Four entry points cover most work:
 
-Per-feature product rules live in [.docs/features/](.docs/features/); provider
-research dossiers in [.docs/provider-dossiers/](.docs/provider-dossiers/); local
-UI prototype harnesses in [.docs/prototypes.md](.docs/prototypes.md).
+- [feature-map.md](.docs/feature-map.md) — where feature X lives
+- [architecture.md](.docs/architecture.md) — playback flow, provider
+  orchestration, persistence, recovery
+- [runtime-boundary-map.md](.docs/runtime-boundary-map.md) — which layer or
+  package work belongs in
+- [glossary.md](.docs/glossary.md) — what we call things; product vocabulary is
+  pinned by [adr/0001](.docs/adr/0001-personal-media-vocabulary.md)
+
+Everything else routes from [.docs/README.md](.docs/README.md) — the full index,
+grouped by subsystem, contract, and working-on-it, and the one that gets updated
+when `.docs/` moves. Per-feature product rules live in
+[.docs/features/](.docs/features/); provider research dossiers in
+[.docs/provider-dossiers/](.docs/provider-dossiers/).
 
 ## Where things are written down
 


### PR DESCRIPTION
## What changed

Prune dated and duplicated text from the agent-facing docs, cutting the always-loaded `AGENTS.md` from ~4,121 to ~2,736 estimated tokens without losing a routing decision.

**Stacked on #255** (`stack/4-anti-slop`). Docs-only; no overlap with that PR's files.

## Why

`AGENTS.md` is read in full at the start of every agent session. Its `## Deep docs` table was 6,551 of 16,486 chars — **40% of the file** — and `.docs/README.md` already covers every row in it (except the ADR-0001 row, which it reaches via `adr/`), plus glossary, analytics-privacy-contract, prototypes, and four directories the table never listed. `AGENTS.md` line 130 already named `.docs/README.md` "the full index" while carrying a second one beside it.

They agree today, which is why this isn't a correctness fix. What tips it is the repo's own warning that doc rot here "is almost always a directory move that leaves routing docs pointing at the old layout" — two indexes means two places to fix on every move, and only one of them shows up in a diff someone reads.

Replaced with the four entry points `.docs/README.md` itself calls "Start here", plus the pointer. The trade: a change landing in, say, `poster-image-rendering.md` now costs one extra read of the 84-line index. Worth it when ~90% of sessions need none of those 28 rows.

## Findings this implements

Verified rather than inferred, in `file:line` terms:

- **`.docs/agents/triage-labels.md:22`** — `Edit the right-hand column to match whatever vocabulary you actually use.` Unfilled template text, verbatim from the generator at `~/.claude/skills/setup-matt-pocock-skills/triage-labels.md:15`; `diff` shows the repo copy added only frontmatter and the L3 banner. It addresses whoever ran setup, but sits in an agent-facing doc and reads as an instruction to edit the file. The table stays — `gh label list` confirms all five labels exist — with the upstream pack's name dropped from the header and a verification date added.
- **`.docs/agents/issue-tracker.md:35-41`** — two sections keyed to phrases (`publish to the issue tracker`, `fetch the relevant ticket`) that appear in **no** installed skill; re-grepped across `~/.claude/skills` and `~/.claude/plugins` before removing.
- **`AGENTS.md` "Hit every seam"** — scoped the seam-walk to changes that add or alter behaviour. Unscoped, it demanded a checklist recitation on doc-only and test-only changes, where a silent no-op isn't reachable.
- **scratchpad `SKILL.md`** — trigger-case enumeration in the frontmatter `description` (five near-synonymous phrases, and descriptions ride in every request) replaced with intent categories; `Chrome/124.0.0.0` pin given a verification anchor; "the ultimate playbook" → "the playbook".

## Deliberately not changed

- `AGENTS.md:15` (`Find code through .docs/feature-map.md before grepping`) stays crisp. Softening a working rule into a hedge is the same failure in the other direction.
- `.docs/agents/issue-tracker.md:25-31` — the `PRs as a request surface: no` flag and its `yes` branch look like a dead option menu, but `~/.claude/skills/triage/SKILL.md:11` consults that flag by name.
- `.docs/agents/domain.md` and `audit-findings-bar.md` — both fully adapted to this repo; nothing to cut.
- The `.docs/` deep docs themselves — swept for behavioural-instruction anti-patterns (pressure language, thinking scaffolds, output caps, prohibition runs); zero hits.

## Checklist

- [x] Changeset added — **N/A, docs-only** (matches #290/#291/#292, which shipped without one)
- [x] `bun run guard` — N/A, no `apps/cli/package.json`, changelog, or `.changeset/**` change
- [x] `bun run verify:doc-paths` — `50 docs and 2049 source files scanned, all paths resolve`
- [x] `bun run fmt:check --force` — `26 successful, 26 total | 0 cached, 26 total` (forced, not a turbo replay)
- [x] `bun run build` — N/A, no source change
- [x] Live provider / Discord smokes — N/A, no runtime change

`typecheck`/`test` not re-run: this branch changes four Markdown files and no TypeScript. #255's own gates cover the code underneath.

https://claude.ai/code/session_01EfworT7Px6Ky5QkuikrWqG
