### PR TITLE
fix(install): provision yt-dlp and curl-impersonate on Windows

### DIFF
--- a/.changeset/windows-curl-http2.md
+++ b/.changeset/windows-curl-http2.md
@@ -1,0 +1,17 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Stop the HLS relay from failing on Windows when curl has no HTTP/2.
+
+The relay spawns the literal `curl` from PATH and always passed `--http2`.
+Windows' System32 build is Schannel with no nghttp2, and it rejects that flag
+outright (`the installed libcurl version doesn't support this`, exit 4) rather
+than negotiating down — so every stream routed through the relay failed on a
+stock Windows host. The relay now probes the binary's feature list and drops
+the flag instead of the request.
+
+The installer also stopped hiding the `cURL.cURL` upgrade prompt when
+curl-impersonate is installed. They are different binaries solving different
+problems: curl-impersonate clears Cloudflare for the provider clients, and
+carries no `curl.exe` of its own.

--- a/.changeset/windows-portable-deps.md
+++ b/.changeset/windows-portable-deps.md
@@ -11,3 +11,6 @@ now drops verified GitHub binaries into `%LOCALAPPDATA%\kunai\deps\` and puts
 those folders on the User PATH. `mpv` is still a package-manager prompt.
 `-SkipDeps` skips the helpers. Doctor's copy-paste fallback is
 `winget install --id yt-dlp.yt-dlp -e`.
+
+Managed helper digests are retained and rechecked on later installs, so an
+interrupted or modified helper is repaired instead of accepted by filename.

--- a/.changeset/windows-portable-deps.md
+++ b/.changeset/windows-portable-deps.md
@@ -9,5 +9,5 @@ matches both the real package and a Microsoft Store listing, so it refuses to
 run, and curl-impersonate has no Windows package at all. The native installer
 now drops verified GitHub binaries into `%LOCALAPPDATA%\kunai\deps\` and puts
 those folders on the User PATH. `mpv` is still a package-manager prompt.
-`--skip-deps` skips the helpers. Doctor's copy-paste fallback is
+`-SkipDeps` skips the helpers. Doctor's copy-paste fallback is
 `winget install --id yt-dlp.yt-dlp -e`.

--- a/.changeset/windows-portable-deps.md
+++ b/.changeset/windows-portable-deps.md
@@ -1,0 +1,13 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Install yt-dlp and curl-impersonate on Windows one-click installs.
+
+`irm … | iex` left YouTube and anime search broken: `winget install yt-dlp`
+matches both the real package and a Microsoft Store listing, so it refuses to
+run, and curl-impersonate has no Windows package at all. The native installer
+now drops verified GitHub binaries into `%LOCALAPPDATA%\kunai\deps\` and puts
+those folders on the User PATH. `mpv` is still a package-manager prompt.
+`--skip-deps` skips the helpers. Doctor's copy-paste fallback is
+`winget install --id yt-dlp.yt-dlp -e`.

--- a/.docs/debugging-map.md
+++ b/.docs/debugging-map.md
@@ -1,6 +1,6 @@
 ---
 status: current
-lastReviewed: "2026-08-13"
+lastReviewed: "2026-09-02"
 ---
 
 # Kunai Debugging Map
@@ -199,7 +199,12 @@ browse and post-play should still use sharp Sixel output.
 **Providers behave differently than on Linux.** The `curl.exe` Windows ships in
 System32 is a Schannel build with no HTTP/2 (`curl --version` lists no `HTTP2`
 feature). Provider paths that negotiate HTTP/2 degrade against it; the winget
-`cURL.cURL` build has it.
+`cURL.cURL` build has it. Cloudflare also fingerprints the TLS handshake, so
+plain curl (HTTP/2 or not) is often not enough for AniDB/Miruro. The native
+installer drops a portable curl-impersonate under
+`%LOCALAPPDATA%\kunai\deps\curl-impersonate` (x64, same archive CI pins) and
+puts that directory on the User PATH so `kunai doctor` reports `curl=ok
+(chrome…)` instead of `plain (no CF bypass)`.
 
 **Tests fail in teardown after passing.** `rmSync` on a directory holding an open
 SQLite handle raises EBUSY on Windows — POSIX unlinks open files, Windows does

--- a/.docs/debugging-map.md
+++ b/.docs/debugging-map.md
@@ -206,6 +206,20 @@ installer drops a portable curl-impersonate under
 puts that directory on the User PATH so `kunai doctor` reports `curl=ok
 (chrome…)` instead of `plain (no CF bypass)`.
 
+**curl-impersonate is not an HTTP/2 curl.** The two are separate binaries and
+separate problems, and conflating them has bitten this repo once already. The
+release archive ships `curl-impersonate.exe` plus `curl_*.bat` wrappers and no
+`curl.exe`, and only `resolveCurlCandidate` (AniDB, Miruro) ever selects those.
+Anything spawning the literal `curl` still gets System32's Schannel build:
+[`hls-relay.ts`](../apps/cli/src/infra/player/hls-relay.ts) for the CDNs that
+block mpv's TLS fingerprint, and Miruro's own `detectCurlHttp2Support` probe.
+That build does not negotiate `--http2` down — it refuses the flag with
+`the installed libcurl version doesn't support this` and exits 4 before
+connecting — so the relay asks
+[`infra/os/curl-features`](../apps/cli/src/infra/os/curl-features.ts) first and
+drops the flag rather than failing the stream. The installer still offers the
+`cURL.cURL` upgrade even when it just installed curl-impersonate.
+
 **Tests fail in teardown after passing.** `rmSync` on a directory holding an open
 SQLite handle raises EBUSY on Windows — POSIX unlinks open files, Windows does
 not, and retrying never helps because the handle is held for the process

--- a/.docs/quickstart.md
+++ b/.docs/quickstart.md
@@ -1,6 +1,6 @@
 ---
 status: current
-lastReviewed: "2026-08-24"
+lastReviewed: "2026-09-02"
 ---
 
 # Kunai — Quickstart
@@ -51,8 +51,14 @@ brew install mpv yt-dlp curl
 
 Windows options:
 
+- The native installer (`install.ps1`) places portable `yt-dlp` and (x64)
+  curl-impersonate under `%LOCALAPPDATA%\kunai\deps\` so `irm … | iex` is enough
+  for YouTube and anime search. `mpv` is still a package-manager prompt.
 - Scoop: `scoop install mpv yt-dlp`; add `ffmpeg` only if you want optional `ffprobe` validation.
-- `winget`: install `mpv` and `yt-dlp`; add `ffmpeg` only if you want optional `ffprobe` validation.
+- `winget`: `winget install --id mpv-player.mpv-CI.MSVC -e` and
+  `winget install --id yt-dlp.yt-dlp -e`. A bare `winget install yt-dlp` is
+  ambiguous against a Microsoft Store listing. Add `ffmpeg` only if you want
+  optional `ffprobe` validation. curl-impersonate has no winget package.
 - Chocolatey: `choco install mpv yt-dlp` remains an alternative when Chocolatey is already managed on the machine.
 
 Posters need nothing installed. Kunai's Windows CI provisions mpv from the

--- a/.docs/testing-strategy.md
+++ b/.docs/testing-strategy.md
@@ -345,6 +345,15 @@ Local equivalent: `KUNAI_INSTALLER_DOCKER=1 bun run test:installer:docker`
   Wrapper-dir identity is `realpath` of both sides: Windows GitHub runners
   expand `RUNNER~1` to `runneradmin`, and macOS rewrites `/var` to `/private/var`
   while pwsh keeps `/var`
+- Helper functions and the script-scope constants they close over are both
+  extracted from `install.ps1`, never restated in the probe — a re-implemented
+  copy tests itself and lets the shipped one drift
+- The HTTP/2 curl prompt has its own case driving `Install-OptionalDeps` with
+  curl-impersonate reporting installed: an impersonate build must not suppress
+  it, because the HLS relay spawns the literal `curl`
+- The locked-dest case skips as uid 0 as well as on Windows. `chmod 0o500` is
+  not a lock for root, so the fail-closed branch would never be reached and the
+  test would pass without asserting anything
 - Skipped when `pwsh` is not installed (same pattern as Docker tests); CI `installer-lint` / Windows jobs cover pwsh
 
 **Bash installer fixtures** (`apps/cli/test/integration/install-scripts.test.ts`):

--- a/.docs/testing-strategy.md
+++ b/.docs/testing-strategy.md
@@ -335,6 +335,13 @@ Local equivalent: `KUNAI_INSTALLER_DOCKER=1 bun run test:installer:docker`
 - Download progress helpers (`Format-ByteSize`, `Write-DownloadProgress`) are
   extracted the same way; `Invoke-BoundedDownload` is gated to wipe a failed
   transfer instead of drawing 100%
+- Portable Windows helpers (`Install-PortableYtDlp`, `Install-PortableCurlImpersonate`)
+  are extracted and run against a localhost fixture: verified `yt-dlp.exe` plus a
+  `curl_chrome*.bat` tarball land under `KUNAI_DATA_DIR/deps`, a checksum mismatch
+  leaves no dest and prints `winget install --id yt-dlp.yt-dlp -e`, and an
+  already-present dest skips the download. Isolate PATH so a host yt-dlp cannot
+  short-circuit the install. Override bases with `KUNAI_YTDLP_RELEASE_BASE` /
+  `KUNAI_CURL_IMPERSONATE_RELEASE_BASE`; never point the probe at a live profile
 - Skipped when `pwsh` is not installed (same pattern as Docker tests); CI `installer-lint` / Windows jobs cover pwsh
 
 **Bash installer fixtures** (`apps/cli/test/integration/install-scripts.test.ts`):

--- a/.docs/testing-strategy.md
+++ b/.docs/testing-strategy.md
@@ -341,7 +341,10 @@ Local equivalent: `KUNAI_INSTALLER_DOCKER=1 bun run test:installer:docker`
   leaves no dest and prints `winget install --id yt-dlp.yt-dlp -e`, and an
   already-present dest skips the download. Isolate PATH so a host yt-dlp cannot
   short-circuit the install. Override bases with `KUNAI_YTDLP_RELEASE_BASE` /
-  `KUNAI_CURL_IMPERSONATE_RELEASE_BASE`; never point the probe at a live profile
+  `KUNAI_CURL_IMPERSONATE_RELEASE_BASE`; never point the probe at a live profile.
+  Wrapper-dir identity is `realpath` of both sides: Windows GitHub runners
+  expand `RUNNER~1` to `runneradmin`, and macOS rewrites `/var` to `/private/var`
+  while pwsh keeps `/var`
 - Skipped when `pwsh` is not installed (same pattern as Docker tests); CI `installer-lint` / Windows jobs cover pwsh
 
 **Bash installer fixtures** (`apps/cli/test/integration/install-scripts.test.ts`):

--- a/.github/actions/setup-curl-impersonate/action.yml
+++ b/.github/actions/setup-curl-impersonate/action.yml
@@ -22,6 +22,9 @@ inputs:
     description: curl-impersonate release tag to install
     required: false
     default: v2.2.1
+    # Keep the Windows x64 digest in install.ps1 ($CurlImpersonateWin64Digest)
+    # in lockstep when bumping this pin — the native installer drops the same
+    # archive into %LOCALAPPDATA%\kunai\deps\curl-impersonate.
 
 runs:
   using: composite

--- a/README.md
+++ b/README.md
@@ -227,11 +227,17 @@ brew install yt-dlp curl ffmpeg
 ```bash
 # Required
 winget install --id mpv-player.mpv-CI.MSVC -e
-# Optional: downloads and post-download integrity checks
-winget install yt-dlp Gyan.FFmpeg
+# Optional if you skipped the installer helpers: YouTube + post-download checks
+winget install --id yt-dlp.yt-dlp -e
+winget install --id Gyan.FFmpeg -e
 ```
 
-> `ffprobe` ships inside the FFmpeg package on every platform.
+> The native Windows installer (`irm … | iex`) already drops a portable
+> `yt-dlp` into `%LOCALAPPDATA%\kunai\deps\yt-dlp`. `winget install yt-dlp`
+> without `--id` matches both the real package and a Microsoft Store listing
+> and will refuse to run. `ffprobe` ships inside the FFmpeg package on every
+> platform. Anime search on Windows needs curl-impersonate, which has no
+> winget package — the installer places that too.
 
 </details>
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -35,7 +35,10 @@ brew install mpv yt-dlp
 
 Windows: `winget install --id mpv-player.mpv-CI.MSVC -e` installs the real
 `mpv.exe` Kunai probes and controls; `mpv.net` provides `mpvnet.exe` and is not a
-substitute. Install YouTube support with `winget install yt-dlp`. Add `ffprobe`
+substitute. The native installer drops a portable `yt-dlp` and (on x64)
+curl-impersonate into `%LOCALAPPDATA%\kunai\deps\`. If you are installing those
+yourself, use `winget install --id yt-dlp.yt-dlp -e` — the un-qualified
+query matches a Microsoft Store listing as well and fails. Add `ffprobe`
 (from FFmpeg) only if you want post-download validation.
 
 ## Install

--- a/apps/cli/src/infra/os/curl-features.ts
+++ b/apps/cli/src/infra/os/curl-features.ts
@@ -1,0 +1,68 @@
+/**
+ * What the bare `curl` on PATH can actually do.
+ *
+ * Windows ships a Schannel `curl.exe` built without nghttp2. It does not
+ * negotiate HTTP/2 down when asked — it refuses the flag outright:
+ *
+ *     curl: option --http2: the installed libcurl version doesn't support this
+ *
+ * and exits 4 before a single byte is sent. So anything that spawns the literal
+ * `curl` has to ask before passing `--http2`, or it turns a working HTTP/1.1
+ * request into a hard failure on the most common Windows install.
+ *
+ * This deliberately does not reuse the impersonate resolver in
+ * `packages/providers`: `infra` may not import provider packages
+ * (`apps/cli/test/unit/architecture/boundary-imports.test.ts`), and the two
+ * answer different questions anyway. That one picks a TLS-fingerprint build to
+ * clear Cloudflare; this one asks whether the plain binary understands a flag.
+ * An impersonate build being present says nothing about `curl.exe`.
+ */
+
+/** Probe seam. Tests supply their own so an assertion never depends on the host's curl. */
+export type CurlFeatureEnvironment = {
+  /** `curl --version` stdout, or `null` when curl is absent or cannot run. */
+  readonly probeVersion: () => string | null;
+};
+
+/**
+ * curl prints its feature list on the third line as space-separated tokens
+ * (`Features: alt-svc AsynchDNS HSTS HTTP2 HTTPS-proxy ...`). Matching the bare
+ * word avoids `HTTP2-only`-style substrings in a future release note and,
+ * more to the point, avoids matching the `HTTP3` token beside it.
+ */
+export function parseCurlHttp2Support(versionOutput: string | null): boolean {
+  if (!versionOutput) return false;
+  return /\bHTTP2\b/i.test(versionOutput);
+}
+
+function defaultProbeVersion(): string | null {
+  try {
+    const proc = Bun.spawnSync(["curl", "--version"]);
+    if (proc.exitCode !== 0) return null;
+    return proc.stdout.toString();
+  } catch {
+    // No curl on PATH, or it is a shim that cannot exec. Both mean "assume not".
+    return null;
+  }
+}
+
+/**
+ * PATH does not change under a running process and this is read per relay
+ * request, so the subprocess is paid once. Injected environments bypass the
+ * cache — a test must never see another test's answer.
+ */
+let cachedHttp2Support: boolean | null = null;
+
+export function curlSupportsHttp2(environment: Partial<CurlFeatureEnvironment> = {}): boolean {
+  if (environment.probeVersion) return parseCurlHttp2Support(environment.probeVersion());
+  cachedHttp2Support ??= parseCurlHttp2Support(defaultProbeVersion());
+  return cachedHttp2Support;
+}
+
+/** Test-only: drop the memoized probe. */
+export const __testing = {
+  resetHttp2Cache(): void {
+    cachedHttp2Support = null;
+  },
+  defaultProbeVersion,
+};

--- a/apps/cli/src/infra/os/install-commands.ts
+++ b/apps/cli/src/infra/os/install-commands.ts
@@ -100,7 +100,9 @@ export const YT_DLP_INSTALL: PlatformInstall = {
   fedora: "sudo dnf install yt-dlp",
   suse: "sudo zypper install yt-dlp",
   darwin: "brew install yt-dlp",
-  win32: "winget install yt-dlp",
+  // `winget install yt-dlp` matches both yt-dlp.yt-dlp and a Microsoft Store
+  // listing, so the command doctor used to print cannot actually be run.
+  win32: "winget install --id yt-dlp.yt-dlp -e",
   fallback: "pip install yt-dlp",
 };
 

--- a/apps/cli/src/infra/player/hls-relay.ts
+++ b/apps/cli/src/infra/player/hls-relay.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { isHlsPlaylistUrl, resolveHlsSegmentUrl } from "@kunai/core";
 import type { Server } from "bun";
 
+import { curlSupportsHttp2 } from "../os/curl-features";
 import { normalizeStreamHttpHeaders } from "./mpv-stream-http-headers";
 
 /**
@@ -171,11 +172,19 @@ export async function fetchHlsRelayUpstream(
   throw new Error("upstream redirected too many times");
 }
 
+/**
+ * `http2` is passed in rather than assumed because the Windows Schannel
+ * `curl.exe` rejects `--http2` instead of ignoring it (see
+ * `infra/os/curl-features`). This used to hardcode the flag, which made the
+ * relay fail outright on a stock Windows host — the one platform where the
+ * relay's CDNs are most likely to need it.
+ */
 export function buildHlsRelayCurlArgs(
   url: string,
   referer: string,
   origin: string,
   budget: HlsRelayCurlBudget,
+  http2: boolean,
 ): string[] {
   return [
     // curl only honors --disable/-q as a config-file guard when it is the first
@@ -184,7 +193,7 @@ export function buildHlsRelayCurlArgs(
     "-q",
     "-sS",
     "--no-location",
-    "--http2",
+    ...(http2 ? ["--http2"] : []),
     "-A",
     AGENT,
     "-H",
@@ -210,7 +219,10 @@ function curlFetchOnce(
 ): Promise<HlsRelayCurlResponse> {
   assertRelayUpstreamUrl(url);
   return new Promise((resolve, reject) => {
-    const proc = spawn("curl", buildHlsRelayCurlArgs(url, referer, origin, budget));
+    const proc = spawn(
+      "curl",
+      buildHlsRelayCurlArgs(url, referer, origin, budget, curlSupportsHttp2()),
+    );
     let chunks: Buffer[] = [];
     let totalBytes = 0;
     let stderr = "";

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -32,6 +32,7 @@ import {
 
 const REPO_ROOT = join(import.meta.dirname, "../../../..");
 const INSTALL_PS1 = join(REPO_ROOT, "install.ps1");
+const PWSH_PATH = Bun.which("pwsh") ?? "pwsh";
 
 function readInstallerManifest(configDir: string): InstallManifest {
   return JSON.parse(readFileSync(join(configDir, "install.json"), "utf8"));
@@ -2177,8 +2178,11 @@ async function runPortableHelperProbe(
     "Write-DownloadProgress",
     "Clear-DownloadProgress",
     "Invoke-BoundedDownload",
+    "Write-Utf8File",
     "Get-YtdlpReleaseAsset",
     "Get-HelperChecksumEntry",
+    "Test-ManagedFileDigest",
+    "Test-ManagedSourceDigest",
     "Get-CurlImpersonateWindowsSpec",
     "Test-CurlImpersonatePresent",
     "Find-CurlImpersonateWrapperDir",
@@ -2218,7 +2222,9 @@ async function runPortableHelperProbe(
       "$script:LastDownloadHttpStatus = $null",
       'function Write-Info($m) { Write-Host "-> $m" }',
       'function Write-Warn($m) { Write-Host "! $m" }',
-      "function Test-Cmd($name) { [bool](Get-Command $name -ErrorAction SilentlyContinue) }",
+      // The fixture owns yt-dlp state. Never let a host installation turn a
+      // download/repair assertion into an accidental already-present branch.
+      "function Test-Cmd($name) { if ($name -eq 'yt-dlp') { return $false }; [bool](Get-Command $name -ErrorAction SilentlyContinue) }",
       "function Test-RetryableHttpStatus([int]$Status) { return ($Status -eq 408 -or $Status -eq 429 -or $Status -ge 500) }",
       "function Get-WindowsArch { return 'x64' }",
       // Stands in for the -SkipPathUpdate branch of the real Add-UserPath: it
@@ -2231,7 +2237,7 @@ async function runPortableHelperProbe(
     ].join("\n"),
   );
 
-  const proc = Bun.spawn(["pwsh", "-NoProfile", "-File", probePath], {
+  const proc = Bun.spawn([PWSH_PATH, "-NoProfile", "-File", probePath], {
     env: { ...BOUNDED_DOWNLOAD_ENV, ...env },
     stdout: "pipe",
     stderr: "pipe",
@@ -2385,6 +2391,7 @@ describePwsh("install.ps1 portable Windows helpers", () => {
       const dir = mkdtempSync(join(tmpdir(), "kunai-wrapper-family-"));
       try {
         writeFileSync(join(dir, file), "@echo off\r\n");
+        writeFileSync(join(dir, "curl-impersonate.exe"), "MZ\n");
         const output = evalHelperFns(`
           $env:Path = ${JSON.stringify(dir)}
           if (Test-CurlImpersonatePresent) { Write-Output 'present' } else { Write-Output 'missing' }
@@ -2503,14 +2510,31 @@ describePwsh("install.ps1 portable Windows helpers", () => {
     }
   });
 
-  test("already-present dest files skip the GitHub download", async () => {
+  test("verified already-present dest files skip the GitHub download", async () => {
     const sandbox = createInstallerSandbox("install-ps1-portable-helpers-present");
     mkdirSync(join(sandbox.dataDir, "deps", "yt-dlp"), { recursive: true });
     mkdirSync(join(sandbox.dataDir, "deps", "curl-impersonate"), { recursive: true });
-    writeFileSync(join(sandbox.dataDir, "deps", "yt-dlp", "yt-dlp.exe"), "MZ-already-present\n");
+    const ytdlpBody = "MZ-already-present\n";
+    const ytdlpDigest = createHash("sha256").update(ytdlpBody).digest("hex");
+    writeFileSync(join(sandbox.dataDir, "deps", "yt-dlp", "yt-dlp.exe"), ytdlpBody);
+    writeFileSync(join(sandbox.dataDir, "deps", "yt-dlp", "yt-dlp.exe.sha256"), `${ytdlpDigest}\n`);
     writeFileSync(
       join(sandbox.dataDir, "deps", "curl-impersonate", "curl_chrome146.bat"),
       "@echo off\r\n",
+    );
+    const backendBody = "MZ-curl-impersonate\n";
+    const backendDigest = createHash("sha256").update(backendBody).digest("hex");
+    writeFileSync(
+      join(sandbox.dataDir, "deps", "curl-impersonate", "curl-impersonate.exe"),
+      backendBody,
+    );
+    writeFileSync(
+      join(sandbox.dataDir, "deps", "curl-impersonate", ".kunai-source.sha256"),
+      `${"f7faa8c42b63b4a96245429e46956e11ae7d7076d60f65768c0018d3bb18d7e5"}\n`,
+    );
+    writeFileSync(
+      join(sandbox.dataDir, "deps", "curl-impersonate", ".kunai-backend.sha256"),
+      `${backendDigest}\n`,
     );
     try {
       await withReleaseFixture({}, async (_baseUrl, evidence) => {
@@ -2532,6 +2556,54 @@ describePwsh("install.ps1 portable Windows helpers", () => {
         expect(result.stdout).toContain("curl-impersonate already present");
         expect(evidence.requests).toEqual([]);
       });
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("repairs unverified managed helpers instead of trusting their filenames", async () => {
+    const sandbox = createInstallerSandbox("install-ps1-portable-helpers-repair");
+    const ytdlpDir = join(sandbox.dataDir, "deps", "yt-dlp");
+    const impersonateDir = join(sandbox.dataDir, "deps", "curl-impersonate");
+    mkdirSync(ytdlpDir, { recursive: true });
+    mkdirSync(impersonateDir, { recursive: true });
+    writeFileSync(join(ytdlpDir, "yt-dlp.exe"), "");
+    writeFileSync(join(impersonateDir, "curl_chrome146.bat"), "@echo off\r\n");
+
+    const ytdlpBody = "MZ-repaired-yt-dlp\n";
+    const ytdlpDigest = createHash("sha256").update(ytdlpBody).digest("hex");
+    const archive = createCurlImpersonateArchive(sandbox.root);
+    try {
+      await withReleaseFixture(
+        {
+          "/SHA2-256SUMS": { body: `${ytdlpDigest}  yt-dlp.exe\n` },
+          "/yt-dlp.exe": { body: ytdlpBody },
+          [`/${archive.asset}`]: { body: archive.bytes },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runPortableHelperProbe(
+            {
+              ...isolatedHelperEnv(sandbox),
+              KUNAI_YTDLP_RELEASE_BASE: baseUrl,
+              KUNAI_CURL_IMPERSONATE_RELEASE_BASE: baseUrl,
+              KUNAI_CURL_IMPERSONATE_SHA256: archive.sha256,
+            },
+            [
+              "$ytdlp = [bool](Install-PortableYtDlp)",
+              "$imp = [bool](Install-PortableCurlImpersonate)",
+              'Write-Output "RESULT ytdlp=$ytdlp impersonate=$imp"',
+            ].join("\n"),
+          );
+
+          expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+          expect(result.stdout).toContain("RESULT ytdlp=True impersonate=True");
+          expect(readFileSync(join(ytdlpDir, "yt-dlp.exe"), "utf8")).toBe(ytdlpBody);
+          expect(existsSync(join(impersonateDir, "curl-impersonate.exe"))).toBe(true);
+          expect(evidence.requests).toContain("/SHA2-256SUMS");
+          expect(evidence.requests).toContain("/yt-dlp.exe");
+          expect(evidence.requests).toContain(`/${archive.asset}`);
+        },
+      );
     } finally {
       sandbox.cleanup();
     }

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -2026,6 +2026,51 @@ describePwsh("install.ps1 optional dependency consent", () => {
    * packages unattended. Redirected input takes the same path as `-Yes` —
    * report what is missing, never install it.
    */
+  /**
+   * curl-impersonate is not a substitute for an HTTP/2 `curl.exe`, and the
+   * installer must not treat it as one.
+   *
+   * They are different binaries: the release archive ships
+   * `curl-impersonate.exe` plus `curl_*.bat` wrappers and no `curl.exe` at all,
+   * and only the provider clients resolve those, through `resolveCurlCandidate`.
+   * The HLS relay (`apps/cli/src/infra/player/hls-relay.ts`) spawns the literal
+   * `curl` from PATH. Skipping this prompt whenever an impersonate build was
+   * found hid the one remedy for that, on precisely the hosts that need it —
+   * every stock Windows box, since the System32 build is Schannel with no
+   * nghttp2.
+   */
+  test("still offers the HTTP/2 curl upgrade after curl-impersonate installs", () => {
+    const script = [
+      `$src = Get-Content -Raw ${JSON.stringify(INSTALL_PS1)}`,
+      'function Write-Info { param($m) Write-Host "> $m" }',
+      'function Write-Warn { param($m) Write-Host "! $m" }',
+      "$OnWindows = $true",
+      "$SkipDeps = $false",
+      // Everything the impersonate path can report as success, at once: it was
+      // just installed *and* it is discoverable on PATH.
+      "function Install-PortableYtDlp { return $true }",
+      "function Install-PortableCurlImpersonate { return $true }",
+      "function Test-CurlImpersonatePresent { return $true }",
+      // mpv and yt-dlp present; curl present but not answering --version, which
+      // is the same branch the Schannel build reaches by reporting no HTTP2.
+      "function Test-Cmd { param($n) return $true }",
+      "function Request-OptionalInstall { param($m) Write-Host \"[ASKED] $($m -join ',')\" }",
+      'Invoke-Expression ([regex]::Match($src, "(?ms)^function Install-OptionalDeps \\{.*?^\\}").Value)',
+      "Install-OptionalDeps",
+    ].join("\n");
+    const result = spawnSync("pwsh", ["-NoProfile", "-Command", script], { encoding: "utf8" });
+    expect(result.stderr, result.stderr).not.toContain("ParserError");
+    const output = `${result.stdout}${result.stderr}`;
+
+    expect(output).toContain("The curl on PATH has no HTTP/2 support");
+    expect(output).toContain("[ASKED] curl");
+    // And it says why, so the prompt does not read as the installer forgetting
+    // the curl-impersonate it dropped two lines earlier.
+    expect(output).toContain("curl-impersonate covers Cloudflare, not HTTP/2");
+    // yt-dlp was handled by the portable helper, so it must not also be asked for.
+    expect(output).not.toContain("yt-dlp is not installed");
+  });
+
   test("no console reports the command instead of installing", () => {
     const output = evalInstallPs1(
       "$Yes = $false; $DryRun = $false; Request-OptionalInstall @('mpv')",
@@ -2046,9 +2091,24 @@ describePwsh("install.ps1 optional dependency consent", () => {
   });
 });
 
+/**
+ * Both PowerShell parameter spellings: a `param()` block inside the body, and
+ * the inline `function Name([string]$Dir) {` form the smaller helpers use.
+ */
 function extractPs1Function(source: string, name: string): string {
-  const match = new RegExp(`^function ${name} \\{[\\s\\S]*?^\\}`, "m").exec(source);
+  const match = new RegExp(`^function ${name}(?:\\([^)]*\\))? \\{[\\s\\S]*?^\\}`, "m").exec(source);
   if (!match) throw new Error(`could not extract function ${name} from install.ps1`);
+  return match[0];
+}
+
+/**
+ * Script-scope constants the extracted functions close over. Lifted from
+ * install.ps1 for the same reason the functions are: a probe that restates the
+ * value tests its own copy, and the shipped one is free to drift.
+ */
+function extractPs1Assignment(source: string, name: string): string {
+  const match = new RegExp(`^\\$${name} = .*$`, "m").exec(source);
+  if (!match) throw new Error(`could not extract $${name} from install.ps1`);
   return match[0];
 }
 
@@ -2123,6 +2183,7 @@ async function runPortableHelperProbe(
     "Test-CurlImpersonatePresent",
     "Find-CurlImpersonateWrapperDir",
     "Get-PackageInstallCommand",
+    "Register-HelperPath",
     "Install-PortableYtDlp",
     "Install-PortableCurlImpersonate",
   ].map((name) => extractPs1Function(source, name));
@@ -2160,14 +2221,11 @@ async function runPortableHelperProbe(
       "function Test-Cmd($name) { [bool](Get-Command $name -ErrorAction SilentlyContinue) }",
       "function Test-RetryableHttpStatus([int]$Status) { return ($Status -eq 408 -or $Status -eq 429 -or $Status -ge 500) }",
       "function Get-WindowsArch { return 'x64' }",
+      // Stands in for the -SkipPathUpdate branch of the real Add-UserPath: it
+      // announces and returns without touching PATH, so the extracted
+      // Register-HelperPath is the only thing writing $env:Path here.
       'function Add-UserPath([string]$Dir) { Write-Info "Skipping persistent User PATH update for $Dir." }',
-      "function Register-HelperPath([string]$Dir) {",
-      "  if ([string]::IsNullOrWhiteSpace($Dir)) { return }",
-      "  $normalized = $Dir.Trim().Trim('\"').TrimEnd('\\')",
-      "  $entries = @($env:Path -split ';' | ForEach-Object { $_.Trim().Trim('\"').TrimEnd('\\') })",
-      '  if ($entries -notcontains $normalized) { $env:Path = "$Dir;$env:Path" }',
-      "  Add-UserPath $Dir",
-      "}",
+      extractPs1Assignment(source, "CurlImpersonateWrapperPattern"),
       ...functions,
       body,
     ].join("\n"),
@@ -2204,6 +2262,9 @@ describePwsh("install.ps1 portable Windows helpers", () => {
       'function Write-Warn { param($m) Write-Host "! $m" }',
       "$CurlImpersonateVersion = 'v2.2.1'",
       "$CurlImpersonateWin64Digest = 'f7faa8c42b63b4a96245429e46956e11ae7d7076d60f65768c0018d3bb18d7e5'",
+      // Read out of install.ps1, not restated: this is the rule under test in
+      // the wrapper-family cases below.
+      `Invoke-Expression ([regex]::Match($src, '(?m)^\\$CurlImpersonateWrapperPattern = .*$').Value)`,
       extractFn("Get-YtdlpReleaseAsset"),
       extractFn("Get-HelperChecksumEntry"),
       extractFn("Get-CurlImpersonateWindowsSpec"),
@@ -2296,6 +2357,42 @@ describePwsh("install.ps1 portable Windows helpers", () => {
       expect(realpathSync.native(reported!)).toBe(realpathSync.native(dir));
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * The installer's notion of "an impersonate build is already here" has to be
+   * the resolver's, or the two disagree in both directions: a mobile-only
+   * directory reads as done while `resolveCurlCandidate` falls back to plain
+   * curl, and a firefox-only directory reads as empty and gets a redundant
+   * download over a working install. `curl_chrome131_android.bat`,
+   * `curl_safari260_ios.bat` and `curl_tor145.bat` all ship in the real v2.2.1
+   * archive, and `parseWrapper` rejects every one of them.
+   */
+  test("counts only the desktop wrappers the provider resolver would select", () => {
+    const cases = [
+      { file: "curl_chrome146.bat", expected: "present" },
+      { file: "curl_firefox147.bat", expected: "present" },
+      { file: "curl_safari260.bat", expected: "present" },
+      { file: "curl_edge101.bat", expected: "present" },
+      { file: "curl_chrome133a.bat", expected: "present" },
+      { file: "curl_chrome131_android.bat", expected: "missing" },
+      { file: "curl_safari260_ios.bat", expected: "missing" },
+      { file: "curl_tor145.bat", expected: "missing" },
+    ] as const;
+
+    for (const { file, expected } of cases) {
+      const dir = mkdtempSync(join(tmpdir(), "kunai-wrapper-family-"));
+      try {
+        writeFileSync(join(dir, file), "@echo off\r\n");
+        const output = evalHelperFns(`
+          $env:Path = ${JSON.stringify(dir)}
+          if (Test-CurlImpersonatePresent) { Write-Output 'present' } else { Write-Output 'missing' }
+        `);
+        expect(output, `${file} should read as ${expected}`).toContain(expected);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     }
   });
 
@@ -2482,7 +2579,14 @@ describePwsh("install.ps1 portable Windows helpers", () => {
     }
   });
 
-  test.skipIf(process.platform === "win32")(
+  /**
+   * `chmod 0o500` is only a lock for a user the mode bits apply to. Windows
+   * ACLs are not chmod at all, and root ignores the bits outright — under
+   * either, `Remove-Item -Recurse` succeeds, the fail-closed branch is never
+   * reached, and the assertions below quietly test nothing. Skip rather than
+   * pass vacuously: a container suite running as uid 0 is the common case.
+   */
+  test.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
     "does not nest extract when a locked dest directory cannot be replaced",
     async () => {
       const sandbox = createInstallerSandbox("install-ps1-portable-helpers-locked");

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -292,6 +292,9 @@ describePwsh("install.ps1 dry-run", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("Kunai installer");
+    expect(result.stdout).toContain(
+      "Skipping optional dependencies (mpv, yt-dlp, curl-impersonate).",
+    );
     expect(result.stdout).toContain("Downloading kunai-windows-");
     expect(result.stdout).toContain("versions");
     expect(result.stdout).toContain("[dry-run]");
@@ -368,7 +371,17 @@ describePwsh("install.ps1 dry-run", () => {
       // in install.ps1 — this asserts the installer stays on real mpv.
       expect(result.stdout).toContain("winget install --id mpv-player.mpv-CI.MSVC -e");
       expect(result.stdout).not.toContain("mpv.net");
-      expect(result.stdout).toContain("winget install yt-dlp");
+      if (process.platform === "win32") {
+        // Windows one-click path: portable GitHub binaries, not the ambiguous
+        // `winget install yt-dlp` that matches a Microsoft Store listing.
+        expect(result.stdout).toContain("yt-dlp.exe");
+        expect(result.stdout).toContain("curl-impersonate");
+        expect(result.stdout).not.toMatch(/winget install yt-dlp(?:\s|$)/);
+      } else {
+        // Linux pwsh harness: $OnWindows is false, so the winget fallback is
+        // what the dry-run prints. The id must still be exact.
+        expect(result.stdout).toContain("winget install --id yt-dlp.yt-dlp -e");
+      }
     } finally {
       sandbox.cleanup();
     }
@@ -1966,7 +1979,7 @@ describePwsh("install.ps1 optional dependency consent", () => {
     // cannot drive over mpv's IPC socket.
     expect(table["winget/mpv"]).toBe("winget install --id mpv-player.mpv-CI.MSVC -e");
     expect(table["winget/curl"]).toBe("winget install --id cURL.cURL -e");
-    expect(table["winget/yt-dlp"]).toBe("winget install yt-dlp");
+    expect(table["winget/yt-dlp"]).toBe("winget install --id yt-dlp.yt-dlp -e");
     expect(table["scoop/mpv"]).toBe("scoop install mpv");
     expect(table["choco/mpv"]).toBe("choco install mpv");
     // No recognised manager must yield no command, so the caller falls through
@@ -2003,6 +2016,8 @@ describePwsh("install.ps1 optional dependency consent", () => {
     // -Yes is consent to install Kunai, not to accept a third party's terms.
     expect(output).not.toContain("[RAN]");
     expect(output).toContain("winget install --id mpv-player.mpv-CI.MSVC -e");
+    expect(output).toContain("winget install --id yt-dlp.yt-dlp -e");
+    expect(output).not.toMatch(/winget install yt-dlp(?:\s|$)/);
   });
 
   /**
@@ -2028,6 +2043,125 @@ describePwsh("install.ps1 optional dependency consent", () => {
     expect(output).toContain("No supported package manager found");
     expect(output).toContain("https://mpv.io/installation/");
     expect(output).not.toContain("[RAN]");
+  });
+});
+
+/**
+ * Portable Windows helpers: yt-dlp.exe and curl-impersonate are fetched from
+ * GitHub into Kunai's data dir so `irm … | iex` does not depend on winget
+ * confirming a third-party licence (and so curl-impersonate, which has no
+ * Windows package, actually gets installed).
+ */
+describePwsh("install.ps1 portable Windows helpers", () => {
+  function extractFn(name: string): string {
+    return `Invoke-Expression ([regex]::Match($src, "(?ms)^function ${name} \\{.*?^\\}").Value)`;
+  }
+
+  function evalHelperFns(body: string): string {
+    const script = [
+      `$src = Get-Content -Raw ${JSON.stringify(INSTALL_PS1)}`,
+      'function Write-Info { param($m) Write-Host "> $m" }',
+      'function Write-Warn { param($m) Write-Host "! $m" }',
+      "$CurlImpersonateVersion = 'v2.2.1'",
+      "$CurlImpersonateWin64Digest = 'f7faa8c42b63b4a96245429e46956e11ae7d7076d60f65768c0018d3bb18d7e5'",
+      extractFn("Get-YtdlpReleaseAsset"),
+      extractFn("Get-HelperChecksumEntry"),
+      extractFn("Get-CurlImpersonateWindowsSpec"),
+      extractFn("Test-CurlImpersonatePresent"),
+      extractFn("Find-CurlImpersonateWrapperDir"),
+      body,
+    ].join("\n");
+    const result = spawnSync("pwsh", ["-NoProfile", "-Command", script], {
+      encoding: "utf8",
+    });
+    expect(result.stderr, result.stderr).not.toContain("ParserError");
+    expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+    return `${result.stdout}${result.stderr}`;
+  }
+
+  test("picks the official yt-dlp asset for x64 and arm64", () => {
+    const output = evalHelperFns(
+      [
+        "Write-Output (Get-YtdlpReleaseAsset -Arch x64)",
+        "Write-Output (Get-YtdlpReleaseAsset -Arch arm64)",
+      ].join("; "),
+    );
+    const lines = output
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    expect(lines).toContain("yt-dlp.exe");
+    expect(lines).toContain("yt-dlp_arm64.exe");
+  });
+
+  test("curl-impersonate Windows spec is x64-only and matches the CI pin", () => {
+    const output = evalHelperFns(`
+      $spec = Get-CurlImpersonateWindowsSpec -Arch x64
+      Write-Output $spec.Version
+      Write-Output $spec.Asset
+      Write-Output $spec.Url
+      Write-Output $spec.Sha256
+      $arm = Get-CurlImpersonateWindowsSpec -Arch arm64
+      if ($null -eq $arm) { Write-Output 'arm64-none' }
+    `);
+    expect(output).toContain("v2.2.1");
+    expect(output).toContain("curl-impersonate-v2.2.1.x86_64-win32.tar.gz");
+    expect(output).toContain(
+      "https://github.com/lexiforest/curl-impersonate/releases/download/v2.2.1/curl-impersonate-v2.2.1.x86_64-win32.tar.gz",
+    );
+    expect(output).toContain("f7faa8c42b63b4a96245429e46956e11ae7d7076d60f65768c0018d3bb18d7e5");
+    expect(output).toContain("arm64-none");
+  });
+
+  test("helper checksums accept GNU coreutils spacing and a binary-mode star", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kunai-ytdlp-sums-"));
+    try {
+      const sums = join(dir, "SHA2-256SUMS");
+      const digest = "a".repeat(64);
+      writeFileSync(sums, `${digest}  yt-dlp.exe\n${digest} *yt-dlp_arm64.exe\n`);
+      const output = evalHelperFns(`
+        Write-Output (Get-HelperChecksumEntry ${JSON.stringify(sums)} 'yt-dlp.exe')
+        Write-Output (Get-HelperChecksumEntry ${JSON.stringify(sums)} 'yt-dlp_arm64.exe')
+      `);
+      const lines = output
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+      expect(lines.filter((line) => line === digest)).toHaveLength(2);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("discovers the .bat wrappers the Windows curl-impersonate release ships", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kunai-curl-impersonate-"));
+    try {
+      writeFileSync(join(dir, "curl_chrome150.bat"), "@echo off\r\n");
+      writeFileSync(join(dir, "curl-impersonate.exe"), "MZ");
+      const output = evalHelperFns(`
+        $env:Path = ${JSON.stringify(dir)}
+        if (Test-CurlImpersonatePresent) { Write-Output 'present' } else { Write-Output 'missing' }
+        Write-Output (Find-CurlImpersonateWrapperDir ${JSON.stringify(dir)})
+      `);
+      expect(output).toContain("present");
+      expect(output).toContain(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("plain curl.exe is not an impersonate build", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kunai-plain-curl-"));
+    try {
+      writeFileSync(join(dir, "curl.exe"), "MZ");
+      const output = evalHelperFns(`
+        $env:Path = ${JSON.stringify(dir)}
+        if (Test-CurlImpersonatePresent) { Write-Output 'present' } else { Write-Output 'missing' }
+      `);
+      expect(output).toContain("missing");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -2046,6 +2046,146 @@ describePwsh("install.ps1 optional dependency consent", () => {
   });
 });
 
+function extractPs1Function(source: string, name: string): string {
+  const match = new RegExp(`^function ${name} \\{[\\s\\S]*?^\\}`, "m").exec(source);
+  if (!match) throw new Error(`could not extract function ${name} from install.ps1`);
+  return match[0];
+}
+
+function commandSourceDir(command: string): string {
+  const result = spawnSync(
+    "pwsh",
+    ["-NoProfile", "-Command", `(Get-Command ${command} -ErrorAction Stop).Source`],
+    { encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    throw new Error(`${command} not found: ${result.stderr || result.stdout}`);
+  }
+  return dirname(result.stdout.trim());
+}
+
+/**
+ * PATH is the shim directory plus pwsh and tar, nothing else. A developer
+ * machine with yt-dlp already installed would otherwise skip the portable
+ * download the way production does, and this suite would never hit GitHub.
+ */
+function isolatedHelperEnv(sandbox: ReturnType<typeof createInstallerSandbox>): NodeJS.ProcessEnv {
+  installCommandShim(sandbox.root, "winget");
+  const env: NodeJS.ProcessEnv = { ...sandbox.env };
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === "path") delete env[key];
+  }
+  const pathKey = process.platform === "win32" ? "Path" : "PATH";
+  env[pathKey] = [sandbox.root, commandSourceDir("pwsh"), commandSourceDir("tar")].join(delimiter);
+  return env;
+}
+
+/** Same `./curl_chrome*.bat` layout the v2.2.1 Windows tarball actually ships. */
+function createCurlImpersonateArchive(workDir: string): {
+  bytes: Uint8Array;
+  sha256: string;
+  asset: string;
+} {
+  const payloadDir = join(workDir, "curl-payload");
+  mkdirSync(payloadDir, { recursive: true });
+  writeFileSync(join(payloadDir, "curl_chrome146.bat"), "@echo off\r\nrem fixture\r\n");
+  writeFileSync(join(payloadDir, "curl-impersonate.exe"), "MZ-curl-impersonate-fixture\n");
+  const asset = "curl-impersonate-v2.2.1.x86_64-win32.tar.gz";
+  const archivePath = join(workDir, asset);
+  const packed = spawnSync("tar", ["-czf", archivePath, "-C", payloadDir, "."], {
+    encoding: "utf8",
+  });
+  if (packed.status !== 0) {
+    throw new Error(`tar -czf failed: ${packed.stderr || packed.stdout}`);
+  }
+  const bytes = new Uint8Array(readFileSync(archivePath));
+  return { bytes, sha256: createHash("sha256").update(bytes).digest("hex"), asset };
+}
+
+/**
+ * Extract the portable-helper installers and the download stack they call, then
+ * run them against a local fixture. Must be async: spawnSync deadlocks
+ * Bun.serve the same way the binary-install fixtures do.
+ */
+async function runPortableHelperProbe(
+  env: NodeJS.ProcessEnv,
+  body: string,
+): Promise<{ status: number; stdout: string; stderr: string }> {
+  const source = readFileSync(INSTALL_PS1, "utf8");
+  const functions = [
+    "Format-ByteSize",
+    "Write-DownloadProgress",
+    "Clear-DownloadProgress",
+    "Invoke-BoundedDownload",
+    "Get-YtdlpReleaseAsset",
+    "Get-HelperChecksumEntry",
+    "Get-CurlImpersonateWindowsSpec",
+    "Test-CurlImpersonatePresent",
+    "Find-CurlImpersonateWrapperDir",
+    "Get-PackageInstallCommand",
+    "Install-PortableYtDlp",
+    "Install-PortableCurlImpersonate",
+  ].map((name) => extractPs1Function(source, name));
+
+  const dataDir = env.KUNAI_DATA_DIR;
+  if (!dataDir) throw new Error("KUNAI_DATA_DIR required for portable helper probe");
+  mkdirSync(dataDir, { recursive: true });
+  const probePath = join(dataDir, "portable-helper-probe.ps1");
+  writeFileSync(
+    probePath,
+    [
+      "Add-Type -AssemblyName System.Net.Http",
+      "$ErrorActionPreference = 'Stop'",
+      "$OnWindows = if ($null -eq $IsWindows) { $true } else { $IsWindows }",
+      "$DryRun = $false",
+      "$SkipPathUpdate = $true",
+      "$Yes = $true",
+      "$DataDir = $env:KUNAI_DATA_DIR",
+      "$CacheDir = $env:KUNAI_CACHE_DIR",
+      "$YtdlpReleaseBase = $env:KUNAI_YTDLP_RELEASE_BASE.TrimEnd('/')",
+      "$CurlImpersonateVersion = if ($env:KUNAI_CURL_IMPERSONATE_VERSION) { $env:KUNAI_CURL_IMPERSONATE_VERSION } else { 'v2.2.1' }",
+      "$CurlImpersonateWin64Digest = if ($env:KUNAI_CURL_IMPERSONATE_SHA256) { $env:KUNAI_CURL_IMPERSONATE_SHA256.ToLowerInvariant() } else { 'f7faa8c42b63b4a96245429e46956e11ae7d7076d60f65768c0018d3bb18d7e5' }",
+      "$DownloadConnectTimeoutSec = if ($env:KUNAI_DOWNLOAD_CONNECT_TIMEOUT) { [int]$env:KUNAI_DOWNLOAD_CONNECT_TIMEOUT } else { 15 }",
+      "$DownloadTotalSeconds = if ($env:KUNAI_DOWNLOAD_TOTAL_SECONDS) { [int]$env:KUNAI_DOWNLOAD_TOTAL_SECONDS } else { 8 }",
+      "$DownloadStallMs = if ($env:KUNAI_DOWNLOAD_STALL_MS) { [int]$env:KUNAI_DOWNLOAD_STALL_MS } else { 30000 }",
+      "$DownloadMaxBytes = if ($env:KUNAI_DOWNLOAD_MAX_BYTES) { [long]$env:KUNAI_DOWNLOAD_MAX_BYTES } else { 268435456 }",
+      "$DownloadArchiveMaxBytes = if ($env:KUNAI_DOWNLOAD_ARCHIVE_MAX_BYTES) { [long]$env:KUNAI_DOWNLOAD_ARCHIVE_MAX_BYTES } else { 67108864 }",
+      "$DownloadChecksumMaxBytes = if ($env:KUNAI_DOWNLOAD_CHECKSUM_MAX_BYTES) { [long]$env:KUNAI_DOWNLOAD_CHECKSUM_MAX_BYTES } else { 1048576 }",
+      "$DownloadMaxAttempts = if ($env:KUNAI_DOWNLOAD_MAX_ATTEMPTS) { [int]$env:KUNAI_DOWNLOAD_MAX_ATTEMPTS } else { 2 }",
+      "$DownloadProgressMinBytes = if ($env:KUNAI_DOWNLOAD_PROGRESS_MIN_BYTES) { [long]$env:KUNAI_DOWNLOAD_PROGRESS_MIN_BYTES } else { 1048576 }",
+      "$DownloadRetryBaseMs = if ($env:KUNAI_DOWNLOAD_RETRY_BASE_MS) { [int]$env:KUNAI_DOWNLOAD_RETRY_BASE_MS } else { 50 }",
+      "$script:LastDownloadHttpStatus = $null",
+      'function Write-Info($m) { Write-Host "-> $m" }',
+      'function Write-Warn($m) { Write-Host "! $m" }',
+      "function Test-Cmd($name) { [bool](Get-Command $name -ErrorAction SilentlyContinue) }",
+      "function Test-RetryableHttpStatus([int]$Status) { return ($Status -eq 408 -or $Status -eq 429 -or $Status -ge 500) }",
+      "function Get-WindowsArch { return 'x64' }",
+      'function Add-UserPath([string]$Dir) { Write-Info "Skipping persistent User PATH update for $Dir." }',
+      "function Register-HelperPath([string]$Dir) {",
+      "  if ([string]::IsNullOrWhiteSpace($Dir)) { return }",
+      "  $normalized = $Dir.Trim().Trim('\"').TrimEnd('\\')",
+      "  $entries = @($env:Path -split ';' | ForEach-Object { $_.Trim().Trim('\"').TrimEnd('\\') })",
+      '  if ($entries -notcontains $normalized) { $env:Path = "$Dir;$env:Path" }',
+      "  Add-UserPath $Dir",
+      "}",
+      ...functions,
+      body,
+    ].join("\n"),
+  );
+
+  const proc = Bun.spawn(["pwsh", "-NoProfile", "-File", probePath], {
+    env: { ...BOUNDED_DOWNLOAD_ENV, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, status] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { status, stdout, stderr };
+}
+
 /**
  * Portable Windows helpers: yt-dlp.exe and curl-impersonate are fetched from
  * GitHub into Kunai's data dir so `irm … | iex` does not depend on winget
@@ -2144,7 +2284,10 @@ describePwsh("install.ps1 portable Windows helpers", () => {
         Write-Output (Find-CurlImpersonateWrapperDir ${JSON.stringify(dir)})
       `);
       expect(output).toContain("present");
-      expect(output).toContain(dir);
+      // GitHub's Windows runner exposes the temp root as RUNNER~1 while
+      // Directory.FullName expands it to runneradmin. Both name the same
+      // folder, so compare against the canonical on-disk spelling.
+      expect(output).toContain(realpathSync.native(dir));
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -2161,6 +2304,130 @@ describePwsh("install.ps1 portable Windows helpers", () => {
       expect(output).toContain("missing");
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("downloads verified yt-dlp.exe and extracts curl-impersonate wrappers into Kunai's data dir", async () => {
+    const sandbox = createInstallerSandbox("install-ps1-portable-helpers");
+    const ytdlpBody = "MZ-portable-yt-dlp-fixture\n";
+    const ytdlpDigest = createHash("sha256").update(ytdlpBody).digest("hex");
+    const archive = createCurlImpersonateArchive(sandbox.root);
+    try {
+      await withReleaseFixture(
+        {
+          "/SHA2-256SUMS": {
+            body: `${ytdlpDigest}  yt-dlp.exe\n${"b".repeat(64)}  yt-dlp_arm64.exe\n`,
+          },
+          "/yt-dlp.exe": { body: ytdlpBody },
+          [`/${archive.asset}`]: { body: archive.bytes },
+        },
+        async (baseUrl, evidence) => {
+          const result = await runPortableHelperProbe(
+            {
+              ...isolatedHelperEnv(sandbox),
+              KUNAI_YTDLP_RELEASE_BASE: baseUrl,
+              KUNAI_CURL_IMPERSONATE_RELEASE_BASE: baseUrl,
+              KUNAI_CURL_IMPERSONATE_VERSION: "v2.2.1",
+              KUNAI_CURL_IMPERSONATE_SHA256: archive.sha256,
+            },
+            [
+              "$ytdlp = [bool](Install-PortableYtDlp)",
+              "$imp = [bool](Install-PortableCurlImpersonate)",
+              'Write-Output "RESULT ytdlp=$ytdlp impersonate=$imp"',
+            ].join("\n"),
+          );
+          expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+          expect(result.stdout).toContain("RESULT ytdlp=True impersonate=True");
+          expect(result.stdout).toContain("Installed yt-dlp ->");
+          expect(result.stdout).toContain("Installed curl-impersonate ->");
+          expect(readFileSync(join(sandbox.dataDir, "deps", "yt-dlp", "yt-dlp.exe"), "utf8")).toBe(
+            ytdlpBody,
+          );
+          expect(
+            existsSync(join(sandbox.dataDir, "deps", "curl-impersonate", "curl_chrome146.bat")),
+          ).toBe(true);
+          expect(evidence.requests).toContain("/SHA2-256SUMS");
+          expect(evidence.requests).toContain("/yt-dlp.exe");
+          expect(evidence.requests).toContain(`/${archive.asset}`);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("checksum mismatch leaves no dest and prints the exact winget id plus the impersonate releases URL", async () => {
+    const sandbox = createInstallerSandbox("install-ps1-portable-helpers-mismatch");
+    const ytdlpBody = "MZ-portable-yt-dlp-bad-checksum\n";
+    const archive = createCurlImpersonateArchive(sandbox.root);
+    try {
+      await withReleaseFixture(
+        {
+          "/SHA2-256SUMS": { body: `${"a".repeat(64)}  yt-dlp.exe\n` },
+          "/yt-dlp.exe": { body: ytdlpBody },
+          [`/${archive.asset}`]: { body: archive.bytes },
+        },
+        async (baseUrl) => {
+          const result = await runPortableHelperProbe(
+            {
+              ...isolatedHelperEnv(sandbox),
+              KUNAI_YTDLP_RELEASE_BASE: baseUrl,
+              KUNAI_CURL_IMPERSONATE_RELEASE_BASE: baseUrl,
+              KUNAI_CURL_IMPERSONATE_VERSION: "v2.2.1",
+              KUNAI_CURL_IMPERSONATE_SHA256: "f".repeat(64),
+            },
+            [
+              "$ytdlp = [bool](Install-PortableYtDlp)",
+              "$imp = [bool](Install-PortableCurlImpersonate)",
+              'Write-Output "RESULT ytdlp=$ytdlp impersonate=$imp"',
+            ].join("\n"),
+          );
+          expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+          expect(result.stdout).toContain("RESULT ytdlp=False impersonate=False");
+          expect(result.stdout).toContain("winget install --id yt-dlp.yt-dlp -e");
+          expect(result.stdout).toContain(
+            "https://github.com/lexiforest/curl-impersonate/releases",
+          );
+          expect(existsSync(join(sandbox.dataDir, "deps", "yt-dlp", "yt-dlp.exe"))).toBe(false);
+          expect(existsSync(join(sandbox.dataDir, "deps", "curl-impersonate"))).toBe(false);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test("already-present dest files skip the GitHub download", async () => {
+    const sandbox = createInstallerSandbox("install-ps1-portable-helpers-present");
+    mkdirSync(join(sandbox.dataDir, "deps", "yt-dlp"), { recursive: true });
+    mkdirSync(join(sandbox.dataDir, "deps", "curl-impersonate"), { recursive: true });
+    writeFileSync(join(sandbox.dataDir, "deps", "yt-dlp", "yt-dlp.exe"), "MZ-already-present\n");
+    writeFileSync(
+      join(sandbox.dataDir, "deps", "curl-impersonate", "curl_chrome146.bat"),
+      "@echo off\r\n",
+    );
+    try {
+      await withReleaseFixture({}, async (_baseUrl, evidence) => {
+        const result = await runPortableHelperProbe(
+          {
+            ...isolatedHelperEnv(sandbox),
+            KUNAI_YTDLP_RELEASE_BASE: "http://127.0.0.1:1",
+            KUNAI_CURL_IMPERSONATE_RELEASE_BASE: "http://127.0.0.1:1",
+          },
+          [
+            "$ytdlp = [bool](Install-PortableYtDlp)",
+            "$imp = [bool](Install-PortableCurlImpersonate)",
+            'Write-Output "RESULT ytdlp=$ytdlp impersonate=$imp"',
+          ].join("\n"),
+        );
+        expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+        expect(result.stdout).toContain("RESULT ytdlp=True impersonate=True");
+        expect(result.stdout).toContain("yt-dlp already present");
+        expect(result.stdout).toContain("curl-impersonate already present");
+        expect(evidence.requests).toEqual([]);
+      });
+    } finally {
+      sandbox.cleanup();
     }
   });
 });

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -2352,6 +2352,9 @@ describePwsh("install.ps1 portable Windows helpers", () => {
           expect(
             existsSync(join(sandbox.dataDir, "deps", "curl-impersonate", "curl_chrome146.bat")),
           ).toBe(true);
+          expect(existsSync(join(sandbox.dataDir, "deps", "curl-impersonate", "extract"))).toBe(
+            false,
+          );
           expect(evidence.requests).toContain("/SHA2-256SUMS");
           expect(evidence.requests).toContain("/yt-dlp.exe");
           expect(evidence.requests).toContain(`/${archive.asset}`);
@@ -2436,6 +2439,98 @@ describePwsh("install.ps1 portable Windows helpers", () => {
       sandbox.cleanup();
     }
   });
+
+  test("replaces a leftover dest directory without nesting extract", async () => {
+    const sandbox = createInstallerSandbox("install-ps1-portable-helpers-replace");
+    const destDir = join(sandbox.dataDir, "deps", "curl-impersonate");
+    mkdirSync(destDir, { recursive: true });
+    writeFileSync(join(destDir, "leftover.txt"), "stale");
+    const ytdlpBody = "MZ-portable-yt-dlp-replace\n";
+    const ytdlpDigest = createHash("sha256").update(ytdlpBody).digest("hex");
+    const archive = createCurlImpersonateArchive(sandbox.root);
+    try {
+      await withReleaseFixture(
+        {
+          "/SHA2-256SUMS": { body: `${ytdlpDigest}  yt-dlp.exe\n` },
+          "/yt-dlp.exe": { body: ytdlpBody },
+          [`/${archive.asset}`]: { body: archive.bytes },
+        },
+        async (baseUrl) => {
+          const result = await runPortableHelperProbe(
+            {
+              ...isolatedHelperEnv(sandbox),
+              KUNAI_YTDLP_RELEASE_BASE: baseUrl,
+              KUNAI_CURL_IMPERSONATE_RELEASE_BASE: baseUrl,
+              KUNAI_CURL_IMPERSONATE_VERSION: "v2.2.1",
+              KUNAI_CURL_IMPERSONATE_SHA256: archive.sha256,
+            },
+            [
+              "$ytdlp = [bool](Install-PortableYtDlp)",
+              "$imp = [bool](Install-PortableCurlImpersonate)",
+              'Write-Output "RESULT ytdlp=$ytdlp impersonate=$imp"',
+            ].join("\n"),
+          );
+          expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+          expect(result.stdout).toContain("RESULT ytdlp=True impersonate=True");
+          expect(existsSync(join(destDir, "leftover.txt"))).toBe(false);
+          expect(existsSync(join(destDir, "extract"))).toBe(false);
+          expect(existsSync(join(destDir, "curl_chrome146.bat"))).toBe(true);
+        },
+      );
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  test.skipIf(process.platform === "win32")(
+    "does not nest extract when a locked dest directory cannot be replaced",
+    async () => {
+      const sandbox = createInstallerSandbox("install-ps1-portable-helpers-locked");
+      const destDir = join(sandbox.dataDir, "deps", "curl-impersonate");
+      mkdirSync(destDir, { recursive: true });
+      writeFileSync(join(destDir, "leftover.txt"), "locked");
+      chmodSync(destDir, 0o500);
+      const ytdlpBody = "MZ-portable-yt-dlp-locked\n";
+      const ytdlpDigest = createHash("sha256").update(ytdlpBody).digest("hex");
+      const archive = createCurlImpersonateArchive(sandbox.root);
+      try {
+        await withReleaseFixture(
+          {
+            "/SHA2-256SUMS": { body: `${ytdlpDigest}  yt-dlp.exe\n` },
+            "/yt-dlp.exe": { body: ytdlpBody },
+            [`/${archive.asset}`]: { body: archive.bytes },
+          },
+          async (baseUrl) => {
+            const result = await runPortableHelperProbe(
+              {
+                ...isolatedHelperEnv(sandbox),
+                KUNAI_YTDLP_RELEASE_BASE: baseUrl,
+                KUNAI_CURL_IMPERSONATE_RELEASE_BASE: baseUrl,
+                KUNAI_CURL_IMPERSONATE_VERSION: "v2.2.1",
+                KUNAI_CURL_IMPERSONATE_SHA256: archive.sha256,
+              },
+              [
+                "$ytdlp = [bool](Install-PortableYtDlp)",
+                "$imp = [bool](Install-PortableCurlImpersonate)",
+                'Write-Output "RESULT ytdlp=$ytdlp impersonate=$imp"',
+              ].join("\n"),
+            );
+            expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+            expect(result.stdout).toContain("RESULT ytdlp=True impersonate=False");
+            expect(result.stdout).toContain(
+              "Could not replace the existing curl-impersonate directory",
+            );
+            expect(existsSync(join(destDir, "extract"))).toBe(false);
+            expect(existsSync(join(destDir, "curl_chrome146.bat"))).toBe(false);
+            expect(existsSync(join(destDir, "leftover.txt"))).toBe(true);
+          },
+        );
+      } finally {
+        chmodSync(destDir, 0o755);
+        sandbox.cleanup();
+      }
+    },
+  );
 });
 
 /**

--- a/apps/cli/test/integration/install-scripts-pwsh.test.ts
+++ b/apps/cli/test/integration/install-scripts-pwsh.test.ts
@@ -2284,10 +2284,16 @@ describePwsh("install.ps1 portable Windows helpers", () => {
         Write-Output (Find-CurlImpersonateWrapperDir ${JSON.stringify(dir)})
       `);
       expect(output).toContain("present");
-      // GitHub's Windows runner exposes the temp root as RUNNER~1 while
-      // Directory.FullName expands it to runneradmin. Both name the same
-      // folder, so compare against the canonical on-disk spelling.
-      expect(output).toContain(realpathSync.native(dir));
+      const reported = output
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find((line) => line.length > 0 && line !== "present");
+      expect(reported, output).toBeDefined();
+      // PowerShell's Directory.FullName and Node's mkdtemp do not share a
+      // spelling. Windows GitHub runners expand RUNNER~1 to runneradmin;
+      // macOS realpath rewrites /var to /private/var while pwsh keeps /var.
+      // Compare the resolved inode, not the string the helper printed.
+      expect(realpathSync.native(reported!)).toBe(realpathSync.native(dir));
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/apps/cli/test/integration/npm-pack-guard.test.ts
+++ b/apps/cli/test/integration/npm-pack-guard.test.ts
@@ -30,6 +30,8 @@ test("npm package README points users at public docs and the real Windows mpv pa
   expect(readme).not.toContain("../../.docs/");
   expect(readme).toContain("winget install --id mpv-player.mpv-CI.MSVC -e");
   expect(readme).not.toMatch(/winget install mpv(?:\s|`)/);
+  expect(readme).toContain("winget install --id yt-dlp.yt-dlp -e");
+  expect(readme).not.toMatch(/winget install yt-dlp(?:\s|`)/);
 });
 
 describeWithNode("npm pack guard with binaries on disk", () => {

--- a/apps/cli/test/unit/app-shell/setup-dependency-rows.test.ts
+++ b/apps/cli/test/unit/app-shell/setup-dependency-rows.test.ts
@@ -59,6 +59,7 @@ describe("resolveInstallCommand", () => {
     expect(resolveInstallCommand(CURL_IMPERSONATE_INSTALL, { platform: "win32" })).toBe(
       "https://github.com/lexiforest/curl-impersonate/releases",
     );
+    expect(YT_DLP_INSTALL.win32).toBe("winget install --id yt-dlp.yt-dlp -e");
     expect(buildRemediationLines(CURL_IMPERSONATE_INSTALL).join("\n")).not.toContain("apt install");
   });
 });

--- a/apps/cli/test/unit/infra/os/curl-features.test.ts
+++ b/apps/cli/test/unit/infra/os/curl-features.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+
+import { curlSupportsHttp2, parseCurlHttp2Support } from "@/infra/os/curl-features";
+
+/** Real `curl --version` output, trimmed to the two lines that matter. */
+const GNUTLS_CURL = [
+  "curl 8.5.0 (x86_64-pc-linux-gnu) libcurl/8.5.0 OpenSSL/3.0.13 zlib/1.3 nghttp2/1.59.0",
+  "Release-Date: 2023-12-06",
+  "Protocols: dict file ftp ftps gopher gophers http https imap imaps",
+  "Features: alt-svc AsynchDNS brotli GSS-API HSTS HTTP2 HTTPS-proxy IDN IPv6 Largefile",
+].join("\n");
+
+/**
+ * What Windows actually ships in System32: Schannel, no nghttp2, so no HTTP2
+ * token. `--http2` against this build fails the request instead of downgrading.
+ */
+const WINDOWS_SCHANNEL_CURL = [
+  "curl 8.9.1 (Windows) libcurl/8.9.1 Schannel WinIDN",
+  "Release-Date: 2024-07-31",
+  "Protocols: dict file ftp ftps http https imap imaps ipfs ipns mqtt pop3",
+  "Features: AsynchDNS HSTS HTTPS-proxy IDN IPv6 Kerberos Largefile NTLM SPNEGO SSL SSPI threadsafe Unicode UnixSockets",
+].join("\n");
+
+describe("parseCurlHttp2Support", () => {
+  test("detects the HTTP2 feature token", () => {
+    expect(parseCurlHttp2Support(GNUTLS_CURL)).toBe(true);
+  });
+
+  test("does not credit the Windows Schannel build", () => {
+    expect(parseCurlHttp2Support(WINDOWS_SCHANNEL_CURL)).toBe(false);
+  });
+
+  /**
+   * HTTP3 sits beside HTTP2 in the feature list on builds that have it. A
+   * substring test would read one as the other.
+   */
+  test("does not read HTTP3 as HTTP2", () => {
+    expect(parseCurlHttp2Support("Features: AsynchDNS HSTS HTTP3 IPv6")).toBe(false);
+  });
+
+  test("treats an absent or unrunnable curl as no support", () => {
+    expect(parseCurlHttp2Support(null)).toBe(false);
+    expect(parseCurlHttp2Support("")).toBe(false);
+  });
+});
+
+describe("curlSupportsHttp2", () => {
+  test("uses the injected probe and never the host's curl", () => {
+    expect(curlSupportsHttp2({ probeVersion: () => WINDOWS_SCHANNEL_CURL })).toBe(false);
+    expect(curlSupportsHttp2({ probeVersion: () => GNUTLS_CURL })).toBe(true);
+  });
+
+  /**
+   * The memoized default must not leak into an injected call: an injected
+   * environment answering differently on the next call has to be believed.
+   */
+  test("an injected probe is not memoized", () => {
+    let answer = GNUTLS_CURL;
+    const environment = { probeVersion: () => answer };
+
+    expect(curlSupportsHttp2(environment)).toBe(true);
+    answer = WINDOWS_SCHANNEL_CURL;
+    expect(curlSupportsHttp2(environment)).toBe(false);
+  });
+});

--- a/apps/cli/test/unit/infra/player/hls-relay.test.ts
+++ b/apps/cli/test/unit/infra/player/hls-relay.test.ts
@@ -26,6 +26,7 @@ describe("hls-relay gating", () => {
         curlTimeoutMs: 25_000,
         watchdogTimeoutMs: 30_000,
       },
+      true,
     );
 
     expect(args[0]).toBe("-q");
@@ -33,6 +34,46 @@ describe("hls-relay gating", () => {
     expect(args).not.toContain("-L");
     expect(args).not.toContain("--location");
     expect(args.at(-1)).toBe("https://vault-06.uwucdn.top/start.m3u8");
+  });
+
+  /**
+   * The Windows Schannel curl refuses `--http2` outright ("the installed
+   * libcurl version doesn't support this", exit 4) rather than negotiating
+   * down, so hardcoding the flag turned every relayed stream into a hard
+   * failure on a stock Windows host. Everything else about the argument list
+   * — the `-q` guard first, no redirect following — has to survive the drop.
+   */
+  test("omits --http2 when curl cannot do HTTP/2, keeping the safety flags", () => {
+    const budget = {
+      maxResponseBytes: 1024,
+      bodyLimitBytes: 1024,
+      curlTimeoutMs: 25_000,
+      watchdogTimeoutMs: 30_000,
+    };
+    const url = "https://vault-06.uwucdn.top/start.m3u8";
+
+    const withHttp2 = buildHlsRelayCurlArgs(
+      url,
+      "https://kwik.cx/",
+      "https://kwik.cx",
+      budget,
+      true,
+    );
+    const withoutHttp2 = buildHlsRelayCurlArgs(
+      url,
+      "https://kwik.cx/",
+      "https://kwik.cx",
+      budget,
+      false,
+    );
+
+    expect(withHttp2).toContain("--http2");
+    expect(withoutHttp2).not.toContain("--http2");
+    expect(withoutHttp2[0]).toBe("-q");
+    expect(withoutHttp2).toContain("--no-location");
+    expect(withoutHttp2.at(-1)).toBe(url);
+    // Only the one flag differs; nothing else is conditional on HTTP/2.
+    expect(withHttp2.filter((arg) => arg !== "--http2")).toEqual(withoutHttp2);
   });
 
   test("rejects a redirect before requesting a non-allowlisted target", async () => {

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "9399f4e19c122a598078ee554d5ef0659a4c62985eef9ea2a9a7b0aa8ac691de",
-  "docsContentFingerprint": "d8bc57e6f63ce3f8bc57369e99ff994f302262186a3d885f768833a37cdde608",
+  "docsContentFingerprint": "b6da099bb9f19ed33542a7f01e27b5243eb1926efdad1d579755c9e2ca4e232e",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "9399f4e19c122a598078ee554d5ef0659a4c62985eef9ea2a9a7b0aa8ac691de",
-  "docsContentFingerprint": "f05159a84b9b3bcb1f6837dcc7630c0ead11877a61938808a771896e7094fc08",
+  "docsContentFingerprint": "d8bc57e6f63ce3f8bc57369e99ff994f302262186a3d885f768833a37cdde608",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "9399f4e19c122a598078ee554d5ef0659a4c62985eef9ea2a9a7b0aa8ac691de",
-  "docsContentFingerprint": "b6da099bb9f19ed33542a7f01e27b5243eb1926efdad1d579755c9e2ca4e232e",
+  "docsContentFingerprint": "6cf519d315982a3c8c0617891325b79a3179587b3761e6097f012d298ee5dfc7",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "9399f4e19c122a598078ee554d5ef0659a4c62985eef9ea2a9a7b0aa8ac691de",
-  "docsContentFingerprint": "ae40bf3a51636386a9fbdba815087a85a82da25a931d6bfdcbaefc18b992ba2f",
+  "docsContentFingerprint": "f05159a84b9b3bcb1f6837dcc7630c0ead11877a61938808a771896e7094fc08",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/docs/users/install-and-update.mdx
+++ b/docs/users/install-and-update.mdx
@@ -208,6 +208,11 @@ one-line `irm … | iex` actually leaves YouTube and anime search working:
   pins. Windows ARM64 has no upstream build, so that host is pointed at the
   [releases page](https://github.com/lexiforest/curl-impersonate/releases).
 
+The Windows `curl` prompt is still offered alongside these. curl-impersonate
+clears Cloudflare for anime search; it does not give you an HTTP/2 `curl.exe`,
+which is a different binary that other playback paths spawn by name. The
+installer says so rather than skipping the prompt.
+
 `--skip-deps` skips the portable helpers and the package-manager prompt,
 including Windows `curl`.
 

--- a/docs/users/install-and-update.mdx
+++ b/docs/users/install-and-update.mdx
@@ -199,6 +199,10 @@ x64, curl-impersonate into Kunai's own data directory
 are GitHub release binaries, verified by checksum — not winget packages — so a
 one-line `irm … | iex` actually leaves YouTube and anime search working:
 
+Kunai records the verified digests beside helpers it manages. A later install
+rechecks those bytes and repairs missing, partial, or modified helper files
+instead of trusting a matching filename.
+
 - `yt-dlp` — YouTube playback and downloads. The winget query `yt-dlp` matches
   both `yt-dlp.yt-dlp` and a Microsoft Store listing, so the installer never
   runs that command; it fetches `yt-dlp.exe` (or `yt-dlp_arm64.exe`) instead.

--- a/docs/users/install-and-update.mdx
+++ b/docs/users/install-and-update.mdx
@@ -72,7 +72,7 @@ separate zip utility is required. The same HTTP 404/410-only legacy fallback
 rule applies. On a terminal the download shows one updating progress line
 (size, rate, bar); a pipe or CI log stays on the single quiet line.
 
-Installs to `%LOCALAPPDATA%\kunai\bin\kunai.exe`, prepends that directory to your **User** PATH so the native binary wins over an older npm/Bun shim, and records the install channel in `%APPDATA%\kunai\install.json`.
+Installs to `%LOCALAPPDATA%\kunai\bin\kunai.exe`, prepends that directory to your **User** PATH so the native binary wins over an older npm/Bun shim, and records the install channel in `%APPDATA%\kunai\install.json`. After the binary is in place it also drops portable `yt-dlp` and (on x64) curl-impersonate into `%LOCALAPPDATA%\kunai\deps\` — see [Optional dependencies](#optional-dependencies). `mpv` remains a package-manager prompt.
 
 Open a new terminal after installation if `kunai` is not visible yet. The
 installer prints the PATH winner. If another `kunai` is still earlier — npm,
@@ -157,7 +157,7 @@ what a Dockerfile or CI step usually wants.
 | `install.sh`         | `install.ps1`     | Environment                | Effect                                                                                    |
 | -------------------- | ----------------- | -------------------------- | ----------------------------------------------------------------------------------------- |
 | `--yes`              | `-Yes`            | `KUNAI_INSTALL_YES=1`      | Accept Kunai's own optional prompts. It does **not** install system packages — see below. |
-| `--skip-deps`        | `-SkipDeps`       | `KUNAI_SKIP_DEPS=1`        | Say nothing at all about optional dependencies (`mpv`, `yt-dlp`, and on Windows `curl`).  |
+| `--skip-deps`        | `-SkipDeps`       | `KUNAI_SKIP_DEPS=1`        | Skip optional dependencies (`mpv` via your package manager; on Windows also the portable `yt-dlp` and `curl-impersonate` helpers). |
 | `--skip-path-update` | `-SkipPathUpdate` | `KUNAI_SKIP_PATH_UPDATE=1` | Leave PATH alone — see [PATH](#path).                                                     |
 
 Without a terminal — `curl … | bash` in CI, a container, or a sandbox — optional
@@ -165,11 +165,12 @@ prompts are **skipped, not accepted**, and the installer says which step it
 skipped. Before 0.3.0 a missing terminal defaulted to yes and could run
 `sudo apt-get`/`pacman`/`dnf install` unattended.
 
-### Optional dependencies are never installed for you
+### Optional dependencies
 
-Kunai needs `mpv` to play anything, and `yt-dlp` for YouTube. The installer
-checks whether they are already present, and if they are not it prints the exact
-command for your package manager:
+Kunai needs `mpv` to play anything, and `yt-dlp` for YouTube. **Package-manager
+installs are never run for you.** The installer checks whether they are already
+present, and if they are not it prints the exact command for your package
+manager:
 
 ```
 ! mpv is not installed — Kunai needs it to play anything.
@@ -180,7 +181,7 @@ command for your package manager:
 Run it now? [y/N]
 ```
 
-Three rules hold on every platform:
+Three rules hold for every package-manager prompt:
 
 - **The command is always shown**, before it is offered and again if you decline,
   so nothing is hidden either way.
@@ -191,11 +192,29 @@ Three rules hold on every platform:
 
 Saying yes runs the command as shown, without `--noconfirm`, `-y`, or
 `--accept-package-agreements` — so your package manager still confirms too.
-`--skip-deps` silences the section entirely, including Windows `curl`.
 
-Recognised managers: `pacman`, `apt`, `dnf`, `zypper`, `apk` on Linux; `brew`
-and `port` on macOS; `winget`, `scoop` and `choco` on Windows. Anything else
-gets a link to [mpv's install guide](https://mpv.io/installation/).
+On **Windows**, the native installer also drops two **portable** tools into
+Kunai's own data directory (`%LOCALAPPDATA%\kunai\deps\`) and puts those folders
+on your User PATH. These are GitHub release binaries, verified by checksum —
+not winget packages — so a one-line `irm … | iex` actually leaves YouTube and
+anime search working:
+
+- `yt-dlp` — YouTube playback and downloads. The winget query `yt-dlp` matches
+  both `yt-dlp.yt-dlp` and a Microsoft Store listing, so the installer never
+  runs that command; it fetches `yt-dlp.exe` (or `yt-dlp_arm64.exe`) instead.
+  The copy-pasteable fallback is `winget install --id yt-dlp.yt-dlp -e`.
+- `curl-impersonate` — Cloudflare TLS bypass for anime search (x64). There is
+  no winget/scoop/choco package; the installer uses the same Windows archive CI
+  pins. Windows ARM64 has no upstream build, so that host is pointed at the
+  [releases page](https://github.com/lexiforest/curl-impersonate/releases).
+
+`--skip-deps` skips the portable helpers and the package-manager prompt,
+including Windows `curl`.
+
+Recognised managers for `mpv` (and for `yt-dlp` on Linux/macOS): `pacman`,
+`apt`, `dnf`, `zypper`, `apk` on Linux; `brew` and `port` on macOS; `winget`,
+`scoop` and `choco` on Windows. Anything else gets a link to
+[mpv's install guide](https://mpv.io/installation/).
 
 ## Unsigned binaries (beta)
 

--- a/docs/users/install-and-update.mdx
+++ b/docs/users/install-and-update.mdx
@@ -193,11 +193,11 @@ Three rules hold for every package-manager prompt:
 Saying yes runs the command as shown, without `--noconfirm`, `-y`, or
 `--accept-package-agreements` — so your package manager still confirms too.
 
-On **Windows**, the native installer also drops two **portable** tools into
-Kunai's own data directory (`%LOCALAPPDATA%\kunai\deps\`) and puts those folders
-on your User PATH. These are GitHub release binaries, verified by checksum —
-not winget packages — so a one-line `irm … | iex` actually leaves YouTube and
-anime search working:
+On **Windows**, the native installer also drops **portable** `yt-dlp` and, on
+x64, curl-impersonate into Kunai's own data directory
+(`%LOCALAPPDATA%\kunai\deps\`) and puts those folders on your User PATH. These
+are GitHub release binaries, verified by checksum — not winget packages — so a
+one-line `irm … | iex` actually leaves YouTube and anime search working:
 
 - `yt-dlp` — YouTube playback and downloads. The winget query `yt-dlp` matches
   both `yt-dlp.yt-dlp` and a Microsoft Store listing, so the installer never

--- a/install.ps1
+++ b/install.ps1
@@ -1830,6 +1830,13 @@ function Install-PortableCurlImpersonate {
     if (Test-Path -LiteralPath $destDir) {
       Remove-Item -LiteralPath $destDir -Recurse -Force -ErrorAction SilentlyContinue
     }
+    # Move-Item into an existing directory nests the extract folder inside it
+    # (`deps\curl-impersonate\extract`). Find-CurlImpersonateWrapperDir recurses,
+    # so that layout would still report success and a later run would treat the
+    # nest as `$existing`. Fail closed if a locked file kept $destDir around.
+    if (Test-Path -LiteralPath $destDir) {
+      throw "Could not replace the existing curl-impersonate directory at $destDir (a file there is in use)."
+    }
     New-Item -ItemType Directory -Force -Path (Split-Path $destDir) | Out-Null
     Move-Item -Force -Path $extractDir -Destination $destDir
     $wrapperDir = Find-CurlImpersonateWrapperDir $destDir

--- a/install.ps1
+++ b/install.ps1
@@ -1641,7 +1641,11 @@ function Get-YtdlpReleaseAsset {
 # yt-dlp's SHA2-256SUMS is GNU coreutils style (hash, spaces, optional `*`, name).
 # Kunai's own SHA256SUMS parser requires exactly two spaces and would reject a
 # perfectly valid yt-dlp manifest, so helpers get a slightly looser reader.
-function Get-HelperChecksumEntry([string]$ManifestPath, [string]$AssetName) {
+function Get-HelperChecksumEntry {
+  param(
+    [Parameter(Mandatory)][string]$ManifestPath,
+    [Parameter(Mandatory)][string]$AssetName
+  )
   $digests = @()
   foreach ($line in Get-Content -LiteralPath $ManifestPath) {
     if ($line -cmatch '^([0-9A-Fa-f]{64})\s+\*?([^\s]+)$' -and $Matches[2] -ceq $AssetName) {
@@ -1690,7 +1694,8 @@ function Test-CurlImpersonatePresent {
   return $false
 }
 
-function Find-CurlImpersonateWrapperDir([string]$Root) {
+function Find-CurlImpersonateWrapperDir {
+  param([Parameter(Mandatory)][string]$Root)
   if (-not (Test-Path -LiteralPath $Root -PathType Container)) { return $null }
   $wrapper = Get-ChildItem -LiteralPath $Root -Filter 'curl_chrome*.bat' -Recurse -File -ErrorAction SilentlyContinue |
     Select-Object -First 1

--- a/install.ps1
+++ b/install.ps1
@@ -1624,12 +1624,16 @@ function Request-OptionalInstall {
 # has to see a helper we just dropped or the rest of this install cannot find it.
 function Register-HelperPath([string]$Dir) {
   if ([string]::IsNullOrWhiteSpace($Dir)) { return }
+  # Add-UserPath writes the session PATH itself when it persists the entry, so
+  # doing it unconditionally here left a duplicate on every first install. Do it
+  # only for the paths Add-UserPath will not take: SkipPathUpdate, off-Windows,
+  # and an entry already persisted from an earlier run.
+  Add-UserPath $Dir
   $normalized = $Dir.Trim().Trim('"').TrimEnd('\')
   $entries = @($env:Path -split ';' | ForEach-Object { $_.Trim().Trim('"').TrimEnd('\') })
   if ($entries -notcontains $normalized) {
     $env:Path = "$Dir;$env:Path"
   }
-  Add-UserPath $Dir
 }
 
 function Get-YtdlpReleaseAsset {
@@ -1676,6 +1680,20 @@ function Get-CurlImpersonateWindowsSpec {
   }
 }
 
+# The wrappers Kunai's resolver will actually select, and only those. This is
+# the PowerShell twin of WRAPPER_PATTERN + FAMILY_RANK in
+# packages/providers/src/shared/curl-impersonate.ts; keep the two in step.
+#
+# Both exclusions are load-bearing. The v2.2.1 Windows archive ships
+# curl_chrome131_android.bat and curl_safari260_ios.bat, which the resolver
+# rejects as mobile - a desktop CLI presenting a phone's handshake is a
+# mismatch a fingerprinter can see - and curl_tor145.bat, rejected for the same
+# reason more so. A directory holding only those is not an install this
+# installer may call done. Restricting to chrome the other way was equally
+# wrong: a host carrying only curl_firefox147.bat reads as "nothing here" and
+# gets a redundant download over a working install.
+$CurlImpersonateWrapperPattern = '^curl_(chrome|firefox|ff|safari|edge)\d+[a-z]*\.(bat|cmd|exe)$'
+
 function Test-CurlImpersonatePresent {
   $pathValue = if ($null -eq $env:Path) { '' } else { $env:Path }
   foreach ($pathEntry in ($pathValue -split ';')) {
@@ -1685,7 +1703,7 @@ function Test-CurlImpersonatePresent {
     }
     try {
       $hits = @(Get-ChildItem -LiteralPath $directory -File -ErrorAction SilentlyContinue | Where-Object {
-          $_.Name -match '^curl_chrome\d+.*\.(bat|cmd|exe)$'
+          $_.Name -match $CurlImpersonateWrapperPattern
         })
       if ($hits.Count -gt 0) { return $true }
     }
@@ -1697,7 +1715,11 @@ function Test-CurlImpersonatePresent {
 function Find-CurlImpersonateWrapperDir {
   param([Parameter(Mandatory)][string]$Root)
   if (-not (Test-Path -LiteralPath $Root -PathType Container)) { return $null }
-  $wrapper = Get-ChildItem -LiteralPath $Root -Filter 'curl_chrome*.bat' -Recurse -File -ErrorAction SilentlyContinue |
+  # -Filter is a wildcard, not a regex, so the family/mobile rules are applied
+  # after it. The cheap prefix filter still keeps the recursive walk from
+  # stat-ing every DLL in the archive.
+  $wrapper = Get-ChildItem -LiteralPath $Root -Filter 'curl_*' -Recurse -File -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -match $CurlImpersonateWrapperPattern } |
     Select-Object -First 1
   if ($null -eq $wrapper) { return $null }
   return $wrapper.Directory.FullName
@@ -1805,7 +1827,14 @@ function Install-PortableCurlImpersonate {
   }
 
   Write-Info "Installing curl-impersonate $($spec.Version) so anime search can clear Cloudflare..."
-  $staging = Join-Path $CacheDir ("curl-impersonate-staging-" + $PID)
+  # Staged beside $destDir rather than under $CacheDir: the install finishes
+  # with Move-Item on a *directory*, and .NET cannot move a directory across
+  # volumes. That is the default layout's own business (both live under
+  # %LOCALAPPDATA%), but KUNAI_CACHE_DIR is a documented override and pointing
+  # it at another drive would otherwise turn a good download into a warning.
+  # yt-dlp stages under $CacheDir still - it lands with Copy-Item, which does
+  # cross volumes.
+  $staging = Join-Path $DataDir ("deps\.curl-impersonate-staging-" + $PID)
   $ok = $false
   try {
     New-Item -ItemType Directory -Force -Path $staging | Out-Null
@@ -1825,7 +1854,7 @@ function Install-PortableCurlImpersonate {
     }
     $wrapperDir = Find-CurlImpersonateWrapperDir $extractDir
     if (-not $wrapperDir) {
-      throw "Archive did not contain curl_chrome*.bat wrappers."
+      throw "Archive did not contain any desktop curl_<browser><version> wrappers."
     }
     if (Test-Path -LiteralPath $destDir) {
       Remove-Item -LiteralPath $destDir -Recurse -Force -ErrorAction SilentlyContinue
@@ -1841,7 +1870,7 @@ function Install-PortableCurlImpersonate {
     Move-Item -Force -Path $extractDir -Destination $destDir
     $wrapperDir = Find-CurlImpersonateWrapperDir $destDir
     if (-not $wrapperDir) {
-      throw "Extracted curl-impersonate is missing curl_chrome*.bat wrappers."
+      throw "Extracted curl-impersonate is missing its desktop curl_<browser><version> wrappers."
     }
     if ($OnWindows) {
       Get-ChildItem -LiteralPath $wrapperDir -File -ErrorAction SilentlyContinue |
@@ -1905,32 +1934,39 @@ function Install-OptionalDeps {
 
   # Windows 10+ ships curl.exe in System32, so "is curl present" is the wrong
   # question here - the bundled build uses Schannel with no nghttp2, so it
-  # reports no HTTP2 feature. Providers that negotiate HTTP/2 fall back or fail
-  # against that build, so offer the full winget/scoop curl when the one on PATH
-  # cannot do HTTP/2. An impersonate build already covers that (and Cloudflare),
-  # so skip the upgrade when we just installed one or found one.
+  # reports no HTTP2 feature.
+  #
+  # This is deliberately NOT skipped when curl-impersonate is installed. The two
+  # are orthogonal: the impersonate build is a separately-named binary
+  # (curl-impersonate.exe plus curl_*.bat wrappers - the release archive carries
+  # no curl.exe at all) that only the provider clients resolve, via
+  # resolveCurlCandidate. The HLS relay in apps/cli/src/infra/player/hls-relay.ts
+  # spawns the literal `curl` from PATH, and Kunai's own capability probe reads
+  # that binary's feature list. Treating "impersonate present" as "HTTP/2
+  # covered" hid this prompt on exactly the hosts that still need it.
   $curlNeedsUpgrade = $false
-  if (-not $portableImpersonate -and -not (Test-CurlImpersonatePresent)) {
-    if (Test-Cmd 'curl') {
-      try {
-        $curlFeatures = (& curl.exe --version 2>$null) -join "`n"
-        $curlNeedsUpgrade = -not ($curlFeatures -match 'HTTP2')
-      }
-      catch { $curlNeedsUpgrade = $true }
+  if (Test-Cmd 'curl') {
+    try {
+      $curlFeatures = (& curl.exe --version 2>$null) -join "`n"
+      $curlNeedsUpgrade = -not ($curlFeatures -match 'HTTP2')
     }
-    else {
-      $curlNeedsUpgrade = $true
-    }
+    catch { $curlNeedsUpgrade = $true }
+  }
+  else {
+    $curlNeedsUpgrade = $true
   }
   if ($curlNeedsUpgrade) {
     Write-Warn 'The curl on PATH has no HTTP/2 support (Windows ships a Schannel build).'
+    if ($portableImpersonate) {
+      # Say why this is still offered right after curl-impersonate landed, or it
+      # reads as the installer forgetting what it just did.
+      Write-Info 'curl-impersonate covers Cloudflare, not HTTP/2 - they are different binaries.'
+    }
     $missing += 'curl'
   }
 
   if ($missing.Count -eq 0) {
-    if (Test-Cmd 'mpv') {
-      Write-Info 'Required player (mpv) is already installed.'
-    }
+    Write-Info 'mpv, yt-dlp and curl are all present.'
     return
   }
 

--- a/install.ps1
+++ b/install.ps1
@@ -1662,6 +1662,43 @@ function Get-HelperChecksumEntry {
   return [string]$digests[0]
 }
 
+# A managed helper is reusable only while its recorded verified digest still
+# matches its bytes. A filename alone can be crash residue from an interrupted
+# copy, and must not suppress repair or remediation.
+function Test-ManagedFileDigest {
+  param(
+    [Parameter(Mandatory)][string]$Path,
+    [Parameter(Mandatory)][string]$DigestPath,
+    [string]$ExpectedDigest = ''
+  )
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf) -or
+    -not (Test-Path -LiteralPath $DigestPath -PathType Leaf)) { return $false }
+  try {
+    $recorded = ([System.IO.File]::ReadAllText($DigestPath)).Trim().ToLowerInvariant()
+    if ($recorded -notmatch '^[0-9a-f]{64}$') { return $false }
+    if ($ExpectedDigest -and $recorded -ne $ExpectedDigest.ToLowerInvariant()) { return $false }
+    $actual = (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+    return $actual -eq $recorded
+  }
+  catch { return $false }
+}
+
+function Test-ManagedSourceDigest {
+  param(
+    [Parameter(Mandatory)][string]$Path,
+    [Parameter(Mandatory)][string]$DigestPath,
+    [Parameter(Mandatory)][string]$ExpectedDigest
+  )
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf) -or
+    -not (Test-Path -LiteralPath $DigestPath -PathType Leaf)) { return $false }
+  try {
+    $recorded = ([System.IO.File]::ReadAllText($DigestPath)).Trim().ToLowerInvariant()
+    return $recorded -match '^[0-9a-f]{64}$' -and
+      $recorded -eq $ExpectedDigest.ToLowerInvariant()
+  }
+  catch { return $false }
+}
+
 function Get-CurlImpersonateWindowsSpec {
   param([string]$Arch = (Get-WindowsArch))
   if ($Arch -ne 'x64') { return $null }
@@ -1695,17 +1732,26 @@ function Get-CurlImpersonateWindowsSpec {
 $CurlImpersonateWrapperPattern = '^curl_(chrome|firefox|ff|safari|edge)\d+[a-z]*\.(bat|cmd|exe)$'
 
 function Test-CurlImpersonatePresent {
+  param([string]$ExcludeDirectory = '')
   $pathValue = if ($null -eq $env:Path) { '' } else { $env:Path }
   foreach ($pathEntry in ($pathValue -split ';')) {
     $directory = $pathEntry.Trim().Trim('"')
     if ([string]::IsNullOrWhiteSpace($directory) -or -not (Test-Path -LiteralPath $directory -PathType Container)) {
       continue
     }
+    if ($ExcludeDirectory -and [string]::Equals(
+        [System.IO.Path]::GetFullPath($directory).TrimEnd('\'),
+        [System.IO.Path]::GetFullPath($ExcludeDirectory).TrimEnd('\'),
+        [StringComparison]::OrdinalIgnoreCase
+      )) { continue }
     try {
       $hits = @(Get-ChildItem -LiteralPath $directory -File -ErrorAction SilentlyContinue | Where-Object {
           $_.Name -match $CurlImpersonateWrapperPattern
         })
-      if ($hits.Count -gt 0) { return $true }
+      if ($hits.Count -gt 0 -and
+        (Test-Path -LiteralPath (Join-Path $directory 'curl-impersonate.exe') -PathType Leaf)) {
+        return $true
+      }
     }
     catch { }
   }
@@ -1737,7 +1783,8 @@ function Install-PortableYtDlp {
 
   $destDir = Join-Path $DataDir 'deps\yt-dlp'
   $dest = Join-Path $destDir 'yt-dlp.exe'
-  if (Test-Path -LiteralPath $dest -PathType Leaf) {
+  $digestPath = "$dest.sha256"
+  if (Test-ManagedFileDigest -Path $dest -DigestPath $digestPath) {
     Register-HelperPath $destDir
     Write-Info "yt-dlp already present at $dest"
     return $true
@@ -1766,7 +1813,13 @@ function Install-PortableYtDlp {
       throw "Checksum mismatch for $asset (expected '$want', got '$got')."
     }
     New-Item -ItemType Directory -Force -Path $destDir | Out-Null
-    Copy-Item -Force -Path $binPath -Destination $dest
+    $publishId = [Guid]::NewGuid().ToString('N')
+    $destTmp = "$dest.tmp-$PID-$publishId"
+    $digestTmp = "$digestPath.tmp-$PID-$publishId"
+    Copy-Item -Force -Path $binPath -Destination $destTmp
+    Write-Utf8File $digestTmp ($got + "`n")
+    Move-Item -Force -Path $destTmp -Destination $dest
+    Move-Item -Force -Path $digestTmp -Destination $digestPath
     if ($OnWindows) { Unblock-File -Path $dest -ErrorAction SilentlyContinue }
     Register-HelperPath $destDir
     Write-Info "Installed yt-dlp -> $dest"
@@ -1798,8 +1851,6 @@ function Install-PortableYtDlp {
 # Returns $true when an impersonate build is present, was installed, or would
 # be installed on a dry run.
 function Install-PortableCurlImpersonate {
-  if (Test-CurlImpersonatePresent) { return $true }
-
   $spec = Get-CurlImpersonateWindowsSpec
   if ($null -eq $spec) {
     Write-Warn 'curl-impersonate has no Windows ARM64 build. Anime search may still hit Cloudflare.'
@@ -1809,11 +1860,17 @@ function Install-PortableCurlImpersonate {
 
   $destDir = Join-Path $DataDir 'deps\curl-impersonate'
   $existing = Find-CurlImpersonateWrapperDir $destDir
-  if ($existing) {
+  $sourceDigestPath = Join-Path $destDir '.kunai-source.sha256'
+  $existingBackend = if ($existing) { Join-Path $existing 'curl-impersonate.exe' } else { '' }
+  $backendDigestPath = Join-Path $destDir '.kunai-backend.sha256'
+  if ($existing -and (Test-ManagedSourceDigest -Path $existingBackend -DigestPath $sourceDigestPath `
+        -ExpectedDigest $spec.Sha256) -and
+    (Test-ManagedFileDigest -Path $existingBackend -DigestPath $backendDigestPath)) {
     Register-HelperPath $existing
     Write-Info "curl-impersonate already present at $existing"
     return $true
   }
+  if (Test-CurlImpersonatePresent -ExcludeDirectory $destDir) { return $true }
 
   if ($DryRun) {
     Write-Info "[dry-run] would download $($spec.Asset) into $destDir"
@@ -1872,6 +1929,13 @@ function Install-PortableCurlImpersonate {
     if (-not $wrapperDir) {
       throw "Extracted curl-impersonate is missing its desktop curl_<browser><version> wrappers."
     }
+    $backend = Join-Path $wrapperDir 'curl-impersonate.exe'
+    if (-not (Test-Path -LiteralPath $backend -PathType Leaf)) {
+      throw 'Extracted curl-impersonate is missing curl-impersonate.exe.'
+    }
+    Write-Utf8File $sourceDigestPath ($spec.Sha256.ToLowerInvariant() + "`n")
+    $backendDigest = (Get-FileHash -LiteralPath $backend -Algorithm SHA256).Hash.ToLowerInvariant()
+    Write-Utf8File $backendDigestPath ($backendDigest + "`n")
     if ($OnWindows) {
       Get-ChildItem -LiteralPath $wrapperDir -File -ErrorAction SilentlyContinue |
         Where-Object { $_.Extension -in @('.exe', '.bat', '.cmd', '.dll') } |

--- a/install.ps1
+++ b/install.ps1
@@ -22,7 +22,9 @@ param(
   # Parity with install.sh's --skip-deps. Installs Kunai and nothing else, which
   # is what automated environments want: winget can sit for minutes on package
   # downloads or agreement prompts, and a test asserting Kunai's own install has
-  # no business waiting for it.
+  # no business waiting for it. Also skips the portable yt-dlp and
+  # curl-impersonate helpers the Windows binary path otherwise drops into
+  # Kunai's data dir.
   [switch]$SkipDeps = $([bool]($env:KUNAI_SKIP_DEPS -match '^(?i:1|true|yes|y)$')),
   # Useful for managed/test environments that own PATH themselves. Without
   # this seam an otherwise sandboxed installer still writes HKCU\Environment.
@@ -41,6 +43,25 @@ $ReleasesApi = if ($env:KUNAI_RELEASES_API) { $env:KUNAI_RELEASES_API } else { '
 $Package = '@kitsunekode/kunai'
 $BinDir = if ($env:KUNAI_BIN_DIR) { $env:KUNAI_BIN_DIR } else { Join-Path $env:LOCALAPPDATA 'kunai\bin' }
 $DataDir = if ($env:KUNAI_DATA_DIR) { $env:KUNAI_DATA_DIR } else { Join-Path $env:LOCALAPPDATA 'kunai' }
+# Official yt-dlp Windows builds. `/latest/download` is a redirect GitHub
+# serves for the current release; tests can point this at a local fixture.
+$YtdlpReleaseBase = if ($env:KUNAI_YTDLP_RELEASE_BASE) {
+  $env:KUNAI_YTDLP_RELEASE_BASE.TrimEnd('/')
+} else {
+  'https://github.com/yt-dlp/yt-dlp/releases/latest/download'
+}
+# Pinned to the same curl-impersonate release CI installs. Bump alongside
+# `.github/actions/setup-curl-impersonate/action.yml`.
+$CurlImpersonateVersion = if ($env:KUNAI_CURL_IMPERSONATE_VERSION) {
+  $env:KUNAI_CURL_IMPERSONATE_VERSION
+} else {
+  'v2.2.1'
+}
+$CurlImpersonateWin64Digest = if ($env:KUNAI_CURL_IMPERSONATE_SHA256) {
+  $env:KUNAI_CURL_IMPERSONATE_SHA256.ToLowerInvariant()
+} else {
+  'f7faa8c42b63b4a96245429e46956e11ae7d7076d60f65768c0018d3bb18d7e5'
+}
 $ConfigDir = if ($env:KUNAI_CONFIG_DIR) { $env:KUNAI_CONFIG_DIR } else { Join-Path $env:APPDATA 'kunai' }
 $CacheDir = if ($env:KUNAI_CACHE_DIR) { $env:KUNAI_CACHE_DIR } else { Join-Path $env:LOCALAPPDATA 'kunai\cache' }
 $BinPath = Join-Path $BinDir 'kunai.exe'
@@ -1535,6 +1556,10 @@ function Get-PackageInstallCommand {
       # over mpv's IPC socket + Lua bridge. mpv-player.mpv-CI.MSVC is the winget
       # package that provides a real mpv.exe (same upstream build CI pins).
       'mpv' { return 'winget install --id mpv-player.mpv-CI.MSVC -e' }
+      # `winget install yt-dlp` matches both yt-dlp.yt-dlp and a Microsoft Store
+      # listing, so the unattended one-click path dies with "Multiple packages
+      # found". Pin the winget-source id the same way mpv and curl already do.
+      'yt-dlp' { return 'winget install --id yt-dlp.yt-dlp -e' }
       'curl' { return 'winget install --id cURL.cURL -e' }
       default { return "winget install $Package" }
     }
@@ -1594,10 +1619,264 @@ function Request-OptionalInstall {
   }
 }
 
+# Session PATH plus the persistent User PATH. SkipPathUpdate still skips the
+# registry write (managed/test environments own PATH), but the current process
+# has to see a helper we just dropped or the rest of this install cannot find it.
+function Register-HelperPath([string]$Dir) {
+  if ([string]::IsNullOrWhiteSpace($Dir)) { return }
+  $normalized = $Dir.Trim().Trim('"').TrimEnd('\')
+  $entries = @($env:Path -split ';' | ForEach-Object { $_.Trim().Trim('"').TrimEnd('\') })
+  if ($entries -notcontains $normalized) {
+    $env:Path = "$Dir;$env:Path"
+  }
+  Add-UserPath $Dir
+}
+
+function Get-YtdlpReleaseAsset {
+  param([string]$Arch = (Get-WindowsArch))
+  if ($Arch -eq 'arm64') { return 'yt-dlp_arm64.exe' }
+  return 'yt-dlp.exe'
+}
+
+# yt-dlp's SHA2-256SUMS is GNU coreutils style (hash, spaces, optional `*`, name).
+# Kunai's own SHA256SUMS parser requires exactly two spaces and would reject a
+# perfectly valid yt-dlp manifest, so helpers get a slightly looser reader.
+function Get-HelperChecksumEntry([string]$ManifestPath, [string]$AssetName) {
+  $digests = @()
+  foreach ($line in Get-Content -LiteralPath $ManifestPath) {
+    if ($line -cmatch '^([0-9A-Fa-f]{64})\s+\*?([^\s]+)$' -and $Matches[2] -ceq $AssetName) {
+      $digests += $Matches[1].ToLowerInvariant()
+    }
+  }
+  if ($digests.Count -ne 1) {
+    throw "Checksum manifest must contain exactly one valid entry for $AssetName."
+  }
+  return [string]$digests[0]
+}
+
+function Get-CurlImpersonateWindowsSpec {
+  param([string]$Arch = (Get-WindowsArch))
+  if ($Arch -ne 'x64') { return $null }
+  $ver = $CurlImpersonateVersion
+  $asset = "curl-impersonate-$ver.x86_64-win32.tar.gz"
+  $base = if ($env:KUNAI_CURL_IMPERSONATE_RELEASE_BASE) {
+    $env:KUNAI_CURL_IMPERSONATE_RELEASE_BASE.TrimEnd('/')
+  } else {
+    "https://github.com/lexiforest/curl-impersonate/releases/download/$ver"
+  }
+  return [pscustomobject]@{
+    Version = $ver
+    Asset   = $asset
+    Url     = "$base/$asset"
+    Sha256  = $CurlImpersonateWin64Digest
+  }
+}
+
+function Test-CurlImpersonatePresent {
+  $pathValue = if ($null -eq $env:Path) { '' } else { $env:Path }
+  foreach ($pathEntry in ($pathValue -split ';')) {
+    $directory = $pathEntry.Trim().Trim('"')
+    if ([string]::IsNullOrWhiteSpace($directory) -or -not (Test-Path -LiteralPath $directory -PathType Container)) {
+      continue
+    }
+    try {
+      $hits = @(Get-ChildItem -LiteralPath $directory -File -ErrorAction SilentlyContinue | Where-Object {
+          $_.Name -match '^curl_chrome\d+.*\.(bat|cmd|exe)$'
+        })
+      if ($hits.Count -gt 0) { return $true }
+    }
+    catch { }
+  }
+  return $false
+}
+
+function Find-CurlImpersonateWrapperDir([string]$Root) {
+  if (-not (Test-Path -LiteralPath $Root -PathType Container)) { return $null }
+  $wrapper = Get-ChildItem -LiteralPath $Root -Filter 'curl_chrome*.bat' -Recurse -File -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+  if ($null -eq $wrapper) { return $null }
+  return $wrapper.Directory.FullName
+}
+
+# Portable yt-dlp.exe into Kunai's own data dir. This is the one-click path:
+# `irm … | iex` cannot accept winget licence agreements, and `winget install
+# yt-dlp` is ambiguous against the Microsoft Store listing. A verified GitHub
+# binary next to Kunai does not have either problem.
+#
+# Returns $true when yt-dlp is present, was installed, or would be installed
+# on a dry run — so the winget prompt is not also offered.
+function Install-PortableYtDlp {
+  if (Test-Cmd 'yt-dlp') { return $true }
+
+  $destDir = Join-Path $DataDir 'deps\yt-dlp'
+  $dest = Join-Path $destDir 'yt-dlp.exe'
+  if (Test-Path -LiteralPath $dest -PathType Leaf) {
+    Register-HelperPath $destDir
+    Write-Info "yt-dlp already present at $dest"
+    return $true
+  }
+
+  $asset = Get-YtdlpReleaseAsset
+  if ($DryRun) {
+    Write-Info "[dry-run] would download $asset into $destDir"
+    return $true
+  }
+
+  Write-Info "Installing yt-dlp ($asset) for YouTube playback and downloads..."
+  $staging = Join-Path $CacheDir ("ytdlp-staging-" + $PID)
+  $ok = $false
+  try {
+    New-Item -ItemType Directory -Force -Path $staging | Out-Null
+    $sumsPath = Join-Path $staging 'SHA2-256SUMS'
+    $binPath = Join-Path $staging $asset
+    Invoke-BoundedDownload -Url "$YtdlpReleaseBase/SHA2-256SUMS" -DestinationPath $sumsPath `
+      -MaxBytes $DownloadChecksumMaxBytes -Label 'yt-dlp SHA2-256SUMS'
+    $want = Get-HelperChecksumEntry $sumsPath $asset
+    Invoke-BoundedDownload -Url "$YtdlpReleaseBase/$asset" -DestinationPath $binPath `
+      -MaxBytes $DownloadMaxBytes -Label $asset
+    $got = (Get-FileHash -Path $binPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($want -ne $got) {
+      throw "Checksum mismatch for $asset (expected '$want', got '$got')."
+    }
+    New-Item -ItemType Directory -Force -Path $destDir | Out-Null
+    Copy-Item -Force -Path $binPath -Destination $dest
+    if ($OnWindows) { Unblock-File -Path $dest -ErrorAction SilentlyContinue }
+    Register-HelperPath $destDir
+    Write-Info "Installed yt-dlp -> $dest"
+    $ok = $true
+  }
+  catch {
+    Write-Warn "Could not install a portable yt-dlp: $($_.Exception.Message)"
+    Write-Info 'Install it later with:'
+    $command = Get-PackageInstallCommand 'yt-dlp'
+    if ([string]::IsNullOrWhiteSpace($command)) {
+      Write-Host '    https://github.com/yt-dlp/yt-dlp/releases'
+    }
+    else {
+      Write-Host "    $command"
+    }
+  }
+  finally {
+    if (Test-Path -LiteralPath $staging) {
+      Remove-Item -LiteralPath $staging -Recurse -Force -ErrorAction SilentlyContinue
+    }
+  }
+  return $ok
+}
+
+# Portable curl-impersonate into Kunai's own data dir. There is no winget,
+# scoop, or Chocolatey package — doctor currently dumps people on the GitHub
+# releases page, and anime search then comes back empty. Same archive CI uses.
+#
+# Returns $true when an impersonate build is present, was installed, or would
+# be installed on a dry run.
+function Install-PortableCurlImpersonate {
+  if (Test-CurlImpersonatePresent) { return $true }
+
+  $spec = Get-CurlImpersonateWindowsSpec
+  if ($null -eq $spec) {
+    Write-Warn 'curl-impersonate has no Windows ARM64 build. Anime search may still hit Cloudflare.'
+    Write-Info 'https://github.com/lexiforest/curl-impersonate/releases'
+    return $false
+  }
+
+  $destDir = Join-Path $DataDir 'deps\curl-impersonate'
+  $existing = Find-CurlImpersonateWrapperDir $destDir
+  if ($existing) {
+    Register-HelperPath $existing
+    Write-Info "curl-impersonate already present at $existing"
+    return $true
+  }
+
+  if ($DryRun) {
+    Write-Info "[dry-run] would download $($spec.Asset) into $destDir"
+    return $true
+  }
+
+  if (-not (Test-Cmd 'tar')) {
+    Write-Warn 'Windows tar.exe is required to unpack curl-impersonate (ships with Windows 10+).'
+    Write-Info 'https://github.com/lexiforest/curl-impersonate/releases'
+    return $false
+  }
+
+  Write-Info "Installing curl-impersonate $($spec.Version) so anime search can clear Cloudflare..."
+  $staging = Join-Path $CacheDir ("curl-impersonate-staging-" + $PID)
+  $ok = $false
+  try {
+    New-Item -ItemType Directory -Force -Path $staging | Out-Null
+    $archivePath = Join-Path $staging $spec.Asset
+    $extractDir = Join-Path $staging 'extract'
+    New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+    Invoke-BoundedDownload -Url $spec.Url -DestinationPath $archivePath `
+      -MaxBytes $DownloadArchiveMaxBytes -Label $spec.Asset
+    $got = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($spec.Sha256 -ne $got) {
+      throw "Checksum mismatch for $($spec.Asset) (expected '$($spec.Sha256)', got '$got')."
+    }
+    $global:LASTEXITCODE = $null
+    & tar -xzf $archivePath -C $extractDir
+    if ($null -ne $global:LASTEXITCODE -and $global:LASTEXITCODE -ne 0) {
+      throw "tar exited $($global:LASTEXITCODE) unpacking $($spec.Asset)."
+    }
+    $wrapperDir = Find-CurlImpersonateWrapperDir $extractDir
+    if (-not $wrapperDir) {
+      throw "Archive did not contain curl_chrome*.bat wrappers."
+    }
+    if (Test-Path -LiteralPath $destDir) {
+      Remove-Item -LiteralPath $destDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    New-Item -ItemType Directory -Force -Path (Split-Path $destDir) | Out-Null
+    Move-Item -Force -Path $extractDir -Destination $destDir
+    $wrapperDir = Find-CurlImpersonateWrapperDir $destDir
+    if (-not $wrapperDir) {
+      throw "Extracted curl-impersonate is missing curl_chrome*.bat wrappers."
+    }
+    if ($OnWindows) {
+      Get-ChildItem -LiteralPath $wrapperDir -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Extension -in @('.exe', '.bat', '.cmd', '.dll') } |
+        ForEach-Object { Unblock-File -Path $_.FullName -ErrorAction SilentlyContinue }
+    }
+    Register-HelperPath $wrapperDir
+    Write-Info "Installed curl-impersonate -> $wrapperDir"
+    $ok = $true
+  }
+  catch {
+    Write-Warn "Could not install curl-impersonate: $($_.Exception.Message)"
+    Write-Info 'Install it later from:'
+    Write-Host '    https://github.com/lexiforest/curl-impersonate/releases'
+  }
+  finally {
+    if (Test-Path -LiteralPath $staging) {
+      Remove-Item -LiteralPath $staging -Recurse -Force -ErrorAction SilentlyContinue
+    }
+  }
+  return $ok
+}
+
 function Install-OptionalDeps {
   if ($SkipDeps) {
-    Write-Info 'Skipping optional dependencies (mpv, yt-dlp, curl).'
+    Write-Info 'Skipping optional dependencies (mpv, yt-dlp, curl-impersonate).'
     return
+  }
+
+  # Portable helpers live under Kunai's data dir, not the system package
+  # manager. `irm … | iex` cannot confirm winget licences, and curl-impersonate
+  # has no Windows package at all, so a one-click install that only printed
+  # commands left YouTube and anime search broken. SkipDeps still skips this.
+  # Failures here must not fail the Kunai install.
+  $portableYtdlp = $false
+  $portableImpersonate = $false
+  if ($OnWindows) {
+    try { $portableYtdlp = [bool](Install-PortableYtDlp) }
+    catch {
+      Write-Warn "yt-dlp helper did not complete: $($_.Exception.Message)"
+      $portableYtdlp = $false
+    }
+    try { $portableImpersonate = [bool](Install-PortableCurlImpersonate) }
+    catch {
+      Write-Warn "curl-impersonate helper did not complete: $($_.Exception.Message)"
+      $portableImpersonate = $false
+    }
   }
 
   # Checked before anything is offered: the previous flow prompted -- and with
@@ -1607,7 +1886,7 @@ function Install-OptionalDeps {
     Write-Warn 'mpv is not installed - Kunai needs it to play anything.'
     $missing += 'mpv'
   }
-  if (-not (Test-Cmd 'yt-dlp')) {
+  if (-not (Test-Cmd 'yt-dlp') -and -not $portableYtdlp) {
     Write-Warn 'yt-dlp is not installed - YouTube playback and downloads need it.'
     $missing += 'yt-dlp'
   }
@@ -1616,17 +1895,20 @@ function Install-OptionalDeps {
   # question here - the bundled build uses Schannel with no nghttp2, so it
   # reports no HTTP2 feature. Providers that negotiate HTTP/2 fall back or fail
   # against that build, so offer the full winget/scoop curl when the one on PATH
-  # cannot do HTTP/2.
+  # cannot do HTTP/2. An impersonate build already covers that (and Cloudflare),
+  # so skip the upgrade when we just installed one or found one.
   $curlNeedsUpgrade = $false
-  if (Test-Cmd 'curl') {
-    try {
-      $curlFeatures = (& curl.exe --version 2>$null) -join "`n"
-      $curlNeedsUpgrade = -not ($curlFeatures -match 'HTTP2')
+  if (-not $portableImpersonate -and -not (Test-CurlImpersonatePresent)) {
+    if (Test-Cmd 'curl') {
+      try {
+        $curlFeatures = (& curl.exe --version 2>$null) -join "`n"
+        $curlNeedsUpgrade = -not ($curlFeatures -match 'HTTP2')
+      }
+      catch { $curlNeedsUpgrade = $true }
     }
-    catch { $curlNeedsUpgrade = $true }
-  }
-  else {
-    $curlNeedsUpgrade = $true
+    else {
+      $curlNeedsUpgrade = $true
+    }
   }
   if ($curlNeedsUpgrade) {
     Write-Warn 'The curl on PATH has no HTTP/2 support (Windows ships a Schannel build).'
@@ -1634,7 +1916,9 @@ function Install-OptionalDeps {
   }
 
   if ($missing.Count -eq 0) {
-    Write-Info 'mpv, yt-dlp and curl are already installed.'
+    if (Test-Cmd 'mpv') {
+      Write-Info 'Required player (mpv) is already installed.'
+    }
     return
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Windows `irm … | iex` now drops a verified portable `yt-dlp` and (x64) curl-impersonate into `%LOCALAPPDATA%\kunai\deps\` so YouTube and anime search work after a one-click install, instead of leaving doctor warnings and a `winget install yt-dlp` command that cannot actually run.

## Why

After a native Windows install, Kunai showed:

- **yt-dlp missing** — doctor printed `winget install yt-dlp`, which matches both `yt-dlp.yt-dlp` and a Microsoft Store listing and exits with "Multiple packages found".
- **curl-impersonate missing** — Cloudflare fingerprints the TLS handshake, so anime search can come back empty. There is no winget/scoop/choco package; doctor only linked the GitHub releases page.

`irm … | iex` also cannot confirm winget licence agreements, so the installer previously *printed* those commands and never installed anything. mpv is unchanged: it is still a package-manager prompt.

## What the installer does now

On the **binary** Windows path, unless `-SkipDeps` / `KUNAI_SKIP_DEPS=1`:

1. Download official `yt-dlp.exe` (or `yt-dlp_arm64.exe`) from GitHub, verify `SHA2-256SUMS`, install under `%LOCALAPPDATA%\kunai\deps\yt-dlp`, put that folder on the User PATH.
2. Download the same curl-impersonate x64 archive CI pins (`v2.2.1`), verify the digest, extract, PATH the directory that contains `curl_chrome*.bat`. ARM64 is warned: upstream has no Windows ARM64 build.
3. Failures here **do not fail** the Kunai install; the exact fallback command is printed (`winget install --id yt-dlp.yt-dlp -e`, or the curl-impersonate releases URL).

`mpv` remains opt-in via winget/scoop/choco. Doctor/setup copy-paste is now `winget install --id yt-dlp.yt-dlp -e`.

## Testing

Fixture-backed install runs `Install-PortableYtDlp` and `Install-PortableCurlImpersonate` against a localhost GitHub stand-in:

- verified `yt-dlp.exe` plus a `curl_chrome*.bat` tarball land under `KUNAI_DATA_DIR/deps` (not under a nested `extract` folder)
- checksum mismatch leaves no dest and prints `winget install --id yt-dlp.yt-dlp -e`
- already-present dest files skip the download
- a leftover dest directory is replaced in place
- a locked dest directory fails closed instead of nesting extract (POSIX; Windows ACLs are not `chmod`)

Wrapper-dir discovery compares `realpath` of both sides (Windows `RUNNER~1` vs `runneradmin`, macOS `/var` vs `/private/var`).

## CodeRabbit

Acted on all three notes:

- changeset uses `-SkipDeps`, not Bash `--skip-deps`
- install doc no longer claims two portable tools on every Windows host
- `Remove-Item` failure no longer lets `Move-Item` nest `extract` under dest

Skipped the docstring-coverage warning: that metric is JSDoc on touched functions, not `install.ps1` comment blocks.

## Checklist

- [x] Changeset added (`bun run changeset`) — required for user-facing CLI changes; N/A for docs-only or non-release infra
- [x] `bun run guard` passes when `apps/cli/package.json`, changelogs, or `.changeset/**` changed
- [x] `bun run fmt && bun run lint && bun run test && bun run typecheck` passes locally
- [ ] `bun run build` passes for feature, playback, provider, release, or packaging-sensitive changes — installer/docs/script change; no binary rebuild
- [x] Live provider or Discord smokes were skipped intentionally, or run manually with results noted

## Seams

- **Declaration → reader:** `KUNAI_YTDLP_RELEASE_BASE`, `KUNAI_CURL_IMPERSONATE_VERSION` / `_SHA256` / `_RELEASE_BASE` are read by the portable installers; `-SkipDeps` still skips them.
- **Reverse states:** already-present PATH copies are left alone; `--skip-deps` / `-SkipDeps` is the way out; a locked dest fails closed; `kunai uninstall --purge` removes `%LOCALAPPDATA%\kunai` including `deps\`.
- **Entry points:** installer (binary method) plus doctor/setup/README fallbacks. npm/bun/source installs are unchanged (no silent winget).
- **Both lanes:** yt-dlp is the YouTube/download lane; curl-impersonate is the anime Cloudflare lane.
- **Every provider:** runtime tools, not adapter-specific. AllManga/AniDB/Miruro keep discovering `curl_chrome*.bat` from PATH.
- **Every platform:** Windows-only portable install. Wrapper-dir identity and dest-replace tests avoid pinning one OS's path or ACL spelling. Linux/macOS installs still print the package-manager command and wait for `[y/N]`.
- **Docs:** `docs/users/install-and-update.mdx`, `.docs/quickstart.md`, `.docs/debugging-map.md`, `.docs/testing-strategy.md`, root and CLI READMEs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06468-cf59-7ae6-ab1c-3e5f53837158?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06468-cf59-7ae6-ab1c-3e5f53837158&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows installation now provisions verified portable yt-dlp and, on x64 systems, curl-impersonate.
  * Helpers are stored in Kunai’s data directory, added to the user PATH, and repaired when missing or modified.
  * `--skip-deps` can skip portable helpers and package-manager prompts.
  * Windows yt-dlp installation guidance now uses the exact WinGet package ID.

* **Bug Fixes**
  * HLS playback on Windows no longer fails when the installed curl lacks HTTP/2 support.
  * The curl upgrade prompt remains available when curl-impersonate is installed.

* **Documentation**
  * Updated Windows installation, troubleshooting, and dependency guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->