### PR TITLE
fix(install): Windows progress and PATH remedies; isolate analytics postgres ids

### DIFF
--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -308,7 +308,7 @@ bun run --cwd apps/analytics-ingest test:pg
 CI runs this same command in the `Analytics Postgres suites` job whenever
 `apps/analytics-ingest/**` changes, and fails if any case reports `skip` — a
 database that never starts otherwise produces a green run with every Postgres
-case silently skipped. Release signoff still needs a local or Neon run recorded
+case silently skipped. The harness serialises the suites and namespaces install ids per file; a leftover `install_lifetime` row from another file is how main used to fail `Expected: 8, Received: 5` on `lifetimeInstalls`. Release signoff still needs a local or Neon run recorded
 against the release commit, but a regression no longer waits for that run to
 surface.
 

--- a/.docs/testing-strategy.md
+++ b/.docs/testing-strategy.md
@@ -329,6 +329,12 @@ Local equivalent: `KUNAI_INSTALLER_DOCKER=1 bun run test:installer:docker`
 
 - Spawns `pwsh -File install.ps1 -DryRun` (no downloads, no sandbox directories)
 - Localhost release fixtures cover empty assets and missing `SHA256SUMS` entries
+- PATH-conflict remediation is extracted from `Get-PathConflictRemedy` so Linux CI
+  covers bun/npm/pnpm/yarn/scoop/choco/winget mappings; the full installer PATH
+  diagnostic still runs on Windows
+- Download progress helpers (`Format-ByteSize`, `Write-DownloadProgress`) are
+  extracted the same way; `Invoke-BoundedDownload` is gated to wipe a failed
+  transfer instead of drawing 100%
 - Skipped when `pwsh` is not installed (same pattern as Docker tests); CI `installer-lint` / Windows jobs cover pwsh
 
 **Bash installer fixtures** (`apps/cli/test/integration/install-scripts.test.ts`):

--- a/apps/analytics-ingest/README.md
+++ b/apps/analytics-ingest/README.md
@@ -85,13 +85,15 @@ bun run --cwd apps/analytics-ingest test      # offline, in-memory store
 bun run --cwd apps/analytics-ingest test:pg   # real Postgres, needs Docker
 ```
 
-`test` runs everything that does not need a database. The two Postgres suites
+`test` runs everything that does not need a database. The Postgres suites
 skip, and a skip reads as a pass — which is why `test:pg` exists.
 
 `test:pg` brings up the throwaway Postgres in `docker-compose.yml`, applies the
-schema, runs `postgres-store` and `postgres-ingest-lifecycle` against it, and
-tears it down. `test:pg -- --keep` leaves the containers up for iteration;
-`db:down` cleans up afterwards.
+schema, runs the `postgres-*.test.ts` files against it with `--max-concurrency 1`,
+and tears it down. Those files share one database and `install_lifetime.first_seen`
+is write-once, so each suite mints install ids through `testInstallId(n, suite)`
+rather than reusing n=1 across files. `test:pg -- --keep` leaves the containers
+up for iteration; `db:down` cleans up afterwards.
 
 The container credentials are `kunai:kunai`. That protects nothing — loopback
 only, tmpfs-backed, destroyed when the run ends — and secret scanners flag it,

--- a/apps/analytics-ingest/scripts/test-postgres.ts
+++ b/apps/analytics-ingest/scripts/test-postgres.ts
@@ -86,8 +86,12 @@ async function main(): Promise<number> {
     // indefinitely with nothing reporting it. Running the directory picks up
     // every new postgres-*.test.ts automatically; the suites that need no
     // database are cheap and pass either way.
+    // One database, several files, write-once first_seen. File order is not
+    // a contract: if hardening pings n=1 on May before lifecycle pings n=1 on
+    // February, February's lifetime count drops the May rows. Disjoint ids
+    // are the isolation; serialising is so a leftover row stays deterministic.
     console.log("→ running postgres-backed suites");
-    return await run("bun", ["test", "test"], env);
+    return await run("bun", ["test", "test", "--max-concurrency", "1"], env);
   } finally {
     if (!external && !keep) {
       console.log("→ tearing down");

--- a/apps/analytics-ingest/test/postgres-hardening.test.ts
+++ b/apps/analytics-ingest/test/postgres-hardening.test.ts
@@ -37,7 +37,7 @@ function ping(
 ) {
   return store.recordPing({
     day,
-    installHash: hashInstallId(HASH_SECRET, testInstallId(n)),
+    installHash: hashInstallId(HASH_SECRET, testInstallId(n, "hardening")),
     version: dimensions.version ?? "0.3.0",
     os: dimensions.os ?? "linux",
     arch: dimensions.arch ?? "x64",

--- a/apps/analytics-ingest/test/postgres-ingest-lifecycle.test.ts
+++ b/apps/analytics-ingest/test/postgres-ingest-lifecycle.test.ts
@@ -19,14 +19,7 @@ import { hashInstallId, ingestAnalyticsPing, RAW_RETENTION_DAYS } from "../src/i
 import { createPostgresAnalyticsStore } from "../src/postgres-store";
 import { buildPublicMetrics, SMALL_CELL_FLOOR } from "../src/public-metrics";
 import type { AnalyticsStore } from "../src/store";
-
-/**
- * Deliberately NOT `DATABASE_URL`. These tests write and prune, and
- * `DATABASE_URL` is set in far too many shells for something destructive to
- * key off it — a stray one must never let `bun run test` mutate a real
- * database. Opting in has to be explicit.
- */
-const TEST_DATABASE_URL = process.env.ANALYTICS_TEST_DATABASE_URL?.trim();
+import { resetAnalyticsTables, TEST_DATABASE_URL, testInstallId } from "./support/pg";
 
 /** Far enough back that no real rollup could occupy these days. */
 const DAY = "1999-02-01";
@@ -35,14 +28,10 @@ const OLD_DAY = "1999-01-01";
 const OTHER_DAY = "1999-02-02";
 const HASH_SECRET = "local-test-secret";
 
-function installId(n: number): string {
-  return `00000000-0000-4000-8000-${String(n).padStart(12, "0")}`;
-}
-
 async function ping(store: AnalyticsStore, n: number, version: string, now: number) {
   return ingestAnalyticsPing({
     method: "POST",
-    body: { installId: installId(n), version, os: "linux", arch: "x64", ts: now },
+    body: { installId: testInstallId(n, "lifecycle"), version, os: "linux", arch: "x64", ts: now },
     hashSecret: HASH_SECRET,
     store,
     now,
@@ -54,8 +43,9 @@ describe.skipIf(!TEST_DATABASE_URL)("postgres ingest lifecycle", () => {
 
   beforeAll(async () => {
     store = createPostgresAnalyticsStore(TEST_DATABASE_URL as string);
-    // These tests own the two scratch days outright.
-    await store.pruneRawBefore("1999-03-01");
+    // Truncate lifetime too: pruneRawBefore leaves install_lifetime, which is
+    // how a prior file's May pings of n=1,2,3 used to shrink February's count.
+    await resetAnalyticsTables();
   });
 
   test("a real payload lands as one row and one lifetime install", async () => {
@@ -165,7 +155,13 @@ describe.skipIf(!TEST_DATABASE_URL)("postgres ingest lifecycle", () => {
     });
     const forged = await ingestAnalyticsPing({
       method: "POST",
-      body: { installId: installId(99), version: "9.9.9-evil", os: "plan9", arch: "x64", ts: now },
+      body: {
+        installId: testInstallId(99, "lifecycle"),
+        version: "9.9.9-evil",
+        os: "plan9",
+        arch: "x64",
+        ts: now,
+      },
       hashSecret: HASH_SECRET,
       store,
       now,
@@ -180,7 +176,7 @@ describe.skipIf(!TEST_DATABASE_URL)("postgres ingest lifecycle", () => {
   });
 
   test("the stored hash is the HMAC, never the raw install id", async () => {
-    const raw = installId(1);
+    const raw = testInstallId(1, "lifecycle");
     const hash = hashInstallId(HASH_SECRET, raw);
 
     expect(hash).toHaveLength(64);

--- a/apps/analytics-ingest/test/postgres-store.test.ts
+++ b/apps/analytics-ingest/test/postgres-store.test.ts
@@ -3,13 +3,16 @@ import { beforeAll, describe, expect, test } from "bun:test";
 // Side-effecting: honours NEON_FETCH_ENDPOINT. Must precede store construction.
 // oxlint-disable-next-line import/no-unassigned-import -- the side effect is the point
 import "../src/neon-fetch-endpoint";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import {
   createPostgresAnalyticsStore,
   PRUNE_LIFETIME_SQL,
   RECORD_PING_SQL,
   ROLL_UP_DAY_SQL,
 } from "../src/postgres-store";
-import { resetAnalyticsTables, TEST_DATABASE_URL } from "./support/pg";
+import { resetAnalyticsTables, TEST_DATABASE_URL, testInstallId } from "./support/pg";
 
 test("recordPing charges the budget and writes both tables in one SQL statement", () => {
   expect(RECORD_PING_SQL).toContain("with budget as");
@@ -44,6 +47,29 @@ test("the rollup is a single statement so its parts share one snapshot", () => {
 test("lifetime pruning and the retired counter move in one statement", () => {
   expect(PRUNE_LIFETIME_SQL).toContain("delete from install_lifetime where last_seen < $1::date");
   expect(PRUNE_LIFETIME_SQL).toContain("update lifetime_retired set retired_installs");
+});
+
+test("postgres suites mint disjoint install ids at the same n", () => {
+  // Main failed after #325 with Expected: 8, Received: 5 on lifetimeInstalls.
+  // Hardening pings installs 1-3 on May; lifecycle pings 1-8 on February.
+  // first_seen is write-once, so 1-3 kept May and dropped out of February's
+  // count: 8 - 3 = 5. The ids must not be the same UUID.
+  const ids = (["lifecycle", "hardening", "store"] as const).map((suite) =>
+    testInstallId(1, suite),
+  );
+  expect(new Set(ids).size).toBe(3);
+});
+
+test("postgres tests mint install ids only through the namespaced helper", () => {
+  const dir = join(import.meta.dir);
+  // Skip this file: it is the assertion, not a minter.
+  const files = readdirSync(dir).filter(
+    (name) => name.endsWith(".test.ts") && name !== "postgres-store.test.ts",
+  );
+  for (const name of files) {
+    const source = readFileSync(join(dir, name), "utf8");
+    expect(source.includes("function installId("), name).toBe(false);
+  }
 });
 
 /**

--- a/apps/analytics-ingest/test/support/pg.ts
+++ b/apps/analytics-ingest/test/support/pg.ts
@@ -25,8 +25,25 @@ export const SCRATCH_DAYS = {
   main: "1999-02-01",
 } as const;
 
-export function testInstallId(n: number): string {
-  return `00000000-0000-4000-8000-${String(n).padStart(12, "0")}`;
+/**
+ * Suite-scoped install ids.
+ *
+ * These files share one scratch database. `install_lifetime.first_seen` is
+ * write-once, so a hardening ping of install 1 on May and a lifecycle ping of
+ * install 1 on February used to be the same HMAC: February's lifetime count
+ * dropped the three May rows and failed on main as Expected 8, Received 5.
+ * Prefixing the last UUID group keeps each suite's n=1 a different install.
+ */
+export type AnalyticsTestSuite = "lifecycle" | "hardening" | "store";
+
+const SUITE_PREFIX: Record<AnalyticsTestSuite, string> = {
+  lifecycle: "00",
+  hardening: "10",
+  store: "20",
+};
+
+export function testInstallId(n: number, suite: AnalyticsTestSuite): string {
+  return `00000000-0000-4000-8000-${SUITE_PREFIX[suite]}${String(n).padStart(10, "0")}`;
 }
 
 export async function resetAnalyticsTables(): Promise<void> {

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -1736,6 +1736,7 @@ describeWindows("install.ps1 PATH diagnostics", () => {
           // the same file, so compare against the canonical on-disk spelling.
           expect(result.stdout).toContain(`PATH winner: ${realpathSync.native(npmShimPath)}`);
           expect(result.stdout).toContain(`Planned native path: ${nativePath}`);
+          expect(result.stdout).toContain("Another kunai comes earlier on your PATH");
           expect(result.stdout).toContain("npm uninstall -g @kitsunekode/kunai");
         },
       );
@@ -2027,5 +2028,158 @@ describePwsh("install.ps1 optional dependency consent", () => {
     expect(output).toContain("No supported package manager found");
     expect(output).toContain("https://mpv.io/installation/");
     expect(output).not.toContain("[RAN]");
+  });
+});
+
+/**
+ * Windows parity for the PATH-conflict remediation added to install.sh. The
+ * PowerShell version tested only the winner, and only against npm, so every
+ * other manager fell through to a generic "move $BinDir ahead" line and never
+ * learned the command that removes the competing install.
+ */
+describePwsh("install.ps1 PATH conflict remediation", () => {
+  function extractFn(name: string): string {
+    return `Invoke-Expression ([regex]::Match($src, "(?ms)^function ${name} \\{.*?^\\}").Value)`;
+  }
+
+  function evalPathFns(body: string): string {
+    const script = [
+      `$src = Get-Content -Raw ${JSON.stringify(INSTALL_PS1)}`,
+      'function Write-Info { param($m) Write-Host "> $m" }',
+      'function Write-Warn { param($m) Write-Host "! $m" }',
+      '$Package = "@kitsunekode/kunai"',
+      extractFn("Get-PathConflictRemedy"),
+      extractFn("Write-KunaiPathDiagnostic"),
+      body,
+    ].join("\n");
+    const result = spawnSync("pwsh", ["-NoProfile", "-Command", script], { encoding: "utf8" });
+    expect(result.stderr, result.stderr).not.toContain("ParserError");
+    return `${result.stdout}${result.stderr}`;
+  }
+
+  function remedyTable(): Record<string, string> {
+    const probe = [
+      "foreach ($e in @(",
+      '  "C:\\Users\\u\\.bun\\bin\\kunai.exe",',
+      '  "C:\\Users\\u\\AppData\\Roaming\\npm\\kunai.cmd",',
+      '  "C:\\Users\\u\\AppData\\Roaming\\nvm\\v22\\kunai.cmd",',
+      '  "C:\\Users\\u\\AppData\\Local\\fnm_multishells\\123_456\\kunai.cmd",',
+      '  "C:\\Users\\u\\AppData\\Local\\pnpm\\kunai.exe",',
+      '  "C:\\Users\\u\\.yarn\\bin\\kunai.cmd",',
+      '  "C:\\Users\\u\\scoop\\shims\\kunai.exe",',
+      '  "C:\\ProgramData\\chocolatey\\bin\\kunai.exe",',
+      '  "C:\\Users\\u\\AppData\\Local\\Microsoft\\WinGet\\Packages\\kunai.exe",',
+      '  "C:\\tools\\kunai.exe")) {',
+      '  Write-Output "$e|$(Get-PathConflictRemedy $e)"',
+      "}",
+    ].join("\n");
+    return Object.fromEntries(
+      evalPathFns(probe)
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.includes("|"))
+        .map((line) => {
+          const index = line.lastIndexOf("|");
+          return [line.slice(0, index), line.slice(index + 1)];
+        }),
+    );
+  }
+
+  test("each Windows package manager maps to its own removal command", () => {
+    const table = remedyTable();
+    expect(table["C:\\Users\\u\\.bun\\bin\\kunai.exe"]).toBe(
+      "bun remove --global @kitsunekode/kunai",
+    );
+    expect(table["C:\\Users\\u\\AppData\\Roaming\\npm\\kunai.cmd"]).toBe(
+      "npm uninstall -g @kitsunekode/kunai",
+    );
+    expect(table["C:\\Users\\u\\AppData\\Roaming\\nvm\\v22\\kunai.cmd"]).toBe(
+      "npm uninstall -g @kitsunekode/kunai",
+    );
+    expect(table["C:\\Users\\u\\AppData\\Local\\fnm_multishells\\123_456\\kunai.cmd"]).toBe(
+      "npm uninstall -g @kitsunekode/kunai",
+    );
+    expect(table["C:\\Users\\u\\AppData\\Local\\pnpm\\kunai.exe"]).toBe(
+      "pnpm remove --global @kitsunekode/kunai",
+    );
+    expect(table["C:\\Users\\u\\.yarn\\bin\\kunai.cmd"]).toBe(
+      "yarn global remove @kitsunekode/kunai",
+    );
+    expect(table["C:\\Users\\u\\scoop\\shims\\kunai.exe"]).toBe("scoop uninstall kunai");
+    expect(table["C:\\ProgramData\\chocolatey\\bin\\kunai.exe"]).toBe("choco uninstall kunai");
+    expect(table["C:\\Users\\u\\AppData\\Local\\Microsoft\\WinGet\\Packages\\kunai.exe"]).toBe(
+      "winget uninstall kunai",
+    );
+  });
+
+  test("an unrecognised install still yields a line naming its path", () => {
+    expect(remedyTable()["C:\\tools\\kunai.exe"]).toBe("# remove or rename C:\\tools\\kunai.exe");
+  });
+
+  test("a conflict lists every competing install, not only the winner", () => {
+    const output = evalPathFns(
+      [
+        "$BinDir = 'C:\\Users\\u\\AppData\\Local\\kunai\\bin'",
+        "function Get-KunaiPathCandidates {",
+        "  return @(",
+        "    'C:\\Users\\u\\AppData\\Roaming\\npm\\kunai.cmd',",
+        "    'C:\\Users\\u\\.bun\\bin\\kunai.exe',",
+        "    'C:\\Users\\u\\AppData\\Local\\kunai\\bin\\kunai.exe'",
+        "  )",
+        "}",
+        "Write-KunaiPathDiagnostic 'C:\\Users\\u\\AppData\\Local\\kunai\\bin\\kunai.exe'",
+      ].join("\n"),
+    );
+    expect(output).toContain("Another kunai comes earlier on your PATH");
+    expect(output).toContain("C:\\Users\\u\\AppData\\Roaming\\npm\\kunai.cmd");
+    expect(output).toContain("C:\\Users\\u\\.bun\\bin\\kunai.exe");
+    expect(output).toContain("npm uninstall -g @kitsunekode/kunai");
+    expect(output).toContain("bun remove --global @kitsunekode/kunai");
+    expect(output).toContain("put C:\\Users\\u\\AppData\\Local\\kunai\\bin earlier in your PATH");
+    expect(output).toContain("Get-Command kunai -All");
+  });
+});
+
+/**
+ * Parity with install.sh: a payload on a console gets one \\r-updated line,
+ * and a failed transfer wipes it so the error is not printed under a 100% bar.
+ */
+describePwsh("install.ps1 download progress", () => {
+  function evalProgressFns(body: string): string {
+    const script = [
+      `$src = Get-Content -Raw ${JSON.stringify(INSTALL_PS1)}`,
+      'Invoke-Expression ([regex]::Match($src, "(?ms)^function Format-ByteSize \\{.*?^\\}").Value)',
+      'Invoke-Expression ([regex]::Match($src, "(?ms)^function Write-DownloadProgress \\{.*?^\\}").Value)',
+      'Invoke-Expression ([regex]::Match($src, "(?ms)^function Clear-DownloadProgress \\{.*?^\\}").Value)',
+      body,
+    ].join("\n");
+    const result = spawnSync("pwsh", ["-NoProfile", "-Command", script], { encoding: "utf8" });
+    expect(result.stderr, result.stderr).not.toContain("ParserError");
+    return `${result.stdout}${result.stderr}`;
+  }
+
+  test("a completed payload renders size, rate, bar and percent", () => {
+    const output = evalProgressFns(
+      "Write-DownloadProgress -Label 'kunai-windows-x64.zip' -Received 40894464 -Total 40894464 -Seconds 8; Write-Host ''",
+    );
+    expect(output).toContain("kunai-windows-x64.zip");
+    expect(output).toMatch(/MiB/);
+    expect(output).toContain("[####################]");
+    expect(output).toContain("100%");
+  });
+
+  test("byte sizes use a dot so a non-English host still matches install.sh", () => {
+    const output = evalProgressFns("Write-Output (Format-ByteSize 1048576)");
+    expect(output.trim()).toBe("1.0 MiB");
+  });
+
+  test("Invoke-BoundedDownload wipes a failed transfer instead of drawing 100%", () => {
+    const source = readFileSync(INSTALL_PS1, "utf8");
+    const fn = /^function Invoke-BoundedDownload \{[\s\S]*?^\}/m.exec(source)?.[0];
+    expect(fn, "could not extract Invoke-BoundedDownload").toBeTruthy();
+    expect(fn!).toContain("Clear-DownloadProgress");
+    expect(fn!).toContain("DownloadProgressMinBytes");
+    // Final frame only on a finished payload, matching install.sh after #322.
+    expect(fn!).toMatch(/Write-DownloadProgress[\s\S]*Write-DownloadProgress/);
   });
 });

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "9399f4e19c122a598078ee554d5ef0659a4c62985eef9ea2a9a7b0aa8ac691de",
-  "docsContentFingerprint": "67f70127b44839911fc9153851dab57912d346e91a2b0974688e9e65fdfa66dd",
+  "docsContentFingerprint": "ae40bf3a51636386a9fbdba815087a85a82da25a931d6bfdcbaefc18b992ba2f",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/docs/users/install-and-update.mdx
+++ b/docs/users/install-and-update.mdx
@@ -69,13 +69,15 @@ irm https://kunai.kitsunekode.in/install.ps1 | iex
 PowerShell downloads the platform `.zip`, verifies the archive and its single
 `kunai.exe` member independently, and extracts through bounded .NET streams; no
 separate zip utility is required. The same HTTP 404/410-only legacy fallback
-rule applies.
+rule applies. On a terminal the download shows one updating progress line
+(size, rate, bar); a pipe or CI log stays on the single quiet line.
 
 Installs to `%LOCALAPPDATA%\kunai\bin\kunai.exe`, prepends that directory to your **User** PATH so the native binary wins over an older npm/Bun shim, and records the install channel in `%APPDATA%\kunai\install.json`.
 
 Open a new terminal after installation if `kunai` is not visible yet. The
-installer also prints the resolved PATH winner so an older npm/Bun shim cannot
-silently shadow the native binary.
+installer prints the PATH winner. If another `kunai` is still earlier — npm,
+Bun, pnpm, Yarn, Scoop, Chocolatey, or WinGet — it lists each competing path
+and the command that removes it, and does not delete those installs itself.
 
 Supported binary targets: `windows-x64`, `windows-arm64`.
 

--- a/install.ps1
+++ b/install.ps1
@@ -58,6 +58,10 @@ $DownloadArchiveMaxBytes = if ($env:KUNAI_DOWNLOAD_ARCHIVE_MAX_BYTES) { [long]$e
 $ExtractedBinaryMaxBytes = if ($env:KUNAI_EXTRACTED_BINARY_MAX_BYTES) { [long]$env:KUNAI_EXTRACTED_BINARY_MAX_BYTES } else { 134217728 }
 $DownloadChecksumMaxBytes = if ($env:KUNAI_DOWNLOAD_CHECKSUM_MAX_BYTES) { [long]$env:KUNAI_DOWNLOAD_CHECKSUM_MAX_BYTES } else { 1048576 }
 $DownloadMaxAttempts = if ($env:KUNAI_DOWNLOAD_MAX_ATTEMPTS) { [int]$env:KUNAI_DOWNLOAD_MAX_ATTEMPTS } else { 3 }
+# Only the platform binary and its archive are worth a progress line; the two
+# checksum manifests finish before a bar could render. Mirrors
+# DOWNLOAD_PROGRESS_MIN_BYTES in install.sh.
+$DownloadProgressMinBytes = if ($env:KUNAI_DOWNLOAD_PROGRESS_MIN_BYTES) { [long]$env:KUNAI_DOWNLOAD_PROGRESS_MIN_BYTES } else { 1048576 }
 $DownloadRetryBaseMs = if ($env:KUNAI_DOWNLOAD_RETRY_BASE_MS) { [int]$env:KUNAI_DOWNLOAD_RETRY_BASE_MS } else { 1000 }
 $ActivationLockTimeoutMs = if ($env:KUNAI_ACTIVATION_LOCK_TIMEOUT_MS) { [int]$env:KUNAI_ACTIVATION_LOCK_TIMEOUT_MS } else { 10000 }
 $ActivationLockPollMs = if ($env:KUNAI_ACTIVATION_LOCK_POLL_MS) { [int]$env:KUNAI_ACTIVATION_LOCK_POLL_MS } else { 50 }
@@ -222,6 +226,63 @@ function Test-RetryableHttpStatus([int]$Status) {
   return ($Status -eq 408 -or $Status -eq 429 -or $Status -ge 500)
 }
 
+# Render a byte count the way a person reads it. Invariant culture so a German
+# host still prints 1.0 MiB rather than 1,0 MiB — the bash installer never
+# localises this line.
+function Format-ByteSize {
+  param([Parameter(Mandatory)][long]$Bytes)
+
+  $invariant = [System.Globalization.CultureInfo]::InvariantCulture
+  if ($Bytes -ge 1048576) {
+    return (([Math]::Round($Bytes / 1048576, 1)).ToString('0.0', $invariant) + ' MiB')
+  }
+  if ($Bytes -ge 1024) {
+    return (([Math]::Round($Bytes / 1024, 1)).ToString('0.0', $invariant) + ' KiB')
+  }
+  return "$Bytes B"
+}
+
+# One `r-updated line: name, size, rate, elapsed, bar, percent.
+#
+#   kunai-windows-x64.zip   38.9 MiB   10.5 MiB/s 00:08 [####################] 100%
+#
+# Parity with install.sh. Only ever drawn to a console — a redirected host keeps
+# the single quiet line the installer has always printed, rather than thousands
+# of carriage returns in a log.
+function Write-DownloadProgress {
+  param(
+    [Parameter(Mandatory)][string]$Label,
+    [Parameter(Mandatory)][long]$Received,
+    [long]$Total = 0,
+    [Parameter(Mandatory)][double]$Seconds
+  )
+
+  $rate = if ($Seconds -gt 0) { [long]($Received / $Seconds) } else { [long]0 }
+  $mins = [int][Math]::Floor($Seconds / 60)
+  $secs = [int]($Seconds % 60)
+  $name = if ($Label.Length -gt 22) { $Label.Substring(0, 22) } else { $Label.PadRight(22) }
+  $line = ' {0} {1,9} {2,9}/s {3:00}:{4:00}' -f $name, (Format-ByteSize $Received), (Format-ByteSize $rate), $mins, $secs
+
+  if ($Total -gt 0) {
+    $percent = [Math]::Min(100, [int](($Received * 100) / $Total))
+    $filled = [int](($percent * 20) / 100)
+    $bar = ('#' * $filled) + ('-' * (20 - $filled))
+    $line += (' [{0}] {1,3}%' -f $bar, $percent)
+  }
+
+  $width = 80
+  try { if ($Host.UI.RawUI.WindowSize.Width -gt 40) { $width = [Math]::Min(100, $Host.UI.RawUI.WindowSize.Width) } } catch { $width = 80 }
+  if ($line.Length -gt $width) { $line = $line.Substring(0, $width) }
+  [Console]::Write("`r" + $line.PadRight($width))
+}
+
+# Wipe the progress line so a following error starts on a clean row.
+function Clear-DownloadProgress {
+  $width = 80
+  try { if ($Host.UI.RawUI.WindowSize.Width -gt 40) { $width = [Math]::Min(100, $Host.UI.RawUI.WindowSize.Width) } } catch { $width = 80 }
+  [Console]::Write("`r" + (' ' * $width) + "`r")
+}
+
 function Invoke-BoundedDownload {
   param(
     [Parameter(Mandatory = $true)][string]$Url,
@@ -284,7 +345,18 @@ function Invoke-BoundedDownload {
       try {
         $buffer = New-Object byte[] 8192
         $total = [long]0
-        $lastProgress = [DateTime]::UtcNow
+        # The response already carries the size, so unlike the bash installer
+        # this needs no extra HEAD request to draw a bar.
+        $expected = [long]0
+        if ($null -ne $response.Content.Headers.ContentLength) {
+          $expected = [long]$response.Content.Headers.ContentLength
+        }
+        # A progress line is for a payload on a console. The two checksum
+        # manifests are a few hundred bytes and finish before a bar could
+        # render, and their cap is the natural boundary.
+        $showProgress = (-not [Console]::IsOutputRedirected) -and ($MaxBytes -gt $DownloadProgressMinBytes)
+        $progressStarted = [DateTime]::UtcNow
+        $lastDraw = [DateTime]::MinValue
         while ($true) {
           $readTask = $stream.ReadAsync($buffer, 0, $buffer.Length, $cts.Token)
           if (-not $readTask.Wait($DownloadStallMs, $cts.Token)) {
@@ -297,13 +369,22 @@ function Invoke-BoundedDownload {
             throw "Download for $Label exceeds max size ($total > $MaxBytes)."
           }
           $outStream.Write($buffer, 0, $read)
-          $lastProgress = [DateTime]::UtcNow
-          if (([DateTime]::UtcNow - $lastProgress).TotalMilliseconds -gt $DownloadStallMs) {
-            throw "Download stalled for $Label."
+          if ($showProgress -and ([DateTime]::UtcNow - $lastDraw).TotalMilliseconds -ge 200) {
+            Write-DownloadProgress -Label $Label -Received $total -Total $expected `
+              -Seconds ([DateTime]::UtcNow - $progressStarted).TotalSeconds
+            $lastDraw = [DateTime]::UtcNow
           }
         }
         if ($total -le 0) {
+          if ($showProgress) { Clear-DownloadProgress }
           throw "Downloaded asset $Label is empty; the release is incomplete."
+        }
+        if ($showProgress) {
+          # Only a transfer that finished earns a final frame; the failure
+          # paths below clear the line so the error starts on a clean row.
+          Write-DownloadProgress -Label $Label -Received $total -Total $expected `
+            -Seconds ([DateTime]::UtcNow - $progressStarted).TotalSeconds
+          [Console]::Write("`n")
         }
         return
       }
@@ -314,6 +395,7 @@ function Invoke-BoundedDownload {
       }
     }
     catch {
+      if (-not [Console]::IsOutputRedirected) { Clear-DownloadProgress }
       if (Test-Path -LiteralPath $DestinationPath) {
         Remove-Item -LiteralPath $DestinationPath -Force -ErrorAction SilentlyContinue
       }
@@ -1373,6 +1455,30 @@ function Get-KunaiPathCandidates {
   return $candidates.ToArray()
 }
 
+# Map one conflicting `kunai` on PATH to the command that removes it.
+#
+# This tested only the winner, and only against npm, so every other manager fell
+# through to the generic "move $BinDir ahead" line and never learned the one
+# command that removes the competing install. Parity with path_conflict_remedy
+# in install.sh. More-specific managers come first: a node version manager
+# shims whatever npm installed.
+function Get-PathConflictRemedy {
+  param([Parameter(Mandatory)][string]$Entry)
+
+  switch -regex ($Entry) {
+    '[\\/]\.bun[\\/]' { return "bun remove --global $Package" }
+    '[\\/]pnpm[\\/]' { return "pnpm remove --global $Package" }
+    '[\\/](\.yarn|yarn)[\\/]' { return "yarn global remove $Package" }
+    '[\\/]scoop[\\/]' { return 'scoop uninstall kunai' }
+    '[\\/]chocolatey[\\/]' { return 'choco uninstall kunai' }
+    '[\\/]WinGet[\\/]' { return 'winget uninstall kunai' }
+    'node_modules|[\\/]npm[\\/]|[\\/]nodejs[\\/]|fnm|[\\/]nvm[\\/]|[\\/]\.nvm[\\/]|volta|asdf' {
+      return "npm uninstall -g $Package"
+    }
+    default { return "# remove or rename $Entry" }
+  }
+}
+
 function Write-KunaiPathDiagnostic {
   param([string]$InstalledPath)
 
@@ -1386,14 +1492,29 @@ function Write-KunaiPathDiagnostic {
     if ($null -eq $winner) {
       Write-Warn 'No kunai executable is currently found on PATH.'
       Write-Info "Add $BinDir to PATH if you want the native install to win."
+      Write-Info 'Reopen your shell, then run: Get-Command kunai -All'
+      return
     }
-    elseif ($winner -match '[\\/]npm[\\/]kunai\.(com|exe|bat|cmd)$') {
-      Write-Warn 'A stale npm shim is earlier in PATH.'
-      Write-Info "After confirming it is unused: npm uninstall -g $Package"
+
+    # Every conflicting entry gets a line, not just the winner: removing the
+    # winner only promotes the next one, so a user told about one of three
+    # installs runs this three times.
+    $others = @($candidates | Where-Object {
+        -not [string]::Equals($_, $InstalledPath, [System.StringComparison]::OrdinalIgnoreCase)
+      })
+    Write-Warn 'Another kunai comes earlier on your PATH and will keep running instead:'
+    foreach ($entry in $others) { Write-Host "    $entry" }
+
+    $remedies = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($entry in $others) {
+      $remedy = Get-PathConflictRemedy $entry
+      if (-not $remedies.Contains($remedy)) { [void]$remedies.Add($remedy) }
     }
-    else {
-      Write-Info "Move $BinDir ahead of $winner in PATH if you want the native install to win."
-    }
+
+    Write-Host ''
+    Write-Host '  Fix it any of these ways:'
+    foreach ($remedy in $remedies) { Write-Host "    $remedy" }
+    Write-Host "    # ...or put $BinDir earlier in your PATH"
     Write-Info 'Reopen your shell, then run: Get-Command kunai -All'
   }
 }


### PR DESCRIPTION
## Summary
- Give `install.ps1` the same one-copy-paste experience `install.sh` already has: a console progress line for the payload download (wiped on failure, quiet in pipes/CI), and a PATH conflict that lists every competing `kunai` with the command that removes it (bun, npm/fnm/nvm, pnpm, yarn, scoop, choco, winget, plus a named fallback). Does not delete anything itself.
- Stop the Analytics Postgres suite failing on main with `Expected: 8, Received: 5` on `lifetimeInstalls`. #325 seeded the eight February pings, but hardening still reused n=1,2,3; `first_seen` is write-once, so a May ping of those hashes dropped them from February's count. Suites now mint through `testInstallId(n, suite)`, and `test:pg` serialises.

Fixes #321.

## Test plan
- [x] Isolation tests: disjoint suite ids; no file still defines `function installId(`
- [x] `bun test` analytics-ingest (84 pass; Postgres cases skip locally without Docker)
- [x] pwsh PATH remedy table (bun/npm/nvm/fnm/pnpm/yarn/scoop/choco/winget + fallback)
- [x] pwsh diagnostic lists every competing install, not only the winner
- [x] pwsh progress: `1.0 MiB` invariant, 100% bar, `Invoke-BoundedDownload` wipes on failure
- [x] Consent tests still pass (no `--noconfirm` / `-y` / winget accept flags)
- [x] `verify:doc-paths`, `verify:doc-frontmatter`, docs fingerprint fresh after oxfmt
- [ ] CI: Docs build, Analytics Postgres suites, Windows CLI parity, macOS/Linux installer lint
- [ ] On a real Windows console: `irm … | iex` shows the progress line, and a leftover npm/Bun shim prints the removal command without deleting it