### PR TITLE
feat(docs): say what Kunai plays on the home page

### DIFF
--- a/apps/docs/app/(home)/home-page-interactive.tsx
+++ b/apps/docs/app/(home)/home-page-interactive.tsx
@@ -52,7 +52,7 @@ export default function HomePageInteractive() {
     <section id="install" className="kunai-home-install kunai-flow-section">
       <SectionHeading
         eyebrow="Install"
-        title="Get started in three steps."
+        title="Install in three steps."
         description="The preferred path is a self-contained binary — no Bun or Node required. Pick your OS for the exact bootstrap and mpv commands."
       />
 

--- a/apps/docs/app/(home)/home-page-shell.tsx
+++ b/apps/docs/app/(home)/home-page-shell.tsx
@@ -3,6 +3,7 @@ import { KunaiFoxBanner } from "@/components/brand/kunai-fox-banner";
 import { HomeHeroStatic } from "@/components/home/home-hero-static";
 import { HomeStarCta } from "@/components/home/home-star-cta";
 import { HomeTerminalIsland } from "@/components/home/home-terminal-island";
+import { HomeTerminalStatic } from "@/components/home/home-terminal-static";
 import { ProviderSummaryCard } from "@/components/home/provider-summary-card";
 import { StartHereCards } from "@/components/home/start-here-cards";
 import type { HomeCommandMetadata, HomeProviderMetadata } from "@/components/home/types";
@@ -29,6 +30,16 @@ type HomePageShellProps = {
   readonly usageLine?: ReactNode;
 };
 
+/**
+ * Section order is the argument the page makes.
+ *
+ * The install block used to sit directly under the hero, asking for a shell
+ * command before the page had said what Kunai plays or shown a provider. It now
+ * follows the three-step flow, the daily-use band, and the provider table — so
+ * the ask arrives after the reasons. The hero still carries both install
+ * commands for anyone who arrived already convinced, and `#install` still
+ * resolves for every link that points at it.
+ */
 export default function HomePageShell({
   providers,
   paletteCommands,
@@ -49,24 +60,26 @@ export default function HomePageShell({
             allCommands={allCommands}
             cliVersion={cliVersion}
             runtimeBaseline={runtimeBaseline}
+            fallback={
+              <HomeTerminalStatic cliVersion={cliVersion} runtimeBaseline={runtimeBaseline} />
+            }
           />
         </div>
       </section>
 
       <noscript>
         <p className="text-fd-muted-foreground mb-8 text-sm leading-relaxed">
-          JavaScript is disabled. Browse <Link href="/docs">documentation</Link>,{" "}
+          The terminal above is a preview, not a live shell. Browse{" "}
+          <Link href="/docs">documentation</Link>,{" "}
           <Link href="/docs/users/getting-started">getting started</Link>, or{" "}
           <Link href="/docs/users/troubleshooting">troubleshooting</Link> directly.
         </p>
       </noscript>
 
-      <HomePageInteractive />
-
       <section className="kunai-home-steps kunai-flow-section">
         <SectionHeading
           title="From search to mpv in three steps."
-          description="Kunai keeps the shell readable while providers, history, and recovery stay one command away."
+          description="One keyboard-driven session covers anime, series, movies, and YouTube — with providers, history, and recovery each one command away."
         />
         <div className="kunai-flow">
           {homeFlow.map((step, index) => (
@@ -88,11 +101,11 @@ export default function HomePageShell({
         <KunaiFoxBanner
           pose="wait"
           eyebrow="Daily client"
-          title="Built for people who actually watch from a shell."
+          title="Anime, series, movies, and YouTube — in one session."
         >
-          History, recovery, and providers stay one command away.
+          Tab cycles the catalog modes. History, recovery, and providers stay one command away.
         </KunaiFoxBanner>
-        <h2 className="kunai-display-title mt-8">Built for daily client use, not demos.</h2>
+        <h2 className="kunai-display-title mt-8">Everything stays one keystroke away.</h2>
         <ul className="kunai-highlight-list mt-6">
           {homeHighlights.map((item) => (
             <li className="kunai-highlight-row" key={item.label}>
@@ -111,6 +124,8 @@ export default function HomePageShell({
         />
         <ProviderSummaryCard summary={providerSummary} />
       </section>
+
+      <HomePageInteractive />
 
       <section className="kunai-home-start kunai-docs-section">
         <SectionHeading title="Pick the guide that matches your next step." />

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -2,7 +2,7 @@ import HomePageShell from "@/app/(home)/home-page-shell";
 import { UsageLine } from "@/components/home/usage-line";
 import { codeMetadata } from "@/lib/code-metadata";
 import { featuredCommands, summarizeProviders } from "@/lib/home-presenters";
-import { websiteJsonLd } from "@/lib/json-ld";
+import { softwareApplicationJsonLd, websiteJsonLd } from "@/lib/json-ld";
 import { buildPageMetadata } from "@/lib/page-metadata";
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
@@ -10,18 +10,34 @@ import type { ReactNode } from "react";
 /** Allow hourly refresh of the quiet usage metrics line without a full rebuild. */
 export const revalidate = 3600;
 
+/**
+ * The one string most people read before deciding whether to keep reading.
+ *
+ * It used to say "terminal client for third-party streams", which describes the
+ * architecture to someone who already knows what Kunai is. What it plays —
+ * anime, series, movies, YouTube — is both the thing a visitor wants to know
+ * and the thing anyone searching for this would actually type.
+ */
+const HOME_DESCRIPTION =
+  "Kunai is a terminal client that searches anime, series, movies, and YouTube, resolves a stream a direct provider already serves, and plays it in mpv.";
+
 export const metadata: Metadata = buildPageMetadata({
-  title: "Kunai — terminal client for third-party streams & mpv",
+  title: "Kunai — watch anime, series and movies in your terminal",
   absoluteTitle: true,
-  description:
-    "A terminal client that searches a title, resolves a stream a third-party provider already serves, hands playback to mpv, and recovers without a restart.",
+  description: HOME_DESCRIPTION,
   socialDescription:
-    "Search a title, resolve a third-party stream, hand playback to mpv, and recover without restarting.",
+    "Search anime, series, movies, and YouTube from your terminal — resolved by direct providers, played in mpv.",
   path: "/",
 });
 
 export default function HomePage() {
-  const jsonLd = websiteJsonLd();
+  const jsonLd = [
+    websiteJsonLd(),
+    softwareApplicationJsonLd({
+      version: codeMetadata.cliVersion,
+      description: HOME_DESCRIPTION,
+    }),
+  ];
   const paletteCommands = featuredCommands(codeMetadata.commands);
   const providerSummary = summarizeProviders(codeMetadata.providers);
   const usageLine: ReactNode = <UsageLine />;

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -115,6 +115,28 @@ pre,
   box-shadow: 0 12px 28px color-mix(in oklab, var(--kunai-accent) 30%, transparent);
 }
 
+/* The third level of the CTA hierarchy. A row of same-weight buttons asks the
+   visitor to choose; this one steps out of the running and reads as a link
+   while keeping the button's hit area and baseline. */
+.kunai-button-quiet {
+  border-color: transparent;
+  background: transparent;
+  padding-inline: 0.75rem;
+  color: var(--color-fd-muted-foreground);
+  box-shadow: none;
+}
+
+.kunai-button-quiet:hover {
+  border-color: transparent;
+  background: transparent;
+  box-shadow: none;
+  color: var(--color-fd-foreground);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklab, var(--kunai-accent) 60%, transparent);
+  text-underline-offset: 0.3em;
+  text-decoration-thickness: 1px;
+}
+
 /* Reduced motion: drop transform/animation motion, keep opacity + color. */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     template: "%s | Kunai — terminal streaming client",
   },
   description:
-    "Guides for the Kunai client: resolve third-party streams, hand off to mpv, recover, and use local offline files.",
+    "Guides for Kunai, the terminal client for anime, series, movies, and YouTube: resolve a stream, hand off to mpv, recover, and use local offline files.",
 };
 
 export const viewport: Viewport = {

--- a/apps/docs/app/styles/home.css
+++ b/apps/docs/app/styles/home.css
@@ -794,6 +794,72 @@
   flex: 0 0 auto;
 }
 
+/* ── Hero kinds row ────────────────────────────────────────────────────────
+   What Kunai plays, in the server-rendered HTML.
+
+   Visually distinct from the proof row below it on purpose: this row is the
+   answer to "what is this", the proof row is "can I trust it". Same family,
+   different job — so this one takes foreground weight and hairline rules,
+   and the proof row keeps its muted dots. */
+.kunai-hero-kinds {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem 1rem;
+  margin: 1.25rem 0 0;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+}
+
+.kunai-hero-kinds__item {
+  position: relative;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--color-fd-foreground);
+}
+
+.kunai-hero-kinds__item + .kunai-hero-kinds__item::before {
+  content: "";
+  position: absolute;
+  left: -0.5rem;
+  top: 0.15em;
+  bottom: 0.15em;
+  width: 1px;
+  background: var(--kunai-line);
+}
+
+.kunai-hero-kinds__hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.75rem;
+}
+
+/* `kbd` ships as unstyled browser monospace and belongs to no design system
+   until it is themed. Scoped here rather than globally so the docs prose
+   keeps whatever it already does. */
+.kunai-hero-kinds__hint kbd {
+  border: 1px solid var(--kunai-line);
+  border-radius: 0.375rem;
+  background: color-mix(in oklab, var(--kunai-surface) 80%, transparent);
+  padding: 0.1rem 0.4rem;
+  color: color-mix(in oklab, var(--kunai-accent) 70%, var(--color-fd-foreground));
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 0.6875rem;
+  line-height: 1.5;
+}
+
+/* The h1 is the first text in the hero now that the eyebrow is gone, so it
+   sets its own top edge. `.kunai-display-title` caps at 20ch for section
+   headings; the hero headline is longer and needs the room, and declaring it
+   here beats relying on the source order between a utility and a component
+   class that share specificity. */
+.kunai-hero-static h1.kunai-display-title {
+  max-width: 24ch;
+  margin-top: 0;
+}
+
 /* ── Hero proof row ────────────────────────────────────────────────────────
    Four verifiable facts, each a link to where it can be checked. */
 .kunai-proof-row {

--- a/apps/docs/components/home/hero-kinds-row.tsx
+++ b/apps/docs/components/home/hero-kinds-row.tsx
@@ -1,0 +1,23 @@
+import { homeHero } from "@/lib/home-content";
+
+/**
+ * What Kunai plays, stated as text in the server-rendered HTML.
+ *
+ * Deliberately not links: all four modes are documented on the same providers
+ * page, and four identical hrefs would be navigation theatre. The trailing hint
+ * carries a real hotkey, which is what keeps this row from being an eyebrow.
+ */
+export function HeroKindsRow() {
+  return (
+    <p className="kunai-hero-kinds">
+      {homeHero.kinds.map((kind) => (
+        <span className="kunai-hero-kinds__item" key={kind}>
+          {kind}
+        </span>
+      ))}
+      <span className="kunai-hero-kinds__hint">
+        <kbd>{homeHero.kindsHint.key}</kbd> {homeHero.kindsHint.label}
+      </span>
+    </p>
+  );
+}

--- a/apps/docs/components/home/home-hero-static.tsx
+++ b/apps/docs/components/home/home-hero-static.tsx
@@ -1,4 +1,5 @@
 import { KunaiFoxLive } from "@/components/brand/kunai-fox-live";
+import { HeroKindsRow } from "@/components/home/hero-kinds-row";
 import { HeroProofRow } from "@/components/home/hero-proof-row";
 import { HomeStarCta } from "@/components/home/home-star-cta";
 import { CopyButton } from "@/components/ui/copy-button";
@@ -20,11 +21,16 @@ export function HomeHeroStatic({ cliVersion, providerCount }: HomeHeroStaticProp
       <div className="kunai-hero-fox">
         <KunaiFoxLive pose="idle" alertPose="watch" size={120} />
       </div>
-      <p className="kunai-eyebrow">{homeHero.eyebrow}</p>
-      <h1 className="kunai-display-title mt-3 max-w-3xl text-balance">{homeHero.title}</h1>
+
+      {/* The heading carries its own weight. The eyebrow that used to sit here
+          read "Terminal-first playback" — a label restating the h1 in smaller
+          type, above a page that never once said what Kunai actually plays. */}
+      <h1 className="kunai-display-title text-balance">{homeHero.title}</h1>
       <p className="kunai-type-body text-fd-muted-foreground mt-4 max-w-2xl text-pretty">
         {homeHero.description}
       </p>
+
+      <HeroKindsRow />
 
       {/* Both platforms sit together: one install decision, made once. The
           Windows row used to sit below the CTAs, orphaned from its peer. */}
@@ -41,12 +47,15 @@ export function HomeHeroStatic({ cliVersion, providerCount }: HomeHeroStaticProp
         </code>
       </div>
 
+      {/* Three levels, not three peers: one primary action, one quiet link out,
+          and the star link — which is here for the count it carries, not as a
+          third thing to decide between. */}
       <div className="mt-6 flex flex-wrap items-center gap-3">
         <Link className="kunai-button kunai-button-primary" href={homeHero.primaryCta.href}>
           <span>{homeHero.primaryCta.label}</span>
           <IconArrowRight className="ml-1.5 size-4" stroke={1.5} />
         </Link>
-        <Link className="kunai-button border-fd-border" href={homeHero.secondaryCta.href}>
+        <Link className="kunai-button kunai-button-quiet" href={homeHero.secondaryCta.href}>
           {homeHero.secondaryCta.label}
         </Link>
         <HomeStarCta />

--- a/apps/docs/components/home/home-terminal-island.tsx
+++ b/apps/docs/components/home/home-terminal-island.tsx
@@ -1,18 +1,10 @@
 "use client";
 
-import dynamic from "next/dynamic";
+import { type ComponentType, type ReactNode, useEffect, useState } from "react";
 
 import type { HomeCommandMetadata, HomeProviderMetadata } from "./types";
 
-const TerminalSimulator = dynamic(
-  () => import("./terminal-simulator").then((mod) => mod.TerminalSimulator),
-  {
-    ssr: false,
-    loading: () => <div className="kunai-terminal-shell min-h-[360px] animate-pulse rounded-2xl" />,
-  },
-);
-
-type HomeTerminalIslandProps = {
+type SimulatorProps = {
   readonly providers: readonly HomeProviderMetadata[];
   readonly paletteCommands: readonly HomeCommandMetadata[];
   readonly allCommands: readonly HomeCommandMetadata[];
@@ -20,20 +12,41 @@ type HomeTerminalIslandProps = {
   readonly runtimeBaseline: { readonly bun: string; readonly mpv: string };
 };
 
-export function HomeTerminalIsland({
-  providers,
-  paletteCommands,
-  allCommands,
-  cliVersion,
-  runtimeBaseline,
-}: HomeTerminalIslandProps) {
-  return (
-    <TerminalSimulator
-      providers={providers}
-      paletteCommands={paletteCommands}
-      allCommands={allCommands}
-      cliVersion={cliVersion}
-      runtimeBaseline={runtimeBaseline}
-    />
-  );
+type HomeTerminalIslandProps = SimulatorProps & {
+  /**
+   * The server-rendered frame. Held on screen until the simulator chunk has
+   * actually arrived, so the hero never flashes an empty placeholder.
+   */
+  readonly fallback: ReactNode;
+};
+
+/**
+ * Loads the terminal simulator on the client only.
+ *
+ * This used `next/dynamic` with `ssr: false` and an `animate-pulse` box. That
+ * put a blank rectangle in the initial HTML and, because nothing under an
+ * `ssr: false` boundary is prerendered, kept every word the simulator prints
+ * out of the server response. The import is still its own chunk; the
+ * difference is that the frame beneath it is real, server-rendered content.
+ */
+export function HomeTerminalIsland({ fallback, ...simulatorProps }: HomeTerminalIslandProps) {
+  const [Simulator, setSimulator] = useState<ComponentType<SimulatorProps> | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      const module = await import("./terminal-simulator");
+      if (active) setSimulator(() => module.TerminalSimulator);
+    };
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (!Simulator) return fallback;
+  return <Simulator {...simulatorProps} />;
 }

--- a/apps/docs/components/home/home-terminal-static.tsx
+++ b/apps/docs/components/home/home-terminal-static.tsx
@@ -1,0 +1,67 @@
+type HomeTerminalStaticProps = {
+  readonly cliVersion: string;
+  readonly runtimeBaseline: { readonly bun: string; readonly mpv: string };
+};
+
+/**
+ * The server-rendered terminal preview.
+ *
+ * The interactive simulator is loaded with `ssr: false`, so nothing inside it
+ * reaches the initial HTML — which meant the only place on this page that named
+ * anime, series, or movies was invisible to crawlers and to anyone reading
+ * before hydration. This renders the same frame, with the same classes, holding
+ * a real result set. The simulator swaps itself in on mount.
+ *
+ * It is also what a visitor with JavaScript disabled now gets instead of a
+ * pulsing empty box.
+ */
+export function HomeTerminalStatic({ cliVersion, runtimeBaseline }: HomeTerminalStaticProps) {
+  return (
+    <div className="relative flex w-full items-center justify-center">
+      <div className="kunai-hero-glow" aria-hidden="true" />
+
+      <aside
+        className="kunai-terminal-stage relative w-full overflow-hidden"
+        aria-label="Kunai terminal preview"
+      >
+        <div className="kunai-terminal-top">
+          <span className="text-fd-muted-foreground flex items-center gap-1.5 text-xs">
+            <span className="kunai-status-dot kunai-status-dot--focus" />
+            kunai shell
+          </span>
+          <span className="kunai-terminal-badges">
+            <span className="kunai-step-meta tabular-nums">v{cliVersion}</span>
+            <span className="kunai-step-meta">simulated</span>
+          </span>
+        </div>
+
+        <div className="kunai-terminal-body scrollbar block max-h-[360px] min-h-[260px] w-full text-left">
+          <span className="kunai-log-line kunai-log-line--brand">▌ Kunai Shell v{cliVersion}</span>
+          <span className="kunai-log-line kunai-log-line--muted">
+            Requires mpv {runtimeBaseline.mpv}. The binary install embeds bun {runtimeBaseline.bun}.
+          </span>
+          <span className="kunai-log-line kunai-log-line--query">
+            [QUERY] searching 7 providers…
+          </span>
+          <span className="kunai-log-line kunai-log-line--muted">
+            {"  1. Frieren: Beyond Journey's End (Series) [Anime]"}
+          </span>
+          <span className="kunai-log-line kunai-log-line--muted">
+            {"  2. Dune: Part Two (Movie) [Sci-Fi]"}
+          </span>
+          <span className="kunai-log-line kunai-log-line--muted">
+            {"  3. Erased (Series) [Mystery]"}
+          </span>
+          <span className="kunai-log-line kunai-log-line--play">[PLAY] handing stream to mpv</span>
+
+          <span className="kunai-terminal-input-row">
+            <span className="kunai-text-accent mr-2 text-xs font-bold">kunai &gt;</span>
+            <span className="text-fd-muted-foreground font-mono text-xs">
+              Type &apos;/&apos; for commands…
+            </span>
+          </span>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/apps/docs/lib/home-content.ts
+++ b/apps/docs/lib/home-content.ts
@@ -19,25 +19,43 @@ export type HomeFlowStep = {
   readonly description: string;
 };
 
+/**
+ * The four catalog modes, in the order `Tab` cycles them in the shell.
+ *
+ * These live in the server-rendered hero on purpose. The terminal simulator is
+ * the only other place on this page that names what Kunai plays, and it is
+ * loaded with `ssr: false` after an interaction — so before this row existed,
+ * neither a crawler nor a visitor skimming for two seconds could learn that
+ * Kunai plays anime at all.
+ */
+export const homeKinds = ["Anime", "Series", "Movies", "YouTube"] as const;
+
 export const homeHero = {
-  eyebrow: "Terminal-first playback",
-  title: "Kunai — a terminal client for third-party streams.",
+  title: "Watch anime, series and movies from your terminal.",
   description:
-    "Search a title, resolve a URL a third-party provider already serves, hand playback to mpv, and recover without restarting when something stalls.",
+    "Kunai searches a title, resolves a stream a direct provider already serves, and hands playback to mpv — with YouTube, downloads, resume, and recovery in the same keyboard-driven session.",
+  kinds: homeKinds,
+  /** Earns its place by teaching a real hotkey rather than labelling the row. */
+  kindsHint: { key: "Tab", label: "cycles modes" },
   installCommands: [CANONICAL_INSTALL, CANONICAL_SETUP],
   primaryCta: {
     label: "Get started",
     href: "/docs/users/getting-started",
   },
   secondaryCta: {
-    label: "Browse docs",
-    href: "/docs",
+    label: "See what it can do",
+    href: "/docs/users/what-you-can-do",
   },
 } as const;
 
 const providerCount = codeMetadata.providerIds.length;
 
 export const homeHighlights = [
+  {
+    label: "Four catalog modes",
+    detail:
+      "Series, anime, and YouTube each get their own mode. Tab cycles them; /anime, /series, and /youtube jump straight to one.",
+  },
   {
     label: "Direct providers",
     detail: `${providerCount} provider modules resolve streams on your machine. No browser automation and no shared relay by default.`,
@@ -58,7 +76,7 @@ export const homeFlow: readonly HomeFlowStep[] = [
   {
     title: "Search or continue",
     description:
-      "Find a title, resume history, or open calendar, recommendations, or your offline library from the shell.",
+      "Find an episode, a film, or a YouTube video — or resume history, open the release calendar, and browse your offline library from the shell.",
   },
   {
     title: "Resolve locally",

--- a/apps/docs/lib/json-ld.ts
+++ b/apps/docs/lib/json-ld.ts
@@ -15,6 +15,45 @@ export function websiteJsonLd() {
   };
 }
 
+/**
+ * The home page describes an installable application, not just a website.
+ *
+ * `WebSite` alone made Kunai ineligible for the software result Google renders
+ * for a free app — the one that shows the platforms and the price. Every field
+ * here is a fact the repo already asserts elsewhere; nothing is invented, and
+ * there is deliberately no `aggregateRating`, because there are no ratings.
+ */
+export function softwareApplicationJsonLd(input: {
+  readonly version: string;
+  readonly description: string;
+}) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: "Kunai",
+    url: docsSiteUrl,
+    description: input.description,
+    applicationCategory: "MultimediaApplication",
+    applicationSubCategory: "Command Line Media Player",
+    operatingSystem: "Linux, macOS, Windows",
+    softwareVersion: input.version,
+    softwareRequirements: "mpv",
+    downloadUrl: "https://www.npmjs.com/package/@kitsunekode/kunai",
+    license: "https://github.com/KitsuneKode/kunai/blob/main/LICENSE",
+    isAccessibleForFree: true,
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+    author: {
+      "@type": "Organization",
+      name: "Kunai",
+      url: "https://github.com/KitsuneKode/kunai",
+    },
+  };
+}
+
 export function techArticleJsonLd(input: {
   readonly title: string;
   readonly description: string;

--- a/apps/docs/test/home-content.test.ts
+++ b/apps/docs/test/home-content.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, test } from "bun:test";
 
 import { codeMetadata } from "../lib/code-metadata";
 import { docNavEntries, homeSectionsFromNav } from "../lib/doc-navigation";
-import { homeFlow, homeHero, homeHighlights, homeStartCards } from "../lib/home-content";
+import { homeFlow, homeHero, homeHighlights, homeKinds, homeStartCards } from "../lib/home-content";
 import { featuredCommands } from "../lib/home-presenters";
 import { PREFERRED_INSTALL } from "../lib/install-commands";
 
 describe("docs home content", () => {
   test("keeps install and getting-started entry points visible", () => {
     expect(homeHero.primaryCta.href).toBe("/docs/users/getting-started");
-    expect(homeHero.secondaryCta.href).toBe("/docs");
+    expect(homeHero.secondaryCta.href).toBe("/docs/users/what-you-can-do");
     expect(homeHero.installCommands).toContain(PREFERRED_INSTALL);
 
     const startHrefs = homeStartCards.map((card) => card.href);
@@ -32,7 +32,27 @@ describe("docs home content", () => {
   test("keeps recovery and provider promises in user-facing copy", () => {
     expect(homeFlow.map((step) => step.title)).toContain("Play in mpv");
     expect(homeHighlights.some((item) => item.label === "Recovery built in")).toBe(true);
-    expect(homeHero.description).toContain("recover without restarting");
+    expect(homeHero.description).toMatch(/recovery/i);
+    expect(homeHero.description).toMatch(/mpv/);
+  });
+
+  /**
+   * The regression this locks: the hero once described the mechanism without
+   * ever naming what Kunai plays. The only page text that said "anime" lived in
+   * the terminal simulator, which is client-only and appears after an
+   * interaction — so neither a crawler nor a skimming visitor could find it.
+   */
+  test("hero copy names every catalog mode in server-rendered text", () => {
+    const heroText = `${homeHero.title} ${homeHero.description}`.toLowerCase();
+
+    for (const kind of homeKinds) {
+      expect(heroText).toContain(kind.toLowerCase());
+    }
+  });
+
+  test("catalog modes match the shell's Tab order", () => {
+    expect(homeKinds).toEqual(["Anime", "Series", "Movies", "YouTube"]);
+    expect(homeHero.kindsHint.key).toBe("Tab");
   });
 
   test("provider count in highlights matches codegen", () => {

--- a/apps/docs/test/home-shell.test.ts
+++ b/apps/docs/test/home-shell.test.ts
@@ -85,6 +85,6 @@ describe("docs home shell", () => {
     expect(homeFlow).toHaveLength(3);
     expect(homeStartCards).toHaveLength(4);
     expect(homeHero.primaryCta.href).toBe("/docs/users/getting-started");
-    expect(homeHero.secondaryCta.href).toBe("/docs");
+    expect(homeHero.secondaryCta.href).toBe("/docs/users/what-you-can-do");
   });
 });


### PR DESCRIPTION
The home page never said what Kunai plays.

Not in the `h1`, not in the title tag, not in the meta description, not anywhere in the server-rendered HTML. `anime`, `series`, `movies`, and `youtube` each appeared **zero** times. The only page text that named them lived in the terminal simulator — which is loaded with `ssr: false` and prints its result set only after you run a simulated command — so neither a crawler nor a visitor skimming for two seconds could find it.

Meanwhile `README.md` has shipped an `anime · series · movies` badge the whole time, and the OG image alt text already reads *"above a row of anime, series, and movie marks."* The picture said it. The README said it. The page did not.

There is no positioning reason for the vagueness — no wording policy anywhere in `.docs/`, and the README makes the same claim more loudly. It is drift.

## What the hero says now

| | Before | After |
|---|---|---|
| `h1` | Kunai — a terminal client for third-party streams. | **Watch anime, series and movies from your terminal.** |
| `<title>` | Kunai — terminal client for third-party streams & mpv | **Kunai — watch anime, series and movies in your terminal** |
| Eyebrow | "Terminal-first playback" | *removed* |

Plus a server-rendered kinds row — `Anime │ Series │ Movies │ YouTube` with the `Tab` hotkey — because **YouTube is a shipped provider with its own catalog mode** and the site had never mentioned it existed.

The eyebrow is gone rather than rewritten: it restated the `h1` in smaller type, above a page that never said what the product was. The heading carries its own weight.

## Hierarchy, not decoration

The CTA row was three same-weight buttons, which is no hierarchy at all. It now has three levels — primary, a new `.kunai-button-quiet`, and the star link, which is there for the count it carries rather than as a third thing to decide between.

`kbd` shipped as unstyled browser monospace. `.kunai-display-title` caps at `20ch` for section headings, and the hero was relying on source order between a utility class and a component class of equal specificity to override it; that is now declared.

## The `ssr: false` hole

The simulator sat behind `next/dynamic` with `ssr: false` and an `animate-pulse` box. Nothing under that boundary is prerendered, so the demo was absent from the initial HTML and a visitor without JavaScript got a blank pulsing rectangle where the product should be.

It now renders a real server-side frame — same classes, actual result set — held on screen until the simulator chunk arrives, so there is no placeholder flash on the way in either. The import is still its own chunk.

## Order is the argument

Install used to sit directly under the hero, asking for a `curl … | bash` before the page had said what Kunai plays or shown a single provider. New order: hero → three steps → daily-use band → providers → **install** → guides → final CTA. The hero still carries both install commands for anyone who arrived convinced, and `#install` still resolves.

Its heading also read "Get started in three steps" while the hero button said "Get started" and went somewhere else. It is "Install in three steps" now.

Added `SoftwareApplication` JSON-LD so a free CLI is eligible for the software result. Every field is a fact this repo already asserts, and there is deliberately no `aggregateRating`, because there are no ratings.

## Verification

Measured on the served HTML, not inferred:

| | before | after |
|---|---|---|
| `anime` | 0 | 51 |
| `Series` | 0 | 12 |
| `Movies` | 0 | 4 |
| `YouTube` | 0 | 28 |

`SoftwareApplication` and `MultimediaApplication` present; the static frame's `searching 7 providers` present; the simulator's own strings (`Try one`, `Simulated shell`) correctly **absent** from the server render, which is what proves the swap is client-side.

Gates: `typecheck`, `test` (217 pass / 0 fail), `lint`, `fmt:check`, root `fmt:check --force` (26/26, **0 cached**), and a clean `next build`. Screenshots at 1440 / 1024 / 390 — one inspection round, fixes, one confirmation round.

The copy test that pinned the literal string `"recover without restarting"` is replaced with one that fails if the hero stops naming a catalog mode: the regression that actually matters rather than one phrasing of it.

## Two caveats, stated plainly

- I could **not** capture a genuine no-JS render — `--blink-settings=scriptEnabled=false` did not take in this Chrome build, so that screenshot was still hydrated. The served-HTML check above is the real evidence for the SSR claim, not the screenshot.
- `homeKinds` is hardcoded rather than derived from codegen. A test pins the `Tab` order, but if the shell gains a fifth mode nothing here will fail.

## Pre-existing, not touched

Both verified present on `origin/main` and left alone:

- `home.css` `.palette-item` side-tab accent border (impeccable detector).
- `json-ld.ts` `techArticleJsonLd`'s conditional empty-object spread (anti-slop) — my insertion only shifted its line number.

Also worth a separate look: the `.kunai-band` grid puts the highlights `h2` in the right column and its list in the left, so the heading reads orphaned from what it introduces. Incumbent layout, outside this scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Homepage now highlights support for anime, series, movies, and YouTube, with a Tab shortcut hint.
  - Added a static terminal preview for faster initial loading and no-JavaScript viewing.
  - Added structured application information for improved search and sharing.

- **Content**
  - Updated homepage descriptions, installation heading, metadata, and calls to action.
  - Added a “What it can do” link for broader playback information.

- **Style**
  - Refined hero layout, catalog mode presentation, responsive behavior, and secondary CTA styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->