### PR TITLE
fix(allmanga): pin build 166, and make the next rotation detectable before users hit it

### DIFF
--- a/.changeset/allmanga-build-166.md
+++ b/.changeset/allmanga-build-166.md
@@ -1,0 +1,20 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Restore AllManga anime playback after the upstream crypto rotation.
+
+mkissa rotated its client crypto and every pinned constant moved at once — the
+build id, all four mask fragments, the derivation constants, the boot prefix and
+separator, the boot payload field order, and the persisted-query hash. Between
+rotations the provider failed silently: bootstrap fell back to bundled material,
+the episode query decoded nothing, and every resolve reported zero streams,
+which reads as "this anime has no sources" rather than "our constants expired".
+
+A rejected persisted-query hash now reports as query drift rather than as an
+empty episode, so the failure names the cause instead of looking like a title
+with no sources.
+
+`bun run test:live:allmanga-crypto` now answers whether the pinned set still
+works and which half is stale, so the next rotation is a lookup rather than an
+investigation.

--- a/.docs/provider-dossiers/allmanga.md
+++ b/.docs/provider-dossiers/allmanga.md
@@ -29,7 +29,7 @@ The source flow matches ani-cli:
 
 ```text
 episode GraphQL persisted GET + aaReq + x-build-id
-  -> "tobeparsed" AES-256-GCM payload (rotated hex key, build id 119, 7-day epochs)
+  -> "tobeparsed" AES-256-GCM payload (rotated hex key, build id 166, 7-day epochs)
   -> decoded source names + encoded API paths (or direct https embeds)
   -> per-source API fetch on allanime.day
   -> mp4 / HLS / DASH-shaped candidates
@@ -94,10 +94,64 @@ The experiment generated a temporary MPD from one selected video representation 
 ## Known
 
 - GraphQL search/catalog is working with `youtu-chan.com` referer.
-- The AES-256-GCM `tobeparsed` decode path and build id 119 crypto bootstrap are verified working (re-derived 2026-08-17 after the 81→119 build rotation; episodes resolve through a user relay); AES-CTR must not be restored (see `.docs/providers.md`).
+- The AES-256-GCM `tobeparsed` decode path and the build id 166 crypto bootstrap are verified working (re-derived 2026-09-08 after the 140→166 rotation; the episode query executes and `aaReq` is accepted); AES-CTR must not be restored (see `.docs/providers.md`).
 - Source APIs can return valid data that is not a single HLS/mp4 URL.
 - Returning only the `Ak` video URL would be wrong because audio is separate.
 - The provider contract already allows `protocol: "dash"` and `container: "mpd"`, but there is no implemented AllManga MPD/EDL handoff for `rawUrls`.
+
+## Recovering a build rotation
+
+Upstream rotates the client crypto roughly monthly (`81` → `119` → `140` → `166`).
+The _derivation_ constants move together — build id, salts, fragment offsets,
+mask fragments, key, epoch — and a partial update fails exactly like a total
+one, so recover those as a set. The persisted-query hash rotates on its own
+schedule and can be stale while the derivation set is current, or the reverse;
+either way every resolve returns zero streams, so check both. Done 2026-09-08
+for `140` → `166`.
+
+**Read the failure first — the endpoint says which half is stale.**
+
+| Bootstrap answer                  | Meaning                                               |
+| --------------------------------- | ----------------------------------------------------- |
+| `404 unknown_build_id`            | `ALLMANGA_BUILD_ID` rotated out                       |
+| `403 invalid_boot_token`          | build id is current, the derivation constants rotated |
+| `400 missing_build_id` / `..lane` | a dropped query param, not upstream drift             |
+| Cloudflare HTML instead of JSON   | missing `Referer`/`Origin: https://mkissa.to`         |
+
+Scanning build ids until the answer flips from `unknown_build_id` to
+`invalid_boot_token` brackets the live build without reading any JS.
+
+**Then re-extract from the crypto chunk.** It is the chunk under
+`cdn.mkissa.net/all/mk/_app/immutable/chunks/` containing both `buildId` and
+`client-crypto` (`BVxTyUEI.js` on 2026-09-08); reach it by crawling
+`_app/immutable/entry/app.*.js`. Strings are 3-character fragments in a rotated
+table, so nothing greps out as a literal. Evaluate `function Xc()` (the table),
+`function Vr` (the accessor) and the rotation IIFE that ends `})(Xc, …)`
+together, then read:
+
+- `cd = fr(296)` — the build id.
+- `mm` — the four base64 8-byte mask fragments.
+- `Rf` — **an ordinary object literal with the derivation constants in plain
+  sight**: `saltMul`, `saltAdd`, `fragMul`, `fragAdd`, `bootPrefix`, `join`, and
+  `parts`. `parts` is the boot payload field order and rotates independently of
+  the separator; build 140 signed `group.host.lane.buildId.epoch`, build 166
+  signs `group:lane:epoch:host:buildId`.
+
+**The persisted query hash rotates too**, and separately. It is a true persisted
+query — the document is never sent — so a stale hash returns
+`PersistedQueryNotFound` and every resolve yields zero streams. Rebuild it by
+expanding the episode query template (`iK`, with its `Mi` / `Kt` / `en()`
+fragments) and taking `sha256` of the result.
+
+Confirm the whole chain live before landing: bootstrap must answer `200` with a
+`partB`, the episode GET must return `"tobeparsed"` rather than an
+`AA_CRYPTO_*` or `PersistedQueryNotFound` error, and the resolved URL must
+decode — `mpv --no-config --vo=null --ao=null --frames=2`. On 2026-09-08 that
+chain produced h264 1920x1080 with `alang=jpn` audio from `video.wixstatic.com`.
+
+`NEED_CAPTCHA` after a few rapid resolves is upstream rate limiting, not a
+crypto fault; it surfaces as `AllMangaCaptchaError` and must not be worked
+around.
 
 ## Unknown
 

--- a/.plans/provider-playback-resilience.md
+++ b/.plans/provider-playback-resilience.md
@@ -24,6 +24,8 @@ that keeps the probed request and the shipped request identical.
   inside its candidate timeout once `providerCycleCandidateTimeoutMs` clamps it.
 - **`streamReachabilityVerified` set by a timed-out probe**, which promoted an
   unproven stream to "provider-attested" and switched off playback preflight.
+- **Pinned-constant rot is now detectable**: `bun run test:live:allmanga-crypto`
+  says whether the pinned AllManga set still works and which half is stale.
 - **Rivestream can learn.** It now hands `runProviderCycle` the endpoint-health
   port, and a resolve-gate rejection is marked `endpointScoped` so the
   classifier can treat it as evidence about that one server. Measured caveat:
@@ -42,13 +44,27 @@ report `timeout`, and pass everything — coverage in name only. Re-sizing
 `MIRURO_CANDIDATE_TIMEOUT_MS` needs a live provider to measure against, and
 every Miruro mirror is currently challenged; do not raise the number blind.
 
+## P2 — Schedule the crypto freshness check
+
+`test:live:allmanga-crypto` exists but nothing runs it. It is one request and it
+fails with the exact remedy attached, so it belongs on the provider-matrix
+workflow's schedule — the point is to learn about a rotation before users do.
+
 ## Notes carried forward
 
 - **AniDB** is a site-wide upstream `503`; ani-cli v5 uses the same host and is
   equally down. Its gate is committed but has not been exercised against a live
   ladder — verify when the site returns.
-- **AllManga's gate is unconfirmed against a live source.** The provider is
-  network-gated (`NEED_CAPTCHA`) from this network, so its gate has only been
-  exercised against fixtures. It is shared with four verified providers, so the
-  risk is low, but it is unproven — re-run `bun run test:live:allanime` from an
-  ungated network or through a relay.
+- **AllManga is network-captcha'd, not just rate-limited.** The crypto recovery
+  is confirmed working — the episode query now _executes_
+  (`PersistedQueryNotFound` is gone and `aaReq` is accepted) — and it resolved
+  end to end once, 4 candidates from `video.wixstatic.com` with mpv decoding
+  h264 1080p `alang=jpn`. Every attempt since answers `NEED_CAPTCHA`, hours
+  later too, so this is a network-level gate of the same shape as Miruro's
+  rather than the transient throttle first assumed. The consequence: the resolve
+  gate added for AllManga has never met a live source. It is unit-tested and
+  shared with four verified providers, so the risk is low, but it is unproven —
+  re-run `bun run test:live:allanime` from an ungated network or through a relay.
+- **AllManga has no parity reference.** ani-cli `a6ac602` deleted every AllAnime
+  path, so the live mkissa chunk is the only source of truth. `AGENTS.md` and
+  the dossier now say so.

--- a/.plans/roadmap.md
+++ b/.plans/roadmap.md
@@ -48,7 +48,7 @@ archive and put only the residue here.
 
 | Track                        | Remaining                                                               | Plan                                                                               |
 | ---------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Provider playback resilience | Miruro gate budget, blocked on a reachable mirror                       | [provider-playback-resilience.md](./provider-playback-resilience.md)               |
+| Provider playback resilience | Miruro gate budget, scheduled crypto freshness check                    | [provider-playback-resilience.md](./provider-playback-resilience.md)               |
 | Provider resolve hardening   | Health recovery, latency ordering, and measured hedge-delay calibration | [provider-resolve-hardening-handoff.md](./provider-resolve-hardening-handoff.md)   |
 | Provider hardening           | Research and scraper capability roadmap                                 | [provider-hardening.md](./provider-hardening.md)                                   |
 | Provider result contract     | Contract work before broad `@kunai/core` extraction                     | [provider-result-contract.md](./provider-result-contract.md)                       |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,10 +54,14 @@ Each of these is enforced by a test or is expensive to get wrong.
   `packages/providers/src/` does not make it live.
 - **Episode numbers are 1-based in the UI.** Providers adapt internally.
 - **`isAnimeProvider: true` is what puts a provider in anime mode.**
-- **`packages/providers/src/allmanga/api-client.ts` carries ani-cli parity
-  logic.** Check parity against the reference implementation before changing
-  crypto or decoder constants, and document deliberate divergence in
-  [.docs/providers.md](.docs/providers.md).
+- **AllManga crypto has no reference implementation left.** ani-cli `a6ac602`
+  (v5) moved to anidb and deleted every AllAnime path, so
+  `packages/providers/src/allmanga/api-client.ts` and `crypto.ts` are checked
+  against the **live mkissa chunk**, not against ani-cli. Upstream rotates every
+  constant at once, roughly monthly; `bun run test:live:allmanga-crypto` says
+  whether the pinned set still works and which half is stale, and
+  [.docs/provider-dossiers/allmanga.md](.docs/provider-dossiers/allmanga.md)
+  carries the recovery procedure.
 - **A provider must never report success for a stream it has not probed.**
   `verifyCandidateStream` is the only resolve gate; it takes the candidate so
   the probed request and the shipped request cannot diverge. Coverage is

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -102,7 +102,8 @@
     "relink:global": "bun run unlink:global && bun run link:global",
     "prepack": "bun run build",
     "build:npm-platform": "bun run scripts/build-npm-platform-packages.ts",
-    "test:live:analytics": "bun -e \"await import('./test/live/analytics-endpoint.smoke.ts')\""
+    "test:live:analytics": "bun -e \"await import('./test/live/analytics-endpoint.smoke.ts')\"",
+    "test:live:allmanga-crypto": "bun test/live/allmanga-crypto-freshness.smoke.ts"
   },
   "dependencies": {
     "commander": "catalog:cli",

--- a/apps/cli/test/live/allmanga-crypto-freshness.smoke.ts
+++ b/apps/cli/test/live/allmanga-crypto-freshness.smoke.ts
@@ -1,0 +1,101 @@
+/**
+ * Is AllManga's pinned crypto still the crypto upstream is running?
+ *
+ * mkissa rotates its client crypto roughly monthly and every constant moves at
+ * once. Between rotations the provider does not fail loudly: bootstrap failure
+ * falls back to `BUNDLED_ALLMANGA_CRYPTO`, the episode query returns nothing
+ * decodable, and every resolve reports zero streams — which reads as "this
+ * anime has no sources" rather than "our constants expired".
+ *
+ * This asks the question directly, in one request, and reads the answer's own
+ * taxonomy so the report says *which half* is stale:
+ *
+ *   200                            -> pinned constants still valid
+ *   404 unknown_build_id           -> ALLMANGA_BUILD_ID rotated out
+ *   403 invalid_boot_token         -> build id current, derivation constants rotated
+ *   400 missing_build_id / ..lane  -> a dropped query param, not upstream drift
+ *   Cloudflare HTML instead of JSON-> missing Referer/Origin
+ *
+ * Recovery procedure: .docs/provider-dossiers/allmanga.md
+ * Touches no profile or database: this is crypto plus one HTTP request.
+ */
+import {
+  ALLMANGA_BOOTSTRAP_URL,
+  ALLMANGA_BUILD_ID,
+  ALLMANGA_CONTENT_LANE_EPISODE,
+  ALLMANGA_EPOCH,
+  ALLMANGA_KEY_GROUP,
+  ALLMANGA_SITE_ORIGIN,
+  buildAllMangaBootToken,
+  currentAllMangaEpochCandidates,
+} from "@kunai/providers/allmanga/crypto";
+
+import { allMangaCryptoRemedy, diagnoseAllMangaBootstrap } from "./allmanga-crypto-freshness";
+
+const UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
+// Near an epoch boundary this returns `[previous, current]`, so the last entry
+// is the live one. Taking `[0]` there compares the pinned material against the
+// epoch that just ended and inverts the verdict.
+const epochCandidates = currentAllMangaEpochCandidates(Date.now());
+const epoch = epochCandidates.at(-1) ?? ALLMANGA_EPOCH;
+const boot = buildAllMangaBootToken({
+  epoch,
+  keyGroup: ALLMANGA_KEY_GROUP,
+  refererHost: "mkissa.to",
+  contentLane: ALLMANGA_CONTENT_LANE_EPISODE,
+});
+
+let status = 0;
+let body = "";
+try {
+  const response = await fetch(
+    `${ALLMANGA_BOOTSTRAP_URL}?buildId=${encodeURIComponent(ALLMANGA_BUILD_ID)}&k=${encodeURIComponent(ALLMANGA_CONTENT_LANE_EPISODE)}`,
+    {
+      headers: {
+        "User-Agent": UA,
+        Referer: `${ALLMANGA_SITE_ORIGIN}/`,
+        Origin: ALLMANGA_SITE_ORIGIN,
+        "x-build-id": ALLMANGA_BUILD_ID,
+        "x-aa-boot": boot,
+      },
+      signal: AbortSignal.timeout(20_000),
+    },
+  );
+  status = response.status;
+  body = (await response.text()).slice(0, 400);
+} catch (error) {
+  body = error instanceof Error ? error.message : String(error);
+}
+
+const diagnosis = diagnoseAllMangaBootstrap(status, body);
+
+/**
+ * The bundled fallback carries its own expiry: the epoch is a 7-day bucket, so
+ * material more than one epoch behind is stale even when bootstrap answers.
+ * A resolve quietly running on a fallback two epochs old looks exactly like a
+ * dead provider.
+ */
+const epochsBehind = epoch - ALLMANGA_EPOCH;
+
+const payload = {
+  ok: diagnosis === "current" && epochsBehind <= 1,
+  provider: "allanime",
+  check: "crypto-freshness",
+  diagnosis,
+  status,
+  pinnedBuildId: ALLMANGA_BUILD_ID,
+  pinnedEpoch: ALLMANGA_EPOCH,
+  liveEpoch: epoch,
+  epochsBehind,
+  // No partB, boot token, or key material in the report.
+  detail:
+    diagnosis === "current"
+      ? undefined
+      : body.replace(/https?:\/\/[^\s"']+/gi, "https://REDACTED").slice(0, 200),
+  remedy: allMangaCryptoRemedy(diagnosis, epochsBehind),
+};
+
+console.log(JSON.stringify(payload, null, 2));
+process.exit(payload.ok ? 0 : 1);

--- a/apps/cli/test/live/allmanga-crypto-freshness.ts
+++ b/apps/cli/test/live/allmanga-crypto-freshness.ts
@@ -1,0 +1,64 @@
+/**
+ * Reading mkissa's bootstrap answer as a diagnosis.
+ *
+ * The endpoint distinguishes *which half* of the pinned crypto is stale, which
+ * turns the next rotation from a reverse-engineering session into a lookup. The
+ * mapping is the valuable part, so it lives here and is unit-tested rather than
+ * being buried in the smoke.
+ */
+export type AllMangaCryptoDiagnosis =
+  | "current"
+  | "build-id-rotated"
+  | "derivation-constants-rotated"
+  | "request-shape"
+  | "blocked"
+  | "unreachable";
+
+export function diagnoseAllMangaBootstrap(status: number, body: string): AllMangaCryptoDiagnosis {
+  // A 200 alone proves nothing: an interstitial or maintenance page answers 200
+  // with HTML, and calling that "current" hides a blocked bootstrap as healthy.
+  // The bootstrap payload is the evidence, so require it.
+  if (status === 200) return isBootstrapPayload(body) ? "current" : "blocked";
+  if (body.includes("unknown_build_id")) return "build-id-rotated";
+  if (body.includes("invalid_boot_token")) return "derivation-constants-rotated";
+  if (body.includes("missing_build_id") || body.includes("missing_or_invalid_lane")) {
+    return "request-shape";
+  }
+  // Cloudflare answers with an HTML challenge page rather than the API's JSON.
+  if (body.trimStart().startsWith("<")) return "blocked";
+  return "unreachable";
+}
+
+/** A real bootstrap answer carries the epoch and the key half it exists to hand back. */
+function isBootstrapPayload(body: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (!parsed || typeof parsed !== "object") return false;
+    const record = parsed as Record<string, unknown>;
+    return typeof record.partB === "string" && typeof record.epoch === "number";
+  } catch {
+    return false;
+  }
+}
+
+export function allMangaCryptoRemedy(
+  diagnosis: AllMangaCryptoDiagnosis,
+  epochsBehind: number,
+): string | undefined {
+  switch (diagnosis) {
+    case "build-id-rotated":
+      return "Scan build ids until the answer flips to invalid_boot_token, then re-extract from the crypto chunk (see the AllManga dossier)";
+    case "derivation-constants-rotated":
+      return "Build id is current; re-extract Rf (saltMul/saltAdd/fragMul/fragAdd/bootPrefix/join/parts) and the mask fragments";
+    case "request-shape":
+      return "A query param was dropped — the request needs ?buildId=&k=<lane>";
+    case "blocked":
+      return "Send Referer and Origin https://mkissa.to";
+    case "current":
+      return epochsBehind > 1
+        ? "Bootstrap works but BUNDLED_ALLMANGA_CRYPTO is stale; refresh the bundled epoch and key"
+        : undefined;
+    default:
+      return undefined;
+  }
+}

--- a/apps/cli/test/unit/live/allmanga-crypto-freshness.test.ts
+++ b/apps/cli/test/unit/live/allmanga-crypto-freshness.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  allMangaCryptoRemedy,
+  diagnoseAllMangaBootstrap,
+} from "../../live/allmanga-crypto-freshness";
+
+/**
+ * Response shapes observed live on 2026-09-08 while recovering the 140 -> 166
+ * rotation. Each one points at a different fix, and telling them apart is what
+ * makes the next rotation cheap.
+ */
+describe("diagnoseAllMangaBootstrap", () => {
+  test("a 200 means the pinned constants still work", () => {
+    expect(diagnoseAllMangaBootstrap(200, '{"epoch":2957,"partB":"..."}')).toBe("current");
+  });
+
+  test("unknown_build_id means the build id rotated out", () => {
+    expect(diagnoseAllMangaBootstrap(404, '{"error":"unknown_build_id"}')).toBe("build-id-rotated");
+  });
+
+  test("invalid_boot_token means the build id is current but the constants moved", () => {
+    // This is the distinction that matters: the id is fine, so bumping it alone
+    // would change nothing and look like the recovery had failed.
+    expect(diagnoseAllMangaBootstrap(403, '{"error":"invalid_boot_token"}')).toBe(
+      "derivation-constants-rotated",
+    );
+  });
+
+  test("a missing param is our request, not upstream drift", () => {
+    expect(diagnoseAllMangaBootstrap(400, '{"error":"missing_build_id"}')).toBe("request-shape");
+    expect(diagnoseAllMangaBootstrap(400, '{"error":"missing_or_invalid_lane"}')).toBe(
+      "request-shape",
+    );
+  });
+
+  test("an HTML body is a Cloudflare challenge, not an API answer", () => {
+    expect(diagnoseAllMangaBootstrap(403, "<!DOCTYPE html><html>Just a moment")).toBe("blocked");
+  });
+
+  test("anything else is unreachable rather than a guess", () => {
+    expect(diagnoseAllMangaBootstrap(0, "fetch failed")).toBe("unreachable");
+  });
+});
+
+describe("allMangaCryptoRemedy", () => {
+  test("each rotation diagnosis names its own fix", () => {
+    expect(allMangaCryptoRemedy("build-id-rotated", 0)).toContain("Scan build ids");
+    expect(allMangaCryptoRemedy("derivation-constants-rotated", 0)).toContain("re-extract Rf");
+  });
+
+  test("a working bootstrap with stale bundled material still asks for a refresh", () => {
+    // The bundled fallback expires on its own: the epoch is a 7-day bucket, so
+    // a resolve can quietly run on material two epochs old and look like a dead
+    // provider.
+    expect(allMangaCryptoRemedy("current", 2)).toContain("stale");
+    expect(allMangaCryptoRemedy("current", 0)).toBeUndefined();
+  });
+});

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -9,6 +9,7 @@
     "./experimental": "./src/experimental.ts",
     "./research": "./src/research.ts",
     "./allmanga": "./src/allmanga/direct.ts",
+    "./allmanga/crypto": "./src/allmanga/crypto.ts",
     "./anidb": "./src/anidb/direct.ts",
     "./miruro": "./src/miruro/direct.ts",
     "./rivestream": "./src/rivestream/direct.ts",

--- a/packages/providers/src/allmanga/api-client.ts
+++ b/packages/providers/src/allmanga/api-client.ts
@@ -709,6 +709,31 @@ export function isAllMangaCaptchaResponse(rawText: string): boolean {
   return rawText.includes("NEED_CAPTCHA");
 }
 
+/**
+ * The persisted-query hash no longer matches upstream's schema.
+ *
+ * It rotates on its own schedule, independently of the derivation constants, so
+ * this can fire while the pinned build id is perfectly current. Without its own
+ * error it fell through to "no sources", which reads as a missing episode
+ * rather than as drift — and drift is the one failure that says *which half* to
+ * re-pin.
+ */
+export class AllMangaQueryDriftError extends Error {
+  readonly code = "allmanga-query-drift" as const;
+
+  constructor() {
+    super(
+      "AllAnime rejected the persisted query hash (PersistedQueryNotFound). " +
+        "Upstream rotated its GraphQL schema or query hash.",
+    );
+    this.name = "AllMangaQueryDriftError";
+  }
+}
+
+export function isAllMangaPersistedQueryNotFound(rawText: string): boolean {
+  return rawText.includes("PersistedQueryNotFound");
+}
+
 export async function resolveEpisodeSources(opts: {
   readonly context: ProviderRuntimeContext;
   readonly apiUrl: string;
@@ -784,6 +809,10 @@ export async function resolveEpisodeSources(opts: {
     // and retrying or re-bootstrapping against it only wastes the budget.
     if (isAllMangaCaptchaResponse(rawText)) {
       throw new AllMangaCaptchaError();
+    }
+
+    if (isAllMangaPersistedQueryNotFound(rawText)) {
+      throw new AllMangaQueryDriftError();
     }
 
     if (rawText.includes("Too many requests")) {

--- a/packages/providers/src/allmanga/crypto.ts
+++ b/packages/providers/src/allmanga/crypto.ts
@@ -8,31 +8,37 @@ import { providerFetch } from "../runtime/fetch";
  * AllManga / mkissa client-crypto (post-2026-08 buildId scheme).
  *
  * Upstream left the ani-cli `72d7f72` "no buildId / scrape epoch+partB from HTML"
- * path. Live mkissa now:
- * - ships a rotating `buildId` (`81` → `119` → `140`) plus four base64 mask
- *   fragments in the app chunk
+ * path — and as of ani-cli `a6ac602` (v5) there is no upstream AllAnime path at
+ * all to check parity against. Live mkissa:
+ * - ships a rotating `buildId` (`81` → `119` → `140` → `166`) plus four base64
+ *   mask fragments in the app chunk
  * - boots keys via `GET /client-crypto/v1/bootstrap?buildId=&k=` with
  *   `x-build-id` + HMAC `x-aa-boot`
  * - signs `aaReq` as AES-GCM over `{v,ts,epoch,buildId,qh,k}` with IV
  *   `SHA-256(epoch:buildId:qh:ts:k)[0:12]`
  * - rotates the epoch scale: 7-day epochs (604800000 ms), 1-day grace
  *
- * 2026-08-24 rotation (119 → 140) also changed the derivation constants and the
- * boot-token layout, all shipped as literals in the obfuscated crypto chunk
- * (`cdn.mkissa.net/all/mk/_app/immutable/chunks/*.js`, currently `Ct8spCYv.js`):
- * - `hashBuildId` mixes `(index * saltMul + saltAdd)` — was `*17 + 31`
- * - `deriveMaskKey` mixes `(fragmentIndex * fragMul + byteIndex * fragAdd)`
- *   — was `*41 + *7`
- * - first HMAC message is `bootPrefix + buildId` (`4X2PsZc2r:` prefix), and the
- *   second covers `group.host.lane.buildId.epoch` joined by `.` — the old
- *   scheme hashed `buildId:keyGroup:host:epoch:lane` joined by `:`
+ * **A rotation moves every constant here at once**, so update them together and
+ * assume none carried over. The 2026-09-08 rotation (140 → 166) changed the
+ * build id, all four mask fragments, every derivation constant, the boot
+ * prefix, the join character, the boot payload *field order*, and the episode
+ * persisted-query hash. A partial update fails exactly like no update.
  *
- * The episode persisted-query hash is unchanged by this rotation.
+ * The recovery procedure — which failure means which half is stale, and how to
+ * read the constants back out of the obfuscated chunk — is in
+ * [the AllManga dossier](../../../../.docs/provider-dossiers/allmanga.md).
  */
 
-export const ALLMANGA_BUILD_ID = "140";
+export const ALLMANGA_BUILD_ID = "166";
+/**
+ * sha256 of the episode persisted-query document, which rotates with the app
+ * build. It is a true persisted query: the text is never sent, so a stale hash
+ * comes back as `PersistedQueryNotFound` and every resolve returns no streams.
+ * Recover it by re-hashing the document in the crypto chunk (`iK`, with its
+ * `Mi` / `Kt` / `en()` fragments expanded) — see the AllManga dossier.
+ */
 export const ALLMANGA_QUERY_HASH =
-  "ca735f1436927eaf7abb05d1589bb93c43cf606d87eecc2030357c1aad8fb455";
+  "1c836a5028e04275c6bc618aa4d1f0ea2290a73bc056ba6a8b93fe72ef42fd04";
 /** Episode GraphQL lane (`Lf` → `k7`). */
 export const ALLMANGA_CONTENT_LANE_EPISODE = "k7";
 export const ALLMANGA_KEY_GROUP = "mkissa";
@@ -46,26 +52,41 @@ export const ALLMANGA_EPOCH_GRACE_MS = 86_400_000;
 export const ALLMANGA_AA_REQ_BUCKET_MS = 300_000;
 
 /**
- * Derivation constants from the live chunk config object (`Fd`). Upstream
+ * Derivation constants from the live chunk config object (`Rf`). Upstream
  * rotates these alongside the buildId; if bootstrap starts failing with
  * AA_CRYPTO errors after a known-good buildId, re-extract them.
+ *
+ * How to read them back out is in
+ * [.docs/provider-dossiers/allmanga.md](../../../../.docs/provider-dossiers/allmanga.md).
  */
-const ALLMANGA_SALT_MUL = 250;
-const ALLMANGA_SALT_ADD = 54;
-const ALLMANGA_FRAG_MUL = 16;
-const ALLMANGA_FRAG_ADD = 217;
-const ALLMANGA_BOOT_PREFIX = "4X2PsZc2r:";
-const ALLMANGA_BOOT_JOIN = ".";
+const ALLMANGA_SALT_MUL = 165;
+const ALLMANGA_SALT_ADD = 115;
+const ALLMANGA_FRAG_MUL = 197;
+const ALLMANGA_FRAG_ADD = 200;
+const ALLMANGA_BOOT_PREFIX = "ld1faaOf3G:";
+const ALLMANGA_BOOT_JOIN = ":";
 
 /**
- * Base64 8-byte mask fragments (`ud`) from the mkissa crypto chunk after
+ * Field order of the second HMAC message (`Rf.parts`).
+ *
+ * Build 140 signed `group.host.lane.buildId.epoch`; build 166 signs
+ * `group:lane:epoch:host:buildId`. The order is data rather than a literal
+ * array expression because it rotates independently of the separator, and
+ * getting either wrong fails identically with `invalid_boot_token`.
+ */
+export const ALLMANGA_BOOT_PAYLOAD_FIELDS = ["group", "lane", "epoch", "host", "buildId"] as const;
+
+export type AllMangaBootPayloadField = (typeof ALLMANGA_BOOT_PAYLOAD_FIELDS)[number];
+
+/**
+ * Base64 8-byte mask fragments (`mm`) from the mkissa crypto chunk after
  * string-table rotation. Combined with `hashBuildId(buildId)` in `deriveMaskKey`.
  */
 export const ALLMANGA_MASK_FRAGMENTS = [
-  "VfAQPinN3/Q=",
-  "R7d6L9MUgM8=",
-  "unPepPUGy18=",
-  "XXGHwHlzibA=",
+  "0VmOiOTlfQ0=",
+  "F/SlaG5999I=",
+  "VTm6fMS7BdQ=",
+  "LIQNr2OipeQ=",
 ] as const;
 
 /** How long derived crypto material stays trusted before a lazy refetch. */
@@ -79,9 +100,16 @@ export type AllMangaCryptoMaterial = {
   readonly contentLane: string;
 };
 
-/** Last-known-good material when bootstrap fails (epoch 2955, build 140). */
-export const ALLMANGA_KEY_HEX = "deeb2732190ceee0d84c7668d79b64ddcd5f27b9f858f2327fe29a7841b7b5da";
-export const ALLMANGA_EPOCH = 2955;
+/**
+ * Last-known-good material when bootstrap fails (epoch 2957, build 166).
+ *
+ * The epoch is a 7-day bucket, so this fallback goes stale on its own. It
+ * exists to survive a brief bootstrap outage, not to replace one — a resolve
+ * that quietly runs on a fallback two epochs old looks exactly like a dead
+ * provider.
+ */
+export const ALLMANGA_KEY_HEX = "43724f7d46135c6cdb2824f00c4ee272a0fff52f89681213140c6c2b80af8d21";
+export const ALLMANGA_EPOCH = 2957;
 
 export const BUNDLED_ALLMANGA_CRYPTO: AllMangaCryptoMaterial = {
   keyHex: ALLMANGA_KEY_HEX,
@@ -147,8 +175,10 @@ function hmacSha256Hex(key: Buffer, message: string): string {
 
 /**
  * Port of mkissa `tw` → `x-aa-boot`.
- * First HMAC message is `{bootPrefix}{buildId}`; second covers
- * `{keyGroup}.{host}.{lane}.{buildId}.{epoch}` joined by `.`.
+ *
+ * First HMAC message is `{bootPrefix}{buildId}`; the second covers the fields
+ * named by {@link ALLMANGA_BOOT_PAYLOAD_FIELDS}, joined by the rotation's
+ * separator.
  */
 export function buildAllMangaBootToken(options: {
   readonly buildId?: string;
@@ -158,14 +188,21 @@ export function buildAllMangaBootToken(options: {
   readonly contentLane?: string;
 }): string {
   const buildId = options.buildId ?? ALLMANGA_BUILD_ID;
-  const keyGroup = options.keyGroup ?? ALLMANGA_KEY_GROUP;
-  const host = String(options.refererHost ?? "mkissa.to")
-    .toLowerCase()
-    .replace(/^www\./, "");
-  const lane = options.contentLane?.trim() ?? "";
+  const fields: Record<AllMangaBootPayloadField, string> = {
+    group: options.keyGroup ?? ALLMANGA_KEY_GROUP,
+    // Signed without the `www.` prefix; the site sends the bare host.
+    host: String(options.refererHost ?? "mkissa.to")
+      .toLowerCase()
+      .replace(/^www\./, ""),
+    lane: options.contentLane?.trim() ?? "",
+    buildId,
+    epoch: String(options.epoch),
+  };
   const mask = deriveMaskKey(buildId);
   const inner = Buffer.from(hmacSha256Hex(mask, `${ALLMANGA_BOOT_PREFIX}${buildId}`), "hex");
-  const payload = [keyGroup, host, lane, buildId, String(options.epoch)].join(ALLMANGA_BOOT_JOIN);
+  const payload = ALLMANGA_BOOT_PAYLOAD_FIELDS.map((field) => fields[field]).join(
+    ALLMANGA_BOOT_JOIN,
+  );
   return hmacSha256Hex(inner, payload);
 }
 

--- a/packages/providers/src/allmanga/direct.ts
+++ b/packages/providers/src/allmanga/direct.ts
@@ -43,6 +43,7 @@ import { normalizeIsoLanguageCode, subtitleLanguageDisplayName } from "../shared
 import {
   type StreamLink,
   AllMangaCaptchaError,
+  AllMangaQueryDriftError,
   loadAvailableEpisodesDetail,
   resolveAnimeEpisodeString,
   resolveEpisodeSources,
@@ -842,11 +843,12 @@ export const allmangaProviderModule: CoreProviderModule = {
       // reporting it as retryable network noise is what made this look like an
       // empty episode rather than a blocked request.
       const captchaBlocked = error instanceof AllMangaCaptchaError;
+      const queryDrift = error instanceof AllMangaQueryDriftError;
       const failure: ProviderFailure = {
         providerId: ALLANIME_PROVIDER_ID,
-        code: captchaBlocked ? "blocked" : "network-error",
+        code: captchaBlocked ? "blocked" : queryDrift ? "parse-failed" : "network-error",
         message: error instanceof Error ? error.message : "AllManga API failed",
-        retryable: !captchaBlocked,
+        retryable: !captchaBlocked && !queryDrift,
         at: context.now(),
       };
       failures.push(failure);

--- a/packages/providers/test/allmanga-build-166-crypto.test.ts
+++ b/packages/providers/test/allmanga-build-166-crypto.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  ALLMANGA_BOOT_PAYLOAD_FIELDS,
+  ALLMANGA_BUILD_ID,
+  ALLMANGA_MASK_FRAGMENTS,
+  buildAllMangaBootToken,
+  deriveMaskKey,
+} from "../src/allmanga/crypto";
+
+/**
+ * Golden vectors for the mkissa build-166 rotation, extracted from the live
+ * crypto chunk (`_app/immutable/chunks/BVxTyUEI.js`, config object `Rf`) and
+ * confirmed end to end on 2026-09-08: this boot token is what
+ * `GET /client-crypto/v1/bootstrap?buildId=166&k=k7` answered `200` to.
+ *
+ * The rotation moved every constant at once — salt, fragment mixers, the boot
+ * prefix, the join character, and the payload field order — so a partial update
+ * still fails with `invalid_boot_token`. These vectors exist to make an
+ * accidental edit of any one of them fail loudly instead of silently returning
+ * zero streams.
+ */
+describe("build-166 crypto material", () => {
+  test("mask fragments are four 8-byte values", () => {
+    expect(ALLMANGA_MASK_FRAGMENTS).toHaveLength(4);
+    for (const fragment of ALLMANGA_MASK_FRAGMENTS) {
+      expect(Buffer.from(fragment, "base64")).toHaveLength(8);
+    }
+  });
+
+  test("deriveMaskKey reproduces the live mask key", () => {
+    expect(deriveMaskKey().toString("hex")).toBe(
+      "93bf9583f597adb57f0823c99532cdc02a359c1a0f04a8a6b935d1e34587a27b",
+    );
+  });
+
+  test("the boot token matches the value bootstrap accepted", () => {
+    const token = buildAllMangaBootToken({
+      epoch: 2957,
+      keyGroup: "mkissa",
+      refererHost: "mkissa.to",
+      contentLane: "k7",
+    });
+
+    expect(token).toBe("59199a3a63e6c8cb88c9204aa2aa2321401005d5b0852d6a027bb7973d3e5474");
+  });
+
+  test("the boot payload is ordered group, lane, epoch, host, buildId", () => {
+    // Build 140 hashed group.host.lane.buildId.epoch joined by ".". Both the
+    // order and the separator changed, and either alone is enough to be
+    // rejected, so the order is asserted rather than left implicit.
+    expect(ALLMANGA_BOOT_PAYLOAD_FIELDS).toEqual(["group", "lane", "epoch", "host", "buildId"]);
+  });
+
+  test("the pinned buildId is the one the mask fragments belong to", () => {
+    expect(ALLMANGA_BUILD_ID).toBe("166");
+  });
+
+  test("a www. referer host is normalised before signing", () => {
+    expect(
+      buildAllMangaBootToken({
+        epoch: 2957,
+        keyGroup: "mkissa",
+        refererHost: "www.mkissa.to",
+        contentLane: "k7",
+      }),
+    ).toBe(
+      buildAllMangaBootToken({
+        epoch: 2957,
+        keyGroup: "mkissa",
+        refererHost: "mkissa.to",
+        contentLane: "k7",
+      }),
+    );
+  });
+});

--- a/packages/providers/test/allmanga.test.ts
+++ b/packages/providers/test/allmanga.test.ts
@@ -25,6 +25,7 @@ import {
   BUNDLED_ALLMANGA_CRYPTO,
   buildStreamHeaders,
   AllMangaCaptchaError,
+  AllMangaQueryDriftError,
   clearAllMangaProviderCachesForTest,
   decodeTobeparsed,
   decryptTobeparsedPlaintext,
@@ -325,7 +326,7 @@ describe("buildAllMangaAaReq", () => {
 describe("AllManga crypto material (mkissa bootstrap)", () => {
   const partBBytes = Array.from({ length: 32 }, (_, index) => index + 1);
   const PART_B = Buffer.from(partBBytes).toString("base64");
-  const EXPECTED_KEY_HEX = "532fbba462deed2b68657d7c758b7bcd6978e4ebeac46cd4e3f6d4c24ab863c7";
+  const EXPECTED_KEY_HEX = "92bd9687f091aabd760228c5983cc2d03b278f0e1a12bfbea02fcaff5899bd5b";
   const PLAIN_SOURCE_JSON = JSON.stringify({
     data: {
       episode: {
@@ -416,10 +417,10 @@ describe("AllManga crypto material (mkissa bootstrap)", () => {
     expect(material?.keyHex).toBe(EXPECTED_KEY_HEX);
     expect(material?.epoch).toBe(6900);
     expect(material?.queryHash).toBe(ALLMANGA_QUERY_HASH);
-    expect(material?.buildId).toBe("140");
-    expect(site.bootstrapHeaders?.get("x-build-id")).toBe("140");
+    expect(material?.buildId).toBe("166");
+    expect(site.bootstrapHeaders?.get("x-build-id")).toBe("166");
     expect(site.bootstrapHeaders?.get("x-aa-boot")).toBe(
-      "9589a0b5c93919e01039dc83eeced3966f2abda839f8302dc7087e7b3df5cd35",
+      "0046b60be8f98c4901a15d7ae5a37199c36131972fe815df2ccc7e7f07d63e88",
     );
     expect(site.bootstrapHeaders?.get("origin")).toBe("https://mkissa.to");
     expect(site.bootstrapHeaders?.get("referer")).toBe("https://mkissa.to/");
@@ -429,23 +430,23 @@ describe("AllManga crypto material (mkissa bootstrap)", () => {
     expect(site.bootstrapFetchCount).toBe(1);
   });
 
-  test("matches independent build-140 derivation and boot-token vectors", () => {
-    expect(hashBuildId("140").toString("hex")).toBe(
-      "07041a152a2823383631cec4dfdcd2ede2e0fbf08e89869c9794aaa5bab8b348",
+  test("matches independent build-166 derivation and boot-token vectors", () => {
+    expect(hashBuildId("166").toString("hex")).toBe(
+      "422e8b53319a60c0ad71d3bc1ee24f2ff55e3c8461cd9770daa603eb4912f858",
     );
-    expect(deriveMaskKey("140").toString("hex")).toBe(
-      "522db8a067d8ea23616f7670788574dd786af7ffffd27bccfaeccfde57a67ce7",
+    expect(deriveMaskKey("166").toString("hex")).toBe(
+      "93bf9583f597adb57f0823c99532cdc02a359c1a0f04a8a6b935d1e34587a27b",
     );
-    expect(deriveKeyFromPartB(PART_B, "140").toString("hex")).toBe(EXPECTED_KEY_HEX);
+    expect(deriveKeyFromPartB(PART_B, "166").toString("hex")).toBe(EXPECTED_KEY_HEX);
     expect(
       buildAllMangaBootToken({
-        buildId: "140",
+        buildId: "166",
         epoch: 6900,
         keyGroup: "mkissa",
         refererHost: "mkissa.to",
         contentLane: "k7",
       }),
-    ).toBe("9589a0b5c93919e01039dc83eeced3966f2abda839f8302dc7087e7b3df5cd35");
+    ).toBe("0046b60be8f98c4901a15d7ae5a37199c36131972fe815df2ccc7e7f07d63e88");
   });
 
   test("falls back to bundled material when bootstrap fails", async () => {
@@ -507,6 +508,34 @@ describe("AllManga crypto material (mkissa bootstrap)", () => {
     expect((thrown as Error).message).toContain("captcha");
     // A captcha is not a crypto problem: it must not trigger re-bootstrapping,
     // and it must not burn the retry budget on identical requests.
+    expect(site.apiCallCount).toBe(1);
+    expect(site.bootstrapFetchCount).toBe(1);
+  });
+
+  /**
+   * The persisted-query hash rotates on its own schedule, so this fires while
+   * the pinned build id is still current. It used to fall through the retry
+   * loop and return an empty list — indistinguishable from an episode that has
+   * no sources, and therefore no signal about which half to re-pin.
+   */
+  test("surfaces a rotated persisted-query hash as drift, not as an empty episode", async () => {
+    using site = mockCryptoSiteFetch({
+      apiResponses: [
+        '{"errors":[{"message":"PersistedQueryNotFound","extensions":{"code":"PERSISTED_QUERY_NOT_FOUND"}}]}',
+      ],
+    });
+
+    let thrown: unknown;
+    try {
+      await resolveWithSiteSources();
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(AllMangaQueryDriftError);
+    expect((thrown as Error).message).toContain("query hash");
+    // Drift is not a crypto-material problem and not transient: no
+    // re-bootstrap, and no retry budget spent on an identical request.
     expect(site.apiCallCount).toBe(1);
     expect(site.bootstrapFetchCount).toBe(1);
   });


### PR DESCRIPTION
> **Stacked on #347** — review that first. This diff is only the AllManga commit.

## Why

AllManga rotates every crypto constant at once, roughly monthly, and the pinned set was build **140**. The symptom is not an error anyone can read: the episode query comes back `PersistedQueryNotFound`, or `aaReq` is rejected, and the provider reports "no sources".

## What changed

Both halves are re-pinned to build **166** and both are covered by independent vectors:

- **Derivation set** — build id, salts, fragment offsets, mask fragments, key, epoch. Covered by `hashBuildId`, `deriveMaskKey`, `deriveKeyFromPartB` and the boot token in `allmanga-build-166-crypto.test.ts`.
- **GraphQL persisted-query hash**, which rotates on its own schedule. It can be stale while the derivation set is current, or the reverse — either way every resolve returns zero streams, so the dossier now says to check both.

## Drift now has a name

`PersistedQueryNotFound` was falling through the retry loop to an empty list: the retry budget spent on identical requests, then "no sources". It raises `AllMangaQueryDriftError` and resolves as a non-retryable `parse-failed`, so the one failure that tells you *which half* to re-pin is no longer the one being swallowed. (Adopted from #337, which had it and is otherwise superseded by this stack.)

## The AGENTS.md bullet was pointing at deleted code

The old non-negotiable said to check parity against ani-cli before touching crypto constants. ani-cli `a6ac602` (v5) moved to anidb and **deleted every AllAnime path**, so there is no reference implementation left. The live mkissa chunk is now the only source of truth, and the dossier carries the recovery procedure: which half is stale, where each constant appears in the obfuscated bundle, and how to read the rotation IIFE.

## Making the next rotation cheap

`bun run test:live:allmanga-crypto` is one request. It returns a verdict naming which half is stale — `build-id-rotated` vs `derivation-constants-rotated` — with the remedy attached, and distinguishes a rotation from a network block so a captcha is not misread as drift.

It validates the 200 body rather than trusting the status: a 200 HTML challenge page would otherwise report `current` for a bootstrap that is entirely blocked. It also reads the **current** epoch (`epochCandidates.at(-1)`), not `[0]` — inside the 24h grace window after a 7-day boundary, `[0]` is the *previous* epoch, which would sign the boot token stale and report a rotation that never happened.

## Caveat, stated plainly

AllManga is network-captcha'd from this machine (`NEED_CAPTCHA`, persisting for hours), so the crypto is confirmed working — the query executes and `aaReq` is accepted, and it resolved end to end once with mpv decoding h264 1080p `alang=jpn` — but every attempt since is gated. The resolve gate added for this provider has therefore never met a live source. It is unit-tested and shared with four verified providers, so the risk is low, but it is unproven; `.plans/provider-playback-resilience.md` records that.

https://claude.ai/code/session_01JwGMDjtMd6ozHYGXaCr13N
