### PR TITLE
ci(docs): fail when a doc changes but its lastReviewed does not

### DIFF
--- a/.docs/repo-infrastructure.md
+++ b/.docs/repo-infrastructure.md
@@ -1,6 +1,6 @@
 ---
 status: current
-lastReviewed: "2026-08-24"
+lastReviewed: "2026-09-03"
 ---
 
 # Kunai — Repo Infrastructure
@@ -126,6 +126,17 @@ every directory the gate scans (`apps/cli/src/{services,domain,infra,app}`,
 `packages/**`), because a new unrouted directory arrives as new _code_ files and
 would otherwise skip the check meant to catch it. It runs `setup-bun` without
 `bun install` — the script imports only `node:fs` and `node:path`.
+
+`verify:doc-frontmatter` (inside `checks-docs`) has two halves. The first is
+static: every live `.docs` doc declares `status`, an ISO `lastReviewed`, and the
+L3 banner. The second compares the change set against `origin/main` and fails
+when a doc's body moved but its `lastReviewed` did not — the field only means
+something if editing a doc forces you to answer for it. Set `lastReviewed` to
+the day you actually re-read the doc against the tree; for a mechanical sweep
+that cannot change meaning, re-run with `SKIP_DOC_FRESHNESS=1`. Both halves need
+history, which is why every `checkout` in the workflow pins `fetch-depth: 0`; on
+a checkout without the base ref the freshness half skips with a notice rather
+than failing on the shape of the clone.
 
 Install cache key: `${{ runner.os }}-bun-store-${{ hashFiles('bun.lock') }}` covering
 `~/.bun/install/cache` only (Bun reconstructs `node_modules` from the store).

--- a/scripts/verify-doc-frontmatter.ts
+++ b/scripts/verify-doc-frontmatter.ts
@@ -14,8 +14,28 @@
 // code. It is NOT a formatting stamp — do not bulk-update it to "today" without
 // actually re-reading the doc against the tree.
 //
+// Enforcing that the field *exists* is not enough. A field nothing checks stops
+// tracking reality: when this half was added, 62 of 66 live docs carried a
+// `lastReviewed` older than their own last commit, so the freshness signal that
+// `AGENTS.md` tells every agent to trust had quietly become decoration. A doc
+// asserting `status: current` over a body the tree has moved past is worse than
+// an undated one — it invites confident work on a description of code that no
+// longer exists.
+//
+// So the check also asks, of every doc a change actually touches: did the body
+// change without the review date changing? That is a question about *this* diff,
+// which is why there is no baseline file and no retroactive sweep. The 62 are
+// not the bug this prevents — they are the reason it exists, and they get
+// reconciled as they are next edited.
+//
+// Escape hatch for mechanical sweeps that cannot change meaning (a formatter
+// run, a path rename): `SKIP_DOC_FRESHNESS=1`. Reach for it rarely, and never to
+// get a content edit past the gate.
+//
 // Usage:
 //   bun run verify:doc-frontmatter
+//   DOC_FRESHNESS_BASE=origin/main bun run verify:doc-frontmatter
+//   SKIP_DOC_FRESHNESS=1 bun run verify:doc-frontmatter
 // =============================================================================
 
 import { readFileSync } from "node:fs";
@@ -28,6 +48,53 @@ const BANNER = "Agent-facing (L3)";
 const EXCLUDED_DIRS = ["archive/"];
 
 const STATUS_VALUES = new Set(["current", "draft", "superseded"]);
+
+const DOC_PREFIX = ".docs/";
+const REVIEWED_LINE = /^[+-]lastReviewed:/m;
+
+function git(...args: string[]): string | null {
+  const proc = Bun.spawnSync(["git", ...args], { cwd: ROOT });
+  if (proc.exitCode !== 0) return null;
+  return new TextDecoder().decode(proc.stdout);
+}
+
+/**
+ * The commit this change set departs from.
+ *
+ * A shallow or detached CI checkout may not have the base ref at all. That is a
+ * missing precondition, not a violation, so the freshness half is skipped with a
+ * notice rather than failing a build for the shape of its checkout.
+ */
+function freshnessBase(): string | null {
+  const configured = process.env.DOC_FRESHNESS_BASE;
+  const candidates = configured ? [configured] : ["origin/main", "main"];
+  for (const ref of candidates) {
+    const merged = git("merge-base", "HEAD", ref)?.trim();
+    if (merged) return merged;
+  }
+  return null;
+}
+
+/**
+ * Docs whose body changed since `base` without their `lastReviewed` moving.
+ *
+ * Deletions are excluded (`--diff-filter=d`): a removed doc has nothing left to
+ * reconcile. Additions are included — a new doc states a review date it should
+ * have actually earned.
+ */
+function unreconciledSince(base: string): string[] {
+  const changed = git("diff", "--name-only", "--diff-filter=d", base, "HEAD", "--", ".docs");
+  if (changed === null) return [];
+
+  const result: string[] = [];
+  for (const path of changed.split("\n")) {
+    if (!path.startsWith(DOC_PREFIX) || !path.endsWith(".md")) continue;
+    if (EXCLUDED_DIRS.some((dir) => path.startsWith(DOC_PREFIX + dir))) continue;
+    const patch = git("diff", "-U0", base, "HEAD", "--", path);
+    if (patch !== null && !REVIEWED_LINE.test(patch)) result.push(path);
+  }
+  return result;
+}
 
 const files = [...new Bun.Glob("**/*.md").scanSync({ cwd: resolve(ROOT, ".docs") })]
   .filter((path) => !EXCLUDED_DIRS.some((dir) => path.startsWith(dir)))
@@ -77,6 +144,37 @@ if (problems.length > 0) {
   process.exit(1);
 }
 
+if (process.env.SKIP_DOC_FRESHNESS === "1") {
+  console.log(
+    `verify:doc-frontmatter — ${files.length} docs scanned, all declare status and ` +
+      `audience. Freshness skipped (SKIP_DOC_FRESHNESS=1).`,
+  );
+  process.exit(0);
+}
+
+const base = freshnessBase();
+if (base === null) {
+  console.log(
+    `verify:doc-frontmatter — ${files.length} docs scanned, all declare status and ` +
+      `audience. Freshness skipped: no base ref (set DOC_FRESHNESS_BASE).`,
+  );
+  process.exit(0);
+}
+
+const unreconciled = unreconciledSince(base);
+if (unreconciled.length > 0) {
+  console.error("verify:doc-frontmatter — changed without being reconciled:\n");
+  for (const path of unreconciled) console.error(`  ${path}`);
+  console.error(
+    `\n${unreconciled.length} doc(s) changed in this change set with no change to ` +
+      `'lastReviewed'. Re-read each against the tree and set lastReviewed to today ` +
+      `— or, for a mechanical sweep that cannot change meaning, re-run with ` +
+      `SKIP_DOC_FRESHNESS=1.`,
+  );
+  process.exit(1);
+}
+
 console.log(
-  `verify:doc-frontmatter — ${files.length} docs scanned, all declare status and audience.`,
+  `verify:doc-frontmatter — ${files.length} docs scanned, all declare status and ` +
+    `audience; every doc changed since ${base.slice(0, 9)} was reconciled.`,
 );


### PR DESCRIPTION
## What changed

`verify:doc-frontmatter` now fails when a doc's body changes in a change set but its `lastReviewed` does not.

## Why

The gate already required `lastReviewed` to exist and parse as an ISO date. It never required it to *track* anything — and a field nothing checks stops tracking reality:

```
lastReviewed >= last content commit:   4
lastReviewed <  last content commit:  62   ← never bumped on edit
```

62 of 66 live docs. `AGENTS.md` tells every agent that `.docs/` is "Current, unless code disagrees", and all 66 declare `status: current`. A doc asserting currency over a body the tree has moved past is worse than an undated one: it invites confident work on a description of code that no longer exists, and the one field that could have said "check this first" is noise in both directions.

## The design, and the one I threw away

My first version compared `lastReviewed` against the file's last commit date across the whole corpus, with a baseline file listing known-stale docs. That baseline came out at **62 of 66 entries** — a ratchet that exempts 94% of its subject is a no-op with ceremony, and it would have demanded a 62-doc reconciliation project before the gate could mean anything.

This version scopes the question to the diff: *of the docs this change touches, did the body move without the review date moving?* That needs no baseline, no retroactive sweep, and fires only on docs you actually edited. The 62 are not the bug this prevents — they are the reason it exists, and they get reconciled as they are next edited.

## Verification

Probed on scratch commits, not reasoned about:

| Case | Expected | Result |
|---|---|---|
| Unchanged tree | pass | `exit 0` |
| Body edit, no date bump | **fail, naming the file** | `exit 1`, lists `.docs/architecture.md` |
| Same edit + `lastReviewed` bumped | pass | `exit 0` |
| `SKIP_DOC_FRESHNESS=1` | pass with notice | `Freshness skipped (SKIP_DOC_FRESHNESS=1).` |
| Base ref absent (shallow clone) | pass with notice | `Freshness skipped: no base ref` |

**Declaration → reader:** CI already runs this at `.github/workflows/ci.yml:570` inside `checks-docs`, and every `checkout` in that workflow pins `fetch-depth: 0`, so `origin/main` is present and the new half actually bites there. On a `push` to `main`, the merge-base is HEAD itself, so the diff is empty and main never fails on its own history.

**Escape hatch:** `SKIP_DOC_FRESHNESS=1`, for mechanical sweeps that cannot change meaning (a formatter run, a path rename). It is a deliberate one-liner in CI logs rather than a silent allowlist that would rot.

## Dogfooded

This PR edits `.docs/repo-infrastructure.md` (documenting the rule in the doc that owns CI) and bumps its `lastReviewed` — the bump is earned: I re-read that section against `ci.yml` while writing it. The gate passes on its own branch.

## Checklist

- [x] Changeset — **N/A, docs/CI tooling only**, no user-facing CLI change
- [x] `bun run guard` — N/A, no `apps/cli/package.json`, changelog, or `.changeset/**` change
- [x] `bun run typecheck --force` — `14 successful, 14 total | 0 cached` (forced, not a replay)
- [x] `bun run lint` — `12 successful, 12 total`
- [x] `bun run verify:doc-paths` — `51 docs and 2112 source files scanned, all paths resolve`
- [x] `bun run verify:doc-frontmatter` — passes on this branch
- [x] `bun run build` — N/A, no runtime source change
- [x] Live provider / Discord smokes — N/A

https://claude.ai/code/session_01EfworT7Px6Ky5QkuikrWqG
