### PR TITLE
fix(relay,providers): forward VidLink's playback header, terminate curl argv, correct the recovery key

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ page or in-app `?` over duplicating chords here.
 ### Playback
 
 - Streams are resolved from direct-provider sources and handed to `mpv`.
-- **Recover** (`r`) refreshes the current stream and resumes from last position.
+- **Recover** (`Ctrl+R`) refreshes the current stream and resumes from last position.
 - **Recompute sources** (`/recompute`) bypasses cached provider memory when provider state looks stale.
 - **Fallback** (`⇧F`) tries the next compatible provider when the current one fails.
 - **Source / quality picker** switches among already-resolved stream options.
@@ -633,7 +633,7 @@ not ship as runtime behavior.
 <details>
 <summary><b>Search works but playback fails or stalls.</b></summary>
 
-Providers break when upstream sites change. In playback, press `r` to recover the
+Providers break when upstream sites change. In playback, press `Ctrl+R` to recover the
 stream, `⇧F` to fall back to the next compatible provider, `o` to pick another
 source, or `k` to pick quality. If sources look stale, `/recompute` bypasses cached provider
 memory. Persistent issues → `/diagnostics`, then `/export-diagnostics` for a

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -248,6 +248,10 @@ export async function anidbFetchText(
     maxTime,
     ...anidbCipherArgs(curl.impersonates),
     ...(options.reportStatus === true ? ANIDB_STATUS_WRITE_OUT : []),
+    // Everything after `--` is an operand, never an option. Embed and playlist
+    // URLs arrive from upstream JSON, so without this a value beginning with
+    // `-` would be read as curl flags rather than as the address to fetch.
+    "--",
     url,
   ];
   const stdout = await runAnidbCurlWithRetry(args, options.signal);

--- a/packages/providers/src/miruro/direct.ts
+++ b/packages/providers/src/miruro/direct.ts
@@ -1612,6 +1612,10 @@ async function fetchMiruroPipeBody(
     String(MIRURO_CURL_STALL_SECONDS),
     "--max-time",
     String(MIRURO_CURL_MAX_SECONDS),
+    // Everything after `--` is an operand, never an option. The URL comes from
+    // an upstream JSON payload, so without this a value beginning with `-`
+    // would be read as curl flags rather than as the address to fetch.
+    "--",
     url,
   ];
 

--- a/packages/providers/test/curl-argv-terminator.test.ts
+++ b/packages/providers/test/curl-argv-terminator.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+
+/**
+ * Both curl call sites put the fetch URL last in argv, and those URLs come from
+ * upstream JSON (AniDB `embed_url`, the Miruro pipe payload). Without a `--`
+ * terminator curl reads a value beginning with `-` as options rather than as
+ * the address, so upstream JSON gets a say in the argv of a local subprocess.
+ *
+ * Guarded at the source because the argv is assembled inside the fetch
+ * helpers, with no seam to observe it from a behavioural test.
+ */
+const CURL_ARGV_SITES = [
+  { file: "src/anidb/client.ts", url: "url" },
+  { file: "src/miruro/direct.ts", url: "url" },
+] as const;
+
+for (const site of CURL_ARGV_SITES) {
+  test(`${site.file} terminates curl options before the URL operand`, async () => {
+    const source = await Bun.file(new URL(`../${site.file}`, import.meta.url)).text();
+
+    // The argv array literal ends with the terminator immediately before the
+    // URL. Comments and whitespace between them are fine; another argument is
+    // not, because it would land after `--` and be read as a second operand.
+    const terminated = new RegExp(String.raw`"--",\s*(?://[^\n]*\n\s*)*${site.url},\s*\]`);
+
+    expect(source).toMatch(terminated);
+  });
+}

--- a/packages/relay/src/forward-headers.ts
+++ b/packages/relay/src/forward-headers.ts
@@ -10,6 +10,11 @@ const METADATA_HEADER_ALLOWLIST = new Set([
   "user-agent",
   "x-build-id",
   "x-aa-boot",
+  // VidLink answers `deliveryType: "file"` without this — bcdn MP4s flagged
+  // `requiresProxy` that 429 every non-browser client, so a relayed lane
+  // resolved and then could not play. Dropping it made the relay the only
+  // difference between a playable DASH manifest and a dead one.
+  "x-playback-environment",
   "x-obfuscated",
   "x-session-token",
 ]);

--- a/packages/relay/test/forward-headers.test.ts
+++ b/packages/relay/test/forward-headers.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+
+import { filterForwardHeaders } from "../src/forward-headers";
+
+/**
+ * VidLink answers `deliveryType: "file"` without `x-playback-environment:
+ * webkit` — bcdn MP4s flagged `requiresProxy` that 429 every non-browser
+ * client. The relay dropped the header, so a relayed VidLink lane resolved and
+ * then would not play, while the same request direct played fine. The relay
+ * being the only difference is what made it hard to see.
+ */
+test("forwards the VidLink playback environment header", () => {
+  const forwarded = filterForwardHeaders({
+    "x-playback-environment": "webkit",
+    "user-agent": "kunai",
+  });
+
+  expect(forwarded["x-playback-environment"]).toBe("webkit");
+});
+
+test("still drops credentials and unlisted headers", () => {
+  const forwarded = filterForwardHeaders({
+    authorization: "Bearer secret",
+    cookie: "session=secret",
+    "x-not-allowed": "nope",
+    connection: "keep-alive",
+    referer: "https://example.test/",
+  });
+
+  expect(forwarded.authorization).toBeUndefined();
+  expect(forwarded.cookie).toBeUndefined();
+  expect(forwarded["x-not-allowed"]).toBeUndefined();
+  expect(forwarded.connection).toBeUndefined();
+  expect(forwarded.Referer).toBe("https://example.test/");
+});


### PR DESCRIPTION
Stacked on #326 — that PR touches the same `anidbFetchText` argv this one changes, so branching from `main` would guarantee a conflict. **Merge #326 first**; the diff here is only the three commits' worth of changes below.

Three findings from an audit sweep, kept because they survived verification against `.docs/agents/audit-findings-bar.md`. Several other findings in the same sweep were refuted and are deliberately not here.

## VidLink is unplayable through a relay

VidLink asks for the browser playback path with `x-playback-environment: webkit` (`vidlink/direct.ts:200`). The relay's metadata allowlist never carried it, so a relayed VidLink lane got `deliveryType: "file"` — bcdn MP4s flagged `requiresProxy` that answer 429 to every non-browser client. It resolves, then will not play, with the relay as the only difference from a working direct request.

`vidlink-dash.test.ts` only asserted that the provider *sends* the header on the direct path; nothing pinned the allowlist, so this was invisible to the suite. Now covered both ways — forwarded, and credentials still dropped.

**Relay operators must redeploy.** The allowlist is baked in at deploy time, so an already-deployed relay keeps stripping the header.

## `--` before the URL operand in both curl call sites

AniDB and Miruro both put the fetch URL last in argv, and those URLs come from upstream JSON (`embed_url`, the Miruro pipe payload). Without a terminator, curl reads a value beginning with `-` as options rather than as the address, so upstream JSON gets a say in a local subprocess's argv.

Scoped deliberately. This is hardening, not an incident: a single trailing argv slot cannot land a working option — `curl … "-o/tmp/pwned"` exits 2 with `no URL specified` and writes nothing — and the whole scenario presupposes a hostile anidb.app, which can already hand mpv arbitrary URLs.

**A scheme allowlist was considered and rejected here.** Rejecting protocol-relative or relative embed URLs would regress the anime lane, which is a likelier outcome than the injection it prevents. `--` closes the option half completely at zero behavioural cost; the scheme check deserves its own change with anime-lane care.

Guarded at the source, in the style of `boundary-imports.test.ts`, because the argv is assembled inside the fetch helpers with no seam to observe it from a behavioural test. Both guards were confirmed red with the terminator removed.

## README documents a recovery key that does nothing

In-player recovery is `Ctrl+R` in both `app-shell/keybindings.ts:514` and `assets/mpv/kunai-bridge.lua:1085`. `README.md` said a bare `r` in two places. `.docs/keybindings.md` was already correct.

Generating that table from `KEYBINDINGS` is already filed in `.plans/023-cli-surface-honesty.md`; this is the textual half only.

## Verification

Full suite with the turbo cache bypassed: **23/23 tasks, 0 fail**. Typecheck 14/14, lint 0 errors, `fmt:check` 26/26, `verify:doc-paths`.

Worth flagging separately: the suite failed twice during this work and passed on re-run with no changes, in `@kunai/providers` and in the pre-push hook. That is the flakiness tracked in #319/#323, not this branch — but it does mean a red run here should be re-run before it is believed.
