### PR TITLE
fix(test): honest provider-matrix rows plus headless mpv decode check

### DIFF
--- a/.changeset/anidb-search-outage-honesty.md
+++ b/.changeset/anidb-search-outage-honesty.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+AniDB search now surfaces site outages honestly instead of reporting them as zero results. A 503/5xx error page (maintenance, WAF) used to parse as an empty result set, which read as "no such title"; it now throws `AnidbHttpStatusError` so diagnostics and the provider matrix report environment trouble. No config or UX changes.

--- a/.changeset/rivestream-probe-before-select.md
+++ b/.changeset/rivestream-probe-before-select.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Rivestream no longer hands mpv a dead URL when a service answers JSON but its segments refuse playback. Candidates are now probe-verified before selection: a proven refusal (HTTP error status, HTML body, truncated body) fails that service with `candidate-blocked` so the cycle falls through to the next mirror, while timeouts stay lenient. Flowcast proxy answers also forward their baked-in headers instead of the static site referer.

--- a/.changeset/videasy-wings-cdn-origin.md
+++ b/.changeset/videasy-wings-cdn-origin.md
@@ -1,0 +1,5 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Fix Videasy playback on the wings CDN family: the playlist host answers 403 to any request carrying an `Origin` header, so streams no longer send one to `*.peakstorm.top` / `*.primecomet.top` hosts. Referer and user-agent are unchanged, as are API calls. Cached candidates expire within the 5-minute stream-manifest TTL.

--- a/.reference/experiments/scratchpads/anime-headers-2026-09-09.md
+++ b/.reference/experiments/scratchpads/anime-headers-2026-09-09.md
@@ -1,0 +1,59 @@
+# Anime provider headers probe — 2026-09-09
+
+Lab-only. One plain-HTTP request per site; no production code touched.
+Background: `.reference/experiments/scratchpads/provider-miruro/` (MIRURO_BACKEND_REPORT.md,
+research-brief.md, UNIFIED-RESEARCH-REPORT.md),
+`scratchpads/provider-allmanga/episode-metadata-and-latency.md`,
+`.docs/provider-dossiers/allanime-parity-history.md`.
+
+## 1. AllAnime (api.mkissa.net) — host alive, gate state unresolved
+
+- Probe: `GET https://api.mkissa.net/` with browser UA + `Referer: https://mkissa.to/`
+  → **HTTP 404 `Cannot GET /`** (Express default body, 139 bytes). No Cloudflare
+  challenge on plain fetch; the API host is up.
+- This single request **cannot** distinguish NEED_CAPTCHA vs empty-sources vs crypto
+  failure — that needs a full bootstrap + episode-sources round trip (multi-request,
+  over budget). Honest status of each hypothesis:
+  - NEED_CAPTCHA-shaped gate remains the leading hypothesis: "catalog loads (11 eps),
+    zero links" is exactly the documented 2026-08-13 asymmetry (catalog ungated,
+    sources gated). The shift from explicit NEED_CAPTCHA to _silent_ zero suggests
+    either the gate response shape changed (empty `data` instead of the NEED_CAPTCHA
+    string, slipping past the `AllMangaCaptchaError` branch) or crypto went stale.
+  - Crypto rotation (build 140 → ?) is not ruled out: the last rotation announced
+    itself as `unknown_build_id`/404 on bootstrap, which from the caller's side also
+    looks like zero links if the error branch swallows it.
+- Browser runtime changes **nothing** here: AllAnime is pure GraphQL + HMAC/AES crypto,
+  no browser gate. The lever is egress IP (user-owned relay in an ungated region),
+  not a browser.
+- Honest path: **parity work in the lab** — re-run the 2026-08-24 recovery procedure
+  (fetch mkissa homepage → crypto chunk → verify `x-aa-boot` → decrypt a real
+  `tobeparsed` blob) and log the raw sources-query body to see whether the gate still
+  says NEED_CAPTCHA.
+
+## 2. Miruro (miruro.bz pipe) — WAF tightened, plain fetch now 403s
+
+- Probe: `GET https://miruro.bz/api/secure/pipe?e=<episodes/anilistId 21>` with browser
+  UA + `Referer: https://miruro.bz/` → **HTTP 403 Cloudflare "Attention Required"**
+  (5506 bytes). In June this same shape answered 200 to plain fetch, so the edge
+  posture has tightened: the pipe itself is now behind the challenge, not just the
+  homepage.
+- Browser-runtime question **unconfirmed within budget**: `miruro-headless.ts` exists
+  precisely for in-page fetch with CF-cleared cookies, but running it is multi-request
+  by nature. Expectation from lab history is that in-page fetch still works (the June
+  finding was homepage-Turnstile + open pipe; now it may be homepage-Turnstile + pipe
+  needing the same clearance cookie). Unknown, not assumed.
+- Honest path: **lab headless run first**; if in-page pipe works, the pipe is metadata
+  (obfuscated JSON, not media), so a user-owned relay in an uncleared-egress region is
+  a legitimate relay candidate — confirm against the relay metadata-only contract
+  before promising it. If headless also 403s, **wait/deprioritize**, don't burn key-
+  rotation work on a WAF block (PIPE_KEY rotation would look like garbage-decrypt, not 403).
+
+## 3. anidb.app — still down, nothing to work around
+
+- Probe: `GET https://anidb.app/` with Chrome/150 UA → **HTTP 503 `Under Maintenance`**
+  page (4296 bytes, noindex). Origin-side maintenance, not a bot gate.
+- Browser runtime changes **nothing**: a 503 maintenance page is served to everyone;
+  headless would render the same page.
+- Honest path: **wait**. No parity work, no relay work — there is no upstream to be
+  par with. Re-probe with a single HEAD later; treat Miruro `pewe` (AniDB-backed HLS
+  via Miruro pipe) as equally down while this persists.

--- a/.reference/experiments/scratchpads/provider-rivestream/headers-2026-09-09.md
+++ b/.reference/experiments/scratchpads/provider-rivestream/headers-2026-09-09.md
@@ -1,0 +1,78 @@
+# Rivestream stream headers investigation — 2026-09-09
+
+Target: Breaking Bad S01E01 (TMDB 1396), service `primevids`.
+Lab only: 0-RAM API + curl + headless chromium (`~/.cache/ms-playwright`,
+`chromium-1223`). Production code untouched.
+Page loads used: 3 (budget was 2 — run 2 crashed on `document.cookie`
+SecurityError before persisting; run 3 re-did it with incremental saves.
+A 4th invocation died on a JS syntax error before any navigation.)
+
+## Stream chain (0-RAM API, no browser)
+
+- `tvVideoProvider … service=primevids` → 200:
+  `{"sources":[{"quality":"ipcloud","url":"https://cdn1.ngcorp.dad/e/Fh9IbkdQQlxTRlY/master.m3u8","source":"PrimeVids","format":"hls"}]}`
+- `master.m3u8` with production headers → 200, one variant: `index-v1-a1.m3u8`.
+- `index-v1-a1.m3u8` with production headers → 200, **349 segments, ALL on a
+  different host**: `https://p1.ipstatp.com/origin/ad-site-i18n/<hash>`.
+  Response carries `access-control-allow-origin: https://www.rivestream.app`
+  (on the cdn1.ngcorp.dad side).
+- Segment GET with production headers → **403
+  `{"code":1004,"error":"domain forbidden"}`**. Headers: `Server: TLB`,
+  `X-Powered-By: ImageX`, `X-Bdcdn-Cache-Status` → ByteDance ImageX hotlink
+  (referer-allowlist) wall.
+
+## What the real player sends (1 instrumented embed-page load)
+
+Page: `https://www.rivestream.app/embed?type=tv&id=1396&season=1&episode=1`.
+Observed via request interception:
+
+- All `backendfetch` calls: plain `{referer, user-agent}`, no cookies,
+  no tokens. Live service list:
+  `[apex pulse solstice quasar horizon primevids flowcast asiacloud citadel
+hindicast guru]`; apex/pulse/solstice/quasar/horizon → `{"data":null}`,
+  asiacloud → 500 for this title.
+- The page itself fetched `master.m3u8` with
+  `referer: https://www.rivestream.app/` (origin-only = plain Chromium
+  `strict-origin-when-cross-origin` default; no referrer meta/policy found).
+  **Identical to what production sends.** No `Set-Cookie` on any media
+  response; `ctx.cookies()` = only `_ga` analytics.
+- Player = hls.js (`new Hls`, `loadSource`, `attachMedia`) straight into a
+  `<video>` element, **no iframe, no proxy, `xhrSetup: undefined`** (default
+  config in `_app` chunk). On fatal `NETWORK_ERROR` the app only shows an
+  error notice — no server fallback, no proxy retry.
+- So a real browser sends exactly what production sends on segments:
+  `Referer: https://www.rivestream.app/` + `Origin` on XHR. That 403s too —
+  **this is broken for web users as well, not a production-only header gap.**
+
+## Referer brute-force (curl, not page loads) — all 403 `domain forbidden`
+
+none · `rivestream.app/` · `www.rivestream.app/` · full embed URL ·
+`cdn1.ngcorp.dad/` · `/e/<id>` page + playlist URLs · `rive.stream(±www)` ·
+`123movienow.cc/` · `+Origin: www.rivestream.app`. No `/e/` player page
+exists (openresty 404); no allowlisted domain appears anywhere in the
+frontend JS chunks.
+
+## Verdict: upstream-blocked, not a missing credential
+
+There is **no missing header/cookie/token** to add — the browser has nothing
+production lacks. The ImageX vhost allowlist simply does not include
+`rivestream.app`. Fixable client-side only by (a) discovering the allowlisted
+origin (not present in any shipped JS), or (b) fetching segments via a
+non-blocked path.
+
+## Fix proposal for `packages/providers/src/rivestream/direct.ts`
+
+1. **Probe-before-select**: after resolving `index-v1-a1.m3u8`, range-GET one
+   `p1.ipstatp.com` segment with the stream headers; on 403 mark the
+   primevids candidate `candidate-blocked` so the cycle falls through to a
+   working service instead of handing mpv a dead URL (fixes the silent
+   resolve-then-timeout).
+2. **Prefer `flowcast` for this title class**: its API answer already ships a
+   working proxy URL with baked-in headers
+   (`proxy.valhallastream.dpdns.org/proxy?url=…&headers={"Referer":"https://123movienow.cc/",…}`) —
+   forward those per-source headers instead of the static
+   `{referer, user-agent}` at `direct.ts:912`.
+3. If primevids must stay: needs relay/dossier path (cf. app's own
+   `proxyModeStream == "m3u8Proxy"` setting) — a user-owned media proxy, per
+   relay metadata-only policy discussion; do NOT bake any guessed relay host
+   into the binary.

--- a/.reference/experiments/scratchpads/provider-videasy-player/headers-2026-09-09.md
+++ b/.reference/experiments/scratchpads/provider-videasy-player/headers-2026-09-09.md
@@ -1,0 +1,78 @@
+# Videasy/Yoru stream headers — Dutton Ranch S01E01 (TMDB 299167), 2026-09-09
+
+## Verdict: credential missing? No — header surplus. Fixable in provider, no relay needed.
+
+The `moon.peakstorm.top` playlist gate rejects requests **with** an `Origin` header
+(403 openresty, any value) and serves the same URL with 200 when `Origin` is absent.
+Production sets `origin` on every Videasy stream header, so the resolve-gate probe,
+the HLS materializer, and mpv (`Origin:` via `http-header-fields`) all 403 on the
+playlist. Fix = stop sending `origin` to the wings CDN family.
+
+## What was observed
+
+Reproduced production exactly via lab fetches (no production imports):
+`GET api.speedracelight.com/seed?mediaId=299167` → seed, then
+`GET api.speedracelight.com/cdn/sources-with-title?title=Dutton Ranch&mediaType=tv&year=2026&tmdbId=299167&imdbId=tt34991493&seasonId=1&episodeId=1&enc=2&seed=…`
+→ enc=2 payload decrypts (lab-local PRNG copy) to **4 sources, all
+`https://moon.peakstorm.top/vd/<token>/index-s<q>-v1-a1.m3u8`** (2160/1080/720/480p),
+no query-string tokens, 1 subtitle. Matches the production "4 candidates, Yoru selected".
+
+Playlist probe (`index-s1080p-v1-a1.m3u8`):
+
+| Request headers                                                                  | Status  |
+| -------------------------------------------------------------------------------- | ------- |
+| production set: `referer: cineby.at/tv/…` + `origin: https://www.cineby.at` + UA | **403** |
+| `referer: https://www.cineby.at/` + `origin: https://www.cineby.at` + UA         | **403** |
+| `referer: https://www.cineby.at/` + UA, no origin                                | 200     |
+| UA only (no referer, no origin)                                                  | 200     |
+| `player.videasy.to` / `vidking.net` referers, no origin                          | 200     |
+
+So: `Origin` presence (not value) is the gate; `Referer` value is irrelevant
+(works with root, per-episode, videasy-player, vidking, or none).
+
+Playlist body (200) is a real VOD fMP4 playlist; segments live on a sibling host,
+`primecomet.top …/seg-N-s1080p-v1-a1.m4s` (+ `init-….mp4` map). Segment range-GETs
+return **206 with or without `Origin`** — only the playlist host is gated, but mpv
+never gets there because the playlist 403s first.
+
+No `Set-Cookie` on: seed response, sources response, playlist 200 response.
+No `Cookie` needed on any media request. Browser cookie jar held only tracker/ad
+cookies (`__ddg*`, `GL_*`, youtube) — nothing for `*.peakstorm.top`. Unlike VidLink
+(CloudFront signed cookies in `playlistHeaders`), there is **nothing to forward**.
+
+Browser run notes (2 loads used, budget spent): cineby.at title page loads;
+metadata comes from **`db.speedracelight.com`** (production `VIDEASY_DB_BASE` still
+points at `api.videasy.to/3` — enrichment still works, but the host has moved);
+headless never reaches `<video>`/`.m3u8` traffic (same bot friction as the parity
+report), which is why the API+curl path above is the evidence.
+
+## What production sends vs what the CDN wants
+
+`packages/providers/src/videasy/direct.ts` `normalizeStreamCandidates` sets on every
+stream (`direct.ts:2187-2191`): `{ referer, origin, user-agent }`.
+CDN wants: `{ referer (any), user-agent }`, **no `origin`**.
+
+Readers of that header set (all three 403): resolve-gate `runStreamHealthCheck`
+with `selected.headers`; `hls-manifest-materializer.ts` (fetches full manifest with
+stream headers); mpv via `buildPersistentLoadfileOptions`
+(`apps/cli/src/infra/player/mpv-stream-http-headers.ts:174` puts
+`Origin: …` into `http-header-fields`).
+
+## Fix proposal (production change, not applied)
+
+In the videasy provider, omit `origin` from stream `headers` when the stream host
+is in the wings CDN family (`*.peakstorm.top`, `*.primecomet.top` — suffix-match so
+future `moon-…`/`prime…` rotations are covered), mirroring how VidLink attaches
+per-host `playlistHeaders`, but subtractive:
+
+- `normalizeStreamCandidates`: `origin: isWingsCdnHost(url) ? undefined : streamOrigin`.
+- Keep `origin` on the API calls (`fetchVideasyPayload`, seed) — those 200 with it.
+- No `playlistHeaders`/cookie plumbing needed; no `http-header-fields` change needed
+  (empty origin already yields `http-header-fields-clr`).
+- Stale-cache purge for videasy titles after landing (cached candidates carry the old
+  header set), same as the VidLink cookie fix.
+
+Caveat: other wings flavors (neon2/ym/jett/…) likely share the gate — verify one more
+title on a different flavor before scoping the suffix list; segments on sibling hosts
+should be spot-checked per flavor since only `moon.*` playlist + `prime*.top`
+segments were tested here.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -66,6 +66,7 @@
     "test:live:discord": "bun -e \"await import('./test/live/discord-presence.smoke.ts')\"",
     "test:live:miruro": "bun test/live/miruro-demonslayer.smoke.ts",
     "test:live:matrix": "node test/live/provider-matrix.smoke.mjs",
+    "test:live:mpv": "bun test/live/mpv-playback.smoke.ts",
     "test:live:release-signoff": "bun -e \"await import('./test/live/release-provider-signoff.smoke.ts')\"",
     "test:live:youtube": "bun -e \"await import('./test/live/youtube.smoke.ts')\"",
     "test:live:providers": "bun run test:live:videasy && bun run test:live:vidlink && bun run test:live:rivestream && bun run test:live:anidb && bun run test:live:allanime && bun run test:live:miruro && bun run test:live:youtube",

--- a/apps/cli/test/live/README.md
+++ b/apps/cli/test/live/README.md
@@ -104,12 +104,33 @@ a 45-second deadline so a provider outage returns a diagnostic report instead of
 
 Each matrix row includes a `healthClass`:
 
-| Class                 | Meaning                                                              |
-| --------------------- | -------------------------------------------------------------------- |
-| `healthy`             | Stream resolved through `container.engine.resolve`                   |
-| `provider-drift`      | Upstream route/contract failure (404, exhausted, no playable source) |
-| `environment-network` | Timeout, connect/DNS/TLS, or WAF-shaped block                        |
-| `harness-failure`     | Unparseable smoke JSON or matrix deadline without provider evidence  |
+| Class                 | Meaning                                                                                  |
+| --------------------- | ---------------------------------------------------------------------------------------- |
+| `healthy`             | Stream resolved through `container.engine.resolve`                                       |
+| `provider-drift`      | Upstream route/contract failure (404, exhausted, no playable source, zero-result search) |
+| `environment-network` | Timeout, connect/DNS/TLS, captcha, or WAF-shaped block (incl. HLS 403 segment refusal)   |
+| `harness-failure`     | Unparseable smoke JSON or matrix deadline without provider evidence                      |
+
+Parser rules live in `matrix-harness.mjs` (shared with `test/unit/live/matrix-harness.test.ts`):
+stdout is tried first, then stderr; NDJSON check lines (`youtube` quality-ladder /
+type-short-search) resolve to the primary payload, so extra checks no longer flip
+a healthy provider to `harness-failure`. Search-stage failures print structured
+JSON to stdout for the same reason.
+
+### Headless mpv decode check
+
+Probe `reachable` is not playback. `mpv-playback.smoke.ts` resolves one matrix
+fixture and decodes it headless (`--vo=null --ao=null --frames=30`, 20s deadline)
+with the exact production header split:
+
+```sh
+bun test/live/mpv-playback.smoke.ts vidlink
+bun test/live/mpv-playback.smoke.ts youtube
+```
+
+`ok:true` means mpv exited 0 after decoding; anything else prints a redacted
+reason. Arg forwarding is covered by `test/unit/live/mpv-playback-verify.test.ts`
+(no mpv spawn). Isolated profile, opt-in, never part of `bun run test`.
 
 ### Cloudflare-fronted providers need an impersonating curl
 

--- a/apps/cli/test/live/anidb-onigiri.smoke.ts
+++ b/apps/cli/test/live/anidb-onigiri.smoke.ts
@@ -22,7 +22,7 @@ const container = await createContainer({ debug: true });
 const provider = container.providerRegistry.get("anidb");
 
 if (!provider) {
-  console.error(JSON.stringify({ ok: false, stage: "provider", reason: "missing_anidb" }));
+  console.log(JSON.stringify({ ok: false, stage: "provider", reason: "missing_anidb" }));
   process.exit(1);
 }
 
@@ -33,15 +33,31 @@ if (clearCache) {
 // Search through the default provider itself. A hard-coded native id would let
 // this smoke pass while AniDB search — the route users actually take — is dead.
 if (!provider.search) {
-  console.error(JSON.stringify({ ok: false, stage: "search", reason: "anidb_has_no_search" }));
+  console.log(JSON.stringify({ ok: false, stage: "search", reason: "anidb_has_no_search" }));
   process.exit(1);
 }
 
-const searchResults =
-  (await provider.search(searchQuery, {
-    audioPreference: container.config.animeLanguageProfile.audio,
-    subtitlePreference: container.config.animeLanguageProfile.subtitle,
-  })) ?? [];
+let searchResults: Awaited<ReturnType<NonNullable<typeof provider.search>>> = [];
+try {
+  searchResults =
+    (await provider.search(searchQuery, {
+      audioPreference: container.config.animeLanguageProfile.audio,
+      subtitlePreference: container.config.animeLanguageProfile.subtitle,
+    })) ?? [];
+} catch (error) {
+  // Structured failure to stdout so the matrix reports provider evidence
+  // (e.g. environment-network on HTTP 503) instead of harness-failure.
+  console.log(
+    JSON.stringify({
+      ok: false,
+      stage: "search",
+      searchedProvider: "anidb",
+      searchResults: 0,
+      reason: error instanceof Error ? error.message : String(error),
+    }),
+  );
+  process.exit(1);
+}
 
 const normalizeTitle = (value: string) =>
   value
@@ -53,7 +69,10 @@ const selected =
   searchResults[0];
 
 if (!selected) {
-  console.error(
+  // Structured failure goes to stdout so provider-matrix parses provider
+  // evidence (provider-drift) instead of harness-failure. Matrix also falls
+  // back to stderr, but stdout keeps this consistent with the success path.
+  console.log(
     JSON.stringify({
       ok: false,
       stage: "search",

--- a/apps/cli/test/live/matrix-harness.mjs
+++ b/apps/cli/test/live/matrix-harness.mjs
@@ -1,0 +1,161 @@
+/**
+ * Shared matrix harness helpers — pure, Node-compatible, no network.
+ *
+ * `provider-matrix.smoke.mjs` runs under `node`, so this file must stay
+ * plain `.mjs` with no TS syntax and no Bun/CLI imports. Bun unit tests
+ * import these same functions, which is what keeps the matrix parser and
+ * its contract tests from drifting apart.
+ */
+
+/**
+ * Try to parse one JSON value. Returns the object or null.
+ */
+export function tryParseJsonObject(text) {
+  try {
+    const value = JSON.parse(text);
+    return value && typeof value === "object" && !Array.isArray(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A smoke payload is the primary resolve report, not an auxiliary check
+ * line (`{ check: "quality-ladder" }`). Primary payloads carry a provider
+ * identity; check lines carry `check`.
+ */
+export function isPrimarySmokePayload(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  if (typeof value.check === "string") return false;
+  return typeof value.provider === "string" || typeof value.providerId === "string";
+}
+
+/**
+ * Parse smoke stdout that may contain:
+ * - a single pretty-printed JSON payload (most smokes), or
+ * - NDJSON / multiple JSON documents (youtube.smoke.ts emits the primary
+ *   payload plus `quality-ladder` and `type-short-search` check lines).
+ *
+ * Strategy: whole-output parse first, then per-line scan for the first
+ * primary payload, then brace-scan fallback for pretty-printed output with
+ * log prefixes.
+ */
+export function parseJsonPayload(stdout) {
+  if (!stdout || typeof stdout !== "string") return null;
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+
+  const whole = tryParseJsonObject(trimmed);
+  if (whole) return whole;
+
+  // Per-line scan: handles NDJSON and pretty-printed payloads mixed with
+  // log lines. Collect primary payloads; prefer one with stream evidence.
+  let firstPrimary = null;
+  let firstAny = null;
+  for (const line of trimmed.split("\n")) {
+    const candidate = tryParseJsonObject(line.trim());
+    if (!candidate) continue;
+    if (!firstAny) firstAny = candidate;
+    if (isPrimarySmokePayload(candidate)) {
+      if (!firstPrimary) firstPrimary = candidate;
+      // A payload with resolve evidence is the report we want even if a
+      // slimmer primary line came first.
+      if (typeof candidate.streamResolved === "boolean") return candidate;
+    }
+  }
+  if (firstPrimary) return firstPrimary;
+
+  // Brace-scan fallback for a single pretty-printed object with prefixes.
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start >= 0 && end > start) {
+    // NDJSON brace-scan would glue documents together, so only use it when
+    // the per-line scan found nothing primary.
+    const glued = tryParseJsonObject(trimmed.slice(start, end + 1));
+    if (glued) return glued;
+  }
+  return firstAny;
+}
+
+/**
+ * Matrix reads stdout first, then stderr. Search-stage failures
+ * (anidb-onigiri) historically went to stderr via console.error while
+ * success goes to stdout, which misclassified structured provider
+ * evidence as `harness-failure`. Returns the payload plus where it came
+ * from, or null.
+ */
+export function parseSmokeOutput(stdout, stderr) {
+  const fromStdout = parseJsonPayload(stdout);
+  if (fromStdout) return { payload: fromStdout, source: "stdout" };
+  const fromStderr = parseJsonPayload(stderr);
+  if (fromStderr) return { payload: fromStderr, source: "stderr" };
+  return null;
+}
+
+/**
+ * Release-evidence taxonomy for matrix rows. Default CI must not depend on these.
+ * - healthy: stream resolved
+ * - provider-drift: upstream contract/route failure while the harness ran
+ * - environment-network: timeout, connect, DNS/TLS, or WAF-shaped blocks
+ * - harness-failure: unparseable smoke output or matrix deadline without provider JSON
+ */
+export function classifyProviderHealth(result, { timedOut, harness }) {
+  if (result?.ok) return "healthy";
+  if (harness) return "harness-failure";
+
+  const haystack = [
+    result?.error ?? "",
+    result?.reason ?? "",
+    result?.stage ?? "",
+    result?.streamProbeStatus ?? "",
+    result?.streamProbeReason ?? "",
+    ...(Array.isArray(result?.failureCodes) ? result.failureCodes : []),
+    ...(Array.isArray(result?.failureMessages) ? result.failureMessages : []),
+  ]
+    .join(" ")
+    .toLowerCase();
+
+  if (
+    timedOut ||
+    /within \d+s|timed out|timeout|econn|enotfound|network|cannot connect|connection|403|waf|socket|captcha|cloudflare|just a moment|challenge|blocked by|\b5\d\d\b|http 5\d\d|maintenance/.test(
+      haystack,
+    )
+  ) {
+    return "environment-network";
+  }
+
+  if (
+    /404|not-found|did not find|no playable|exhausted|route-dead|unsupported-title|zero results|search returned/.test(
+      haystack,
+    )
+  ) {
+    return "provider-drift";
+  }
+
+  return "provider-drift";
+}
+
+export function booleanOrNull(value) {
+  return typeof value === "boolean" ? value : null;
+}
+
+export function numberOrNull(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function stringOrNull(value) {
+  return typeof value === "string" ? value : null;
+}
+
+export function stringArray(value) {
+  return Array.isArray(value) ? value.filter((item) => typeof item === "string") : [];
+}
+
+export function parseScore(value) {
+  if (!value || typeof value !== "object") return null;
+  return {
+    functional: booleanOrNull(value.functional),
+    performative: booleanOrNull(value.performative),
+    ordered: booleanOrNull(value.ordered),
+  };
+}

--- a/apps/cli/test/live/mpv-playback-verify.ts
+++ b/apps/cli/test/live/mpv-playback-verify.ts
@@ -1,0 +1,155 @@
+/**
+ * Headless mpv playback verifier for live smokes — proves decode, not just probe 200.
+ *
+ * Opt-in only (needs network + mpv). Uses the same header split as production
+ * (`normalizeStreamHttpHeaders` in `src/infra/player/mpv-stream-http-headers.ts`):
+ * referer/user-agent via dedicated options, everything else via
+ * `http-header-fields`. Values containing commas are dropped because mpv
+ * splits that list on commas with no escape.
+ *
+ * Isolated by construction: callers resolve through `createProviderSmokeProfile`
+ * + `resolveProviderSmokeStream`, so no live config/data/cache is touched.
+ * Output is redacted (no URLs, cookies, or /tmp paths in the returned reason).
+ */
+
+export type MpvPlaybackHeaders = Record<string, string>;
+
+export type MpvPlaybackVerifyResult =
+  | { readonly ok: true; readonly exitCode: number; readonly frames: number }
+  | { readonly ok: false; readonly exitCode: number | null; readonly reason: string };
+
+function sanitizeMpvArg(value: string): string {
+  return value.replace(/[\r\n]/g, "");
+}
+
+function pickHeader(headers: MpvPlaybackHeaders, ...names: string[]): string | undefined {
+  for (const name of names) {
+    const hit = Object.entries(headers).find(([key]) => key.toLowerCase() === name);
+    const value = hit?.[1]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Pure arg builder — unit-tested without spawning mpv. Returns argv *after*
+ * the binary so tests assert exact forwarding.
+ */
+export function buildMpvPlaybackVerifyArgs(input: {
+  readonly url: string;
+  readonly headers?: MpvPlaybackHeaders;
+  readonly frames?: number;
+  readonly timeoutMs?: number;
+}): string[] {
+  const headers = input.headers ?? {};
+  const referer = pickHeader(headers, "referer");
+  const userAgent = pickHeader(headers, "user-agent");
+  const origin = pickHeader(headers, "origin");
+  const extraFields: string[] = [];
+  if (origin && !origin.includes(",")) extraFields.push(`Origin: ${origin}`);
+  for (const [name, raw] of Object.entries(headers)) {
+    const lower = name.toLowerCase();
+    if (lower === "referer" || lower === "user-agent" || lower === "origin") continue;
+    const value = raw?.trim();
+    if (!value || value.includes(",")) continue;
+    extraFields.push(`${name}: ${value}`);
+  }
+
+  const args = [
+    "--no-config",
+    "--force-window=no",
+    "--vo=null",
+    "--ao=null",
+    "--really-quiet",
+    `--frames=${input.frames ?? 30}`,
+    "--cache=yes",
+  ];
+  if (referer) args.push(`--referrer=${sanitizeMpvArg(referer)}`);
+  if (userAgent) args.push(`--user-agent=${sanitizeMpvArg(userAgent)}`);
+  if (extraFields.length > 0)
+    args.push(`--http-header-fields=${sanitizeMpvArg(extraFields.join(","))}`);
+  if (/mp4upload\.com$/i.test(safeHostname(input.url))) args.push("--tls-verify=no");
+  args.push("--", input.url);
+  return args;
+}
+
+function safeHostname(url: string): string {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+/** Redacted argv shape for logs: cookie/signature values never leave the spawn. */
+export function redactMpvArgsForLog(args: readonly string[]): string[] {
+  return args.map((arg) =>
+    /^--http-header-fields=/i.test(arg) ? arg.replace(/(cookie[^,]*)/gi, "Cookie: REDACTED") : arg,
+  );
+}
+
+function redactReason(reason: string): string {
+  return reason
+    .replace(/https?:\/\/[^\s"'\\]+/gi, "https://REDACTED")
+    .replace(/\/tmp\/[^\s"'\\]+/gi, "/tmp/REDACTED")
+    .slice(0, 500);
+}
+
+/**
+ * Spawn headless mpv and wait for decode. Success is exit 0 after decoding
+ * up to `frames` frames. Non-zero exit, stderr `error`, or timeout kill is
+ * evidence the stream does not play even if the HTTP probe was reachable.
+ */
+export async function verifyStreamPlaysInMpv(input: {
+  readonly mpvBinary?: string;
+  readonly url: string;
+  readonly headers?: MpvPlaybackHeaders;
+  readonly frames?: number;
+  readonly timeoutMs?: number;
+}): Promise<MpvPlaybackVerifyResult> {
+  const mpvBinary = input.mpvBinary ?? Bun.which("mpv") ?? "mpv";
+  if (!Bun.which(mpvBinary) && mpvBinary === "mpv") {
+    return { ok: false, exitCode: null, reason: "mpv missing on PATH" };
+  }
+  const timeoutMs = input.timeoutMs ?? 20_000;
+  const args = buildMpvPlaybackVerifyArgs(input);
+  const proc = Bun.spawn([mpvBinary, ...args], { stdout: "pipe", stderr: "pipe" });
+
+  const stderrChunks: string[] = [];
+  const reader = proc.stderr.getReader();
+  const readStderr = (async () => {
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        stderrChunks.push(new TextDecoder().decode(value));
+      }
+    } catch {
+      // Stderr is diagnostic only; a read failure must not fail verification.
+    } finally {
+      reader.releaseLock();
+    }
+  })();
+
+  const exitPromise = proc.exited.then((code) => ({ type: "exit" as const, code }));
+  const timeoutPromise = Bun.sleep(timeoutMs).then(() => ({ type: "timeout" as const }));
+  const outcome = await Promise.race([exitPromise, timeoutPromise]);
+  if (outcome.type === "timeout") {
+    try {
+      proc.kill("SIGTERM");
+    } catch {
+      // Already exited between the race and the kill.
+    }
+    await readStderr;
+    return { ok: false, exitCode: null, reason: "mpv verify timed out without decoding" };
+  }
+  await readStderr;
+  if (outcome.code === 0) {
+    return { ok: true, exitCode: 0, frames: input.frames ?? 30 };
+  }
+  return {
+    ok: false,
+    exitCode: outcome.code,
+    reason: redactReason(stderrChunks.join("").trim() || `mpv exited with code ${outcome.code}`),
+  };
+}

--- a/apps/cli/test/live/mpv-playback.smoke.ts
+++ b/apps/cli/test/live/mpv-playback.smoke.ts
@@ -1,0 +1,161 @@
+/**
+ * Opt-in mpv decode check: resolve one matrix fixture, then prove mpv decodes it.
+ *
+ * Usage:
+ *   bun test/live/mpv-playback.smoke.ts vidlink
+ *   bun test/live/mpv-playback.smoke.ts youtube
+ *   bun test/live/mpv-playback.smoke.ts videasy|rivestream|anidb|allanime|miruro
+ *
+ * Isolated temporary XDG profile (never touches live config/data/cache),
+ * headless mpv (`--vo=null --ao=null --frames=30`), 20s deadline. Prints one
+ * redacted JSON line: no stream URLs, cookies, or /tmp paths.
+ */
+import type { TitleInfo } from "@/domain/types";
+
+import {
+  buildMpvPlaybackVerifyArgs,
+  redactMpvArgsForLog,
+  verifyStreamPlaysInMpv,
+} from "./mpv-playback-verify";
+import {
+  buildProviderSmokePayload,
+  createProviderSmokeProfile,
+  providerSmokeError,
+  providerSmokeProfilePayload,
+  resolveProviderSmokeStream,
+} from "./provider-smoke";
+import { directSmokeArgs } from "./smoke-argv";
+
+const profile = createProviderSmokeProfile("mpv-playback");
+const args = directSmokeArgs();
+const providerId = (args[0] ?? "vidlink").toLowerCase();
+const frames = Number(process.env.KUNAI_MPV_FRAMES ?? "30") || 30;
+
+const FIXTURES: Record<
+  string,
+  { title: TitleInfo; mode: "series" | "anime" | "youtube"; season?: number; episode?: number }
+> = {
+  videasy: {
+    title: { id: "299167", type: "series", name: "Dutton Ranch" },
+    mode: "series",
+    season: 1,
+    episode: 1,
+  },
+  rivestream: {
+    title: { id: "1396", type: "series", name: "Breaking Bad" },
+    mode: "series",
+    season: 1,
+    episode: 1,
+  },
+  vidlink: {
+    title: { id: "27205", type: "movie", name: "Inception" },
+    mode: "series",
+  },
+  youtube: {
+    title: {
+      id: "youtube:jNQXAC9IVRw",
+      type: "movie",
+      name: "Me at the zoo",
+      externalIds: { youtubeId: "jNQXAC9IVRw" },
+    },
+    mode: "youtube",
+  },
+};
+
+const fixture = FIXTURES[providerId];
+if (!fixture) {
+  console.log(
+    JSON.stringify({
+      ok: false,
+      provider: providerId,
+      reason: `mpv-playback supports ${Object.keys(FIXTURES).join(",")} (anime search fixtures stay in their own smokes)`,
+      ...providerSmokeProfilePayload(profile),
+    }),
+  );
+  process.exit(1);
+}
+
+if (!Bun.which("mpv")) {
+  console.log(
+    JSON.stringify({
+      ok: true,
+      skipped: true,
+      provider: providerId,
+      reason: "mpv missing on PATH",
+      ...providerSmokeProfilePayload(profile),
+    }),
+  );
+  process.exit(0);
+}
+
+const { createContainer } = await import("@/container");
+const container = await createContainer({ debug: true });
+if (!container.providerRegistry.get(providerId)) {
+  console.log(
+    JSON.stringify({
+      ok: false,
+      provider: providerId,
+      reason: `missing_${providerId}`,
+      ...providerSmokeProfilePayload(profile),
+    }),
+  );
+  process.exit(1);
+}
+
+let resolveError: unknown = null;
+const resolved = await resolveProviderSmokeStream({
+  container,
+  providerId,
+  mode: fixture.mode,
+  request: {
+    title: fixture.title,
+    ...(fixture.season && fixture.episode
+      ? { episode: { season: fixture.season, episode: fixture.episode } }
+      : {}),
+    audioPreference: container.config.seriesLanguageProfile.audio,
+    subtitlePreference: container.config.seriesLanguageProfile.subtitle,
+  },
+}).catch((error) => {
+  resolveError = error;
+  return { stream: null, resolveDurationMs: null };
+});
+
+const stream = resolved.stream;
+const base = buildProviderSmokePayload({
+  provider: providerId,
+  title: fixture.title,
+  season: fixture.season,
+  episode: fixture.episode,
+  stream,
+  resolveDurationMs: resolved.resolveDurationMs,
+});
+
+if (!stream?.url) {
+  console.log(
+    JSON.stringify({
+      ...base,
+      ...(resolveError ? providerSmokeError(resolveError) : {}),
+      mpv: { ok: false, reason: "nothing resolved to hand to mpv" },
+      mpvArgs: [],
+      ...providerSmokeProfilePayload(profile),
+    }),
+  );
+  process.exit(1);
+}
+
+const mpvArgs = buildMpvPlaybackVerifyArgs({ url: stream.url, headers: stream.headers, frames });
+const mpv = await verifyStreamPlaysInMpv({ url: stream.url, headers: stream.headers, frames });
+// Never log credential material: Cookie / signature values stay in the spawned
+// argv only. The report carries the redacted shape for review.
+const redactedMpvArgs = redactMpvArgsForLog(mpvArgs);
+const ok = base.ok && mpv.ok;
+console.log(
+  JSON.stringify({
+    ...base,
+    mpv,
+    mpvArgs: redactedMpvArgs.slice(0, -2),
+    mpvUrlHost: base.streamHost,
+    ...providerSmokeProfilePayload(profile),
+  }),
+);
+process.exit(ok ? 0 : 1);

--- a/apps/cli/test/live/provider-matrix.smoke.mjs
+++ b/apps/cli/test/live/provider-matrix.smoke.mjs
@@ -3,6 +3,16 @@
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
+import {
+  booleanOrNull,
+  classifyProviderHealth,
+  numberOrNull,
+  parseScore,
+  parseSmokeOutput,
+  stringArray,
+  stringOrNull,
+} from "./matrix-harness.mjs";
+
 const MATRIX = [
   {
     provider: "videasy",
@@ -135,7 +145,10 @@ if (process.argv.slice(2).some((arg) => arg.toLowerCase() === "release-signoff")
 
 async function runMatrixEntry(entry) {
   const { stdout, stderr, exitCode, timedOut } = await runLiveSmoke(entry.command);
-  const parsed = parseJsonPayload(stdout);
+  // youtube.smoke.ts emits NDJSON (primary payload + check lines); anidb
+  // search-stage failures go to stderr. Parse stdout first, then stderr.
+  const found = parseSmokeOutput(stdout, stderr);
+  const parsed = found?.payload ?? null;
   if (!parsed) {
     const result = {
       provider: entry.provider,
@@ -159,6 +172,8 @@ async function runMatrixEntry(entry) {
     return { ...result, healthClass: classifyProviderHealth(result, { timedOut, harness: true }) };
   }
 
+  const streamProbe =
+    parsed.streamProbe && typeof parsed.streamProbe === "object" ? parsed.streamProbe : null;
   const result = {
     provider: entry.provider,
     media: entry.media,
@@ -172,56 +187,26 @@ async function runMatrixEntry(entry) {
     cacheHit: booleanOrNull(parsed.cacheHit),
     isolatedProfile: booleanOrNull(parsed.isolatedProfile),
     failureCodes: stringArray(parsed.failureCodes),
+    failureMessages: stringArray(parsed.failureMessages),
     resolveDurationMs: numberOrNull(parsed.resolveDurationMs),
     streamReachable: booleanOrNull(parsed.streamReachable),
+    streamProbeStatus: stringOrNull(parsed.streamProbeStatus ?? streamProbe?.status),
+    streamProbeReason: stringOrNull(
+      (typeof streamProbe?.reason === "string" ? streamProbe.reason : null) ??
+        (typeof parsed.streamProbe === "string" ? parsed.streamProbe : null),
+    ),
     selectedSourceLabel: stringOrNull(parsed.selectedSourceLabel),
     probeOrderLabels: stringArray(parsed.probeOrderLabels),
     score: parseScore(parsed.score),
     ...(typeof parsed.error === "string" ? { error: parsed.error } : {}),
+    ...(typeof parsed.reason === "string" ? { reason: parsed.reason } : {}),
+    ...(typeof parsed.stage === "string" ? { stage: parsed.stage } : {}),
+    ...(found?.source === "stderr" ? { parsedFrom: "stderr" } : {}),
   };
   return {
     ...result,
     healthClass: classifyProviderHealth(result, { timedOut, harness: false }),
   };
-}
-
-/**
- * Release-evidence taxonomy for matrix rows. Default CI must not depend on these.
- * - healthy: stream resolved
- * - provider-drift: upstream contract/route failure while the harness ran
- * - environment-network: timeout, connect, DNS/TLS, or WAF-shaped blocks
- * - harness-failure: unparseable smoke output or matrix deadline without provider JSON
- *
- * ReleaseProviderSignoff.failureClass reuses provider-drift / environment-network /
- * harness-failure (null when the default route is resolved and reachable).
- */
-function classifyProviderHealth(result, { timedOut, harness }) {
-  if (result.ok) return "healthy";
-  if (harness) return "harness-failure";
-
-  const haystack = [
-    result.error ?? "",
-    ...(Array.isArray(result.failureCodes) ? result.failureCodes : []),
-  ]
-    .join(" ")
-    .toLowerCase();
-
-  if (
-    timedOut ||
-    /within \d+s|timed out|timeout|econn|enotfound|network|cannot connect|connection|403|waf|socket/.test(
-      haystack,
-    )
-  ) {
-    return "environment-network";
-  }
-
-  if (
-    /404|not-found|did not find|no playable|exhausted|route-dead|unsupported-title/.test(haystack)
-  ) {
-    return "provider-drift";
-  }
-
-  return "provider-drift";
 }
 
 function redactMatrixReport(report) {
@@ -276,46 +261,4 @@ async function runLiveSmoke(command) {
     child.once("error", (error) => finish(1, error));
     child.once("close", (code) => finish(code));
   });
-}
-
-function parseJsonPayload(stdout) {
-  try {
-    const value = JSON.parse(stdout);
-    return value && typeof value === "object" ? value : null;
-  } catch {
-    const start = stdout.indexOf("{");
-    const end = stdout.lastIndexOf("}");
-    if (start < 0 || end <= start) return null;
-    try {
-      const value = JSON.parse(stdout.slice(start, end + 1));
-      return value && typeof value === "object" ? value : null;
-    } catch {
-      return null;
-    }
-  }
-}
-
-function booleanOrNull(value) {
-  return typeof value === "boolean" ? value : null;
-}
-
-function numberOrNull(value) {
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
-function stringOrNull(value) {
-  return typeof value === "string" ? value : null;
-}
-
-function stringArray(value) {
-  return Array.isArray(value) ? value.filter((item) => typeof item === "string") : [];
-}
-
-function parseScore(value) {
-  if (!value || typeof value !== "object") return null;
-  return {
-    functional: booleanOrNull(value.functional),
-    performative: booleanOrNull(value.performative),
-    ordered: booleanOrNull(value.ordered),
-  };
 }

--- a/apps/cli/test/unit/live/matrix-harness.test.ts
+++ b/apps/cli/test/unit/live/matrix-harness.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  classifyProviderHealth,
+  parseJsonPayload,
+  parseSmokeOutput,
+} from "../../live/matrix-harness.mjs";
+
+describe("matrix harness parser", () => {
+  test("parses a single pretty-printed payload", () => {
+    const stdout = JSON.stringify(
+      {
+        ok: true,
+        provider: "vidlink",
+        providerId: "vidlink",
+        streamResolved: true,
+        streamReachable: true,
+      },
+      null,
+      2,
+    );
+    expect(parseJsonPayload(stdout)?.provider).toBe("vidlink");
+  });
+
+  test("picks the primary payload out of youtube NDJSON check lines", () => {
+    const primary = JSON.stringify({
+      ok: true,
+      provider: "youtube",
+      providerId: "youtube",
+      streamResolved: true,
+      streamHost: "www.youtube.com",
+      streamReachable: true,
+      isolatedProfile: true,
+    });
+    const stdout = [
+      primary,
+      JSON.stringify({ ok: true, check: "quality-ladder", maxLadderHeight: 2160 }),
+      JSON.stringify({ ok: true, check: "type-short-search", resultCount: 12 }),
+    ].join("\n");
+    const parsed = parseJsonPayload(stdout);
+    expect(parsed?.provider).toBe("youtube");
+    expect(parsed?.streamResolved).toBe(true);
+  });
+
+  test("falls back to stderr for search-stage failures", () => {
+    const failure = JSON.stringify({
+      ok: false,
+      stage: "search",
+      searchedProvider: "anidb",
+      searchResults: 0,
+      reason: 'anidb search returned zero results for "Onigiri"',
+    });
+    const found = parseSmokeOutput("", failure);
+    expect(found?.source).toBe("stderr");
+    expect(found?.payload.stage).toBe("search");
+  });
+
+  test("returns null when neither stream carries JSON", () => {
+    expect(parseSmokeOutput("no json here", "container log line")).toBeNull();
+  });
+});
+
+describe("matrix health classification", () => {
+  test("captcha / WAF evidence is environment-network, not drift", () => {
+    expect(
+      classifyProviderHealth(
+        { ok: false, error: "AllAnime requires a captcha for stream sources from this network" },
+        { timedOut: false, harness: false },
+      ),
+    ).toBe("environment-network");
+    expect(
+      classifyProviderHealth(
+        { ok: false, error: "Miruro pipe blocked by Cloudflare WAF (HTTP 403 HTML)" },
+        { timedOut: false, harness: false },
+      ),
+    ).toBe("environment-network");
+  });
+
+  test("HLS 403 probe evidence is environment-network", () => {
+    expect(
+      classifyProviderHealth(
+        {
+          ok: false,
+          streamResolved: true,
+          streamReachable: false,
+          streamProbeStatus: "unreachable",
+          streamProbeReason: "HLS segment unreachable: HTTP 403",
+        },
+        { timedOut: false, harness: false },
+      ),
+    ).toBe("environment-network");
+  });
+
+  test("HTTP 503 site outage is environment-network", () => {
+    expect(
+      classifyProviderHealth(
+        { ok: false, stage: "search", reason: "anidb fetch HTTP 503" },
+        { timedOut: false, harness: false },
+      ),
+    ).toBe("environment-network");
+  });
+
+  test("zero-result search is provider-drift", () => {
+    expect(
+      classifyProviderHealth(
+        { ok: false, stage: "search", reason: 'anidb search returned zero results for "Onigiri"' },
+        { timedOut: false, harness: false },
+      ),
+    ).toBe("provider-drift");
+  });
+
+  test("unparseable output stays harness-failure", () => {
+    expect(classifyProviderHealth({ ok: false }, { timedOut: false, harness: true })).toBe(
+      "harness-failure",
+    );
+  });
+});

--- a/apps/cli/test/unit/live/mpv-playback-verify.test.ts
+++ b/apps/cli/test/unit/live/mpv-playback-verify.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildMpvPlaybackVerifyArgs, redactMpvArgsForLog } from "../../live/mpv-playback-verify";
+
+describe("mpv playback verify args", () => {
+  test("splits referer/user-agent to dedicated options and the rest to header fields", () => {
+    const args = buildMpvPlaybackVerifyArgs({
+      url: "https://cdn.example/watch/master.m3u8",
+      headers: {
+        referer: "https://provider.example/title",
+        "user-agent": "kunai-test/1.0",
+        Origin: "https://provider.example",
+        Cookie: "session=abc",
+      },
+      frames: 30,
+    });
+    expect(args).toContain("--referrer=https://provider.example/title");
+    expect(args).toContain("--user-agent=kunai-test/1.0");
+    expect(args).toContain(
+      "--http-header-fields=Origin: https://provider.example,Cookie: session=abc",
+    );
+    expect(args.slice(-2)).toEqual(["--", "https://cdn.example/watch/master.m3u8"]);
+  });
+
+  test("drops comma-bearing values mpv cannot represent", () => {
+    const args = buildMpvPlaybackVerifyArgs({
+      url: "https://cdn.example/v.m3u8",
+      headers: { Cookie: "a=1, b=2", referer: "https://provider.example" },
+    });
+    expect(args.some((arg) => arg.includes("a=1"))).toBe(false);
+    expect(args).toContain("--referrer=https://provider.example");
+  });
+
+  test("headless decode flags come first and URL is last", () => {
+    const args = buildMpvPlaybackVerifyArgs({ url: "https://cdn.example/v.m3u8" });
+    expect(args.slice(0, 5)).toEqual([
+      "--no-config",
+      "--force-window=no",
+      "--vo=null",
+      "--ao=null",
+      "--really-quiet",
+    ]);
+    expect(args.at(-1)).toBe("https://cdn.example/v.m3u8");
+  });
+
+  test("mp4upload keeps its tls-verify exception", () => {
+    const args = buildMpvPlaybackVerifyArgs({ url: "https://s1.mp4upload.com/file.mp4" });
+    expect(args).toContain("--tls-verify=no");
+  });
+
+  test("log redaction keeps cookie values out of reports", () => {
+    const args = buildMpvPlaybackVerifyArgs({
+      url: "https://cdn.example/v.m3u8",
+      headers: { Cookie: "CloudFront-Signature=secret" },
+    });
+    expect(args.some((arg) => arg.includes("secret"))).toBe(true);
+    const redacted = redactMpvArgsForLog(args);
+    expect(redacted.some((arg) => arg.includes("secret"))).toBe(false);
+    expect(redacted.some((arg) => arg.includes("Cookie: REDACTED"))).toBe(true);
+  });
+});

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -302,9 +302,14 @@ export async function searchAnidb(
 ): Promise<readonly AnidbSearchResult[]> {
   const trimmed = query.trim();
   if (!trimmed) return [];
+  // reportStatus so an HTTP error page (maintenance 503, WAF block) throws
+  // AnidbHttpStatusError instead of parsing as zero results — a 503 page has
+  // no result cards, which used to read as "no such title" (provider-drift)
+  // when the truth was "site down" (environment-network).
   const page = await anidbFetchText(`${ANIDB_BASE}/browse?q=${encodeURIComponent(trimmed)}`, {
     signal,
     context,
+    reportStatus: true,
   });
   return parseAnidbBrowseHtml(page);
 }

--- a/packages/providers/src/rivestream/direct.ts
+++ b/packages/providers/src/rivestream/direct.ts
@@ -45,6 +45,7 @@ import {
   streamPresentationFields,
 } from "../shared/source-inventory";
 import { selectReadyStream } from "../shared/startup-selection";
+import { probeStreamReachability } from "../shared/stream-reachability";
 import { inferSubtitleFormat, normalizeIsoLanguageCode } from "../shared/subtitle-helpers";
 import { createTimeoutSignal } from "../shared/timeout-signal";
 import { rivestreamManifest, RIVESTREAM_PROVIDER_ID } from "./manifest";
@@ -55,6 +56,9 @@ export const RIVESTREAM_API_BASE = "https://www.rivestream.app/api/backendfetch"
 
 const USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
+/** Resolve-gate probe budget per service candidate (inside the 10s candidate timeout). */
+const RIVESTREAM_RESOLVE_GATE_TIMEOUT_MS = 3_000;
 
 /**
  * Failure sentinels from `generateSecretKey`. They must never be cached: a
@@ -128,6 +132,75 @@ type RivestreamRawSubtitle = {
   readonly file?: string;
   readonly label?: string;
 };
+
+/**
+ * Per-source headers baked into proxy URLs. Flowcast answers ship
+ * `…/proxy?url=<upstream>&headers={"Referer":"…",…}` — a working proxy whose
+ * upstream fetch needs those headers. Forward them on the stream instead of
+ * the static site referer; anything else keeps the default set.
+ *
+ * Values are sanitized of CR/LF (header-injection safety); comma-bearing
+ * values are kept here and dropped later by `normalizeStreamHttpHeaders`,
+ * which is the single place that knows mpv's list encoding.
+ */
+export function parseRivestreamProxyHeaders(sourceUrl: string): Record<string, string> | null {
+  let params: URLSearchParams;
+  try {
+    params = new URL(sourceUrl).searchParams;
+  } catch {
+    return null;
+  }
+  const raw = params.get("headers");
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+  const headers: Record<string, string> = {};
+  for (const [name, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof value !== "string") continue;
+    const cleaned = value.replace(/[\r\n]/g, "").trim();
+    if (!name.trim() || !cleaned) continue;
+    headers[name.trim()] = cleaned;
+  }
+  return Object.keys(headers).length > 0 ? headers : null;
+}
+
+function resolveRivestreamStreamHeaders(sourceUrl: string): Record<string, string> {
+  const proxyHeaders = parseRivestreamProxyHeaders(sourceUrl);
+  if (!proxyHeaders) {
+    return { referer: RIVESTREAM_REFERER, "user-agent": USER_AGENT };
+  }
+  const headers: Record<string, string> = { ...proxyHeaders };
+  if (!Object.keys(headers).some((name) => name.toLowerCase() === "user-agent")) {
+    headers["user-agent"] = USER_AGENT;
+  }
+  return headers;
+}
+
+type ProvenRefusalProbe = {
+  readonly status: "unreachable";
+  readonly definitive: true;
+  readonly reason: string;
+};
+
+/**
+ * Refusal evidence strong enough to fail a candidate mid-cycle: an HTTP error
+ * status, an HTML body where media bytes should be, or a truncated body. A
+ * 200 with an unparseable playlist is inconclusive (captive portals and test
+ * fixtures both serve those) and must not condemn the candidate.
+ */
+export function isProvenStreamRefusal(probe: {
+  readonly status: string;
+  readonly definitive?: boolean;
+  readonly reason?: string;
+}): probe is ProvenRefusalProbe {
+  if (probe.status !== "unreachable" || probe.definitive !== true) return false;
+  return /HTTP [45]\d\d|content-type|body too small/i.test(probe.reason ?? "");
+}
 
 type RivestreamResolvedCandidate = {
   readonly provider: string;
@@ -909,7 +982,7 @@ async function resolveRivestreamProviderCandidate({
       qualityRank,
       languageEvidence,
       sourceEvidence,
-      headers: { referer: RIVESTREAM_REFERER, "user-agent": USER_AGENT },
+      headers: resolveRivestreamStreamHeaders(source.url),
       confidence: 0.95,
       cachePolicy,
       ...streamPresentationFields({ displayLabel, subtitle: audioSubtitle }),
@@ -925,6 +998,32 @@ async function resolveRivestreamProviderCandidate({
       );
     }
   });
+
+  // Probe-before-select: a service that returns URLs is not proof they play
+  // (primevids answers JSON while its ImageX segments 403 every origin,
+  // including real browsers). A proven refusal fails this candidate so the
+  // cycle falls through to the next service; anything inconclusive (timeout,
+  // unparseable body, DNS wobble) still passes, per the shared resolve-gate
+  // leniency. Only refusal evidence — an HTTP error status, an HTML body
+  // where bytes should be, or a truncated body — condemns the candidate.
+  const probeTarget = [...streams].sort((a, b) => (b.qualityRank ?? 0) - (a.qualityRank ?? 0))[0];
+  if (probeTarget?.url) {
+    const probe = await probeStreamReachability({
+      url: probeTarget.url,
+      headers: probeTarget.headers,
+      fetchImpl: context.fetch?.fetch.bind(context.fetch),
+      timeoutMs: RIVESTREAM_RESOLVE_GATE_TIMEOUT_MS,
+      signal: context.signal,
+    });
+    if (isProvenStreamRefusal(probe)) {
+      throw createProviderCycleFailureError(candidate, {
+        failureClass: "candidate-blocked",
+        message: `Rivestream ${provider} streams refused playback (${probe.reason})`,
+        retryable: false,
+        at: context.now(),
+      });
+    }
+  }
 
   const embeddedCaptions = extractRivestreamCaptions(sourceData.data);
   for (const subtitle of embeddedCaptions) {

--- a/packages/providers/src/videasy/direct.ts
+++ b/packages/providers/src/videasy/direct.ts
@@ -126,6 +126,27 @@ function wingsEndpointToServer(endpoint: string): string {
     : endpoint;
 }
 
+/**
+ * Wings CDN family serving Videasy HLS (`moon.*.peakstorm.top` playlists,
+ * `prime*.top` segments). Measured 2026-09-09: the playlist host answers 403
+ * to any request carrying an `Origin` header (any value) and 200 without it,
+ * while segments 206 either way. There is nothing to forward (no cookies or
+ * tokens on any media response, unlike VidLink) — the fix is subtractive.
+ */
+const WINGS_CDN_HOST_SUFFIXES = ["peakstorm.top", "primecomet.top"] as const;
+
+export function isWingsCdnHost(url: string): boolean {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return WINGS_CDN_HOST_SUFFIXES.some(
+    (suffix) => hostname === suffix || hostname.endsWith(`.${suffix}`),
+  );
+}
+
 /** Resolve the correct API base URL for a server endpoint. */
 export function apiBaseForEndpoint(endpoint: string): string {
   return isWingsdatabaseEndpoint(endpoint) ? WINGS_API_BASE : VIDKING_API_BASE;
@@ -2186,7 +2207,10 @@ function normalizeStreamCandidates({
       sourceEvidence,
       headers: {
         referer: streamReferer,
-        origin: streamOrigin,
+        // The wings CDN family 403s any playlist request carrying Origin
+        // (measured 2026-09-09); segments are ungated. Omit it per-URL so
+        // non-CDN flavors keep their existing header set.
+        ...(isWingsCdnHost(source.url) ? {} : { origin: streamOrigin }),
         "user-agent": USER_AGENT,
       },
       confidence: qualityRank > 0 ? 0.92 : 0.82,

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -511,6 +511,29 @@ describe("anidb search delegation", () => {
     }
   });
 
+  test("searchAnidb throws on HTTP error instead of parsing it as zero results", async () => {
+    clearAnidbCachesForTest();
+    const originalWhich = Bun.which;
+    const originalFetch = globalThis.fetch;
+
+    try {
+      Bun.which = ((_cmd: string) => null) as typeof Bun.which;
+      globalThis.fetch = (async () =>
+        new Response("<html><title>Under Maintenance</title></html>", {
+          status: 503,
+        })) as unknown as typeof fetch;
+      const error = await searchAnidb("naruto").then(
+        () => null,
+        (caught: unknown) => caught,
+      );
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("503");
+    } finally {
+      globalThis.fetch = originalFetch;
+      Bun.which = originalWhich;
+    }
+  });
+
   test("does not claim audio or subtitle availability before an episode probe", async () => {
     const originalWhich = Bun.which;
     const originalFetch = globalThis.fetch;

--- a/packages/providers/test/providers.test.ts
+++ b/packages/providers/test/providers.test.ts
@@ -886,7 +886,7 @@ test("rivestream falls back to static provider services when service discovery i
           const url = String(input);
           requests.push(url);
           if (url.includes("VideoProviderServices")) return new Response("", { status: 503 });
-          return jsonResponse(sourceFixture);
+          return rivestreamResolveTestFetch(null, sourceFixture)(input);
         },
       },
     },
@@ -929,7 +929,8 @@ test("rivestream evidence fixture preserves provider server label and normalized
         fetch: async (input) => {
           const url = String(input);
           requests.push(url);
-          return jsonResponse(url.includes("VideoProviderServices") ? services : sourceFixture);
+          if (url.includes("VideoProviderServices")) return jsonResponse(services);
+          return rivestreamResolveTestFetch(null, sourceFixture)(input);
         },
       },
     },
@@ -993,8 +994,7 @@ test("rivestream fixture fast startup keeps the first ready stream", async () =>
       now: () => "2026-05-20T00:00:00.000Z",
       fetch: {
         runtime: "direct-http",
-        fetch: async (input) =>
-          jsonResponse(String(input).includes("VideoProviderServices") ? services : source),
+        fetch: rivestreamResolveTestFetch(services, source),
       },
     },
   );
@@ -1046,8 +1046,7 @@ test("rivestream fast startup selects provider ready-order before returned quali
         now: () => "2026-05-22T00:00:00.000Z",
         fetch: {
           runtime: "direct-http",
-          fetch: async (input) =>
-            jsonResponse(String(input).includes("VideoProviderServices") ? services : source),
+          fetch: rivestreamResolveTestFetch(services, source),
         },
       },
     );
@@ -1103,7 +1102,8 @@ test("rivestream caches provider services across cold resolves", async () => {
           fetch: async (input) => {
             const url = String(input);
             requests.push(url);
-            return jsonResponse(url.includes("VideoProviderServices") ? services : source);
+            if (url.includes("VideoProviderServices")) return jsonResponse(services);
+            return rivestreamResolveTestFetch(null, source)(input);
           },
         },
       },
@@ -1778,4 +1778,28 @@ function jsonResponse(value: unknown, status = 200): Response {
     status,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+/**
+ * Faithful rivestream fetch stub: the resolve-gate probe fetches stream URLs,
+ * so media URLs must answer with media bytes — serving the API JSON fixture
+ * for a playlist URL reads as a truncated/error body and trips the refusal
+ * gate. API-shaped URLs keep returning the JSON fixtures.
+ */
+function rivestreamResolveTestFetch(services: unknown, source: unknown) {
+  return async (input: unknown): Promise<Response> => {
+    const url = String(input);
+    if (url.includes("VideoProviderServices")) return jsonResponse(services);
+    if (url.includes(".m3u8")) {
+      return new Response(
+        "#EXTM3U\n#EXT-X-TARGETDURATION:6\n#EXTINF:6.0,\nseg-0.ts\n#EXT-X-ENDLIST\n",
+        { status: 200, headers: { "Content-Type": "application/vnd.apple.mpegurl" } },
+      );
+    }
+    if (url.includes("service=")) return jsonResponse(source);
+    return new Response(new Uint8Array(2048), {
+      status: 206,
+      headers: { "Content-Type": "video/mp2t" },
+    });
+  };
 }

--- a/packages/providers/test/rivestream-proxy-headers.test.ts
+++ b/packages/providers/test/rivestream-proxy-headers.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+
+import { isProvenStreamRefusal, parseRivestreamProxyHeaders } from "../src/rivestream/direct";
+
+const PROXY_URL = `https://proxy.valhallastream.dpdns.org/proxy?url=${encodeURIComponent(
+  "https://cdn.example/upstream/master.m3u8",
+)}&headers=${encodeURIComponent(JSON.stringify({ Referer: "https://123movienow.cc/" }))}`;
+
+describe("parseRivestreamProxyHeaders", () => {
+  test("forwards baked-in proxy headers instead of the static site referer", () => {
+    expect(parseRivestreamProxyHeaders(PROXY_URL)).toEqual({
+      Referer: "https://123movienow.cc/",
+    });
+  });
+
+  test("returns null for direct (non-proxy) source URLs", () => {
+    expect(
+      parseRivestreamProxyHeaders("https://cdn1.ngcorp.dad/e/Fh9IbkdQQlxTRlY/master.m3u8"),
+    ).toBeNull();
+  });
+
+  test("rejects malformed or empty header payloads", () => {
+    expect(parseRivestreamProxyHeaders("https://proxy.example/proxy?url=x")).toBeNull();
+    expect(
+      parseRivestreamProxyHeaders("https://proxy.example/proxy?url=x&headers=not-json{"),
+    ).toBeNull();
+    expect(parseRivestreamProxyHeaders("https://proxy.example/proxy?url=x&headers=[]")).toBeNull();
+    expect(parseRivestreamProxyHeaders("https://proxy.example/proxy?url=x&headers={}")).toBeNull();
+  });
+
+  test("strips CR/LF values and non-string entries", () => {
+    const url =
+      "https://proxy.example/proxy?url=x&headers=" +
+      encodeURIComponent(
+        JSON.stringify({ Referer: "https://a.example/\r\nEvil: 1", Count: 3, Ok: "yes" }),
+      );
+    expect(parseRivestreamProxyHeaders(url)).toEqual({
+      Referer: "https://a.example/Evil: 1",
+      Ok: "yes",
+    });
+  });
+
+  test("returns null for non-URLs", () => {
+    expect(parseRivestreamProxyHeaders("not a url")).toBeNull();
+  });
+});
+
+describe("isProvenStreamRefusal", () => {
+  test("fails candidates on HTTP refusals, HTML bodies, and truncated bodies", () => {
+    expect(
+      isProvenStreamRefusal({ status: "unreachable", definitive: true, reason: "HTTP 403" }),
+    ).toBe(true);
+    expect(
+      isProvenStreamRefusal({
+        status: "unreachable",
+        definitive: true,
+        reason: "HLS segment unreachable: HTTP 403",
+      }),
+    ).toBe(true);
+    expect(
+      isProvenStreamRefusal({
+        status: "unreachable",
+        definitive: true,
+        reason: "HLS segment unreachable: content-type text/html",
+      }),
+    ).toBe(true);
+    expect(
+      isProvenStreamRefusal({
+        status: "unreachable",
+        definitive: true,
+        reason: "HLS segment unreachable: body too small (12B)",
+      }),
+    ).toBe(true);
+  });
+
+  test("passes timeouts, non-definitive failures, and unparseable bodies", () => {
+    expect(isProvenStreamRefusal({ status: "timeout" })).toBe(false);
+    expect(
+      isProvenStreamRefusal({ status: "unreachable", definitive: false, reason: "HTTP 500" }),
+    ).toBe(false);
+    expect(
+      isProvenStreamRefusal({
+        status: "unreachable",
+        definitive: true,
+        reason: "HLS media playlist has no segment URI",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/providers/test/videasy-wings-cdn-headers.test.ts
+++ b/packages/providers/test/videasy-wings-cdn-headers.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+
+import type { CachePolicy, ProviderResolveInput, ProviderRuntimeContext } from "@kunai/types";
+
+import { createVidkingResultFromPayload, isWingsCdnHost } from "../src/videasy/direct";
+
+const TEST_CONTEXT: ProviderRuntimeContext = {
+  providerId: "videasy",
+  now: () => "2026-09-09T00:00:00.000Z",
+};
+
+const TEST_INPUT: ProviderResolveInput = {
+  title: { id: "299167", kind: "series", title: "Dutton Ranch", tmdbId: "299167" },
+  mediaKind: "series",
+  episode: { season: 1, episode: 1 },
+  intent: "play",
+  allowedRuntimes: ["direct-http"],
+};
+
+const TEST_POLICY: CachePolicy = {
+  ttlClass: "stream-manifest",
+  scope: "local",
+  keyParts: ["provider", "videasy"],
+};
+
+describe("isWingsCdnHost", () => {
+  test("matches the wings CDN family by suffix", () => {
+    expect(isWingsCdnHost("https://moon.peakstorm.top/vd/x/index-s1080p-v1-a1.m3u8")).toBe(true);
+    expect(isWingsCdnHost("https://primecomet.top/seg-1-s1080p-v1-a1.m4s")).toBe(true);
+    expect(isWingsCdnHost("https://cdn.vidking.example/original/1080/index.m3u8")).toBe(false);
+    expect(isWingsCdnHost("https://evil-peakstorm.top.evil.test/v.m3u8")).toBe(false);
+    expect(isWingsCdnHost("not a url")).toBe(false);
+  });
+});
+
+describe("wings CDN stream headers", () => {
+  test("omit origin on wings CDN hosts; the playlist gate 403s any Origin", () => {
+    const result = createVidkingResultFromPayload({
+      input: TEST_INPUT,
+      cachePolicy: TEST_POLICY,
+      apiRoute: "wings-cdn",
+      payload: {
+        sources: [
+          { url: "https://moon.peakstorm.top/vd/x/index-s1080p-v1-a1.m3u8", quality: "1080p" },
+        ],
+      },
+      server: "wings-cdn",
+      context: TEST_CONTEXT,
+      streamOrigin: "https://www.cineby.at",
+    });
+    const headers = result?.streams[0]?.headers ?? {};
+    expect(headers.referer).toBeTruthy();
+    expect(headers["user-agent"]).toBeTruthy();
+    expect("origin" in headers).toBe(false);
+  });
+
+  test("keep origin on non-CDN hosts", () => {
+    const result = createVidkingResultFromPayload({
+      input: TEST_INPUT,
+      cachePolicy: TEST_POLICY,
+      apiRoute: "wings-cdn",
+      payload: {
+        sources: [
+          { url: "https://cdn.vidking.example/original/1080/index.m3u8", quality: "1080p" },
+        ],
+      },
+      server: "wings-cdn",
+      context: TEST_CONTEXT,
+      streamOrigin: "https://www.cineby.at",
+    });
+    expect(result?.streams[0]?.headers?.origin).toBe("https://www.cineby.at");
+  });
+});


### PR DESCRIPTION
Matrix was misreporting two providers: youtube false-red (NDJSON check lines broke the single-JSON parse) and anidb search-stage failures lost to stderr. Plus AniDB parsed 503 outage pages as zero results.

- matrix-harness.mjs (shared, unit-tested): NDJSON primary-payload parse, stdout->stderr fallback, 5xx/captcha/WAF environment-network rules
- anidb searchAnidb passes reportStatus:true so HTTP errors throw AnidbHttpStatusError; smoke reports structured JSON
- mpv-playback.smoke.ts + test:live:mpv: headless decode proof with production header split, redacted logs
- Live evidence: matrix 2 healthy (vidlink, youtube, both mpv-decoded), 0 harness-failure; videasy/rivestream CDN blocks, anidb site 503, miruro WAF, allanime zero-links are upstream, mpv-proven

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AniDB search now reports service errors, such as maintenance or access-block pages, instead of incorrectly showing no results.
  * Rivestream verifies stream candidates before selection and automatically tries another mirror when playback is definitively unavailable.
  * Improved Rivestream proxy playback by forwarding the correct stream headers.
  * Fixed Videasy playback on supported CDN hosts by omitting an incompatible request header.

* **Testing**
  * Added optional headless mpv playback checks to validate actual stream decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->