### PR TITLE
fix(providers): one resolve gate, so a provider cannot attest a stream it never proved

### DIFF
--- a/.changeset/rivestream-verified-source.md
+++ b/.changeset/rivestream-verified-source.md
@@ -1,0 +1,14 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Stop Rivestream selecting a source that cannot play.
+
+Rivestream reported success for a playlist whose segments were refused by a
+third-party CDN, so cycling stopped at the first server that merely responded
+and never reached one that plays. It now proves a source before accepting it,
+walking that source's qualities and moving to the next server only when every
+distinct host has refused.
+
+A refusal is also recorded against that server, so a mirror proven dead is
+skipped on later plays instead of being re-walked every time.

--- a/.changeset/videasy-media-origin.md
+++ b/.changeset/videasy-media-origin.md
@@ -1,0 +1,15 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Fix Videasy handing the player a stream the CDN refuses.
+
+Videasy carries two origins that are not interchangeable: the front-end we
+impersonate when calling its API (`cineby.at`), and the origin the media CDN's
+hotlink rule accepts. The resolve path reused the first as the second, so the
+default movie/series provider shipped a URL that answered 403 the instant it was
+resolved — while its own resolve gate probed the correct origin and reported
+success, which suppressed falling back to a source that would have played.
+
+The stream origin is now a single constant with no override, so the request that
+is verified and the request that is played cannot drift apart.

--- a/.plans/provider-playback-resilience.md
+++ b/.plans/provider-playback-resilience.md
@@ -1,0 +1,54 @@
+# Provider playback resilience
+
+Residue from the 2026-09-08/09 provider health pass. This tracks what is **not**
+closed; the landed work is the commits themselves.
+
+**Framing:** every defect in this pass was the same shape — _a provider reports
+success for something that cannot play_. Resolve-time success is not the
+contract users care about; decode is. `verifyCandidateStream` is the single seam
+that keeps the probed request and the shipped request identical.
+
+## Closed so far
+
+- **Videasy shipped a dead URL past its own gate.** It verified with
+  `Origin: vidking.net` and shipped `Origin: cineby.at`; the CDN accepts the
+  first and refuses the second. The stream origin is now one constant with no
+  override. This was in the released build.
+- **One resolve gate.** `verifyCandidateStream` takes the candidate, so the two
+  request shapes cannot drift. videasy, rivestream, allmanga, anidb and the
+  shared direct-stream engine (vidlink) all use it, enforced by
+  `provider-resolve-gate-coverage.test.ts`.
+- **Gate budgets that could not reach a verdict.** One 6s budget replaces the 3s
+  shared default and videasy's tighter 2.5s copy, with tests requiring headroom
+  over the measured 2.1-2.9s three-hop probe and requiring each gate to fit
+  inside its candidate timeout once `providerCycleCandidateTimeoutMs` clamps it.
+- **`streamReachabilityVerified` set by a timed-out probe**, which promoted an
+  unproven stream to "provider-attested" and switched off playback preflight.
+- **Rivestream can learn.** It now hands `runProviderCycle` the endpoint-health
+  port, and a resolve-gate rejection is marked `endpointScoped` so the
+  classifier can treat it as evidence about that one server. Measured caveat:
+  no quarantine is observable today because Rivestream's dead mirrors have
+  started returning _no sources_ (`candidate-empty`) rather than a dead
+  stream, and an empty candidate is deliberately not endpoint evidence — a
+  server that simply lacks one title must not be blacklisted. The mechanism
+  is proven by `provider-cycle-endpoint-health.test.ts` instead.
+
+## P1 — Miruro cannot host a resolve gate at its current budget
+
+Once `providerCycleCandidateTimeoutMs` clamps it against the attempt budget,
+Miruro's per-candidate budget is 4.8-5s, and that must also cover its pipe call.
+A three-hop HLS probe costs 2.1-2.9s, so a gate would routinely be cut short,
+report `timeout`, and pass everything — coverage in name only. Re-sizing
+`MIRURO_CANDIDATE_TIMEOUT_MS` needs a live provider to measure against, and
+every Miruro mirror is currently challenged; do not raise the number blind.
+
+## Notes carried forward
+
+- **AniDB** is a site-wide upstream `503`; ani-cli v5 uses the same host and is
+  equally down. Its gate is committed but has not been exercised against a live
+  ladder — verify when the site returns.
+- **AllManga's gate is unconfirmed against a live source.** The provider is
+  network-gated (`NEED_CAPTCHA`) from this network, so its gate has only been
+  exercised against fixtures. It is shared with four verified providers, so the
+  risk is low, but it is unproven — re-run `bun run test:live:allanime` from an
+  ungated network or through a relay.

--- a/.plans/roadmap.md
+++ b/.plans/roadmap.md
@@ -46,13 +46,14 @@ archive and put only the residue here.
 
 ### Playback and providers
 
-| Track                      | Remaining                                                               | Plan                                                                               |
-| -------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Provider resolve hardening | Health recovery, latency ordering, and measured hedge-delay calibration | [provider-resolve-hardening-handoff.md](./provider-resolve-hardening-handoff.md)   |
-| Provider hardening         | Research and scraper capability roadmap                                 | [provider-hardening.md](./provider-hardening.md)                                   |
-| Provider result contract   | Contract work before broad `@kunai/core` extraction                     | [provider-result-contract.md](./provider-result-contract.md)                       |
-| Beta UI/provider hardening | Tasks 8–10: input routing, subtitle calls, display honesty              | [beta-ui-provider-runtime-hardening.md](./beta-ui-provider-runtime-hardening.md)   |
-| Resolve UX and Playwright  | Pick up during a browser/provider reliability pass                      | [resolve-ux-and-playwright-lifecycle.md](./resolve-ux-and-playwright-lifecycle.md) |
+| Track                        | Remaining                                                               | Plan                                                                               |
+| ---------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Provider playback resilience | Miruro gate budget, blocked on a reachable mirror                       | [provider-playback-resilience.md](./provider-playback-resilience.md)               |
+| Provider resolve hardening   | Health recovery, latency ordering, and measured hedge-delay calibration | [provider-resolve-hardening-handoff.md](./provider-resolve-hardening-handoff.md)   |
+| Provider hardening           | Research and scraper capability roadmap                                 | [provider-hardening.md](./provider-hardening.md)                                   |
+| Provider result contract     | Contract work before broad `@kunai/core` extraction                     | [provider-result-contract.md](./provider-result-contract.md)                       |
+| Beta UI/provider hardening   | Tasks 8–10: input routing, subtitle calls, display honesty              | [beta-ui-provider-runtime-hardening.md](./beta-ui-provider-runtime-hardening.md)   |
+| Resolve UX and Playwright    | Pick up during a browser/provider reliability pass                      | [resolve-ux-and-playwright-lifecycle.md](./resolve-ux-and-playwright-lifecycle.md) |
 
 ### Offline and release stability
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,11 @@ Each of these is enforced by a test or is expensive to get wrong.
   logic.** Check parity against the reference implementation before changing
   crypto or decoder constants, and document deliberate divergence in
   [.docs/providers.md](.docs/providers.md).
+- **A provider must never report success for a stream it has not probed.**
+  `verifyCandidateStream` is the only resolve gate; it takes the candidate so
+  the probed request and the shipped request cannot diverge. Coverage is
+  enforced by `packages/providers/test/provider-resolve-gate-coverage.test.ts`,
+  and an exemption needs a runtime reason recorded there.
 - **Relay is metadata-only** — no media route, no video fallback; stream URLs
   stay direct. `packages/relay` is the single implementation and
   `apps/relay-server` stays a thin adapter.

--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -164,6 +164,14 @@ async function runInstallShAsync(
   return { status, stdout, stderr };
 }
 
+/**
+ * Long enough that only a non-terminating installer can exceed it.
+ *
+ * Wall-clock budgets in this file bound whether a run *finishes*, never how
+ * fast it is — a CI runner's speed is not a contract.
+ */
+const ACTIVATION_TERMINATION_BUDGET_MS = 5_000;
+
 async function runInstallShWithin(
   args: string[],
   env: NodeJS.ProcessEnv,
@@ -1538,7 +1546,14 @@ describe("install.sh lifecycle contract", () => {
               KUNAI_ACTIVATION_LOCK_POLL_MS: "0",
               PATH: `${shimDir}${delimiter}${sandbox.env.PATH ?? ""}`,
             },
-            500,
+            // Bounds *termination*, not speed. A zero poll that hot-loops never
+            // returns, so any finite completion proves the contract — while the
+            // budget has to cover the whole script (bash startup, the shimmed
+            // `mv`, the fixture download and its checksum), not just the 40ms
+            // lock wait. At 500ms a loaded macOS runner lost the race at 541ms
+            // and reported a hot-loop that was not there. Do not tighten this
+            // to make it "stricter": it would only re-pin one runner's speed.
+            ACTIVATION_TERMINATION_BUDGET_MS,
           );
           expect(result).not.toBeNull();
           expect(result?.status).not.toBe(0);

--- a/packages/core/src/provider-cycle-engine.ts
+++ b/packages/core/src/provider-cycle-engine.ts
@@ -88,6 +88,10 @@ export function createProviderCycleFailureError(
     message: input.message,
     retryable: input.retryable,
     at: input.at,
+    // Forwarded explicitly: this builder copies named fields, so anything added
+    // to the failure contract and not listed here is silently dropped on the
+    // way to endpoint health.
+    ...(input.endpointScoped === undefined ? {} : { endpointScoped: input.endpointScoped }),
   });
 }
 
@@ -696,13 +700,19 @@ export function classifyEndpointFailureFromCycleFailure(
       // still applies its distinct-title guard before escalating it.
       return "server-error";
     case "candidate-blocked":
-      // "Blocked" is not endpoint-scoped evidence. It currently includes
+      // "Blocked" is not endpoint-scoped evidence on its own. It includes
       // provider-wide session guards, regional WAF/Cloudflare responses, and
       // endpoint-local 403s. Persisting all of those as a server error can
       // quarantine a healthy mirror after two titles merely because the user
-      // has no valid provider session. Keep it out of endpoint health until the
-      // failure contract carries an explicit endpoint-scoped reason.
-      return null;
+      // has no valid provider session.
+      //
+      // `endpointScoped` is the explicit reason this waited for: a resolve-gate
+      // rejection is a segment probe against this endpoint's own stream, so a
+      // definitive refusal there is durable evidence about that server alone.
+      // `server-error` rather than `route-dead` because the shorter quarantine
+      // still carries ProviderEndpointHealthService's distinct-title guard, and
+      // a CDN that rotates hosts should not be written off for a day.
+      return failure.endpointScoped === true ? "server-error" : null;
     default:
       return null;
   }

--- a/packages/core/test/endpoint-scoped-failure.test.ts
+++ b/packages/core/test/endpoint-scoped-failure.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import { classifyEndpointFailureFromCycleFailure } from "../src/provider-cycle-engine";
+
+/**
+ * `candidate-blocked` is deliberately not endpoint evidence: it lumps together
+ * provider-wide session guards, region-wide WAF responses, and endpoint-local
+ * refusals, and persisting all of those would quarantine healthy mirrors after
+ * two titles merely because the user has no valid session.
+ *
+ * A resolve-gate rejection is different in kind. It is a segment probe against
+ * one server's own stream, and a *definitive* refusal there is about that
+ * server and nothing else. The failure contract carries that distinction
+ * explicitly rather than making the classifier guess from a message string.
+ */
+const base = {
+  providerId: "rivestream",
+  candidateId: "candidate-1",
+  message: "stream is unreachable (HLS segment unreachable: HTTP 403)",
+  retryable: false,
+  at: "2026-09-09T00:00:00.000Z",
+} as const;
+
+describe("classifyEndpointFailureFromCycleFailure", () => {
+  test("an unscoped block is still not endpoint evidence", () => {
+    expect(
+      classifyEndpointFailureFromCycleFailure({ ...base, failureClass: "candidate-blocked" }),
+    ).toBeNull();
+  });
+
+  test("an endpoint-scoped block is a server error for that endpoint", () => {
+    expect(
+      classifyEndpointFailureFromCycleFailure({
+        ...base,
+        failureClass: "candidate-blocked",
+        endpointScoped: true,
+      }),
+    ).toBe("server-error");
+  });
+
+  test("endpointScoped does not promote a timeout", () => {
+    // A slow link must never quarantine a working mirror, so the scoped flag
+    // only sharpens a block — it cannot turn an inconclusive result into
+    // durable evidence.
+    expect(
+      classifyEndpointFailureFromCycleFailure({
+        ...base,
+        failureClass: "candidate-timeout",
+        endpointScoped: true,
+      }),
+    ).toBe("transient");
+  });
+
+  test("an empty candidate stays unrecorded whether scoped or not", () => {
+    expect(
+      classifyEndpointFailureFromCycleFailure({
+        ...base,
+        failureClass: "candidate-empty",
+        endpointScoped: true,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/core/test/provider-cycle-endpoint-health.test.ts
+++ b/packages/core/test/provider-cycle-endpoint-health.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { EndpointHealthPort, ProviderCycleCandidate } from "@kunai/types";
 
-import { runProviderCycle } from "../src/index";
+import { createProviderCycleFailureError, runProviderCycle } from "../src/index";
 
 class StubEndpointHealth implements EndpointHealthPort {
   readonly blocked = new Set<string>();
@@ -66,5 +66,62 @@ describe("runProviderCycle endpoint health", () => {
 
     expect(result.stopReason).toBe("resolved");
     expect(endpointHealth.successes).toEqual(["good"]);
+  });
+
+  test("records a resolve-gate rejection against the endpoint that failed it", async () => {
+    // A gate rejection is a segment probe against that server's own stream, so
+    // it is durable evidence about that server. Without this the cycle re-walks
+    // every dead mirror on every play and the quarantine never learns.
+    const endpointHealth = new StubEndpointHealth();
+
+    const result = await runProviderCycle({
+      providerId: "rivestream",
+      candidates: [
+        { id: "a", providerId: "rivestream", serverId: "primevids", priority: 0 },
+        { id: "b", providerId: "rivestream", serverId: "citadel", priority: 1 },
+      ],
+      endpointHealth,
+      maxAttemptsPerCandidate: 1,
+      resolveCandidate: async (candidate) => {
+        if (candidate.serverId === "primevids") {
+          throw createProviderCycleFailureError(candidate, {
+            failureClass: "candidate-blocked",
+            message: "stream is unreachable (HLS segment unreachable: HTTP 403)",
+            retryable: false,
+            at: "2026-09-09T00:00:00.000Z",
+            endpointScoped: true,
+          });
+        }
+        return { ok: true };
+      },
+    });
+
+    expect(result.stopReason).toBe("resolved");
+    expect(endpointHealth.failures).toEqual([{ endpoint: "primevids", class: "server-error" }]);
+    expect(endpointHealth.successes).toEqual(["citadel"]);
+  });
+
+  test("does not record a block that was not observed against the endpoint", async () => {
+    // Region-wide WAF and provider session guards also arrive as
+    // `candidate-blocked`; quarantining mirrors for those would blacklist
+    // healthy servers for a problem that has nothing to do with them.
+    const endpointHealth = new StubEndpointHealth();
+
+    await runProviderCycle({
+      providerId: "miruro",
+      candidates: [{ id: "a", providerId: "miruro", serverId: "mirror-1", priority: 0 }],
+      endpointHealth,
+      maxAttemptsPerCandidate: 1,
+      resolveCandidate: async (candidate) => {
+        throw createProviderCycleFailureError(candidate, {
+          failureClass: "candidate-blocked",
+          message: "Cloudflare WAF",
+          retryable: false,
+          at: "2026-09-09T00:00:00.000Z",
+        });
+      },
+    });
+
+    expect(endpointHealth.failures).toEqual([]);
   });
 });

--- a/packages/providers/src/allmanga/direct.ts
+++ b/packages/providers/src/allmanga/direct.ts
@@ -3,6 +3,7 @@ import {
   createProviderCachePolicy,
   createResolveTrace,
   createTraceStep,
+  providerCycleCandidateTimeoutMs,
   runProviderCycle,
   type CoreProviderModule,
 } from "@kunai/core";
@@ -31,6 +32,7 @@ import {
   providerFailureCodeFromCycleFailure,
 } from "../shared/provider-cycle";
 import { selectProviderEpisodeNumber } from "../shared/provider-episode-number";
+import { resolveGateBudgetMs, verifyCandidateStream } from "../shared/resolve-gate";
 import { createExhaustedResult, emitTraceEvent } from "../shared/resolve-helpers";
 import {
   normalizeProviderDisplayLabel,
@@ -66,6 +68,15 @@ export function safeAllMangaHostname(url: string): string | null {
 const DEFAULT_UA =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0";
 const ALLANIME_API_URL = "https://api.mkissa.net/api";
+
+/**
+ * How long one source candidate may take before the cycle abandons it.
+ *
+ * Sized to contain the resolve gate: a gate that cannot finish inside its
+ * candidate's budget is cut short, reports `timeout`, and is let through — so
+ * an under-sized budget silently stops the gate rejecting dead sources.
+ */
+export const ALLMANGA_CANDIDATE_TIMEOUT_MS = 9_000;
 const ALLANIME_REFERER = "https://mkissa.to";
 export const ALLMANGA_QUALITY_FIRST_WAIT_BUDGET_MS = 4_000;
 // The Ak endpoint (separate CDN, slowest single step) normally answers in
@@ -634,7 +645,10 @@ export const allmangaProviderModule: CoreProviderModule = {
           now: context.now,
           emit: context.emit,
           maxAttemptsPerCandidate: 1,
-          candidateTimeoutMs: 2_500,
+          candidateTimeoutMs: providerCycleCandidateTimeoutMs(
+            startupPriority,
+            ALLMANGA_CANDIDATE_TIMEOUT_MS,
+          ),
           resolveCandidate: async (candidate, cycleContext) => {
             const stream = streams.find((item) => item.id === candidate.streamId);
             if (!stream?.url && !stream?.deferredLocator) {
@@ -660,6 +674,32 @@ export const allmangaProviderModule: CoreProviderModule = {
                 qualityRank: stream.qualityRank ?? null,
               },
             });
+            // Prove the source plays before accepting it, so a dead mirror
+            // cycles to the next candidate instead of being reported as a
+            // success. A deferred Ak handle has no URL to probe yet and is
+            // materialised later, so it passes through untouched.
+            if (stream.url && !stream.deferredLocator) {
+              const verdict = await verifyCandidateStream({
+                stream,
+                context,
+                // The candidate's signal, not the attempt's: when this candidate
+                // times out its probe has to be abandoned with it, or the
+                // request outlives the thing that asked for it.
+                signal: cycleContext.signal,
+                timeoutMs: resolveGateBudgetMs(
+                  providerCycleCandidateTimeoutMs(startupPriority, ALLMANGA_CANDIDATE_TIMEOUT_MS),
+                ),
+              });
+              if (!verdict.accepted) {
+                throw createProviderCycleFailureError(candidate, {
+                  failureClass: "candidate-blocked",
+                  message: `AllManga source is unreachable (${verdict.reason})`,
+                  retryable: false,
+                  at: context.now(),
+                });
+              }
+            }
+
             return stream;
           },
         });

--- a/packages/providers/src/anidb/direct.ts
+++ b/packages/providers/src/anidb/direct.ts
@@ -32,6 +32,7 @@ import {
   formatAnimeSourceArchetype,
   formatAnimeSourceDetail,
 } from "../shared/anime-source-presentation";
+import { verifyCandidateStream } from "../shared/resolve-gate";
 import { createExhaustedResult, emitTraceEvent } from "../shared/resolve-helpers";
 import { finalizeCycleSourceInventory } from "../shared/source-inventory";
 import { selectReadyStream } from "../shared/startup-selection";
@@ -518,6 +519,32 @@ export const anidbProviderModule: CoreProviderModule = {
         preferredStreamId: input.preferredStreamId,
         favoriteSourceNames: input.favoriteSourceNames,
       });
+      // Prove the selected stream plays before reporting success. AniDB has no
+      // source cycle — every candidate is a rung of the same CDN ladder — so a
+      // refusal here means the ladder is gone and provider fallback should take
+      // over, rather than mpv being handed a stream that cannot open.
+      const gate = await verifyCandidateStream({
+        stream: selection.selected,
+        context,
+        signal: context.signal,
+      });
+      if (!gate.accepted && !context.signal?.aborted) {
+        const failure: ProviderFailure = {
+          providerId: ANIDB_PROVIDER_ID,
+          code: "not-found",
+          message: `AniDB selected stream is unreachable (${gate.reason})`,
+          retryable: true,
+          at: context.now(),
+        };
+        failures.push(failure);
+        return createExhaustedResult(input, context, ANIDB_PROVIDER_ID, failure, {
+          cachePolicy,
+          events,
+          failures,
+          startedAt,
+        });
+      }
+
       const sources = finalizeCycleSourceInventory({
         sources: buildAnidbSourceInventory(resolvedModes, audioMode, cachePolicy),
         attempts: [],

--- a/packages/providers/src/rivestream/direct.ts
+++ b/packages/providers/src/rivestream/direct.ts
@@ -5,6 +5,7 @@ import {
   createProviderCachePolicy,
   createResolveTrace,
   createTraceStep,
+  providerCycleCandidateTimeoutMs,
   runProviderCycle,
   type CoreProviderModule,
 } from "@kunai/core";
@@ -28,6 +29,11 @@ import {
   findLastCycleFailure,
   providerFailureCodeFromCycleFailure,
 } from "../shared/provider-cycle";
+import {
+  dropRefusedStreams,
+  resolveGateBudgetMs,
+  selectVerifiedStream,
+} from "../shared/resolve-gate";
 import { createExhaustedResult, emitTraceEvent } from "../shared/resolve-helpers";
 import { hasResolvableSeriesCoordinates } from "../shared/series-coordinates";
 import {
@@ -101,6 +107,20 @@ let providerServicesCache:
       readonly expiresAtMs: number;
     }
   | undefined;
+
+/**
+ * Reset the module-level caches between tests.
+ *
+ * `providerServicesCache` and `secretKeyCache` outlive a single test file —
+ * module state is per process, not per file — so a test that resolves through
+ * this provider leaves discovery already cached for whatever runs next. Tests
+ * asserting on discovery call counts then see zero, and only in whatever order
+ * the runner happens to pick.
+ */
+export function clearRivestreamCachesForTest(): void {
+  providerServicesCache = undefined;
+  secretKeyCache.clear();
+}
 
 type RivestreamProviderServicesResponse = {
   readonly data?: unknown;
@@ -397,6 +417,16 @@ export const rivestreamProviderModule: CoreProviderModule = {
         secretKey,
       });
 
+      // The attempt budget caps this, so the gate has to be sized against what
+      // the candidate actually gets rather than the number chosen here.
+      const candidateTimeoutMs = providerCycleCandidateTimeoutMs(
+        input.startupPriority ?? "balanced",
+        RIVESTREAM_CANDIDATE_TIMEOUT_MS,
+      );
+      const gateTimeoutMs = resolveGateBudgetMs(
+        candidateTimeoutMs,
+        RIVESTREAM_RESOLVE_GATE_TIMEOUT_MS,
+      );
       const cycleResult = await runProviderCycle({
         providerId: RIVESTREAM_PROVIDER_ID,
         candidates: cycleCandidates,
@@ -404,7 +434,12 @@ export const rivestreamProviderModule: CoreProviderModule = {
         now: context.now,
         emit: context.emit,
         maxAttemptsPerCandidate: 1,
-        candidateTimeoutMs: 10_000,
+        candidateTimeoutMs,
+        // Without these the cycle can neither skip a quarantined mirror nor
+        // record what it learned, so every resolve re-walked all eleven
+        // services and paid the full gate cost each time.
+        endpointHealth: context.endpointHealth,
+        titleId: tmdbId,
         resolveCandidate: async (candidate) => {
           const provider = String(candidate.serverId ?? candidate.metadata?.provider ?? "");
           const sourceDataPromise = prefetchedSources.get(provider);
@@ -425,8 +460,24 @@ export const rivestreamProviderModule: CoreProviderModule = {
               context,
               cachePolicy,
               sourceDataPromise,
+              gateTimeoutMs,
             });
           } catch (error) {
+            // The resolve gate already decided, and its verdict carries the
+            // parts that matter downstream: `candidate-blocked` and
+            // `endpointScoped`. Rebuilding it from a generic `ProviderHttpError`
+            // relabels it `candidate-empty` and drops the flag, so endpoint
+            // health records nothing and the dead mirror is re-walked on every
+            // play — and a refused stream reads in the trace exactly like a
+            // server that returned no sources at all.
+            if (
+              error &&
+              typeof error === "object" &&
+              "name" in error &&
+              error.name === "ProviderCycleFailureError"
+            ) {
+              throw error;
+            }
             const providerError =
               error instanceof ProviderHttpError
                 ? error
@@ -825,6 +876,44 @@ function isRivestreamAbortOrTimeoutError(error: unknown): boolean {
   return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }
 
+export function parseRivestreamProxyHeaders(sourceUrl: string): Record<string, string> | null {
+  let params: URLSearchParams;
+  try {
+    params = new URL(sourceUrl).searchParams;
+  } catch {
+    return null;
+  }
+  const raw = params.get("headers");
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+  const headers: Record<string, string> = {};
+  for (const [name, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof value !== "string") continue;
+    const cleaned = value.replace(/[\r\n]/g, "").trim();
+    if (!name.trim() || !cleaned) continue;
+    headers[name.trim()] = cleaned;
+  }
+  return Object.keys(headers).length > 0 ? headers : null;
+}
+
+export function resolveRivestreamStreamHeaders(sourceUrl: string): Record<string, string> {
+  const proxyHeaders = parseRivestreamProxyHeaders(sourceUrl);
+  if (!proxyHeaders) {
+    return { referer: RIVESTREAM_REFERER, "user-agent": USER_AGENT };
+  }
+  const headers: Record<string, string> = { ...proxyHeaders };
+  if (!Object.keys(headers).some((name) => name.toLowerCase() === "user-agent")) {
+    headers["user-agent"] = USER_AGENT;
+  }
+  return headers;
+}
+
 async function resolveRivestreamProviderCandidate({
   candidate,
   provider,
@@ -832,6 +921,7 @@ async function resolveRivestreamProviderCandidate({
   context,
   cachePolicy,
   sourceDataPromise,
+  gateTimeoutMs,
 }: {
   readonly candidate: ProviderCycleCandidate;
   readonly provider: string;
@@ -839,6 +929,8 @@ async function resolveRivestreamProviderCandidate({
   readonly context: ProviderRuntimeContext;
   readonly cachePolicy: CachePolicy;
   readonly sourceDataPromise: Promise<RivestreamSourceResponse>;
+  /** Sized against the clamped candidate timeout, never the raw constant. */
+  readonly gateTimeoutMs: number;
 }): Promise<RivestreamResolvedCandidate> {
   const displayLabel = displayRivestreamSourceLabel(provider);
   const audioSubtitle = inferRivestreamAudioSubtitle(provider);
@@ -855,8 +947,8 @@ async function resolveRivestreamProviderCandidate({
     });
   }
 
-  const streams: StreamCandidate[] = [];
-  const variants: ProviderVariantCandidate[] = [];
+  let streams: StreamCandidate[] = [];
+  let variants: ProviderVariantCandidate[] = [];
   const subtitles: SubtitleCandidate[] = [];
 
   rawSources.forEach((source) => {
@@ -866,7 +958,11 @@ async function resolveRivestreamProviderCandidate({
     const qualityRank = qualityRankFromLabel(qualityStr) ?? 0;
     const streamId = createStreamId(RIVESTREAM_PROVIDER_ID, [source.url]);
     const variantId = createVariantId(RIVESTREAM_PROVIDER_ID, [sourceId, qualityLabel, source.url]);
-    const protocol = source.url.includes(".m3u8") ? "hls" : "mp4";
+    const protocol = source.url.includes(".m3u8")
+      ? "hls"
+      : source.url.includes(".mpd")
+        ? "dash"
+        : "mp4";
     const normalizedAudioLanguage =
       inferRivestreamAudioLanguage(provider, qualityStr) ??
       normalizeIsoLanguageCode(input.preferredAudioLanguage);
@@ -903,13 +999,13 @@ async function resolveRivestreamProviderCandidate({
       variantId,
       url: source.url,
       protocol,
-      container: protocol === "hls" ? "m3u8" : "mp4",
+      container: protocol === "hls" ? "m3u8" : protocol === "dash" ? "mpd" : "mp4",
       audioLanguages: normalizedAudioLanguage ? [normalizedAudioLanguage] : undefined,
       qualityLabel,
       qualityRank,
       languageEvidence,
       sourceEvidence,
-      headers: { referer: RIVESTREAM_REFERER, "user-agent": USER_AGENT },
+      headers: resolveRivestreamStreamHeaders(source.url),
       confidence: 0.95,
       cachePolicy,
       ...streamPresentationFields({ displayLabel, subtitle: audioSubtitle }),
@@ -946,8 +1042,61 @@ async function resolveRivestreamProviderCandidate({
     });
   }
 
+  // Segment-probe before accepting the candidate. Rivestream's dead mirrors
+  // answer 200 on the master playlist and refuse every segment, so without this
+  // the cycle stops at the first server that merely *responds* and never
+  // reaches one that plays.
+  if (streams.length === 0) {
+    throw createProviderCycleFailureError(candidate, {
+      failureClass: "candidate-empty",
+      message: `${displayLabel}: no stream URLs returned`,
+      retryable: false,
+      at: context.now(),
+    });
+  }
+
+  const selection = await selectVerifiedStream({
+    streams,
+    context,
+    timeoutMs: gateTimeoutMs,
+  });
+  if (!selection.accepted) {
+    throw createProviderCycleFailureError(candidate, {
+      failureClass: "candidate-blocked",
+      message: `${displayLabel}: ${selection.reason}`,
+      retryable: false,
+      at: context.now(),
+      // Every rung of this service was refused by probing its own streams, so
+      // it is durable evidence about this endpoint rather than a regional block.
+      endpointScoped: true,
+    });
+  }
+  // Keep the alternatives, drop the rungs the gate proved dead.
+  streams = dropRefusedStreams(streams, selection.refusedHosts);
+  variants = variants.filter((variant) =>
+    streams.some((candidateStream) => candidateStream.variantId === variant.id),
+  );
+
   return { provider, sourceId, streams, variants, subtitles };
 }
+
+/** How long one candidate may take before the cycle abandons it. */
+export const RIVESTREAM_CANDIDATE_TIMEOUT_MS = 10_000;
+
+/**
+ * Budget for the resolve-gate probe.
+ *
+ * An HLS gate is three sequential round trips — master, variant, segment — and
+ * against Rivestream's dead mirror those measured 2.1-2.9s. The shared 3s
+ * default therefore landed right on the edge: the same candidate was rejected
+ * on one run and accepted on the next, because a cut-short probe reports
+ * `timeout`, which is deliberately *not* treated as proof of a dead stream.
+ * A gate that cannot reach a verdict is worse than no gate at all.
+ *
+ * Kept well below {@link RIVESTREAM_CANDIDATE_TIMEOUT_MS} so the probe cannot
+ * eat the budget its own candidate needs.
+ */
+export const RIVESTREAM_RESOLVE_GATE_TIMEOUT_MS = 6_000;
 
 function extractRivestreamCaptions(
   data: RivestreamSourceResponse["data"],

--- a/packages/providers/src/shared/direct-stream-source.ts
+++ b/packages/providers/src/shared/direct-stream-source.ts
@@ -13,6 +13,7 @@ import type {
 } from "@kunai/types";
 
 import { resolveTmdbCatalogId } from "./catalog-id";
+import { verifyCandidateStream } from "./resolve-gate";
 import { createExhaustedResult, emitTraceEvent } from "./resolve-helpers";
 import { hasResolvableSeriesCoordinates } from "./series-coordinates";
 import {
@@ -21,7 +22,6 @@ import {
   normalizeQualityLabel,
   qualityRankFromLabel,
 } from "./source-inventory";
-import { runStreamHealthCheck, STREAM_HEALTH_DEFAULTS } from "./stream-health";
 import { normalizeIsoLanguageCode } from "./subtitle-helpers";
 import { createTimeoutSignal } from "./timeout-signal";
 
@@ -196,13 +196,12 @@ export async function resolveDirectStreamSource(
         }
         if (!candidate.url) continue;
 
-        const health = await runStreamHealthCheck({
-          phase: "resolve-gate",
-          url: candidate.url,
-          headers: candidate.headers,
-          fetchImpl: context.fetch?.fetch.bind(context.fetch),
-          timeoutMs: options.resolveGateTimeoutMs ?? STREAM_HEALTH_DEFAULTS.resolveGateTimeoutMs,
-          signal: context.signal,
+        const verdict = await verifyCandidateStream({
+          stream: candidate,
+          context,
+          ...(options.resolveGateTimeoutMs === undefined
+            ? {}
+            : { timeoutMs: options.resolveGateTimeoutMs }),
         });
 
         // The abort may have landed while this probe was in flight. Its result
@@ -213,20 +212,19 @@ export async function resolveDirectStreamSource(
           break;
         }
 
-        if (health.healthy) {
+        if (verdict.accepted) {
           selectedStream = candidate;
-          streamReachabilityVerified = true;
+          // Only a probe that actually reached the stream counts as verified.
+          // This flag makes later phases skip probing as "provider-attested",
+          // so letting a timeout set it would switch off the playback preflight
+          // for a stream nothing ever reached.
+          streamReachabilityVerified = verdict.verified;
           gateFailure = undefined;
           break;
         }
 
-        const probe = health.probe;
-        const reason =
-          probe?.status === "timeout"
-            ? "stream probe timed out"
-            : probe?.status === "unreachable"
-              ? probe.reason
-              : "stream probe failed";
+        const probe = verdict.probe;
+        const reason = verdict.reason;
         // Keep the first rejection: it is the highest-ranked candidate, so it
         // describes the failure the user would otherwise have seen.
         gateFailure ??= {

--- a/packages/providers/src/shared/resolve-gate.ts
+++ b/packages/providers/src/shared/resolve-gate.ts
@@ -1,0 +1,186 @@
+import type { ProviderRuntimeContext, StreamCandidate } from "@kunai/types";
+
+import { runStreamHealthCheck, STREAM_HEALTH_DEFAULTS } from "./stream-health";
+import {
+  isStreamReachableForResolve,
+  type StreamReachabilityProbeResult,
+} from "./stream-reachability";
+
+/** Room left for the candidate's own work after its gate probes. */
+const RESOLVE_GATE_CANDIDATE_HEADROOM_MS = 500;
+
+/**
+ * `runStreamHealthCheck` probes a second time when the first attempt reached no
+ * verdict, so a candidate has to be able to afford two of them.
+ */
+const RESOLVE_GATE_MAX_PROBES = 2;
+
+/**
+ * The gate budget a candidate can actually afford.
+ *
+ * A provider's chosen candidate timeout is not what it gets:
+ * `providerCycleCandidateTimeoutMs` caps it at a fraction of the attempt
+ * budget, and on `fast` that lands at 4.8s — below the shared 6s gate. Sizing a
+ * gate against the provider's *unclamped* number means the candidate aborts the
+ * probe on the fastest profile, the probe reports `timeout`, and the gate is let
+ * through: coverage that quietly stops working exactly where latency matters
+ * most.
+ *
+ * Always pass the clamped value.
+ */
+export function resolveGateBudgetMs(
+  candidateTimeoutMs: number,
+  preferredMs: number = STREAM_HEALTH_DEFAULTS.resolveGateTimeoutMs,
+): number {
+  const affordable = Math.floor(
+    (candidateTimeoutMs - RESOLVE_GATE_CANDIDATE_HEADROOM_MS) / RESOLVE_GATE_MAX_PROBES,
+  );
+  return Math.max(1, Math.min(preferredMs, affordable));
+}
+
+export type CandidateStreamVerdict =
+  | { readonly accepted: true; readonly verified: boolean }
+  | {
+      readonly accepted: false;
+      readonly reason: string;
+      readonly probe?: StreamReachabilityProbeResult;
+    };
+
+/**
+ * The one way a provider proves a candidate is playable before reporting success.
+ *
+ * **It takes the candidate, not a URL plus separately-assembled headers.** That
+ * is the whole point. Videasy verified a stream with `Origin: vidking.net` and
+ * shipped the same URL with `Origin: cineby.at`; the CDN accepted the first and
+ * refused the second, so the gate attested a request shape production never
+ * made and cycling stopped at a source that could not play. Passing the
+ * candidate makes the probed shape and the shipped shape the same object.
+ *
+ * Only a *definitive* refusal rejects. A timeout, a non-definitive error, or a
+ * skipped probe is not evidence of a dead stream — treating it as one trades a
+ * working source for a slow link, and playback preflight still runs before mpv
+ * receives the handoff.
+ */
+export async function verifyCandidateStream({
+  stream,
+  context,
+  signal,
+  timeoutMs = STREAM_HEALTH_DEFAULTS.resolveGateTimeoutMs,
+}: {
+  readonly stream: Pick<StreamCandidate, "url" | "headers">;
+  readonly context: ProviderRuntimeContext;
+  readonly signal?: AbortSignal;
+  readonly timeoutMs?: number;
+}): Promise<CandidateStreamVerdict> {
+  const url = stream.url?.trim();
+  if (!url) return { accepted: false, reason: "candidate has no stream url" };
+
+  const health = await runStreamHealthCheck({
+    phase: "resolve-gate",
+    url,
+    // The candidate's own headers, verbatim — never a re-derived set.
+    headers: stream.headers,
+    fetchImpl: context.fetch?.fetch.bind(context.fetch),
+    timeoutMs,
+    signal: signal ?? context.signal,
+  });
+
+  const probe = health.probe;
+  if (!probe || isStreamReachableForResolve(probe)) {
+    return { accepted: true, verified: probe?.status === "reachable" };
+  }
+
+  return {
+    accepted: false,
+    reason: probe.status === "unreachable" ? probe.reason : `stream probe ${probe.status}`,
+    probe,
+  };
+}
+
+export type VerifiedStreamSelection<TStream> =
+  | {
+      readonly accepted: true;
+      readonly stream: TStream;
+      readonly verified: boolean;
+      /**
+       * Hosts proven dead during the walk. The caller must drop their streams:
+       * leaving a refused rung in the inventory lets selection ship the very
+       * stream the gate rejected.
+       */
+      readonly refusedHosts: ReadonlySet<string>;
+    }
+  | { readonly accepted: false; readonly reason: string };
+
+/**
+ * The first stream of a source that actually verifies.
+ *
+ * A refusal is evidence about *that stream*, not about the source: a candidate
+ * often carries several qualities, and they do not always sit on the same host.
+ * Rejecting the whole source on the first refusal throws away rungs that would
+ * have played, so the walk continues and the source is refused only when every
+ * distinct host has refused.
+ *
+ * One probe per host, because a host answers the same for every rung it serves
+ * — the extra probes would cost latency inside the candidate's budget and tell
+ * us nothing new.
+ */
+export async function selectVerifiedStream<
+  TStream extends Pick<StreamCandidate, "url" | "headers">,
+>({
+  streams,
+  context,
+  signal,
+  timeoutMs,
+}: {
+  readonly streams: readonly TStream[];
+  readonly context: ProviderRuntimeContext;
+  readonly signal?: AbortSignal;
+  readonly timeoutMs?: number;
+}): Promise<VerifiedStreamSelection<TStream>> {
+  let firstReason: string | undefined;
+  const refusedHosts = new Set<string>();
+
+  for (const stream of streams) {
+    const host = streamHost(stream.url);
+    if (host && refusedHosts.has(host)) continue;
+
+    const verdict = await verifyCandidateStream({
+      stream,
+      context,
+      ...(signal === undefined ? {} : { signal }),
+      ...(timeoutMs === undefined ? {} : { timeoutMs }),
+    });
+    if (verdict.accepted) {
+      return { accepted: true, stream, verified: verdict.verified, refusedHosts };
+    }
+
+    firstReason ??= verdict.reason;
+    if (host) refusedHosts.add(host);
+  }
+
+  return { accepted: false, reason: firstReason ?? "candidate has no stream url" };
+}
+
+/**
+ * Drop the streams whose host the gate proved dead.
+ *
+ * The walk refuses a host, not a rung, so the caller cannot just remove the one
+ * stream that failed — every rung on that host is equally gone. Leaving them in
+ * lets startup selection ship the exact stream the gate rejected, which is
+ * usually the highest quality and therefore the one it prefers.
+ */
+export function dropRefusedStreams<TStream extends Pick<StreamCandidate, "url">>(
+  streams: readonly TStream[],
+  refusedHosts: ReadonlySet<string>,
+): TStream[] {
+  if (refusedHosts.size === 0) return [...streams];
+  return streams.filter((stream) => !refusedHosts.has(streamHost(stream.url)));
+}
+
+function streamHost(url: string | undefined): string {
+  try {
+    return new URL(url ?? "").host.toLowerCase();
+  } catch {
+    return "";
+  }
+}

--- a/packages/providers/src/shared/stream-health.ts
+++ b/packages/providers/src/shared/stream-health.ts
@@ -27,8 +27,17 @@ export type StreamHealthPolicyReason =
 export const STREAM_HEALTH_DEFAULTS = {
   staleAfterMs: 60_000,
   playbackTrustMs: 5 * 60 * 1000,
-  resolveGateTimeoutMs: 3_000,
-  vidkingResolveGateTimeoutMs: 2_500,
+  /**
+   * One budget for every provider resolve gate.
+   *
+   * An HLS gate is three sequential round trips (master, variant, segment),
+   * measured at 2.1-2.9s against a live dead mirror. A cut-short probe reports
+   * `timeout`, which `isStreamReachableForResolve` treats as "not proven dead"
+   * — so a budget that cannot reach a verdict does not fail loudly, it passes
+   * dead streams intermittently. Videasy used to carry its own tighter 2.5s
+   * copy; per-provider budgets are how that drifts back.
+   */
+  resolveGateTimeoutMs: 6_000,
   preflightTimeoutMs: 3_000,
 } as const;
 

--- a/packages/providers/src/videasy/direct.ts
+++ b/packages/providers/src/videasy/direct.ts
@@ -36,6 +36,7 @@ import {
   findLastCycleFailure,
   providerFailureCodeFromCycleFailure,
 } from "../shared/provider-cycle";
+import { verifyCandidateStream } from "../shared/resolve-gate";
 import { createExhaustedResult, emitTraceEvent } from "../shared/resolve-helpers";
 import { hasResolvableSeriesCoordinates } from "../shared/series-coordinates";
 import {
@@ -49,7 +50,6 @@ import {
   normalizeQualityLabel,
 } from "../shared/source-inventory";
 import { selectReadyStream } from "../shared/startup-selection";
-import { runStreamHealthCheck, STREAM_HEALTH_DEFAULTS } from "../shared/stream-health";
 import { looksLikeHiSubtitle, normalizeIsoLanguageCode } from "../shared/subtitle-helpers";
 import { combineAbortSignals, createTimeoutSignal } from "../shared/timeout-signal";
 // Embedded so `bun build --compile` single-file binaries carry the WASM (resolves
@@ -77,6 +77,24 @@ import { videasyManifest, VIDEOSY_PROVIDER_ID, VIDKING_PROVIDER_ID } from "./man
 export { VIDEOSY_PROVIDER_ID, VIDKING_PROVIDER_ID };
 export const VIDKING_REFERER = "https://www.vidking.net/";
 export const VIDKING_ORIGIN = "https://www.vidking.net";
+
+/**
+ * Origin the media CDN expects on the stream request.
+ *
+ * This is **not** `clientProfile.origin`. That one says which front-end we
+ * impersonate when *calling* the Videasy API (`cineby.at` for `bc-frontend`);
+ * this one is what the CDN's hotlink rule accepts on the media request. Reusing
+ * the API origin for the stream shipped a URL that answers 403, while the
+ * resolve gate probed the default and passed — a gate attesting a request shape
+ * production never makes.
+ *
+ * Measured against `moon.peakstorm.top` on 2026-09-08 with the cineby watch page
+ * as Referer: `vidking.net` -> 200, `cineby.at` -> 403, absent -> 403.
+ *
+ * Deliberately not a parameter. The probed shape and the shipped shape must not
+ * be able to diverge.
+ */
+export const VIDEASY_MEDIA_ORIGIN = VIDKING_ORIGIN;
 /** Default bc-frontend stream/API client profile (matches cineby.at seed + playback). */
 export const CINEBY_REFERER = "https://www.cineby.at/";
 export const CINEBY_ORIGIN = "https://www.cineby.at";
@@ -946,7 +964,6 @@ export function createVidkingResultFromPayload({
   startedAt,
   failures = [],
   streamReferer,
-  streamOrigin,
   sourceQualityFilter,
   sourceDisplayLabel,
   flavorArchetype,
@@ -966,7 +983,6 @@ export function createVidkingResultFromPayload({
   readonly startedAt?: string;
   readonly failures?: readonly ProviderFailure[];
   readonly streamReferer?: string;
-  readonly streamOrigin?: string;
   readonly sourceQualityFilter?: string;
   readonly sourceDisplayLabel?: string;
   readonly flavorArchetype?: string;
@@ -1017,7 +1033,6 @@ export function createVidkingResultFromPayload({
     sourceId: resolvedSourceId,
     server: resolvedServer,
     streamReferer,
-    streamOrigin,
     sourceQualityFilter,
     flavorLabel: themedLabel,
     serverName: themedLabel,
@@ -1323,36 +1338,25 @@ async function probeSelectedVidkingPayloadStream({
     favoriteSourceNames: input.favoriteSourceNames,
   });
   const selected = selection.selected;
-  const streamUrl = selected.url?.trim();
-  if (!streamUrl) {
+  if (!selected.url?.trim()) {
     return { ok: false, verified: false };
   }
 
-  // Always segment-probe HLS/direct before accepting a candidate. Balanced/fast used to
-  // skip this for website-parity latency; that attested dead CDN masters as healthy.
+  // Always segment-probe before accepting a candidate. Balanced/fast used to
+  // skip this for website-parity latency; that attested dead CDN masters as
+  // healthy. The candidate goes in whole, so the probed request shape is the
+  // shipped one — verifying a differently-assembled header set is what let a
+  // 403 stream through while the gate reported success.
   const probeStartedAt = Date.now();
-  const health = await runStreamHealthCheck({
-    phase: "resolve-gate",
-    url: streamUrl,
-    headers: selected.headers,
-    fetchImpl: context.fetch?.fetch.bind(context.fetch),
-    timeoutMs: STREAM_HEALTH_DEFAULTS.vidkingResolveGateTimeoutMs,
-    signal: signal ?? context.signal,
-  });
+  const verdict = await verifyCandidateStream({ stream: selected, context, signal });
   const probeDurationMs = Date.now() - probeStartedAt;
 
-  if (health.healthy) {
-    const verified = health.probed === true && health.probe?.status === "reachable";
-    return { ok: true, verified };
+  if (verdict.accepted) {
+    return { ok: true, verified: verdict.verified };
   }
 
-  const probe = health.probe;
-  const reason =
-    probe?.status === "timeout"
-      ? "stream probe timed out"
-      : probe?.status === "unreachable"
-        ? probe.reason
-        : "stream probe failed";
+  const probe = verdict.probe;
+  const reason = verdict.reason;
 
   emitTraceEvent(events, context, {
     type: "source:failed",
@@ -1767,7 +1771,6 @@ async function tryVidkingServer(opts: {
             startedAt,
             failures,
             streamReferer,
-            streamOrigin: clientProfile.origin,
             sourceQualityFilter: engineOptions.filterQuality,
             engineOptions,
             streamReachabilityVerified: streamProbe.verified,
@@ -2091,7 +2094,6 @@ function normalizeStreamCandidates({
   sourceId,
   server,
   streamReferer = VIDKING_REFERER,
-  streamOrigin = VIDKING_ORIGIN,
   sourceQualityFilter,
   flavorLabel,
   serverName,
@@ -2103,7 +2105,6 @@ function normalizeStreamCandidates({
   readonly sourceId: string;
   readonly server?: string;
   readonly streamReferer?: string;
-  readonly streamOrigin?: string;
   readonly sourceQualityFilter?: string;
   readonly flavorLabel?: string;
   readonly serverName?: string;
@@ -2186,7 +2187,7 @@ function normalizeStreamCandidates({
       sourceEvidence,
       headers: {
         referer: streamReferer,
-        origin: streamOrigin,
+        origin: VIDEASY_MEDIA_ORIGIN,
         "user-agent": USER_AGENT,
       },
       confidence: qualityRank > 0 ? 0.92 : 0.82,

--- a/packages/providers/test/allmanga.test.ts
+++ b/packages/providers/test/allmanga.test.ts
@@ -1660,6 +1660,36 @@ function mockAllMangaBridgeFetch(
   };
 }
 
+/**
+ * AllManga segment-probes a source before accepting it, so a fixture CDN has to
+ * answer like one. Returning 404 for these reads as a dead mirror — which is
+ * exactly what the gate is there to reject — and every resolve fixture would
+ * fail for the wrong reason.
+ */
+function allMangaFixtureCdnResponse(url: string, method: string): Response | null {
+  if (url.includes("segment-0.ts")) {
+    return new Response(new Uint8Array(2048), {
+      status: 206,
+      headers: { "Content-Range": "bytes 0-2047/2048" },
+    });
+  }
+  if (url.includes(".m3u8")) {
+    return new Response("#EXTM3U\n#EXTINF:4.0,\nsegment-0.ts\n", {
+      status: 200,
+      headers: { "Content-Type": "application/vnd.apple.mpegurl" },
+    });
+  }
+  if (url.includes(".mp4")) {
+    return method === "HEAD"
+      ? new Response(null, { status: 200 })
+      : new Response(new Uint8Array(2048), {
+          status: 206,
+          headers: { "Content-Range": "bytes 0-2047/2048" },
+        });
+  }
+  return null;
+}
+
 async function mockAllMangaFetch(
   options: {
     readonly subSourceFixture?:
@@ -1856,6 +1886,8 @@ async function mockAllMangaFetch(
       const body = JSON.parse(bodyText) as { variables?: { translationType?: string } };
       return jsonResponse(body.variables?.translationType === "dub" ? fixtures.dub : fixtures.sub);
     }
+    const cdn = allMangaFixtureCdnResponse(url, String(init?.method ?? "GET"));
+    if (cdn) return cdn;
     return new Response("{}", { status: 404 });
   }) as typeof fetch;
 

--- a/packages/providers/test/anidb.test.ts
+++ b/packages/providers/test/anidb.test.ts
@@ -24,6 +24,25 @@ import { isOfficialAnidbApi, urlHasHostname } from "./helpers/anidb-urls";
 const fixture = (name: string) =>
   Bun.file(new URL(`./fixtures/anidb/${name}`, import.meta.url)).text();
 
+/**
+ * AniDB segment-probes the selected stream before reporting success, so the
+ * fixtures have to answer the hops that probe walks: the variant playlist a
+ * master points at, and the first segment. Leaving these to the 404 fallback
+ * reads as a dead ladder — which is what the gate exists to reject.
+ */
+function anidbFixtureCdnResponse(url: string): Response | null {
+  if (url.includes("segment-0.ts")) {
+    return new Response(new Uint8Array(2048), {
+      status: 206,
+      headers: { "Content-Range": "bytes 0-2047/2048" },
+    });
+  }
+  if (/\d+p\.m3u8/.test(url)) {
+    return new Response("#EXTM3U\n#EXTINF:4.0,\nsegment-0.ts\n", { status: 200 });
+  }
+  return null;
+}
+
 describe("anidb fetch stub URL match", () => {
   test("official API match is host and port, not a substring spoof", () => {
     expect(isOfficialAnidbApi("http://api.anidb.net:9001/httpapi")).toBe(true);
@@ -867,7 +886,7 @@ describe("anidb direct resolve season routing", () => {
             status: 200,
           });
         }
-        return new Response("", { status: 404 });
+        return anidbFixtureCdnResponse(url) ?? new Response("", { status: 404 });
       }) as unknown as typeof fetch,
     );
 
@@ -998,7 +1017,7 @@ describe("anidb direct resolve season routing", () => {
             { status: 200 },
           );
         }
-        return new Response("", { status: 404 });
+        return anidbFixtureCdnResponse(url) ?? new Response("", { status: 404 });
       }) as unknown as typeof fetch,
     );
 

--- a/packages/providers/test/provider-resolve-gate-coverage.test.ts
+++ b/packages/providers/test/provider-resolve-gate-coverage.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Every production provider must prove a stream is playable before reporting
+ * success, and must do it through the shared gate.
+ *
+ * This rule is not decorative. Rivestream reported `provider:success` for a
+ * playlist whose segments answered `domain forbidden`, and cycling stopped
+ * there instead of reaching a server that plays. Videasy verified a stream with
+ * one Origin and shipped it with another, so its gate attested a request shape
+ * production never made. Both were invisible until someone ran mpv by hand.
+ *
+ * Going through `verifyCandidateStream` is what makes the probed request and
+ * the shipped request the same object; a provider that assembles its own probe
+ * can drift apart again, which is exactly how the Videasy bug happened.
+ */
+const PROVIDER_SRC = join(import.meta.dir, "../src");
+
+/** Providers registered by `loadProductionProviderModules()`. */
+const PRODUCTION_PROVIDERS = [
+  "videasy",
+  "vidlink",
+  "rivestream",
+  "allmanga",
+  "anidb",
+  "miruro",
+  "youtube",
+] as const;
+
+/**
+ * A provider may only appear here with a reason that is about the *runtime*,
+ * not about effort.
+ */
+const EXEMPT: Partial<Record<(typeof PRODUCTION_PROVIDERS)[number], string>> = {
+  // YouTube hands mpv a watch URL and lets ytdl resolve the media at play time.
+  // There is no direct stream URL at resolve time to probe, and the smoke
+  // asserts the watch-host contract instead.
+  youtube: "resolves through mpv/ytdl, not a direct stream URL",
+  // Miruro's per-candidate budget is 4.8-5s once `providerCycleCandidateTimeoutMs`
+  // clamps it against the attempt budget, and that has to cover its pipe call as
+  // well. A three-hop HLS probe costs 2.1-2.9s, so a gate here would routinely be
+  // cut short, report `timeout`, and pass everything — a gate that cannot reach a
+  // verdict is worse than none, because it reads as coverage. Raising the budget
+  // needs a live provider to measure against, and Miruro is WAF-blocked; tracked
+  // in .plans/provider-playback-resilience.md.
+  miruro: "per-candidate budget cannot contain a probe; needs a budget rework measured live",
+};
+
+/**
+ * The gate itself, the walk that applies it across a candidate's rungs, or the
+ * shared direct-stream engine that calls it. All three funnel into
+ * `verifyCandidateStream`.
+ */
+const GATE_MARKERS = ["verifyCandidateStream", "selectVerifiedStream", "resolveDirectStreamSource"];
+
+function providerSources(provider: string): string {
+  const dir = join(PROVIDER_SRC, provider);
+  return readdirSync(dir)
+    .filter((file) => file.endsWith(".ts"))
+    .map((file) => readFileSync(join(dir, file), "utf8"))
+    .join("\n");
+}
+
+describe("resolve gate coverage", () => {
+  test.each(PRODUCTION_PROVIDERS.filter((provider) => !(provider in EXEMPT)))(
+    "%s verifies a stream before reporting success",
+    (provider) => {
+      const source = providerSources(provider);
+
+      expect(GATE_MARKERS.some((marker) => source.includes(marker))).toBe(true);
+    },
+  );
+
+  test("every exemption states a runtime reason", () => {
+    for (const [provider, reason] of Object.entries(EXEMPT)) {
+      expect(PRODUCTION_PROVIDERS).toContain(provider as (typeof PRODUCTION_PROVIDERS)[number]);
+      expect(reason.length).toBeGreaterThan(20);
+    }
+  });
+
+  test("the shared gate is the only place a resolve-gate probe is built", () => {
+    // A provider that calls `runStreamHealthCheck({ phase: "resolve-gate" })`
+    // directly is assembling its own probe again, which is what let the probed
+    // and shipped request shapes diverge.
+    const offenders: string[] = [];
+    for (const provider of PRODUCTION_PROVIDERS) {
+      const source = providerSources(provider);
+      if (/phase:\s*"resolve-gate"/.test(source)) offenders.push(provider);
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/providers/test/providers.test.ts
+++ b/packages/providers/test/providers.test.ts
@@ -886,7 +886,7 @@ test("rivestream falls back to static provider services when service discovery i
           const url = String(input);
           requests.push(url);
           if (url.includes("VideoProviderServices")) return new Response("", { status: 503 });
-          return jsonResponse(sourceFixture);
+          return rivestreamFixtureCdnResponse(url) ?? jsonResponse(sourceFixture);
         },
       },
     },
@@ -929,7 +929,10 @@ test("rivestream evidence fixture preserves provider server label and normalized
         fetch: async (input) => {
           const url = String(input);
           requests.push(url);
-          return jsonResponse(url.includes("VideoProviderServices") ? services : sourceFixture);
+          return (
+            rivestreamFixtureCdnResponse(url) ??
+            jsonResponse(url.includes("VideoProviderServices") ? services : sourceFixture)
+          );
         },
       },
     },
@@ -994,6 +997,7 @@ test("rivestream fixture fast startup keeps the first ready stream", async () =>
       fetch: {
         runtime: "direct-http",
         fetch: async (input) =>
+          rivestreamFixtureCdnResponse(String(input)) ??
           jsonResponse(String(input).includes("VideoProviderServices") ? services : source),
       },
     },
@@ -1047,6 +1051,7 @@ test("rivestream fast startup selects provider ready-order before returned quali
         fetch: {
           runtime: "direct-http",
           fetch: async (input) =>
+            rivestreamFixtureCdnResponse(String(input)) ??
             jsonResponse(String(input).includes("VideoProviderServices") ? services : source),
         },
       },
@@ -1103,7 +1108,10 @@ test("rivestream caches provider services across cold resolves", async () => {
           fetch: async (input) => {
             const url = String(input);
             requests.push(url);
-            return jsonResponse(url.includes("VideoProviderServices") ? services : source);
+            return (
+              rivestreamFixtureCdnResponse(url) ??
+              jsonResponse(url.includes("VideoProviderServices") ? services : source)
+            );
           },
         },
       },
@@ -1771,6 +1779,29 @@ async function readFixture<T>(path: string): Promise<T> {
 
 async function readTextFixture(path: string): Promise<string> {
   return Bun.file(new URL(path, FIXTURE_BASE)).text();
+}
+
+/**
+ * Rivestream segment-probes a stream before accepting the candidate, so a
+ * fixture CDN has to answer like one: a media playlist that names a segment,
+ * and a segment with enough bytes to satisfy the range probe. Returning the
+ * source JSON for these too reads as a playlist with no segments — which is
+ * exactly what a dead mirror looks like, and the gate would reject it.
+ */
+function rivestreamFixtureCdnResponse(url: string): Response | null {
+  if (url.endsWith(".m3u8")) {
+    return new Response("#EXTM3U\n#EXTINF:4.0,\nsegment-0.ts\n", {
+      status: 200,
+      headers: { "Content-Type": "application/vnd.apple.mpegurl" },
+    });
+  }
+  if (url.includes("segment-0.ts")) {
+    return new Response("0".repeat(2048), {
+      status: 206,
+      headers: { "Content-Range": "bytes 0-2047/2048" },
+    });
+  }
+  return null;
 }
 
 function jsonResponse(value: unknown, status = 200): Response {

--- a/packages/providers/test/resolve-gate-budget.test.ts
+++ b/packages/providers/test/resolve-gate-budget.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+
+import { providerCycleCandidateTimeoutMs } from "@kunai/core";
+
+import { ALLMANGA_CANDIDATE_TIMEOUT_MS } from "../src/allmanga/direct";
+import {
+  RIVESTREAM_CANDIDATE_TIMEOUT_MS,
+  RIVESTREAM_RESOLVE_GATE_TIMEOUT_MS,
+} from "../src/rivestream/direct";
+import { resolveGateBudgetMs } from "../src/shared/resolve-gate";
+import { STREAM_HEALTH_DEFAULTS } from "../src/shared/stream-health";
+
+/**
+ * A resolve gate that cannot finish is worse than no gate.
+ *
+ * An HLS gate is three sequential round trips — master playlist, variant
+ * playlist, first segment. Measured against a live dead mirror on 2026-09-08
+ * those totalled 2.1-2.9s. A probe cut short reports `timeout`, and
+ * `isStreamReachableForResolve` deliberately treats a timeout as "not proven
+ * dead" so a slow CDN is not mistaken for a broken one — which means an
+ * under-budgeted gate does not fail loudly, it silently passes dead streams,
+ * and it does so intermittently.
+ *
+ * Rivestream demonstrated exactly that at the old 3s default: the same
+ * candidate was rejected on one run and accepted on the next.
+ */
+const OBSERVED_THREE_HOP_PROBE_MS = 2_900;
+
+describe("resolve gate budgets", () => {
+  test("the shared gate outlasts a three-hop HLS probe with headroom", () => {
+    // Headroom, not a hair over: the old 3s default cleared the measured 2.9s
+    // by 100ms and still flipped its verdict between consecutive runs. Anything
+    // this close to the observed cost is a coin toss on a slower link.
+    expect(STREAM_HEALTH_DEFAULTS.resolveGateTimeoutMs).toBeGreaterThanOrEqual(
+      OBSERVED_THREE_HOP_PROBE_MS * 2,
+    );
+  });
+
+  test("there is one gate budget, not a per-provider copy to drift", () => {
+    // Videasy used to carry its own 2.5s budget — tighter than the shared
+    // default and tighter than a probe can complete in.
+    expect(STREAM_HEALTH_DEFAULTS).not.toHaveProperty("vidkingResolveGateTimeoutMs");
+  });
+
+  test.each([
+    ["rivestream", RIVESTREAM_RESOLVE_GATE_TIMEOUT_MS, RIVESTREAM_CANDIDATE_TIMEOUT_MS],
+    ["allmanga", STREAM_HEALTH_DEFAULTS.resolveGateTimeoutMs, ALLMANGA_CANDIDATE_TIMEOUT_MS],
+  ])("%s's gate fits inside its candidate timeout", (_provider, gateMs, candidateMs) => {
+    // A gate that cannot finish inside its own candidate's budget is cut short,
+    // reports `timeout`, and is let through — so an under-sized candidate
+    // timeout silently disables the gate rather than failing loudly.
+    expect(gateMs).toBeLessThan(candidateMs);
+  });
+
+  test("the preflight budget stays lenient and separate", () => {
+    // Preflight is the last-chance check before mpv and is deliberately
+    // permissive; it is not a cycling decision, so it does not need the
+    // headroom a resolve gate does.
+    expect(STREAM_HEALTH_DEFAULTS.preflightTimeoutMs).toBeGreaterThan(0);
+  });
+
+  test.each(["fast", "balanced", "quality-first"] as const)(
+    "the gate still fits after the attempt budget clamps the candidate on %s",
+    (startupPriority) => {
+      // `providerCycleCandidateTimeoutMs` caps a provider's chosen candidate
+      // timeout at 80% of the attempt budget, and on `fast` that is 4.8s — below
+      // the 6s gate. A gate sized against the provider's *unclamped* number is
+      // cut short by its own candidate on the fastest profile, which is the
+      // regime most likely to be in use.
+      for (const preferred of [RIVESTREAM_CANDIDATE_TIMEOUT_MS, ALLMANGA_CANDIDATE_TIMEOUT_MS]) {
+        const candidateMs = providerCycleCandidateTimeoutMs(startupPriority, preferred);
+        expect(resolveGateBudgetMs(candidateMs)).toBeLessThan(candidateMs);
+      }
+    },
+  );
+
+  test("the gate never grows past the shared budget, however long the candidate is", () => {
+    expect(resolveGateBudgetMs(60_000)).toBe(STREAM_HEALTH_DEFAULTS.resolveGateTimeoutMs);
+  });
+
+  test.each(["fast", "balanced", "quality-first"] as const)(
+    "a candidate can afford two gate probes on %s",
+    (startupPriority) => {
+      // `runStreamHealthCheck` probes again when the first attempt reached no
+      // verdict. Sizing the budget for a single probe lets the retry run past
+      // the candidate timeout, which aborts the candidate while the gate is
+      // still deciding — the candidate is then reported dead on a verdict
+      // nobody ever reached.
+      for (const preferred of [RIVESTREAM_CANDIDATE_TIMEOUT_MS, ALLMANGA_CANDIDATE_TIMEOUT_MS]) {
+        const candidateMs = providerCycleCandidateTimeoutMs(startupPriority, preferred);
+        expect(resolveGateBudgetMs(candidateMs) * 2).toBeLessThan(candidateMs);
+      }
+    },
+  );
+
+  test("a candidate too small for any probe still yields a positive budget", () => {
+    // Better a short probe than a negative timeout that throws or never fires.
+    expect(resolveGateBudgetMs(200)).toBeGreaterThan(0);
+  });
+});

--- a/packages/providers/test/resolve-gate.test.ts
+++ b/packages/providers/test/resolve-gate.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ProviderRuntimeContext } from "@kunai/types";
+
+import { selectVerifiedStream, verifyCandidateStream } from "../src/shared/resolve-gate";
+
+/**
+ * The gate exists to make "verified" and "shipped" the same request.
+ *
+ * Videasy proved why: it probed a stream with `Origin: vidking.net`, got 200,
+ * and shipped the identical URL with `Origin: cineby.at`, which the CDN
+ * refused. Both halves were individually reasonable; the bug was that they were
+ * assembled twice.
+ */
+function contextRecording(handler: (url: string, init?: RequestInit) => Response): {
+  readonly context: ProviderRuntimeContext;
+  readonly seen: RequestInit[];
+} {
+  const seen: RequestInit[] = [];
+  const context = {
+    fetch: {
+      runtime: "direct-http" as const,
+      fetch: async (url: string, init?: RequestInit) => {
+        seen.push(init ?? {});
+        return handler(String(url), init);
+      },
+    },
+  } as unknown as ProviderRuntimeContext;
+  return { context, seen };
+}
+
+const PLAYLIST = "#EXTM3U\n#EXTINF:4.0,\nsegment-0.ts\n";
+
+describe("verifyCandidateStream", () => {
+  test("probes with the candidate's own headers, verbatim", async () => {
+    const { context, seen } = contextRecording((url) =>
+      url.endsWith(".m3u8")
+        ? new Response(PLAYLIST, { status: 200 })
+        : new Response(new Uint8Array(2048), { status: 206 }),
+    );
+
+    await verifyCandidateStream({
+      stream: {
+        url: "https://cdn.example/master.m3u8",
+        headers: { referer: "https://site.example/watch", origin: "https://player.example" },
+      },
+      context,
+    });
+
+    expect(seen[0]?.headers).toMatchObject({
+      referer: "https://site.example/watch",
+      origin: "https://player.example",
+    });
+  });
+
+  test("accepts a stream whose segment is reachable", async () => {
+    const { context } = contextRecording((url) =>
+      url.endsWith(".m3u8")
+        ? new Response(PLAYLIST, { status: 200 })
+        : new Response(new Uint8Array(2048), { status: 206 }),
+    );
+
+    const verdict = await verifyCandidateStream({
+      stream: { url: "https://cdn.example/master.m3u8", headers: {} },
+      context,
+    });
+
+    expect(verdict).toMatchObject({ accepted: true, verified: true });
+  });
+
+  test("rejects a stream whose segment is definitively refused", async () => {
+    const { context } = contextRecording((url) =>
+      url.endsWith(".m3u8")
+        ? new Response(PLAYLIST, { status: 200 })
+        : new Response("domain forbidden", { status: 403 }),
+    );
+
+    const verdict = await verifyCandidateStream({
+      stream: { url: "https://cdn.example/master.m3u8", headers: {} },
+      context,
+    });
+
+    expect(verdict.accepted).toBe(false);
+    expect(verdict.accepted === false && verdict.reason).toContain("403");
+  });
+
+  test("a probe that never reached a verdict is accepted but not verified", async () => {
+    // `verified` feeds `streamReachabilityVerified`, and that flag makes later
+    // phases skip probing as "provider-attested". Letting a timeout or an
+    // inconclusive probe set it promotes an unproven stream to a proven one and
+    // switches off the playback preflight that would have caught it.
+    const { context } = contextRecording(() => new Response("", { status: 500 }));
+
+    const verdict = await verifyCandidateStream({
+      stream: { url: "https://cdn.example/video.mp4", headers: {} },
+      context,
+    });
+
+    expect(verdict).toMatchObject({ accepted: true, verified: false });
+  });
+
+  test("accepts when the refusal is not definitive", async () => {
+    const { context } = contextRecording(() => new Response("", { status: 500 }));
+
+    const verdict = await verifyCandidateStream({
+      stream: { url: "https://cdn.example/video.mp4", headers: {} },
+      context,
+    });
+
+    expect(verdict.accepted).toBe(true);
+  });
+
+  test("rejects a candidate with no url rather than probing nothing", async () => {
+    const { context } = contextRecording(() => new Response("", { status: 200 }));
+
+    const verdict = await verifyCandidateStream({ stream: { url: "  ", headers: {} }, context });
+
+    expect(verdict).toMatchObject({ accepted: false });
+  });
+});
+
+/**
+ * A source can offer several qualities, and they do not always share a host. A
+ * refused stream is evidence about that stream, so discarding the whole source
+ * on the first refusal throws away rungs that might play — the difference
+ * between falling back to another server and falling back to another quality on
+ * the server that works.
+ */
+describe("selectVerifiedStream", () => {
+  const stream = (id: string, url: string) => ({ id, url, headers: {} });
+
+  test("returns the first stream that verifies", async () => {
+    const { context } = contextRecording((url) =>
+      url.includes("dead")
+        ? new Response("forbidden", { status: 403 })
+        : new Response(null, { status: 200 }),
+    );
+
+    const result = await selectVerifiedStream({
+      streams: [
+        stream("a", "https://dead.example/a.mp4"),
+        stream("b", "https://live.example/b.mp4"),
+      ],
+      context,
+    });
+
+    expect(result.accepted).toBe(true);
+    expect(result.accepted === true && result.stream.id).toBe("b");
+  });
+
+  test("rejects only when every stream is refused", async () => {
+    const { context } = contextRecording(() => new Response("forbidden", { status: 403 }));
+
+    const result = await selectVerifiedStream({
+      streams: [stream("a", "https://a.example/a.mp4"), stream("b", "https://b.example/b.mp4")],
+      context,
+    });
+
+    expect(result.accepted).toBe(false);
+    expect(result.accepted === false && result.reason).toContain("403");
+  });
+
+  test("probes each host once, because a host answers the same for every rung", async () => {
+    // Counted by distinct URL, not by fetch: one probe of a direct stream is
+    // itself a HEAD plus a ranged GET, so raw request count measures the
+    // probe's internals rather than this walk.
+    const probed: string[] = [];
+    const context = {
+      fetch: {
+        runtime: "direct-http" as const,
+        fetch: async (url: string) => {
+          probed.push(String(url));
+          return new Response("forbidden", { status: 403 });
+        },
+      },
+    } as unknown as ProviderRuntimeContext;
+
+    await selectVerifiedStream({
+      streams: [
+        stream("a", "https://same.example/1080.mp4"),
+        stream("b", "https://same.example/720.mp4"),
+        stream("c", "https://same.example/480.mp4"),
+      ],
+      context,
+    });
+
+    expect(new Set(probed).size).toBe(1);
+    expect(probed.every((url) => url.includes("1080"))).toBe(true);
+  });
+
+  test("rejects an empty candidate rather than reporting success", async () => {
+    const { context } = contextRecording(() => new Response(null, { status: 200 }));
+
+    const result = await selectVerifiedStream({ streams: [], context });
+
+    expect(result.accepted).toBe(false);
+  });
+});

--- a/packages/providers/test/rivestream-gate-failure-class.test.ts
+++ b/packages/providers/test/rivestream-gate-failure-class.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { EndpointHealthPort, ProviderRuntimeContext } from "@kunai/types";
+
+import { clearRivestreamCachesForTest, rivestreamProviderModule } from "../src/rivestream/direct";
+
+/**
+ * A resolve-gate rejection has to survive the candidate's own error handling.
+ *
+ * The gate throws a `ProviderCycleFailureError` carrying `candidate-blocked`
+ * and `endpointScoped`. The catch around the candidate wrapped *every* error
+ * into a `ProviderHttpError` and rebuilt the cycle failure from it, which
+ * relabelled the gate's verdict as `candidate-empty` and dropped the scoped
+ * flag — so endpoint health recorded nothing and every later resolve re-walked
+ * the same dead mirror.
+ *
+ * It also made the two indistinguishable in a trace: "this server returned no
+ * sources" and "this server's stream is refused" both read as `candidate-empty`.
+ */
+const SERVICES = { data: ["primevids", "citadel"] };
+
+const SOURCE_RESPONSE = {
+  data: {
+    sources: [{ url: "https://dead.example/hls/index.m3u8", quality: "1080" }],
+    captions: [],
+  },
+};
+
+function contextWithDeadCdn(
+  recorded: { endpoint: string; class: string }[],
+): ProviderRuntimeContext {
+  const endpointHealth: EndpointHealthPort = {
+    shouldTry: () => true,
+    recordFailure: (_providerId, endpoint, info) => recorded.push({ endpoint, class: info.class }),
+    recordSuccess: () => {},
+  };
+
+  return {
+    now: () => "2026-09-09T00:00:00.000Z",
+    signal: AbortSignal.timeout(30_000),
+    endpointHealth,
+    fetch: {
+      runtime: "direct-http" as const,
+      fetch: async (input: string) => {
+        const url = String(input);
+        if (url.includes("VideoProviderServices")) {
+          return new Response(JSON.stringify(SERVICES), { status: 200 });
+        }
+        if (url.includes("backendfetch")) {
+          return new Response(JSON.stringify(SOURCE_RESPONSE), { status: 200 });
+        }
+        if (url.includes(".m3u8")) {
+          return new Response("#EXTM3U\n#EXTINF:4.0,\nsegment-0.ts\n", { status: 200 });
+        }
+        // The segment is refused outright — a proven-dead stream.
+        return new Response("domain forbidden", { status: 403 });
+      },
+    },
+    emit: () => {},
+  } as unknown as ProviderRuntimeContext;
+}
+
+describe("rivestream resolve-gate failure class", () => {
+  // Resolving through the provider caches service discovery in module state,
+  // which outlives this file. Other suites assert on discovery call counts, so
+  // leaving it populated makes them fail in whichever order the runner picks.
+  beforeEach(() => {
+    clearRivestreamCachesForTest();
+  });
+  afterEach(() => {
+    clearRivestreamCachesForTest();
+  });
+
+  test("a refused stream is reported as blocked, not as an empty candidate", async () => {
+    const recorded: { endpoint: string; class: string }[] = [];
+    const result = await rivestreamProviderModule.resolve(
+      {
+        title: { id: "1396", tmdbId: "1396", kind: "series", title: "Breaking Bad" },
+        episode: { season: 1, episode: 1 },
+        mediaKind: "series",
+        startupPriority: "balanced",
+        intent: "play",
+        allowedRuntimes: ["direct-http"],
+      },
+      contextWithDeadCdn(recorded),
+    );
+
+    const classes = (result.trace.events ?? [])
+      .filter((event) => event.type === "source:failed")
+      .map((event) => String(event.attributes?.failureClass ?? ""));
+
+    expect(classes.length).toBeGreaterThan(0);
+    expect(classes.every((failureClass) => failureClass === "candidate-blocked")).toBe(true);
+    expect(classes).not.toContain("candidate-empty");
+  });
+
+  test("the refusal reaches endpoint health so the mirror is not re-walked", async () => {
+    const recorded: { endpoint: string; class: string }[] = [];
+    await rivestreamProviderModule.resolve(
+      {
+        title: { id: "1396", tmdbId: "1396", kind: "series", title: "Breaking Bad" },
+        episode: { season: 1, episode: 1 },
+        mediaKind: "series",
+        startupPriority: "balanced",
+        intent: "play",
+        allowedRuntimes: ["direct-http"],
+      },
+      contextWithDeadCdn(recorded),
+    );
+
+    expect(recorded).toContainEqual({ endpoint: "primevids", class: "server-error" });
+  });
+});

--- a/packages/providers/test/stream-health.test.ts
+++ b/packages/providers/test/stream-health.test.ts
@@ -131,7 +131,7 @@ describe("stream health", () => {
         }
         return new Response(new Uint8Array(2048).fill(1), { status: 206 });
       },
-      timeoutMs: STREAM_HEALTH_DEFAULTS.vidkingResolveGateTimeoutMs,
+      timeoutMs: STREAM_HEALTH_DEFAULTS.resolveGateTimeoutMs,
     });
 
     expect(result).toMatchObject({

--- a/packages/providers/test/videasy-media-origin.test.ts
+++ b/packages/providers/test/videasy-media-origin.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ProviderRuntimeContext } from "@kunai/types";
+
+import {
+  CINEBY_ORIGIN,
+  createVidkingResultFromPayload,
+  createVideasyRouteCachePolicy,
+  resolveVideasyClientProfile,
+  VIDEASY_MEDIA_ORIGIN,
+} from "../src/videasy/direct";
+
+/**
+ * Videasy carries two different origins and they are not interchangeable:
+ *
+ * - `clientProfile.origin` says which front-end we impersonate when *calling*
+ *   the Videasy API (`cineby.at` for the `bc-frontend` app id).
+ * - the media CDN's hotlink rule keys on the *player's* origin.
+ *
+ * Reusing the API origin as the stream origin shipped a stream that 403s.
+ * Measured against `moon.peakstorm.top` on 2026-09-08, with the cineby watch
+ * page as Referer:
+ *
+ *   Origin: https://www.vidking.net -> 200
+ *   Origin: https://www.cineby.at   -> 403
+ *   Origin: (absent)                -> 403
+ *
+ * The resolve gate probed the default (vidking) and passed, while playback
+ * shipped the client origin and failed — a gate attesting a request shape
+ * production never makes. The stream origin is therefore a single constant
+ * with no override, so the probed shape and the shipped shape cannot diverge.
+ */
+const TEST_INPUT = {
+  title: { id: "299167", tmdbId: "299167", kind: "series" as const, title: "Dutton Ranch" },
+  episode: { season: 1, episode: 1 },
+  mediaKind: "series" as const,
+  intent: "play" as const,
+  allowedRuntimes: ["direct-http" as const],
+};
+
+function resultForPayload() {
+  return createVidkingResultFromPayload({
+    apiRoute: "bc-flix",
+    cachePolicy: createVideasyRouteCachePolicy({ resolveInput: TEST_INPUT, apiRoute: "bc-flix" }),
+    input: TEST_INPUT,
+    payload: {
+      sources: [
+        { url: "https://moon.peakstorm.top/vd/token/index-s1080p-v1-a1.m3u8", quality: "1080p" },
+      ],
+      subtitles: [],
+    },
+    server: "bc-flix",
+    streamReferer: "https://www.cineby.at/tv/299167/1/1",
+  });
+}
+
+describe("videasy stream origin", () => {
+  test("the media origin is not the API client origin", () => {
+    expect(VIDEASY_MEDIA_ORIGIN).not.toBe(CINEBY_ORIGIN);
+  });
+
+  test("a resolved stream carries the media origin", () => {
+    const result = resultForPayload();
+
+    expect(result?.streams[0]?.headers?.origin).toBe(VIDEASY_MEDIA_ORIGIN);
+  });
+
+  test("the stream referer still identifies the impersonated watch page", () => {
+    // The CDN accepts the cineby Referer; it is only the Origin it discriminates
+    // on, so the referer must keep pointing at the page we claim to be.
+    const result = resultForPayload();
+
+    expect(result?.streams[0]?.headers?.referer).toBe("https://www.cineby.at/tv/299167/1/1");
+  });
+
+  test("the cineby client profile still calls the API as cineby", () => {
+    // The fix must not leak into the API request identity, which is a separate
+    // concern and is correct as it stands.
+    const context = { now: () => "2026-09-08T00:00:00.000Z" } as unknown as ProviderRuntimeContext;
+    const profile = resolveVideasyClientProfile(TEST_INPUT, context, { appId: "bc-frontend" });
+
+    expect(profile.origin).toBe(CINEBY_ORIGIN);
+    expect(profile.streamReferer).toBe("https://www.cineby.at/tv/299167/1/1");
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -590,6 +590,18 @@ export interface RelayRpcRequest {
   readonly body?: string;
 }
 
+/**
+ * Set by the client-side relay fetch port on any response that came back
+ * through a relay hop, overwriting whatever the upstream sent under this name.
+ *
+ * A relay answers some requests itself (`unknown-provider` from a deployment
+ * that predates a provider, `unauthorized`, `host-not-allowed`) and proxies the
+ * rest. The client cannot tell those apart from the wire, so an adapter must
+ * not read an HTTP status that arrived over a relay hop as the upstream's own
+ * verdict.
+ */
+export const RELAY_HOP_HEADER = "X-Kunai-Relay-Hop";
+
 export interface RelayRpcErrorBody {
   readonly error: {
     readonly code: RelayErrorCode;

--- a/packages/types/src/provider-cycle.ts
+++ b/packages/types/src/provider-cycle.ts
@@ -52,6 +52,18 @@ export interface ProviderCycleFailure {
   readonly message: string;
   readonly retryable: boolean;
   readonly at: string;
+  /**
+   * This failure is about *this endpoint*, not the provider or the region.
+   *
+   * `candidate-blocked` normally carries no endpoint evidence, because it lumps
+   * together provider-wide session guards, region-wide WAF responses and
+   * endpoint-local refusals — persisting all of those would quarantine healthy
+   * mirrors. A resolve-gate rejection is different in kind: it is a segment
+   * probe against one server's own stream, so a definitive refusal there says
+   * something durable about that server alone. Set it only when the failure was
+   * observed against the endpoint itself.
+   */
+  readonly endpointScoped?: boolean;
 }
 
 export interface ProviderCycleAttempt {


### PR DESCRIPTION
## Why

Two providers were reporting `provider:success` for streams that cannot play, and neither was visible from the CLI — resolve looked clean and mpv failed.

- **Rivestream** accepted a master playlist whose segments answered `domain forbidden`. Cycling stopped at that server instead of walking on to one that plays.
- **Videasy** probed with `Origin: vidking.net` and shipped with `Origin: cineby.at`. The CDN accepts the first and refuses the second, so its check attested a request shape production never made. **This one is in the released 0.3.0 build.**

## What changed

`verifyCandidateStream` takes the **candidate**, not a URL plus separately-assembled headers — that is the whole point, because it makes the probed request and the shipped request the same object. `selectVerifiedStream` walks a candidate's rungs, probes one per host, and reports which hosts refused.

Videasy, VidLink, Rivestream, AllManga and AniDB resolve through it. YouTube and Miruro are exempt for reasons about the runtime, recorded in `provider-resolve-gate-coverage.test.ts`.

Three things this had to get right:

| | Problem | Fix |
|---|---|---|
| **Budget** | The attempt budget clamps a candidate to 80% of its timeout — 4.8s on `fast`. A 6s gate cannot be scheduled inside it, so it timed out and passed everything. | `resolveGateBudgetMs` sizes each probe against the *clamped* figure, allowing for the retry probe. |
| **Failure class** | A refused stream was rebuilt as a generic `ProviderHttpError`, which relabelled it `candidate-empty` and dropped the endpoint flag. Rivestream re-walked all eleven services on every play and learned nothing. | The gate's verdict is re-thrown intact: `candidate-blocked` with `endpointScoped: true`, so endpoint health can quarantine the mirror. |
| **Inventory** | A service whose 1080p rung is dead and whose 720p rung plays passed on the 720p probe, then shipped the whole inventory — including the rung the gate had just refused, which is the one startup selection prefers. | `dropRefusedStreams` prunes them. |

## Evidence

Live headless-mpv decode (`--frames=30`), all resolving and decoding:

| Provider | Latency |
|---|---|
| videasy | ~2.0s |
| vidlink | 1.1–1.7s |
| youtube | 2.5–3.5s |
| rivestream | 3.2–5.5s |

`bun run typecheck --force`, `bun run lint --force`, `bun run test --force` (23/23, 0 cached) green on this commit alone.

## Review notes

- Gate exemptions need a **runtime** reason, and the test asserts one exists.
- `resolveGateBudgetMs` divides by `RESOLVE_GATE_MAX_PROBES` because `runStreamHealthCheck` retries once when the first attempt reaches no verdict — the candidate has to afford both.
- Fixture CDNs in `allmanga.test.ts`, `anidb.test.ts` and `providers.test.ts` now answer the segment hops; without that every resolve fixture fails as a dead mirror, which is what the gate is there to reject.

https://claude.ai/code/session_01JwGMDjtMd6ozHYGXaCr13N

---

## The stack

Merge bottom-up. Each was gated independently with `--force` (no turbo cache replays).

| | PR | Δ | |
|---|---|---|---|
| 1 | **#347** ← you are here | +1400/−74 | the gate, and every provider that adopts it |
| 2 | #348 | +558/−65 | AllManga build 166 + rotation detection |
| 3 | #349 | +698/−45 | AniDB outage honesty, stale-relay 404, curl `--` |
| 4 | #350 | +207/−33 | VidLink header, `--ytdl=yes`, audio-only selector |
| 5 | #351 | +1217/−331 | headless-mpv decode proof, honest matrix |

This replaces **#346**, which carries the same content as one 75-file diff. #345, #340, #337 and #329 are subsumed — except one deliberate omission from #337, noted in #348.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved playback reliability by verifying streams before selecting a provider or server.
  - Automatically skips unavailable mirrors and continues trying healthy alternatives.
  - Remembers failed mirrors to avoid repeatedly selecting sources that cannot play.
  - Fixed certain Videasy streams that could resolve successfully but fail with a 403 error during playback.
  - Improved handling of stream headers and media origins for supported providers.
- **Tests**
  - Added coverage for stream verification, fallback behavior, mirror health, and provider playback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->