### PR TITLE
fix(docs): give Kanna's dismissal a way back, and stop her taking clicks

### DIFF
--- a/apps/docs/app/styles/fox.css
+++ b/apps/docs/app/styles/fox.css
@@ -257,7 +257,8 @@ a:focus-visible .kunai-nav-title .kunai-fox {
    Kanna loose on the page. Fixed and transformed every frame from a ref, so
    moving her never queues a React render. Pointer events pass straight through
    the host — only she, and her dismiss button while it is actually visible, are
-   clickable, because a companion that eats clicks is a companion people close. */
+   clickable, and both stand down while she is in front of something the page
+   wanted clicked, because a companion that eats clicks is one people close. */
 
 .kunai-roamer {
   position: fixed;
@@ -380,6 +381,19 @@ a:focus-visible .kunai-nav-title .kunai-fox {
 .kunai-roamer:hover .kunai-roamer__close {
   opacity: 1;
   pointer-events: auto;
+}
+
+/* She stands down while she is between the reader and something clickable —
+   see `updateYield` in the component. Both controls go at once: a dismiss
+   button still reachable through a fox that is pretending not to be there
+   would be the invisible target again, wearing a different hat.
+
+   Last on purpose. It ties on specificity with the `:hover` rule above, so
+   order is what decides, and the rule that gives a click back to the page has
+   to be the one that wins. */
+.kunai-roamer[data-yield="true"] .kunai-roamer__fox,
+.kunai-roamer[data-yield="true"] .kunai-roamer__close {
+  pointer-events: none;
 }
 
 /* ── Undo ───────────────────────────────────────────────────────────────────

--- a/apps/docs/app/styles/fox.css
+++ b/apps/docs/app/styles/fox.css
@@ -256,8 +256,8 @@ a:focus-visible .kunai-nav-title .kunai-fox {
 /* ── Roamer ─────────────────────────────────────────────────────────────────
    Kanna loose on the page. Fixed and transformed every frame from a ref, so
    moving her never queues a React render. Pointer events pass straight through
-   the host — only she and her dismiss button are clickable, because a companion
-   that eats clicks is a companion people close. */
+   the host — only she, and her dismiss button while it is actually visible, are
+   clickable, because a companion that eats clicks is a companion people close. */
 
 .kunai-roamer {
   position: fixed;
@@ -272,7 +272,6 @@ a:focus-visible .kunai-nav-title .kunai-fox {
 
 .kunai-roamer__fox,
 .kunai-roamer__close {
-  pointer-events: auto;
   border: none;
   background: none;
   padding: 0;
@@ -282,6 +281,7 @@ a:focus-visible .kunai-nav-title .kunai-fox {
 }
 
 .kunai-roamer__fox {
+  pointer-events: auto;
   display: block;
   transform-origin: 50% 90%;
   transition: transform 260ms cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -369,11 +369,81 @@ a:focus-visible .kunai-nav-title .kunai-fox {
   font-size: 0.72rem;
   line-height: 1;
   opacity: 0;
+  /* Invisible has to mean unclickable. `opacity: 0` on its own left a live
+     18px target parked over her ear — on the very silhouette you are invited
+     to click to talk to her — so a slightly high click retired her for good,
+     having shown nothing that could be aimed at or avoided. */
+  pointer-events: none;
   transition: opacity 160ms ease-out;
 }
 
 .kunai-roamer:hover .kunai-roamer__close {
   opacity: 1;
+  pointer-events: auto;
+}
+
+/* ── Undo ───────────────────────────────────────────────────────────────────
+   The way back, offered for twelve seconds after she is dismissed. Bottom
+   *left* on purpose: the right-hand corners are where this site's own chrome
+   and Vercel's preview toolbar sit, and an undo that is covered is not one. */
+
+.kunai-roamer-undo {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  /* Her band — above the page, below the sticky nav (40) and search (50). */
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 0.55rem 0.5rem 0.85rem;
+  border: 1px solid var(--kunai-line);
+  border-radius: 999px;
+  background: var(--kunai-surface);
+  box-shadow: 0 6px 20px rgb(0 0 0 / 0.35);
+  font-size: 0.8rem;
+  line-height: 1;
+  /* Its own keyframes rather than the bubble's: `kunai-roamer-say` carries the
+     `translateX(-50%)` that centres a bubble over her head, and `both` would
+     leave that offset applied to a corner-anchored pill. */
+  animation: kunai-roamer-undo-in 220ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+@keyframes kunai-roamer-undo-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.kunai-roamer-undo__text {
+  color: var(--color-fd-muted-foreground);
+}
+
+.kunai-roamer-undo__action {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  background: color-mix(in oklab, var(--kunai-accent) 14%, transparent);
+  color: var(--kunai-accent);
+  font: inherit;
+  cursor: pointer;
+  transition:
+    background-color 160ms ease-out,
+    border-color 160ms ease-out;
+}
+
+.kunai-roamer-undo__action:hover {
+  background: color-mix(in oklab, var(--kunai-accent) 24%, transparent);
+}
+
+.kunai-roamer-undo__action:focus-visible {
+  outline: none;
+  border-color: var(--kunai-accent);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -381,5 +451,12 @@ a:focus-visible .kunai-nav-title .kunai-fox {
      is only a floor in case the query flips after mount. */
   .kunai-roamer {
     display: none;
+  }
+
+  /* The undo is a control, not decoration, so it stays — only its entrance
+     goes. Hiding it here would be the same one-way door in a new place: the
+     query can flip on between the dismissing click and this rule. */
+  .kunai-roamer-undo {
+    animation: none;
   }
 }

--- a/apps/docs/components/brand/kanna-roamer-toggle.tsx
+++ b/apps/docs/components/brand/kanna-roamer-toggle.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  browserRoamerStore,
+  readRoamerDismissed,
+  setRoamerDismissed,
+  subscribeRoamerPreference,
+} from "@/lib/roamer-preference";
+import { useEffect, useState } from "react";
+
+/**
+ * The durable way back, on the page about her.
+ *
+ * The undo that follows a dismissal expires, and `?kanna=on` only helps someone
+ * who already knows it exists. This is the answer to "where do I see the state
+ * and change it" — and the page named after her is the one place a reader would
+ * think to look. It writes the same flag through the same module the roamer
+ * reads, and the roamer is subscribed, so flipping it here moves her on the
+ * page behind this one without a reload.
+ *
+ * The two things that decide whether a fox is on screen are tracked separately
+ * on purpose. Folding them into one status made the button lie: on a touch
+ * device the label is derived from the environment, so clicking it changed the
+ * stored preference and nothing visible moved.
+ */
+
+/** Whether this browser would roam her at all, ignoring what the reader asked for. */
+type Capability = "unknown" | "yes" | "no";
+
+function describe(capability: Capability, dismissed: boolean | null): string {
+  if (capability === "unknown" || dismissed === null) return "Checking…";
+  if (capability === "no") {
+    return dismissed
+      ? "Kanna is set to hidden. This browser would not roam her anyway — it reports a coarse pointer or reduced motion."
+      : "Kanna is welcome here, but this browser reports a coarse pointer or reduced motion, so she does not roam.";
+  }
+  return dismissed ? "Kanna is hidden on this site." : "Kanna is roaming this site.";
+}
+
+export function KannaRoamerToggle() {
+  // Both start unresolved rather than at a guess: every input is client-only,
+  // and rendering "she is roaming" on the server would flash the wrong answer
+  // at every reader whose browser says otherwise.
+  const [capability, setCapability] = useState<Capability>("unknown");
+  const [dismissed, setDismissed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const finePointer = window.matchMedia("(pointer: fine)");
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const store = browserRoamerStore();
+
+    const evaluate = () => {
+      setCapability(finePointer.matches && !reducedMotion.matches ? "yes" : "no");
+      setDismissed(readRoamerDismissed(store));
+    };
+
+    evaluate();
+    finePointer.addEventListener("change", evaluate);
+    reducedMotion.addEventListener("change", evaluate);
+    const unsubscribe = subscribeRoamerPreference(evaluate);
+    return () => {
+      finePointer.removeEventListener("change", evaluate);
+      reducedMotion.removeEventListener("change", evaluate);
+      unsubscribe();
+    };
+  }, []);
+
+  // The control stays live even where she cannot roam. The stored preference is
+  // real and worth being able to set from whatever machine you are reading on,
+  // and withholding the button would be the same one-way door in a politer
+  // costume.
+  return (
+    <div className="border-fd-border bg-fd-card my-6 flex flex-wrap items-center gap-3 rounded-xl border p-4">
+      <p className="text-fd-muted-foreground m-0 flex-1 text-sm">
+        {describe(capability, dismissed)}
+      </p>
+      <Button
+        type="button"
+        variant={dismissed ? "primary" : "outline"}
+        size="sm"
+        disabled={dismissed === null}
+        onClick={() => setRoamerDismissed(!dismissed)}
+      >
+        {dismissed ? "Bring her back" : "Hide her"}
+      </Button>
+    </div>
+  );
+}

--- a/apps/docs/components/brand/kunai-fox-roamer.tsx
+++ b/apps/docs/components/brand/kunai-fox-roamer.tsx
@@ -3,6 +3,7 @@
 import { KunaiFox, type KunaiFoxPose } from "@/components/brand/kunai-fox";
 import {
   createRoamerState,
+  pointerIsOver,
   poseForPhase,
   stepRoamer,
   type RoamerPhase,
@@ -32,10 +33,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
  *
  * ## Restraint
  *
- * She is dismissible and stays dismissed, she never covers anything (pointer
- * events pass straight through except on her), she only exists on a fine
- * pointer, and `prefers-reduced-motion` removes her entirely rather than
- * freezing her mid-page.
+ * She is dismissible and stays dismissed, she never takes a click the page
+ * wanted (events pass through the host always, and through her the moment she
+ * is standing in front of something clickable — see `updateYield`), she only
+ * exists on a fine pointer, and `prefers-reduced-motion` removes her entirely
+ * rather than freezing her mid-page.
  *
  * ## The way back
  *
@@ -89,6 +91,28 @@ const BUBBLE_MS = 4200;
  * toggle — are what is left, and both are documented.
  */
 const UNDO_MS = 12000;
+
+/**
+ * What counts as something of the page's own that she must not stand in front of.
+ *
+ * Deliberately generous — a `[tabindex]` or a `[role]` is enough. Being wrong in
+ * this direction costs one un-poked fox; being wrong the other way costs a
+ * reader a link they clicked and did not get.
+ */
+const INTERACTIVE_SELECTOR = [
+  "a[href]",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "summary",
+  "label",
+  "[role='button']",
+  "[role='link']",
+  "[role='tab']",
+  "[role='menuitem']",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
 
 /**
  * What she says, by state.
@@ -153,6 +177,19 @@ function pickLine(pool: readonly string[], last: string | null): string {
   const fresh = pool.filter((candidate) => candidate !== last);
   const choices = fresh.length > 0 ? fresh : pool;
   return choices[Math.floor(Math.random() * choices.length)] as string;
+}
+
+/**
+ * Is there something of the page's own under this point, behind her?
+ *
+ * `elementsFromPoint` returns the whole stack at a point, not just the top of
+ * it, so this can ask what a click would have reached had she not been standing
+ * there. Her own subtree is skipped: she is not what the reader was aiming at.
+ */
+function occludesInteractive(host: HTMLElement, x: number, y: number): boolean {
+  return document
+    .elementsFromPoint(x, y)
+    .some((element) => !host.contains(element) && element.closest(INTERACTIVE_SELECTOR) !== null);
 }
 
 export function KunaiFoxRoamer({ size = 58 }: { readonly size?: number }) {
@@ -238,6 +275,31 @@ export function KunaiFoxRoamer({ size = 58 }: { readonly size?: number }) {
         const at = { x: event.clientX - 90, y: event.clientY + 50 };
         machine.current = { ...createRoamerState(at), phase: "sitting" };
       }
+      updateYield(event.clientX, event.clientY);
+    }
+
+    /**
+     * Stand down whenever she is between the reader and the page.
+     *
+     * `SETTLE_PX` is 70 and she is 58 across, so at rest her edge is ~41px from
+     * the cursor: reaching for anything near where you stopped puts the pointer
+     * on her, and her click handler — the one that makes her talk — was eating
+     * the click. Her own doc comment claimed she never covers anything, which
+     * was true of the host and not of her body.
+     *
+     * The rule is what is *behind* her, not how the pointer got there. Dwell
+     * timing was the obvious alternative and is wrong: aiming at a link is
+     * itself a pause, so any dwell long enough to mean "I want the fox" is also
+     * long enough to be someone lining up a click on what she is covering.
+     *
+     * Both reads are guarded by the cheap geometric test, so the hit test only
+     * runs on the rare frames where the pointer is genuinely on her.
+     */
+    function updateYield(x: number, y: number) {
+      const host = hostRef.current;
+      if (!host) return;
+      const over = pointerIsOver(machine.current.pos, { x, y }, size);
+      host.dataset.yield = over && occludesInteractive(host, x, y) ? "true" : "false";
     }
 
     function tick(timestamp: number) {
@@ -285,6 +347,12 @@ export function KunaiFoxRoamer({ size = 58 }: { readonly size?: number }) {
         next.pos.y -
         size / 2
       ).toFixed(1)}px, 0)`;
+
+      // Also here, not only on pointer move: what is behind her changes without
+      // the pointer moving at all — the reader scrolls a link under a resting
+      // fox, or she walks over one. The geometric guard inside means this costs
+      // four comparisons on the frames where she is nowhere near the cursor.
+      if (pointer.current) updateYield(pointer.current.x, pointer.current.y);
     }
 
     window.addEventListener("pointermove", onMove, { passive: true });

--- a/apps/docs/components/brand/kunai-fox-roamer.tsx
+++ b/apps/docs/components/brand/kunai-fox-roamer.tsx
@@ -7,6 +7,14 @@ import {
   stepRoamer,
   type RoamerPhase,
 } from "@/lib/roamer-machine";
+import {
+  browserRoamerStore,
+  readRoamerDismissed,
+  resolveRoamerUrlOverride,
+  setRoamerDismissed,
+  subscribeRoamerPreference,
+  writeRoamerDismissed,
+} from "@/lib/roamer-preference";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
@@ -28,6 +36,16 @@ import { useCallback, useEffect, useRef, useState } from "react";
  * events pass straight through except on her), she only exists on a fine
  * pointer, and `prefers-reduced-motion` removes her entirely rather than
  * freezing her mid-page.
+ *
+ * ## The way back
+ *
+ * Dismissing her is reversible three ways, because a one-click permanent
+ * decision taken by a button that sits over her ear is a decision people make
+ * by accident. An undo offers itself for {@link UNDO_MS} straight after the
+ * click, `?kanna=on` restores her from a link, and the toggle on her docs page
+ * shows the current state and flips it. All three go through
+ * `lib/roamer-preference.ts`; none of them are this component's own idea of
+ * where the flag lives.
  */
 
 /**
@@ -61,7 +79,16 @@ const CHATTER_WINDOW_MS: Partial<Record<RoamerPhase, readonly [number, number]>>
 /** How long to wait before re-checking a phase that has no line of its own. */
 const CHATTER_RECHECK_MS = 1200;
 const BUBBLE_MS = 4200;
-const STORAGE_KEY = "kunai.roamer.dismissed";
+/**
+ * How long the undo stays offered after she is dismissed.
+ *
+ * Long enough to notice a fox you did not mean to close and read one line about
+ * it, short enough that a deliberate dismissal is not nagged at. The reference
+ * is Gmail's undo-send window, which sits in the same range for the same
+ * reason. After it lapses the durable routes — `?kanna=on` and the docs-page
+ * toggle — are what is left, and both are documented.
+ */
+const UNDO_MS = 12000;
 
 /**
  * What she says, by state.
@@ -145,18 +172,46 @@ export function KunaiFoxRoamer({ size = 58 }: { readonly size?: number }) {
   const [facing, setFacing] = useState<"left" | "right">("right");
   const [line, setLine] = useState<string | null>(null);
   const [enabled, setEnabled] = useState(false);
+  const [undoOffered, setUndoOffered] = useState(false);
 
-  // Resolved after mount so server and client agree on the first render, and so
-  // a dismissal from a previous visit is honoured before she is ever painted.
+  /**
+   * The single place that decides whether she may exist.
+   *
+   * Resolved after mount so server and client agree on the first render, and so
+   * a dismissal from a previous visit is honoured before she is ever painted.
+   *
+   * It stays subscribed rather than answering once, because every input can
+   * change while the page is open: a mouse gets plugged into a tablet, the OS
+   * reduced-motion switch is flipped, another tab restores her, or the toggle
+   * on her docs page does. The previous one-shot read meant reduced-motion
+   * turned on mid-visit left the stylesheet hiding her while this component
+   * went on running a `requestAnimationFrame` loop against an invisible fox
+   * forever.
+   */
   useEffect(() => {
-    if (!window.matchMedia("(pointer: fine)").matches) return;
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
-    try {
-      if (window.localStorage.getItem(STORAGE_KEY) === "1") return;
-    } catch {
-      // A blocked or unavailable store is not a reason to refuse to render.
-    }
-    setEnabled(true);
+    const finePointer = window.matchMedia("(pointer: fine)");
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const store = browserRoamerStore();
+
+    // A `?kanna=` link is an instruction, not a query: persist it first so it
+    // survives the navigation that follows, then let the normal gate read it
+    // back like any other stored preference.
+    const override = resolveRoamerUrlOverride(window.location.search);
+    if (override) writeRoamerDismissed(store, override === "off");
+
+    const evaluate = () => {
+      setEnabled(finePointer.matches && !reducedMotion.matches && !readRoamerDismissed(store));
+    };
+
+    evaluate();
+    finePointer.addEventListener("change", evaluate);
+    reducedMotion.addEventListener("change", evaluate);
+    const unsubscribe = subscribeRoamerPreference(evaluate);
+    return () => {
+      finePointer.removeEventListener("change", evaluate);
+      reducedMotion.removeEventListener("change", evaluate);
+      unsubscribe();
+    };
   }, []);
 
   const say = useCallback((pool: readonly string[]) => {
@@ -274,16 +329,48 @@ export function KunaiFoxRoamer({ size = 58 }: { readonly size?: number }) {
     return () => window.clearTimeout(timer);
   }, [enabled, say]);
 
+  // Neither of these touches `enabled` directly. They move the preference and
+  // let the gate effect above re-derive from it, so there is exactly one
+  // expression in this file that decides whether she is on screen — including
+  // when the change arrives from another tab or her docs page.
   const dismiss = useCallback(() => {
-    setEnabled(false);
-    try {
-      window.localStorage.setItem(STORAGE_KEY, "1");
-    } catch {
-      // Dismissal still holds for this page view even if it cannot be stored.
-    }
+    setRoamerDismissed(true);
+    setUndoOffered(true);
   }, []);
 
-  if (!enabled) return null;
+  const restore = useCallback(() => {
+    setUndoOffered(false);
+    // Come back beside the pointer rather than resuming from wherever she was
+    // standing when she was dismissed, which by now is nowhere near it.
+    seeded.current = false;
+    lastFrame.current = 0;
+    machine.current = createRoamerState({ x: -400, y: -400 });
+    setLine(null);
+    setRoamerDismissed(false);
+  }, []);
+
+  // The undo withdraws itself. It is an offer, not a state you have to clear.
+  useEffect(() => {
+    if (!undoOffered) return undefined;
+    const timer = window.setTimeout(() => setUndoOffered(false), UNDO_MS);
+    return () => window.clearTimeout(timer);
+  }, [undoOffered]);
+
+  if (!enabled) {
+    // Not `null` any more: the moment after a dismissal is the one moment the
+    // way back is worth showing unprompted.
+    // `<output>` rather than a div with `role="status"`: same announcement,
+    // and unlike her it is not decorative — it is the only visible trace of a
+    // state change, so a screen reader should get it.
+    return undoOffered ? (
+      <output className="kunai-roamer-undo">
+        <span className="kunai-roamer-undo__text">Kanna is hidden.</span>
+        <button type="button" className="kunai-roamer-undo__action" onClick={restore}>
+          Bring her back
+        </button>
+      </output>
+    ) : null;
+  }
 
   const pose: KunaiFoxPose = poseForPhase(phase);
 

--- a/apps/docs/components/brand/kunai-fox-roamer.tsx
+++ b/apps/docs/components/brand/kunai-fox-roamer.tsx
@@ -205,6 +205,8 @@ export function KunaiFoxRoamer({ size = 58 }: { readonly size?: number }) {
   const stepMs = useRef(0);
   const lastFrame = useRef(0);
   const seeded = useRef(false);
+  /** Last value written to `data-yield`, so an unchanged frame writes nothing. */
+  const yielding = useRef(false);
 
   const [phase, setPhase] = useState<RoamerPhase>("sitting");
   const [facing, setFacing] = useState<"left" | "right">("right");
@@ -276,6 +278,12 @@ export function KunaiFoxRoamer({ size = 58 }: { readonly size?: number }) {
   useEffect(() => {
     if (!enabled) return undefined;
 
+    // She is re-mounted whenever this effect runs, so the fresh host carries no
+    // `data-yield` yet. Without this the memo below could hold a stale `true`
+    // and skip the write that CSS is waiting for, leaving her permanently
+    // unclickable after a restore.
+    yielding.current = false;
+
     function onMove(event: PointerEvent) {
       pointer.current = { x: event.clientX, y: event.clientY };
       if (!seeded.current) {
@@ -309,7 +317,14 @@ export function KunaiFoxRoamer({ size = 58 }: { readonly size?: number }) {
       const host = hostRef.current;
       if (!host) return;
       const over = pointerIsOver(machine.current.pos, { x, y }, size);
-      host.dataset.yield = over && occludesInteractive(host, x, y) ? "true" : "false";
+      const next = over && occludesInteractive(host, x, y);
+      // Only on a real change. This runs every frame, and an attribute write
+      // goes through the setter and dirties style whether or not the value
+      // differs — the same reason the gait clock above only touches
+      // `dataset.step` when the flag actually flips.
+      if (next === yielding.current) return;
+      yielding.current = next;
+      host.dataset.yield = next ? "true" : "false";
     }
 
     function tick(timestamp: number) {

--- a/apps/docs/components/brand/kunai-fox-roamer.tsx
+++ b/apps/docs/components/brand/kunai-fox-roamer.tsx
@@ -14,6 +14,7 @@ import {
   resolveRoamerUrlOverride,
   setRoamerDismissed,
   subscribeRoamerPreference,
+  urlWithoutRoamerParam,
   writeRoamerDismissed,
 } from "@/lib/roamer-preference";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -232,9 +233,18 @@ export function KunaiFoxRoamer({ size = 58 }: { readonly size?: number }) {
 
     // A `?kanna=` link is an instruction, not a query: persist it first so it
     // survives the navigation that follows, then let the normal gate read it
-    // back like any other stored preference.
+    // back like any other stored preference. Once carried out it is spent, so
+    // it comes back out of the address bar rather than riding along into a
+    // copied link or into the URL web analytics records.
     const override = resolveRoamerUrlOverride(window.location.search);
-    if (override) writeRoamerDismissed(store, override === "off");
+    if (override) {
+      writeRoamerDismissed(store, override === "off");
+      const cleaned = urlWithoutRoamerParam(window.location.href);
+      // `replaceState` rather than a router call: this must not add a history
+      // entry that the back button walks into, and Next treats a direct
+      // `replaceState` as a shallow update it does not need to re-render for.
+      if (cleaned !== null) window.history.replaceState(null, "", cleaned);
+    }
 
     const evaluate = () => {
       setEnabled(finePointer.matches && !reducedMotion.matches && !readRoamerDismissed(store));

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "9399f4e19c122a598078ee554d5ef0659a4c62985eef9ea2a9a7b0aa8ac691de",
-  "docsContentFingerprint": "239678967e1aa94a94d59ab6e06a1f1191a6f4cf107c7cfc3193707518a6fc3e",
+  "docsContentFingerprint": "ef42c3f62e9864858cd617ad984a6c592b91d8ff87e39bbd50d30e2570d45bc3",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "9399f4e19c122a598078ee554d5ef0659a4c62985eef9ea2a9a7b0aa8ac691de",
-  "docsContentFingerprint": "6cf519d315982a3c8c0617891325b79a3179587b3761e6097f012d298ee5dfc7",
+  "docsContentFingerprint": "239678967e1aa94a94d59ab6e06a1f1191a6f4cf107c7cfc3193707518a6fc3e",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/apps/docs/lib/roamer-machine.ts
+++ b/apps/docs/lib/roamer-machine.ts
@@ -64,6 +64,24 @@ export const IDLE_TO_SLEEP_MS = 20000;
 /** Only commit to a direction on real horizontal travel, so she does not flip about. */
 const FACING_DEADBAND_PX = 10;
 
+/**
+ * Is the pointer inside the square she occupies on screen?
+ *
+ * Square rather than round because that is the box the browser hit-tests: her
+ * button is `size` across, and treating her as a circle would call a corner
+ * "not over her" while the browser was already handing her the click.
+ *
+ * Derived from her state rather than read back off the DOM on purpose. The
+ * caller writes her transform every frame, so a `getBoundingClientRect` here
+ * would force a synchronous layout on a hot path to recover a number the caller
+ * already knows.
+ */
+export function pointerIsOver(pos: Point, pointer: Point | null, size: number): boolean {
+  if (!pointer) return false;
+  const half = size / 2;
+  return Math.abs(pointer.x - pos.x) <= half && Math.abs(pointer.y - pos.y) <= half;
+}
+
 export function createRoamerState(at: Point): RoamerState {
   return {
     pos: at,

--- a/apps/docs/lib/roamer-preference.ts
+++ b/apps/docs/lib/roamer-preference.ts
@@ -127,6 +127,25 @@ export function resolveRoamerUrlOverride(search: string): RoamerUrlOverride | nu
   return null;
 }
 
+/**
+ * The same URL with our parameter taken out, or `null` if it was not there.
+ *
+ * Returned rather than applied so this stays testable without a browser, and so
+ * the one caller that touches history does it in one obvious place.
+ *
+ * Worth doing because the parameter is an instruction that has already been
+ * carried out. Left in the address bar it rides along into a copied link — and
+ * a link that silently retires someone else's fox is a worse version of the bug
+ * this whole change is about — and into the page URL that web analytics
+ * records, which has no business knowing.
+ */
+export function urlWithoutRoamerParam(href: string): string | null {
+  const url = new URL(href);
+  if (!url.searchParams.has(ROAMER_URL_PARAM)) return null;
+  url.searchParams.delete(ROAMER_URL_PARAM);
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
 /** Write the preference and tell every listener in this tab about it. */
 export function setRoamerDismissed(dismissed: boolean): void {
   writeRoamerDismissed(browserRoamerStore(), dismissed);

--- a/apps/docs/lib/roamer-preference.ts
+++ b/apps/docs/lib/roamer-preference.ts
@@ -1,0 +1,161 @@
+/**
+ * Whether Kanna is welcome on this site.
+ *
+ * One module owns the flag because three surfaces now read or write it — her
+ * dismiss button, the undo that follows it, and the toggle on her docs page —
+ * and a preference three places each poke at their own way is a preference that
+ * drifts.
+ *
+ * Everything here is total. A blocked, full, or absent store degrades to "she is
+ * welcome" rather than throwing: a browser refusing to persist a mascot
+ * preference is not a reason to refuse to draw the mascot. That asymmetry is
+ * deliberate — the failure mode of a lost preference is a fox you have to
+ * dismiss again, and the failure mode of a thrown exception is a blank page.
+ *
+ * The storage handle is a parameter rather than a module-level `localStorage`
+ * read so the rules here are testable without a DOM, and so a caller on the
+ * server can pass `null` and get honest defaults instead of a crash.
+ */
+
+/** Where the dismissal lives. Changing this stands people back up who had sat her down. */
+export const ROAMER_DISMISSED_KEY = "kunai.roamer.dismissed";
+
+/**
+ * Fired on `window` when the flag changes in this tab.
+ *
+ * The browser's own `storage` event only fires in *other* tabs, so without this
+ * the docs-page toggle would flip the flag and the roamer — mounted once in the
+ * root layout and never remounted — would not notice until a reload.
+ */
+export const ROAMER_PREFERENCE_EVENT = "kunai:roamer-preference";
+
+/** `?kanna=on` brings her back, `?kanna=off` sends her away. Both persist. */
+export const ROAMER_URL_PARAM = "kanna";
+
+/**
+ * The slice of `Storage` this needs.
+ *
+ * Narrow on purpose: it is the whole contract a test double has to honour, and
+ * it makes it obvious at a glance that nothing here enumerates or clears keys
+ * that are not ours.
+ */
+export type RoamerStore = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+/** What a `?kanna=` link asked for, if it asked for anything legible. */
+export type RoamerUrlOverride = "on" | "off";
+
+/**
+ * Stands in for `localStorage` when the real one cannot be reached.
+ *
+ * Firefox with cookies blocked for the origin throws on the property access
+ * itself, not on the read. Without a fallback every caller would need its own
+ * "the write may not have landed" branch, and the dismiss button would have to
+ * keep a second copy of the preference just to make a click hold. The trade is
+ * honest and stated once, here: the preference works normally for the page view
+ * and is forgotten on reload, which is the most a store that refuses to store
+ * anything can offer.
+ */
+function createMemoryStore(): RoamerStore {
+  const cells = new Map<string, string>();
+  return {
+    getItem: (key) => cells.get(key) ?? null,
+    setItem: (key, value) => void cells.set(key, value),
+    removeItem: (key) => void cells.delete(key),
+  };
+}
+
+/** Module-level so every caller in a page shares one fallback, not one each. */
+const memoryStore = createMemoryStore();
+
+/**
+ * Where the preference lives for this caller.
+ *
+ * `null` means there is no browser at all — a server render, where the honest
+ * answer to "has she been dismissed" is "there is nobody here to have dismissed
+ * her". A browser that merely refuses to persist still gets a working store.
+ */
+export function browserRoamerStore(): RoamerStore | null {
+  if (!globalThis.window) return null;
+  try {
+    // Touch it, rather than trusting that it exists: the throw is on access.
+    return globalThis.window.localStorage ?? memoryStore;
+  } catch {
+    return memoryStore;
+  }
+}
+
+/** True when she has been sent away. Unreadable storage means she has not been. */
+export function readRoamerDismissed(store: RoamerStore | null): boolean {
+  if (!store) return false;
+  try {
+    return store.getItem(ROAMER_DISMISSED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Record the preference.
+ *
+ * Restoring *removes* the key rather than writing `"0"`. The read only ever
+ * treats `"1"` as dismissed, so a `"0"` would work — but it would leave a
+ * permanent row in every visitor's storage recording that they once clicked an
+ * `×`, which is a thing to keep only if something reads it. Nothing does.
+ */
+export function writeRoamerDismissed(store: RoamerStore | null, dismissed: boolean): void {
+  if (!store) return;
+  try {
+    if (dismissed) store.setItem(ROAMER_DISMISSED_KEY, "1");
+    else store.removeItem(ROAMER_DISMISSED_KEY);
+  } catch {
+    // The preference holds for this page view either way; the caller has
+    // already updated its own state and does not depend on the write landing.
+  }
+}
+
+/**
+ * What `?kanna=` in a query string asks for.
+ *
+ * Strict about the two documented values: anything else is a typo or an
+ * unrelated parameter, and quietly reading `?kanna=maybe` as "off" would hide
+ * her for reasons no one could work out afterwards.
+ */
+export function resolveRoamerUrlOverride(search: string): RoamerUrlOverride | null {
+  const value = new URLSearchParams(search).get(ROAMER_URL_PARAM)?.trim().toLowerCase();
+  if (value === "on") return "on";
+  if (value === "off") return "off";
+  return null;
+}
+
+/** Write the preference and tell every listener in this tab about it. */
+export function setRoamerDismissed(dismissed: boolean): void {
+  writeRoamerDismissed(browserRoamerStore(), dismissed);
+  globalThis.window?.dispatchEvent(
+    new CustomEvent(ROAMER_PREFERENCE_EVENT, { detail: { dismissed } }),
+  );
+}
+
+/**
+ * Run `onChange` whenever the preference moves — here or in another tab.
+ *
+ * Returns the unsubscribe. The `storage` listener is filtered to our key
+ * because the callback re-evaluates whether a fox may exist, and doing that on
+ * every unrelated write in the origin is work nobody asked for.
+ */
+export function subscribeRoamerPreference(onChange: () => void): () => void {
+  const target = globalThis.window;
+  if (!target) return () => {};
+
+  const onStorage = (event: StorageEvent) => {
+    // A `null` key is the whole store being cleared, which is also our answer
+    // changing.
+    if (event.key === null || event.key === ROAMER_DISMISSED_KEY) onChange();
+  };
+
+  target.addEventListener(ROAMER_PREFERENCE_EVENT, onChange);
+  target.addEventListener("storage", onStorage);
+  return () => {
+    target.removeEventListener(ROAMER_PREFERENCE_EVENT, onChange);
+    target.removeEventListener("storage", onStorage);
+  };
+}

--- a/apps/docs/mdx-components.tsx
+++ b/apps/docs/mdx-components.tsx
@@ -1,3 +1,4 @@
+import { KannaRoamerToggle } from "@/components/brand/kanna-roamer-toggle";
 import { KunaiFoxBanner } from "@/components/brand/kunai-fox-banner";
 import { DocSectionCards } from "@/components/docs/doc-section-cards";
 import { DocsHubIntro } from "@/components/docs/docs-hub-intro";
@@ -39,6 +40,7 @@ const kunaiMdxComponents = {
   ScopeCallout,
   ProviderDocSection,
   KunaiFoxBanner,
+  KannaRoamerToggle,
 } satisfies MDXComponents;
 
 export function useMDXComponents(components?: MDXComponents): MDXComponents {

--- a/apps/docs/test/roamer-affordance.test.tsx
+++ b/apps/docs/test/roamer-affordance.test.tsx
@@ -110,6 +110,26 @@ describe("roamer dismiss affordance", () => {
     expect(declares(reveal?.body ?? "", "pointer-events", "auto")).toBe(true);
   });
 
+  test("yielding stands both controls down, and wins over the hover reveal", () => {
+    const rules = flattenRules(css);
+    const yielding = rules.filter(
+      (rule) =>
+        rule.selector.includes('[data-yield="true"]') &&
+        declares(rule.body, "pointer-events", "none"),
+    );
+    const covered = yielding.flatMap((rule) => rule.selector.split(",").map((part) => part.trim()));
+    expect(covered).toContain('.kunai-roamer[data-yield="true"] .kunai-roamer__fox');
+    expect(covered).toContain('.kunai-roamer[data-yield="true"] .kunai-roamer__close');
+
+    // Both selectors carry the same specificity, so source order is what
+    // decides. The rule that hands a click back to the page has to be last.
+    const yieldAt = rules.findIndex((rule) => rule.selector.includes('[data-yield="true"]'));
+    const hoverAt = rules.findIndex(
+      (rule) => rule.selector === ".kunai-roamer:hover .kunai-roamer__close",
+    );
+    expect(yieldAt).toBeGreaterThan(hoverAt);
+  });
+
   test("the undo is not swept up by the reduced-motion floor that hides her", () => {
     // She is motion and is removed under reduced motion; the undo is a control
     // and must survive, or the query flipping between the dismissing click and

--- a/apps/docs/test/roamer-affordance.test.tsx
+++ b/apps/docs/test/roamer-affordance.test.tsx
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { KunaiFoxRoamer } from "../components/brand/kunai-fox-roamer";
+
+const FOX_CSS = path.join(import.meta.dir, "../app/styles/fox.css");
+
+type CssRule = { readonly selector: string; readonly body: string };
+
+/**
+ * Flatten a stylesheet to its plain rules.
+ *
+ * `@keyframes` bodies are dropped rather than descended into: a `0%` step is a
+ * moment in an animation, not a state anything can be clicked in, and the whole
+ * point of the check below is which states are clickable. `@media` bodies are
+ * descended into, because a rule inside one is a real rule.
+ */
+function flattenRules(css: string): CssRule[] {
+  const rules: CssRule[] = [];
+  let prelude = "";
+  let index = 0;
+
+  while (index < css.length) {
+    const character = css[index];
+
+    if (character === "{") {
+      let depth = 1;
+      let cursor = index + 1;
+      while (cursor < css.length && depth > 0) {
+        if (css[cursor] === "{") depth += 1;
+        else if (css[cursor] === "}") depth -= 1;
+        cursor += 1;
+      }
+      const body = css.slice(index + 1, cursor - 1);
+      const selector = prelude.replace(/\/\*[\s\S]*?\*\//g, "").trim();
+
+      if (selector.startsWith("@media")) rules.push(...flattenRules(body));
+      else if (!selector.startsWith("@")) rules.push({ selector, body });
+
+      prelude = "";
+      index = cursor;
+      continue;
+    }
+
+    if (character === "}") {
+      prelude = "";
+      index += 1;
+      continue;
+    }
+
+    prelude += character;
+    index += 1;
+  }
+
+  return rules;
+}
+
+function declares(body: string, property: string, value: string): boolean {
+  return new RegExp(`(^|;|\\*/)\\s*${property}\\s*:\\s*${value}\\s*(;|$)`).test(body);
+}
+
+/**
+ * Rules that hide a roamer element without also making it unclickable.
+ *
+ * This is the shape of the bug that took Kanna off the deployed site: the
+ * dismiss button was `opacity: 0` with live pointer events, an 18px invisible
+ * target sitting over the ear you are invited to click, and one stray click
+ * retired her permanently in that browser. The guard is written against the
+ * class rather than that one selector so the next transparent control in this
+ * subtree cannot reintroduce it.
+ */
+function invisibleButClickable(css: string): string[] {
+  return flattenRules(css)
+    .filter((rule) => rule.selector.includes(".kunai-roamer"))
+    .filter((rule) => declares(rule.body, "opacity", "0"))
+    .filter((rule) => !declares(rule.body, "pointer-events", "none"))
+    .map((rule) => rule.selector);
+}
+
+describe("roamer dismiss affordance", () => {
+  const css = fs.readFileSync(FOX_CSS, "utf-8");
+
+  test("nothing in the roamer is transparent and still clickable", () => {
+    expect(invisibleButClickable(css)).toEqual([]);
+  });
+
+  test("the guard actually catches the shape it is written against", () => {
+    // Without this the test above passes just as happily against a stylesheet
+    // the checker cannot read at all.
+    const regression = `
+      .kunai-roamer__close {
+        position: absolute;
+        pointer-events: auto;
+        opacity: 0;
+        transition: opacity 160ms ease-out;
+      }
+    `;
+    expect(invisibleButClickable(regression)).toEqual([".kunai-roamer__close"]);
+  });
+
+  test("the dismiss button becomes clickable exactly when it becomes visible", () => {
+    const reveal = flattenRules(css).find(
+      (rule) => rule.selector === ".kunai-roamer:hover .kunai-roamer__close",
+    );
+    expect(reveal).toBeDefined();
+    expect(declares(reveal?.body ?? "", "opacity", "1")).toBe(true);
+    expect(declares(reveal?.body ?? "", "pointer-events", "auto")).toBe(true);
+  });
+
+  test("the undo is not swept up by the reduced-motion floor that hides her", () => {
+    // She is motion and is removed under reduced motion; the undo is a control
+    // and must survive, or the query flipping between the dismissing click and
+    // this rule would put the one-way door straight back.
+    const hidden = flattenRules(css)
+      .filter((rule) => declares(rule.body, "display", "none"))
+      .map((rule) => rule.selector);
+    expect(hidden).toContain(".kunai-roamer");
+    expect(hidden).not.toContain(".kunai-roamer-undo");
+  });
+});
+
+describe("roamer server render", () => {
+  test("renders nothing, so there is no hydration mismatch to reconcile", () => {
+    // `app/layout.tsx` mounts her as a direct child of <body> and states this
+    // as the reason it is safe under every rendering mode the site uses.
+    expect(renderToStaticMarkup(<KunaiFoxRoamer />)).toBe("");
+  });
+});

--- a/apps/docs/test/roamer-machine.test.ts
+++ b/apps/docs/test/roamer-machine.test.ts
@@ -6,6 +6,7 @@ import {
   isResting,
   NOTICE_MS,
   NOTICE_PX,
+  pointerIsOver,
   poseForPhase,
   SETTLE_PX,
   SIT_TO_IDLE_MS,
@@ -157,5 +158,45 @@ describe("rest", () => {
     expect(isResting("asleep")).toBe(true);
     expect(isResting("walking")).toBe(false);
     expect(isResting("noticing")).toBe(false);
+  });
+});
+
+describe("standing in the way", () => {
+  const size = 58;
+  const half = size / 2;
+  const at = { x: 400, y: 300 };
+
+  test("the pointer is over her inside her box and not outside it", () => {
+    expect(pointerIsOver(at, at, size)).toBe(true);
+    expect(pointerIsOver(at, { x: at.x + half - 1, y: at.y }, size)).toBe(true);
+    expect(pointerIsOver(at, { x: at.x + half + 1, y: at.y }, size)).toBe(false);
+    expect(pointerIsOver(at, { x: at.x, y: at.y - half - 1 }, size)).toBe(false);
+  });
+
+  test("her corners count, because the browser hit-tests a box", () => {
+    // Treating her as a circle would call this "not over her" while the browser
+    // was already handing her the click.
+    const corner = { x: at.x + half - 1, y: at.y + half - 1 };
+    expect(Math.hypot(corner.x - at.x, corner.y - at.y)).toBeGreaterThan(half);
+    expect(pointerIsOver(at, corner, size)).toBe(true);
+  });
+
+  test("no pointer is not over her", () => {
+    expect(pointerIsOver(at, null, size)).toBe(false);
+  });
+
+  test("where she settles is close enough to reach back onto her", () => {
+    // This is the arithmetic that made the bug real rather than theoretical:
+    // she stops SETTLE_PX away, so her near edge is well inside the distance a
+    // reader moves to click something near where they stopped.
+    const edgeGap = SETTLE_PX - half;
+    expect(edgeGap).toBeGreaterThan(0);
+    expect(edgeGap).toBeLessThan(NOTICE_PX);
+
+    // A pointer that has drifted onto her has not moved far enough for her to
+    // notice and walk away, so she stays there — she cannot solve this by moving.
+    const settled = { ...createRoamerState(at), phase: "sitting" as const };
+    expect(pointerIsOver(at, at, size)).toBe(true);
+    expect(run(settled, 500, at).phase).toBe("sitting");
   });
 });

--- a/apps/docs/test/roamer-preference.test.ts
+++ b/apps/docs/test/roamer-preference.test.ts
@@ -7,6 +7,7 @@ import {
   ROAMER_DISMISSED_KEY,
   setRoamerDismissed,
   subscribeRoamerPreference,
+  urlWithoutRoamerParam,
   writeRoamerDismissed,
   type RoamerStore,
 } from "../lib/roamer-preference";
@@ -166,5 +167,26 @@ describe("cross-surface notification", () => {
     expect(calls).toBe(2);
 
     unsubscribe();
+  });
+});
+
+describe("spending the ?kanna= parameter", () => {
+  test("takes only our parameter out, keeping the rest of the URL intact", () => {
+    expect(urlWithoutRoamerParam("https://x.dev/docs?kanna=on")).toBe("/docs");
+    expect(urlWithoutRoamerParam("https://x.dev/docs?a=1&kanna=on&b=2")).toBe("/docs?a=1&b=2");
+    expect(urlWithoutRoamerParam("https://x.dev/docs?kanna=off#poses")).toBe("/docs#poses");
+    expect(urlWithoutRoamerParam("https://x.dev/?kanna=on")).toBe("/");
+  });
+
+  test("is null when there is nothing to spend, so history is left alone", () => {
+    expect(urlWithoutRoamerParam("https://x.dev/docs")).toBeNull();
+    expect(urlWithoutRoamerParam("https://x.dev/docs?a=1")).toBeNull();
+  });
+
+  test("removes the parameter even when its value was not a legible instruction", () => {
+    // `?kanna=maybe` changes nothing, but leaving it in the bar would still let
+    // it ride into a copied link and look like it meant something.
+    expect(resolveRoamerUrlOverride("?kanna=maybe")).toBeNull();
+    expect(urlWithoutRoamerParam("https://x.dev/docs?kanna=maybe")).toBe("/docs");
   });
 });

--- a/apps/docs/test/roamer-preference.test.ts
+++ b/apps/docs/test/roamer-preference.test.ts
@@ -38,14 +38,29 @@ const hostileStore: RoamerStore = {
 };
 
 /** Bun has no `window`; these tests install one only for the cases that need it. */
-function installWindow(localStorage: RoamerStore | (() => never)): void {
+function installWindow(descriptor: PropertyDescriptor): void {
   const target = new EventTarget();
-  if (typeof localStorage === "function") {
-    Object.defineProperty(target, "localStorage", { get: localStorage });
-  } else {
-    Object.defineProperty(target, "localStorage", { value: localStorage });
-  }
+  Object.defineProperty(target, "localStorage", descriptor);
   Object.defineProperty(globalThis, "window", { value: target, configurable: true });
+}
+
+/** A window whose `localStorage` is readable and holds `store`. */
+function withStorage(store: RoamerStore): void {
+  installWindow({ value: store });
+}
+
+/**
+ * A window whose `localStorage` throws on the property *access*, not the read.
+ *
+ * That is the real Firefox shape with cookies blocked for the origin, and it is
+ * why `browserRoamerStore` cannot be a plain expression at the call site.
+ */
+function withBlockedStorage(): void {
+  installWindow({
+    get: () => {
+      throw new Error("blocked");
+    },
+  });
 }
 
 // `window` is process-global, so leaving one installed would leak into every
@@ -105,9 +120,7 @@ describe("browserRoamerStore", () => {
   });
 
   test("falls back to memory when the browser refuses storage, so a click still holds", () => {
-    installWindow(() => {
-      throw new Error("blocked");
-    });
+    withBlockedStorage();
 
     const store = browserRoamerStore();
     expect(store).not.toBeNull();
@@ -120,7 +133,7 @@ describe("browserRoamerStore", () => {
 
   test("uses the real store when there is one", () => {
     const real = fakeStore();
-    installWindow(real);
+    withStorage(real);
 
     writeRoamerDismissed(browserRoamerStore(), true);
     expect(real.cells.get(ROAMER_DISMISSED_KEY)).toBe("1");
@@ -129,7 +142,7 @@ describe("browserRoamerStore", () => {
 
 describe("cross-surface notification", () => {
   test("setting the preference tells listeners in this tab", () => {
-    installWindow(fakeStore());
+    withStorage(fakeStore());
     let calls = 0;
     const unsubscribe = subscribeRoamerPreference(() => (calls += 1));
 
@@ -147,10 +160,14 @@ describe("cross-surface notification", () => {
   });
 
   test("another tab's write counts, and only for our key", () => {
-    installWindow(fakeStore());
+    withStorage(fakeStore());
     let calls = 0;
     const unsubscribe = subscribeRoamerPreference(() => (calls += 1));
     const emit = (key: string | null) => {
+      // SAFETY: Bun has no `StorageEvent` constructor, so the one field the
+      // subscriber reads is attached to a plain `Event`. The assertion widens
+      // the local type to match what is actually being dispatched; the
+      // listener under test only ever touches `.key`.
       const event = new Event("storage") as Event & { key: string | null };
       event.key = key;
       globalThis.window.dispatchEvent(event);

--- a/apps/docs/test/roamer-preference.test.ts
+++ b/apps/docs/test/roamer-preference.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  browserRoamerStore,
+  readRoamerDismissed,
+  resolveRoamerUrlOverride,
+  ROAMER_DISMISSED_KEY,
+  setRoamerDismissed,
+  subscribeRoamerPreference,
+  writeRoamerDismissed,
+  type RoamerStore,
+} from "../lib/roamer-preference";
+
+function fakeStore(
+  seed: Record<string, string> = {},
+): RoamerStore & { cells: Map<string, string> } {
+  const cells = new Map(Object.entries(seed));
+  return {
+    cells,
+    getItem: (key) => cells.get(key) ?? null,
+    setItem: (key, value) => void cells.set(key, value),
+    removeItem: (key) => void cells.delete(key),
+  };
+}
+
+/** A browser that has decided you may not have storage. Firefox does this with cookies blocked. */
+const hostileStore: RoamerStore = {
+  getItem: () => {
+    throw new Error("blocked");
+  },
+  setItem: () => {
+    throw new Error("blocked");
+  },
+  removeItem: () => {
+    throw new Error("blocked");
+  },
+};
+
+/** Bun has no `window`; these tests install one only for the cases that need it. */
+function installWindow(localStorage: RoamerStore | (() => never)): void {
+  const target = new EventTarget();
+  if (typeof localStorage === "function") {
+    Object.defineProperty(target, "localStorage", { get: localStorage });
+  } else {
+    Object.defineProperty(target, "localStorage", { value: localStorage });
+  }
+  Object.defineProperty(globalThis, "window", { value: target, configurable: true });
+}
+
+// `window` is process-global, so leaving one installed would leak into every
+// other test file in the run — see the module-mocking note in the testing docs.
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, "window");
+});
+
+describe("roamer preference flag", () => {
+  test("only the literal '1' counts as dismissed", () => {
+    expect(readRoamerDismissed(fakeStore({ [ROAMER_DISMISSED_KEY]: "1" }))).toBe(true);
+    expect(readRoamerDismissed(fakeStore({ [ROAMER_DISMISSED_KEY]: "0" }))).toBe(false);
+    expect(readRoamerDismissed(fakeStore({ [ROAMER_DISMISSED_KEY]: "true" }))).toBe(false);
+    expect(readRoamerDismissed(fakeStore())).toBe(false);
+  });
+
+  test("no store at all means she has not been dismissed", () => {
+    expect(readRoamerDismissed(null)).toBe(false);
+  });
+
+  test("restoring removes the key rather than recording a '0'", () => {
+    const store = fakeStore({ [ROAMER_DISMISSED_KEY]: "1" });
+    writeRoamerDismissed(store, false);
+    expect(store.cells.has(ROAMER_DISMISSED_KEY)).toBe(false);
+  });
+
+  test("a store that throws on every call degrades to 'she is welcome'", () => {
+    expect(readRoamerDismissed(hostileStore)).toBe(false);
+    expect(() => writeRoamerDismissed(hostileStore, true)).not.toThrow();
+  });
+});
+
+describe("?kanna= override", () => {
+  test("reads the two documented values, either case, with stray whitespace", () => {
+    expect(resolveRoamerUrlOverride("?kanna=on")).toBe("on");
+    expect(resolveRoamerUrlOverride("?kanna=off")).toBe("off");
+    expect(resolveRoamerUrlOverride("?kanna=OFF")).toBe("off");
+    expect(resolveRoamerUrlOverride("?kanna=%20on%20")).toBe("on");
+    expect(resolveRoamerUrlOverride("?a=1&kanna=on&b=2")).toBe("on");
+  });
+
+  test("anything else is not an instruction to hide her", () => {
+    // The failure this guards is silent: reading an unrecognised value as
+    // "off" would retire her for a reason nobody could reconstruct later.
+    expect(resolveRoamerUrlOverride("?kanna=maybe")).toBeNull();
+    expect(resolveRoamerUrlOverride("?kanna=1")).toBeNull();
+    expect(resolveRoamerUrlOverride("?kanna=")).toBeNull();
+    expect(resolveRoamerUrlOverride("?kannabis=off")).toBeNull();
+    expect(resolveRoamerUrlOverride("")).toBeNull();
+  });
+});
+
+describe("browserRoamerStore", () => {
+  test("is null on the server, where nobody has dismissed anything", () => {
+    expect("window" in globalThis).toBe(false);
+    expect(browserRoamerStore()).toBeNull();
+  });
+
+  test("falls back to memory when the browser refuses storage, so a click still holds", () => {
+    installWindow(() => {
+      throw new Error("blocked");
+    });
+
+    const store = browserRoamerStore();
+    expect(store).not.toBeNull();
+    writeRoamerDismissed(store, true);
+    expect(readRoamerDismissed(store)).toBe(true);
+
+    // The fallback is a module-level singleton, so this test has to put it back.
+    writeRoamerDismissed(store, false);
+  });
+
+  test("uses the real store when there is one", () => {
+    const real = fakeStore();
+    installWindow(real);
+
+    writeRoamerDismissed(browserRoamerStore(), true);
+    expect(real.cells.get(ROAMER_DISMISSED_KEY)).toBe("1");
+  });
+});
+
+describe("cross-surface notification", () => {
+  test("setting the preference tells listeners in this tab", () => {
+    installWindow(fakeStore());
+    let calls = 0;
+    const unsubscribe = subscribeRoamerPreference(() => (calls += 1));
+
+    setRoamerDismissed(true);
+    expect(calls).toBe(1);
+
+    // Without this the docs-page toggle would flip the flag and the roamer —
+    // mounted once in the root layout — would not notice until a reload.
+    setRoamerDismissed(false);
+    expect(calls).toBe(2);
+
+    unsubscribe();
+    setRoamerDismissed(true);
+    expect(calls).toBe(2);
+  });
+
+  test("another tab's write counts, and only for our key", () => {
+    installWindow(fakeStore());
+    let calls = 0;
+    const unsubscribe = subscribeRoamerPreference(() => (calls += 1));
+    const emit = (key: string | null) => {
+      const event = new Event("storage") as Event & { key: string | null };
+      event.key = key;
+      globalThis.window.dispatchEvent(event);
+    };
+
+    emit(ROAMER_DISMISSED_KEY);
+    expect(calls).toBe(1);
+
+    emit("some.other.key");
+    expect(calls).toBe(1);
+
+    // A null key is the whole store being cleared, which is also our answer.
+    emit(null);
+    expect(calls).toBe(2);
+
+    unsubscribe();
+  });
+});

--- a/docs/users/kanna.mdx
+++ b/docs/users/kanna.mdx
@@ -76,6 +76,22 @@ KUNAI_PET=off kunai
 
 `KUNAI_POSTER=0` turns off images without retiring her, since the glyph is not an image. Both variables sit alongside the rest of the environment overrides in [Customization](/docs/users/customization).
 
+### On this site
+
+The fox that walks around these pages is a separate switch from `KUNAI_PET`, because it is a separate thing: one is your terminal, the other is a website you are visiting.
+
+Hover her and an `×` appears at her ear. It hides her, and the preference is stored in the browser you are using — so hiding her in Firefox leaves her walking in Chrome, and clearing site data brings her back everywhere.
+
+<KannaRoamerToggle />
+
+Three ways back, because a click on a small button over a moving fox is a thing people do by accident:
+
+- The **undo** she leaves in the corner for twelve seconds after you hide her.
+- The toggle above, which reads the state on whichever browser you are reading in and flips it. She reacts immediately — no reload.
+- **`?kanna=on`** on any page of this site. `?kanna=off` sends her away the same way, and both stick.
+
+None of them override the two rules below her: she never appears on a touch device, and she is not rendered under reduced motion.
+
 ## Reduced motion
 
 Every animation on this site and in the terminal is gated on your system's reduced-motion preference. With it on, the illustrated stills hold still — she does not breathe, lean, or react.

--- a/docs/users/kanna.mdx
+++ b/docs/users/kanna.mdx
@@ -92,6 +92,8 @@ Three ways back, because a click on a small button over a moving fox is a thing 
 
 None of them override the two rules below her: she never appears on a touch device, and she is not rendered under reduced motion.
 
+She also gets out of the way on her own. She settles beside your cursor rather than under it, and whenever she is standing in front of a link or a button she stops taking clicks entirely — the page gets them instead. Click her over empty page and she still has something to say.
+
 ## Reduced motion
 
 Every animation on this site and in the terminal is gated on your system's reduced-motion preference. With it on, the illustrated stills hold still — she does not breathe, lean, or react.


### PR DESCRIPTION
Kanna was missing from the deployed site in Zen (a Firefox fork) while still walking in Chrome. Not a rendering bug: `kunai.roamer.dismissed` was set to `"1"` in that profile, and nothing in the app ever removed it.

Two defects of the same shape — something that intercepts input it never showed you, and a door that only opens one way.

## The invisible ×

`.kunai-roamer__close` was `opacity: 0` with live pointer events: an ~18px invisible target at `top:-2px; right:-2px`, sitting over her ear — on the very silhouette you are invited to click to make her talk. A slightly high click retired her permanently, in that browser only, with no confirmation and nothing visible to have aimed at or avoided.

It is now `pointer-events: none`, restored to `auto` in the same rule that makes it visible on hover.

## The way back

Dismissal is now reversible three ways, all through one new module (`lib/roamer-preference.ts`) rather than three components each poking at `localStorage` their own way:

- **Undo** — a pill offered for 12s straight after the click.
- **`?kanna=on`** on any page, with `?kanna=off` as the symmetric way out. Both persist, and the parameter is removed from the address bar once applied so it cannot ride into a copied link or into the URL web analytics records.
- **A live toggle on `/docs/users/kanna`** — the durable, discoverable one. It reports the current state and flips it, and she reacts on the page behind it with no reload.

## Two more found while reading

- **Stale one-shot gate.** `pointer: fine` and `prefers-reduced-motion` were read once at mount. Turning reduced motion on mid-visit left the stylesheet hiding her while the component kept running a `requestAnimationFrame` loop against an invisible fox for the rest of the session; plugging in a mouse later never brought her at all. The gate is now subscribed.
- **She ate clicks meant for the page.** `SETTLE_PX` is 70 and she is 58 across, so at rest her edge is ~41px from your cursor: reaching for anything near where you stopped put the pointer on her, and her click handler took it. Her own doc comment claimed she never covers anything, which was true of the host element and not of the fox. She now stands down — she and her dismiss button both leave hit testing — whenever something interactive is behind her. Over inert page she is still pokeable.

She cannot solve that one by moving, which is why the fix is not a dodge: a pointer that has drifted onto a resting fox has travelled far less than `NOTICE_PX`, so she never notices and never walks away. There is a test for exactly that. Dwell timing was the obvious alternative and is wrong — aiming at a link is itself a pause.

## Scope

I swept the docs app for both classes. Each had exactly one instance, both in the roamer: every other `opacity: 0` is a `@keyframes` step or an SVG crossfade layer, and the roamer was the *only* web-storage user in the entire app. No cookies; Vercel Analytics is cookieless.

## Verification

The CSS guard is written against the **class**, not the selector: any future rule under `.kunai-roamer` that sets `opacity: 0` without `pointer-events: none` fails `test/roamer-affordance.test.tsx`, and it carries a self-check proving the checker is not vacuous.

Beyond unit tests, both fixes were driven end to end in real headless Chrome over CDP, each with a **negative control** that re-injects the old declaration and confirms the bug reappears — without that, a green check proves nothing:

- 16/16 on dismissal, restore, the URL parameter, and the docs toggle, including that client-side routing still works after the history rewrite and that back does not land on the spent parameter.
- 4/4 on yielding, where the probe *sweeps pointer positions until she genuinely parks on a sidebar link* — no rigged transform — then checks who wins `elementFromPoint`.

Gates, all re-run with `--force` past the turbo cache: root `typecheck`, `test` (255 pass / 25 skip / 0 fail on the CLI integration suite), `lint`, `fmt:check`, `verify:doc-paths`, `verify:doc-coverage`, `lint:anti-slop:changed`, plus a clean `next build` from a deleted `.next`.

Two anti-slop findings remain in `kunai-fox-roamer.tsx`; both are on lines that exist unchanged on `main` and are untouched here.

## Note for existing visitors

Anyone who already dismissed her stays dismissed — that is correct, it was their choice. They get the restore routes above. My own Zen profile is one of them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a documentation-site toggle for enabling or dismissing the roaming fox.
  - Added a 12-second undo option after dismissal.
  - Added URL controls to enable or disable the fox with `?kanna=on` or `?kanna=off`.
- **Bug Fixes**
  - The fox now yields interaction when positioned over links and buttons.
  - Preferences stay synchronized across browser tabs and documentation pages.
  - The fox responds to pointer and reduced-motion setting changes.
- **Documentation**
  - Documented the fox’s controls, availability, preferences, URL options, and accessibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->