### PR TITLE
fix(anime): report AniDB's outage instead of an empty result, and terminate curl's argv

### DIFF
--- a/.changeset/anidb-outage-honesty.md
+++ b/.changeset/anidb-outage-honesty.md
@@ -1,0 +1,12 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Report an AniDB outage instead of showing no results.
+
+AniDB answers a site-wide outage with a `503` maintenance page on every route.
+Scraping that page for result rows finds none, so search reported zero results
+for every query alike — an outage wearing the costume of "no such anime", with
+nothing thrown and no signal for provider fallback to act on. Every read now
+surfaces its HTTP status, and only the statuses a different TLS fingerprint
+could change are retried.

--- a/.docs/provider-dossiers/anidb-runtime-contract.md
+++ b/.docs/provider-dossiers/anidb-runtime-contract.md
@@ -64,11 +64,20 @@ instead of pretending those fields came from `anidb.app`.
   evidence (`chooseAnidbSearchMatch(..., { requireTitleEvidence: true })`) — the ordinary
   "best guess is the top card" fallback is disabled there, since substituting a search result for a
   _persisted_ id would silently swap the show the user chose.
-- The 404 has to be asked for. `anidb.app` is fetched with `curl -sL`, which has no `--fail`, so a
-  missing id returns the error page with exit 0 and is otherwise indistinguishable from a body that
-  failed to parse. Reads that branch on the status pass `reportStatus: true`, which appends
-  `-w '\n%{http_code}'` and raises `AnidbHttpStatusError`. A caller that reads the status out of a
+- The status has to be asked for, so **every** read asks. `anidb.app` is fetched with `curl -sL`,
+  which has no `--fail`, so an error page returns with exit 0 and is otherwise indistinguishable
+  from a body that failed to parse. `anidbFetchText` always appends `-w '\n%{http_code}'` and
+  raises `AnidbHttpStatusError` for any status ≥ 400. A caller that reads the status out of a
   message string is reading prose, not a status.
+- There is no best-effort mode, because it hid a site-wide outage. `anidb.app` answers maintenance
+  with `503` on every route; scraping that page for result rows found none, so search reported zero
+  results for every query alike — an outage wearing the costume of "no such anime", with nothing
+  thrown and no health signal for fallback. Callers that treat a missing id as a real answer catch
+  the 404 explicitly (`fetchAnidbEpisodeCatalog`, `fetchAnidbExternalIds`); everything else lets the
+  status propagate so the search phase can surface it and `server-error` quarantine can see it.
+- Only `403`/`429` earn the curl retry. The fallback exists so a Cloudflare challenge gets a second
+  chance with a better TLS fingerprint; a 404 or a 5xx is the upstream's real answer, and retrying
+  it only doubles the latency before the same result.
 - Only exact `jpn` (sub/original) and `eng` (dub) catalog evidence is accepted.
   The requested mode resolves first; the alternate starts concurrently but is
   skipped for `fast`, bounded to 1 second for `balanced`, and bounded to 4

--- a/.docs/provider-dossiers/miruro.md
+++ b/.docs/provider-dossiers/miruro.md
@@ -334,6 +334,33 @@ Miruro resolves entirely through `GET /api/secure/pipe?e=…` on `www.miruro.bz`
   "Just a moment" challenge on the pipe too, so that region does **not** count
   as ungated for Miruro — only a relay on an egress Miruro's WAF tolerates
   (unproven region, likely non-US cloud IPs) would clear the gate.
+- **2026-09-09 sweep — no local fix exists, and the relay wiring is proven.**
+  Re-checked because "Miruro used to work here":
+  - Every mirror is challenged, not just the two on the resolve list:
+    `www.miruro.bz`, `.ru`, `.to` and `.tv` all answer `403 Just a moment...`.
+  - **Twelve** impersonation profiles were tried against the pipe with the exact
+    `buildMiruroPipeHeaders` shape — chrome116/131/136/142/145/146/150,
+    firefox135/144/147, safari153, chrome131_android. All twelve are challenged.
+    So this is a JS/managed challenge, not a fingerprint gap: installing a newer
+    curl-impersonate build cannot clear it, and the "newest build wins" discovery
+    below buys nothing while the challenge is on.
+  - `www.miruro.com` answers 200 but is a hub page — every path returns the SPA
+    shell, there is no `/api/secure/pipe`, and it only links to the mirrors and a
+    status page. No `api.` / `backend.` / `pipe.` / `cdn.` subdomain resolves on
+    any mirror domain.
+  - **The relay path itself works.** Pointing `KUNAI_RELAY_BASE_URL` at a local
+    recording stand-in showed four `POST /rpc/miruro` calls carrying the correct
+    upstream URLs for both mirrors, so the failure message's remedy is wired end
+    to end and only wants a tolerated egress.
+  - Methodology warning: `fallbackToDirect` defaults to **true**, so aiming the
+    relay at a dead port yields the _same_ Cloudflare error as no relay at all.
+    That fakes a negative result — use a recording stand-in, never an
+    unreachable port, when testing whether relay routing engages.
+- **Superseded by the 2026-09-09 sweep above, and kept because it is still the
+  right diagnosis whenever the managed challenge is _not_ on.** As of
+  2026-09-09 every mirror answers the challenge from this network and no
+  impersonate build clears it, so do not install one expecting it to help. What
+  follows describes the pipe's behaviour when the challenge is absent.
 - **The pipe itself is fingerprint-gated, not dead.** From a real browser the
   envelope (`?e=base64url({path,method,query,body,version})`, e.g.
   `{"path":"episodes","query":{"anilistId":"21"},"version":"0.2.0"}`) answers

--- a/.plans/provider-playback-resilience.md
+++ b/.plans/provider-playback-resilience.md
@@ -35,6 +35,39 @@ that keeps the probed request and the shipped request identical.
   server that simply lacks one title must not be blacklisted. The mechanism
   is proven by `provider-cycle-endpoint-health.test.ts` instead.
 
+## P1 — Miruro: the block is a JS challenge, and the relay is the only way through
+
+Investigated 2026-09-09. What is actually wrong, in order of what was ruled out:
+
+- **Every mirror is Cloudflare-challenged.** `www.miruro.bz`, `.ru`, `.to` and
+  `.tv` all answer `403 Just a moment...` — a managed challenge page, not a hard
+  block.
+- **It is not a TLS fingerprint problem.** Twelve impersonation profiles were
+  tried (chrome116/131/136/142/145/146/150, firefox135/144/147, safari153,
+  chrome131_android). All twelve get the same challenge, so no newer
+  curl-impersonate build will fix it and installing one is not the answer.
+- **`miruro.com` is a hub, not the app.** It answers 200, but every path returns
+  the SPA shell and it has no `/api/secure/pipe`; its homepage just links to the
+  mirrors and a status page.
+- **There is no unchallenged API host.** `api.`/`backend.`/`pipe.`/`cdn.`
+  subdomains do not resolve on any mirror domain.
+
+So the challenge has to be solved by something that runs JS, or the request has
+to come from a network Cloudflare is not challenging.
+
+**The relay path is verified working.** Pointing `KUNAI_RELAY_BASE_URL` at a
+local recording stand-in showed the CLI sending four `POST /rpc/miruro` calls
+carrying the correct upstream URLs for both mirrors — so the remedy the failure
+message names is real, wired end to end, and only needs a relay host outside the
+blocked network. (A local relay cannot help: same IP, same challenge.)
+
+One methodological warning for whoever picks this up: `fallbackToDirect`
+defaults to **true**, so pointing the relay at a dead port produces the _same_
+Cloudflare error as no relay at all. That silently fakes a negative result — use
+a recording stand-in, not an unreachable port.
+
+The gate exemption stands for the separate reason below.
+
 ## P1 — Miruro cannot host a resolve gate at its current budget
 
 Once `providerCycleCandidateTimeoutMs` clamps it against the attempt budget,

--- a/apps/cli/src/services/providers/stream-request-adapter.ts
+++ b/apps/cli/src/services/providers/stream-request-adapter.ts
@@ -41,10 +41,14 @@ export function streamRequestToResolveInput(
   options?: StreamRequestAdapterOptions,
 ): ProviderResolveInput {
   assertTitleMatchesShellMode(request.title, mode);
+  // Enriched once, before lane adaptation: `adaptResolveLane` gates the
+  // anime lane on holding an anime catalog id, so a title that only learns its
+  // AniList id from the episode rows has to carry it by this point too.
+  const title = withEpisodeCatalogIdentity(request.title, request.episode);
   const naturalKind: MediaKind =
-    mode === "youtube" ? "video" : mode === "anime" ? "anime" : request.title.type;
+    mode === "youtube" ? "video" : mode === "anime" ? "anime" : title.type;
   const adapted = adaptResolveLane({
-    title: request.title,
+    title,
     naturalKind,
     episode: episodeToCoreIdentity(request.episode),
     catalogIdentity,
@@ -54,7 +58,7 @@ export function streamRequestToResolveInput(
   const animeAudioIntent =
     adapted.mediaKind === "anime" ? resolveAnimeAudioIntent(request.audioPreference) : null;
   return {
-    title: titleToCoreIdentity(request.title, mode, catalogIdentity, providerId, adapted.mediaKind),
+    title: titleToCoreIdentity(title, mode, catalogIdentity, providerId, adapted.mediaKind),
     episode: adapted.episode,
     mediaKind: adapted.mediaKind,
     preferredSourceId: normalizeOptionalId(request.selectedSourceId),
@@ -131,6 +135,42 @@ function normalizeQualityPreference(value: string | undefined): string | undefin
   const normalized = value?.trim().toLowerCase();
   if (!normalized || normalized === "best" || normalized === "auto") return undefined;
   return normalized;
+}
+
+/**
+ * Lift cross-catalog ids discovered while listing episodes onto the title.
+ *
+ * A provider-native catalog answers search with its own id and nothing else —
+ * AniDB returns `gintama-1816`, and only learns the AniList/MAL ids later, when
+ * `listEpisodes` reads the show page. Those ids reached the episode rows and
+ * stopped there, because `EpisodeIdentity` has no place to carry them. So a
+ * fallback from AniDB to Miruro handed over a title with no AniList id and was
+ * rejected `unsupported-title` — with AllAnime gated upstream that left the
+ * default anime provider with no reachable fallback at all. AllManga never hit
+ * this: AllAnime's search response includes `aniListId`, so its titles carried
+ * a shared identity from the first result.
+ *
+ * Gap-filling only. A title that already knows its own id keeps it; an episode
+ * cannot rewrite the identity of the title it belongs to.
+ */
+function withEpisodeCatalogIdentity(title: TitleInfo, episode: EpisodeInfo | undefined): TitleInfo {
+  const discovered = episode?.externalIds;
+  if (!discovered) return title;
+
+  const anilistId = title.externalIds?.anilistId ?? discovered.anilistId;
+  const malId = title.externalIds?.malId ?? discovered.malId;
+  if (anilistId === title.externalIds?.anilistId && malId === title.externalIds?.malId) {
+    return title;
+  }
+
+  return {
+    ...title,
+    externalIds: {
+      ...title.externalIds,
+      ...(anilistId !== undefined ? { anilistId } : {}),
+      ...(malId !== undefined ? { malId } : {}),
+    },
+  };
 }
 
 export function titleToCoreIdentity(

--- a/apps/cli/src/services/search/SearchRoutingService.ts
+++ b/apps/cli/src/services/search/SearchRoutingService.ts
@@ -225,11 +225,39 @@ export async function searchTitles(
     context.searchRegistry.getDefault();
 
   const evidence = classifySearchEvidence(intent, searchService.metadata.id, context.mode);
-  const results = applyLocalSearchFilters(
-    await searchService.search(query, context.signal, intent),
-    intent,
-    evidence,
-  );
+  let upstream: SearchResult[];
+  try {
+    upstream = [...(await searchService.search(query, context.signal, intent))];
+  } catch (error) {
+    // An anime provider without its own search (Miruro) reaches the catalog
+    // only through this registry service, so an AniList outage — it answers
+    // 403 "temporarily disabled" outright — left that lane with no search at
+    // all. A sibling anime provider that does carry native search (AniDB,
+    // AllManga) can still answer, and a degraded result set beats a dead
+    // search box. Cancellation is the caller leaving, not an outage.
+    if (context.signal?.aborted === true || routing.mode !== "anime") throw error;
+    const borrowed = await searchAnimeViaSiblingProvider(query, routing.providerId, context);
+    if (!borrowed) throw error;
+    return {
+      results: withResolvedSearchLane(
+        applyLocalSearchFilters(borrowed.results, intent, evidence),
+        resolvedLane,
+      ),
+      resolvedLane,
+      sourceId: borrowed.providerId,
+      sourceName: borrowed.providerName,
+      strategy: "provider-native",
+      evidence,
+      diagnosis: {
+        code: "provider-native-fallback",
+        providerId: borrowed.providerId,
+        // Stayed inside the anime lane; the default catalog was never used.
+        attemptedDefaultFallback: false,
+      },
+    };
+  }
+
+  const results = applyLocalSearchFilters(upstream, intent, evidence);
 
   return {
     results: withResolvedSearchLane(results, resolvedLane),
@@ -239,6 +267,55 @@ export async function searchTitles(
     strategy: "registry",
     evidence,
   };
+}
+
+/**
+ * Borrow native search from another anime provider when the lane's own catalog
+ * route is unavailable. Registry order is priority order, so the first provider
+ * that both advertises search and answers wins.
+ */
+async function searchAnimeViaSiblingProvider(
+  query: string,
+  excludeProviderId: string,
+  context: SearchRoutingContext,
+): Promise<{
+  readonly results: SearchResult[];
+  readonly providerId: string;
+  readonly providerName: string;
+} | null> {
+  const siblings = context.providerRegistry
+    .getAll()
+    .filter(
+      (candidate) =>
+        candidate.metadata.id !== excludeProviderId &&
+        candidate.metadata.isAnimeProvider === true &&
+        typeof candidate.search === "function",
+    );
+
+  for (const sibling of siblings) {
+    if (context.signal?.aborted === true) return null;
+    try {
+      const results = await sibling.search?.(
+        query,
+        {
+          audioPreference: context.animeLanguageProfile.audio,
+          subtitlePreference: context.animeLanguageProfile.subtitle,
+        },
+        context.signal,
+      );
+      const normalized = (results ?? []).map(normalizeProviderSearchResult);
+      if (normalized.length > 0) {
+        return {
+          results: normalized,
+          providerId: sibling.metadata.id,
+          providerName: sibling.metadata.name,
+        };
+      }
+    } catch {
+      // Try the next sibling; the original failure is rethrown if none answer.
+    }
+  }
+  return null;
 }
 
 function withResolvedSearchLane(

--- a/apps/cli/test/live/anidb-onigiri.smoke.ts
+++ b/apps/cli/test/live/anidb-onigiri.smoke.ts
@@ -22,7 +22,7 @@ const container = await createContainer({ debug: true });
 const provider = container.providerRegistry.get("anidb");
 
 if (!provider) {
-  console.error(JSON.stringify({ ok: false, stage: "provider", reason: "missing_anidb" }));
+  console.log(JSON.stringify({ ok: false, stage: "provider", reason: "missing_anidb" }));
   process.exit(1);
 }
 
@@ -33,15 +33,35 @@ if (clearCache) {
 // Search through the default provider itself. A hard-coded native id would let
 // this smoke pass while AniDB search — the route users actually take — is dead.
 if (!provider.search) {
-  console.error(JSON.stringify({ ok: false, stage: "search", reason: "anidb_has_no_search" }));
+  console.log(JSON.stringify({ ok: false, stage: "search", reason: "anidb_has_no_search" }));
   process.exit(1);
 }
 
-const searchResults =
-  (await provider.search(searchQuery, {
-    audioPreference: container.config.animeLanguageProfile.audio,
-    subtitlePreference: container.config.animeLanguageProfile.subtitle,
-  })) ?? [];
+// AniDB search now raises `AnidbHttpStatusError` rather than parsing an error
+// page into zero results, so an outage arrives here as a throw. Uncaught, it
+// would exit with a stack trace and no payload — which the matrix can only
+// report as `harness-failure`, hiding the very outage the throw exists to
+// surface. Report it as provider evidence instead.
+let searchResults: Awaited<ReturnType<NonNullable<typeof provider.search>>> = [];
+try {
+  searchResults =
+    (await provider.search(searchQuery, {
+      audioPreference: container.config.animeLanguageProfile.audio,
+      subtitlePreference: container.config.animeLanguageProfile.subtitle,
+    })) ?? [];
+} catch (error) {
+  console.log(
+    JSON.stringify({
+      ...providerSmokeProfilePayload(profile),
+      ok: false,
+      stage: "search",
+      searchedProvider: "anidb",
+      searchResults: 0,
+      reason: error instanceof Error ? error.message : String(error),
+    }),
+  );
+  process.exit(1);
+}
 
 const normalizeTitle = (value: string) =>
   value
@@ -53,8 +73,9 @@ const selected =
   searchResults[0];
 
 if (!selected) {
-  console.error(
+  console.log(
     JSON.stringify({
+      ...providerSmokeProfilePayload(profile),
       ok: false,
       stage: "search",
       searchedProvider: "anidb",

--- a/apps/cli/test/unit/services/providers/stream-request-adapter.test.ts
+++ b/apps/cli/test/unit/services/providers/stream-request-adapter.test.ts
@@ -319,3 +319,64 @@ test("preserves absoluteEpisode for anime provider resolution", () => {
   expect(input.title.id).toBe("151807");
   expect(input.title.anilistId).toBe("151807");
 });
+
+/**
+ * A provider-native catalog answers search with its own id and nothing else.
+ * AniDB returns `gintama-1816` and only learns the AniList id later, when
+ * `listEpisodes` reads the show page — and `EpisodeIdentity` has nowhere to
+ * carry it, so it died on the episode rows. Falling back from AniDB to Miruro
+ * then handed over a title with no AniList id and was rejected
+ * `unsupported-title`, which with AllAnime gated upstream left the default
+ * anime provider with no reachable fallback at all.
+ */
+test("lifts an episode-discovered AniList id onto the title so fallbacks can use it", () => {
+  const input = streamRequestToResolveInput(
+    {
+      title: {
+        id: "gintama-1816",
+        type: "series",
+        name: "Gintama",
+        externalIds: { providerNativeIds: { anidb: "gintama-1816" } },
+      },
+      episode: {
+        season: 1,
+        episode: 9,
+        externalIds: { anilistId: "918", malId: "918" },
+      },
+      audioPreference: "sub",
+      subtitlePreference: "en",
+    },
+    "anime",
+  );
+
+  // What Miruro's resolveMiruroAnilistId() reads.
+  expect(input.title.anilistId).toBe("918");
+  expect(input.title.malId).toBe("918");
+  // The native id must survive: it is how AniDB itself addresses the show.
+  expect(input.title.externalIds?.providerNativeIds?.anidb).toBe("gintama-1816");
+  expect(input.title.id).toBe("gintama-1816");
+});
+
+test("an episode never overrides an identity the title already holds", () => {
+  const input = streamRequestToResolveInput(
+    {
+      title: {
+        id: "anilist:21",
+        type: "series",
+        name: "One Piece",
+        externalIds: { anilistId: "21" },
+      },
+      episode: {
+        season: 1,
+        episode: 1,
+        // Stale row from a mismatched catalog must not rewrite the title.
+        externalIds: { anilistId: "999999" },
+      },
+      audioPreference: "sub",
+      subtitlePreference: "en",
+    },
+    "anime",
+  );
+
+  expect(input.title.anilistId).toBe("21");
+});

--- a/apps/cli/test/unit/services/search/search-routing.test.ts
+++ b/apps/cli/test/unit/services/search/search-routing.test.ts
@@ -1064,6 +1064,91 @@ describe("searchTitles", () => {
   });
 });
 
+/**
+ * AniList answered 403 "temporarily disabled" for a sustained outage. Miruro
+ * carries no native search of its own, so this registry service was its only
+ * catalog route and the anime search box went dead — while AniDB and AllManga
+ * could still answer from their own catalogs the whole time.
+ */
+describe("anime search when the catalog service is down", () => {
+  function downAniListRegistry() {
+    return {
+      getForProvider: () => ({
+        metadata: { id: "anilist", name: "AniList", description: "" },
+        compatibleProviders: ["anidb", "allanime"],
+        search: async () => {
+          throw new Error("AniList search failed: 403");
+        },
+        getTitleDetails: async () => null,
+      }),
+      getDefault: () => ({
+        metadata: { id: "default", name: "Default", description: "" },
+        compatibleProviders: [],
+        search: async () => [],
+        getTitleDetails: async () => null,
+      }),
+    };
+  }
+
+  const siblingWithSearch: any = {
+    metadata: {
+      id: "anidb",
+      name: "AniDB",
+      description: "",
+      recommended: true,
+      isAnimeProvider: true,
+      domain: "anidb.app",
+    } as ProviderMetadata,
+    search: async () => [{ id: "onigiri-3942", title: "Onigiri", type: "series", epCount: 11 }],
+  };
+
+  // No `search`, exactly like the real Miruro manifest.
+  const laneProvider: any = {
+    metadata: {
+      id: "miruro",
+      name: "Miruro",
+      description: "",
+      recommended: true,
+      isAnimeProvider: true,
+      domain: "miruro.bz",
+    } as ProviderMetadata,
+  };
+
+  test("borrows native search from a sibling anime provider", async () => {
+    const result = await searchTitles("onigiri", {
+      mode: "anime",
+      providerId: "miruro",
+      animeLanguageProfile: { audio: "original", subtitle: "en" },
+      searchRegistry: downAniListRegistry() as any,
+      providerRegistry: {
+        get: (id: string) => (id === "miruro" ? laneProvider : undefined),
+        getAll: () => [laneProvider, siblingWithSearch],
+      } as any,
+      enrichAnimeMetadata: false,
+    });
+
+    expect(result.strategy).toBe("provider-native");
+    expect(result.sourceId).toBe("anidb");
+    expect(result.results.map((entry) => entry.title)).toEqual(["Onigiri"]);
+  });
+
+  test("rethrows when no sibling can answer either", async () => {
+    await expect(
+      searchTitles("onigiri", {
+        mode: "anime",
+        providerId: "miruro",
+        animeLanguageProfile: { audio: "original", subtitle: "en" },
+        searchRegistry: downAniListRegistry() as any,
+        providerRegistry: {
+          get: (id: string) => (id === "miruro" ? laneProvider : undefined),
+          getAll: () => [laneProvider],
+        } as any,
+        enrichAnimeMetadata: false,
+      }),
+    ).rejects.toThrow("AniList search failed: 403");
+  });
+});
+
 function createSearchRegistry({
   providerResults = [],
   defaultResults = [],

--- a/packages/providers/src/anidb/client.ts
+++ b/packages/providers/src/anidb/client.ts
@@ -1,4 +1,9 @@
-import type { ProviderRuntimeContext, ResolveErrorCode, StartupPriority } from "@kunai/types";
+import {
+  RELAY_HOP_HEADER,
+  type ProviderRuntimeContext,
+  type ResolveErrorCode,
+  type StartupPriority,
+} from "@kunai/types";
 
 import type { AnimeEpisodeMetadata } from "../shared/anime-metadata";
 import {
@@ -159,18 +164,31 @@ function splitAnidbStatus(stdout: string): { readonly body: string; readonly sta
   return { body: stdout.slice(0, cut), status: Number.isFinite(status) ? status : 0 };
 }
 
+/**
+ * Statuses where a better TLS fingerprint can still change the answer, so the
+ * curl fallback is worth a request. Everything else — a missing id, a 5xx
+ * outage — is the upstream's real answer, and retrying only doubles the
+ * latency before the same result.
+ */
+function isFingerprintRetryableStatus(status: number): boolean {
+  return status === 403 || status === 429;
+}
+
+/**
+ * Fetches an AniDB page as text, or throws {@link AnidbHttpStatusError}.
+ *
+ * Every read reports its status. A best-effort mode used to hand the caller
+ * whatever body an error carried, so a `503 Under Maintenance` page was scraped
+ * for result rows, found none, and reported an outage as "no such anime" —
+ * silently, with no health signal for provider fallback. Callers that treat a
+ * missing id as a real answer catch the 404 explicitly.
+ */
 export async function anidbFetchText(
   url: string,
   options: {
     readonly context?: ProviderRuntimeContext;
     readonly signal?: AbortSignal;
     readonly maxTimeSec?: number;
-    /**
-     * Turn an HTTP error status into an {@link AnidbHttpStatusError} instead of
-     * an opaque failure. Only the JSON API reads need it; HTML scrapes are
-     * happier with the existing best-effort behaviour.
-     */
-    readonly reportStatus?: boolean;
   } = {},
 ): Promise<string> {
   if (options.context?.fetch) {
@@ -184,12 +202,22 @@ export async function anidbFetchText(
         if (!isCloudflareChallengeText(text)) {
           return text;
         }
-      } else if (options.reportStatus === true && response.status === 404) {
+      } else if (
+        !isFingerprintRetryableStatus(response.status) &&
+        !(response.status === 404 && response.headers.get(RELAY_HOP_HEADER) !== null)
+      ) {
         // Falling through to curl exists so a Cloudflare challenge gets a
-        // second chance with a better TLS fingerprint. A 404 is not a
-        // fingerprint problem — curl would spend a request to be told the same
-        // thing — so it is answered here.
-        throw new AnidbHttpStatusError(404);
+        // second chance with a better TLS fingerprint. An upstream outage or
+        // a genuine 404 is not a fingerprint problem, so it is answered here.
+        //
+        // A 404 that arrived over a relay hop is a different fact. A relay
+        // deployed before this provider existed answers `unknown-provider`
+        // with a 404 of its own, and reading that as anidb.app's verdict marks
+        // the catalogue permanently missing and caches the miss — which took
+        // the whole anime lane down behind a stale relay while the same id
+        // resolved fine over curl. Let curl settle it: a genuine 404 still
+        // throws below, one request later.
+        throw new AnidbHttpStatusError(response.status);
       }
     } catch (error) {
       if (error instanceof AnidbHttpStatusError) throw error;
@@ -230,7 +258,11 @@ export async function anidbFetchText(
     "--max-time",
     maxTime,
     ...anidbCipherArgs(curl.impersonates),
-    ...(options.reportStatus === true ? ANIDB_STATUS_WRITE_OUT : []),
+    ...ANIDB_STATUS_WRITE_OUT,
+    // Everything after `--` is an operand, never an option. Embed and playlist
+    // URLs arrive from upstream JSON, so without this a value beginning with
+    // `-` would be read as curl flags rather than as the address to fetch.
+    "--",
     url,
   ];
   const stdout = await runAnidbCurlWithRetry(args, options.signal);
@@ -238,21 +270,19 @@ export async function anidbFetchText(
   // 404. Without asking for the status explicitly the miss is indistinguishable
   // from a body that merely failed to parse, which is how a reindexed id used
   // to look exactly like an empty catalogue.
-  if (options.reportStatus === true) {
-    const { body, status } = splitAnidbStatus(stdout);
-    if (status >= 400) throw new AnidbHttpStatusError(status);
-    if (isCloudflareChallengeText(body)) {
-      throw new Error("anidb blocked by Cloudflare (try curl-impersonate)");
-    }
-    return body;
-  }
-  if (isCloudflareChallengeText(stdout)) {
+  const { body, status } = splitAnidbStatus(stdout);
+  if (status >= 400) throw new AnidbHttpStatusError(status);
+  if (isCloudflareChallengeText(body)) {
     throw new Error("anidb blocked by Cloudflare (try curl-impersonate)");
   }
-  return stdout;
+  return body;
 }
 
 const ANIDB_CURL_TIMEOUT_EXIT_CODE = 28;
+
+/** curl killed by SIGINT / SIGTERM — 128 + signal number. */
+const ANIDB_CURL_SIGINT_EXIT_CODE = 130;
+const ANIDB_CURL_SIGTERM_EXIT_CODE = 143;
 
 /**
  * AniDB TTFB from constrained networks sits close to the curl budget, so a lone
@@ -274,6 +304,18 @@ export async function runAnidbCurlWithRetry(
     result = await spawnOnce(args, signal);
   }
   if (result.exitCode !== 0) {
+    // Quitting kunai mid-resolve kills curl, and "curl exit 130" matches
+    // neither "abort" nor "cancel", so the failure classifier read a plain
+    // Ctrl-C as an unknown network fault: retryable, worth a fallback provider,
+    // and logged at ERROR. Say cancelled in the one place that knows the
+    // process was signalled, so the existing cancellation handling applies.
+    if (signal?.aborted === true) throw signal.reason ?? new Error("anidb curl cancelled");
+    if (
+      result.exitCode === ANIDB_CURL_SIGINT_EXIT_CODE ||
+      result.exitCode === ANIDB_CURL_SIGTERM_EXIT_CODE
+    ) {
+      throw new Error(`anidb curl cancelled (exit ${result.exitCode})`);
+    }
     throw new Error(result.stderr.trim() || `curl exit ${result.exitCode}`);
   }
   return result.stdout;
@@ -514,7 +556,7 @@ export async function fetchAnidbEpisodeCatalog(
   const url = `${ANIDB_BASE}/api/frontend/anime/${numericId}/episodes`;
   let text: string;
   try {
-    text = await anidbFetchText(url, { signal, context, reportStatus: true });
+    text = await anidbFetchText(url, { signal, context });
   } catch (error) {
     // A reindexed slug (Solo Leveling 19413 → 4883) 404s permanently. Record
     // it as a miss so the caller can re-search, and cache it briefly so a dead
@@ -580,7 +622,7 @@ export async function fetchAnidbLanguages(
   const url = `${ANIDB_BASE}/api/frontend/episode/${episodeId}/languages`;
   let text: string;
   try {
-    text = await anidbFetchText(url, { signal, context, reportStatus: true });
+    text = await anidbFetchText(url, { signal, context });
   } catch (error) {
     // No languages row for this episode is a real answer, not a failure.
     if (error instanceof AnidbHttpStatusError && error.status === 404) return [];

--- a/packages/providers/src/miruro/direct.ts
+++ b/packages/providers/src/miruro/direct.ts
@@ -1612,6 +1612,10 @@ async function fetchMiruroPipeBody(
     String(MIRURO_CURL_STALL_SECONDS),
     "--max-time",
     String(MIRURO_CURL_MAX_SECONDS),
+    // Everything after `--` is an operand, never an option. The URL comes from
+    // an upstream JSON payload, so without this a value beginning with `-`
+    // would be read as curl flags rather than as the address to fetch.
+    "--",
     url,
   ];
 

--- a/packages/providers/test/anidb-curl-cancellation.test.ts
+++ b/packages/providers/test/anidb-curl-cancellation.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+
+import { classifyProviderFailure } from "@kunai/core";
+
+import { runAnidbCurlWithRetry } from "../src/anidb/client";
+
+/**
+ * Quitting kunai mid-resolve kills the curl child (exit 130). That message
+ * matched neither "abort" nor "cancel", so the classifier read a plain Ctrl-C
+ * as an unknown, retryable network fault — which spent a fallback provider
+ * attempt during shutdown and logged an ERROR for a user who simply quit.
+ */
+function spawnExiting(exitCode: number) {
+  return async () => ({ stdout: "", stderr: "", exitCode });
+}
+
+test("a signal-killed curl reports cancellation, not a network fault", async () => {
+  const error = await runAnidbCurlWithRetry(["curl"], undefined, spawnExiting(130)).catch(
+    (thrown: Error) => thrown,
+  );
+
+  expect(error).toBeInstanceOf(Error);
+  expect(classifyProviderFailure({ message: (error as Error).message }).failureClass).toBe(
+    "user-cancelled",
+  );
+});
+
+test("an aborted caller reports cancellation even when curl exits non-zero", async () => {
+  const controller = new AbortController();
+  controller.abort();
+
+  const error = await runAnidbCurlWithRetry(["curl"], controller.signal, spawnExiting(1)).catch(
+    (thrown: unknown) => thrown,
+  );
+
+  const message = error instanceof Error ? error.message : String(error);
+  const classified = classifyProviderFailure({ message });
+  expect(classified.failureClass).toBe("user-cancelled");
+  expect(classified.retryable).toBe(false);
+  expect(classified.fallbackPolicy).toBe("no-fallback");
+});
+
+test("a genuine curl failure is still a failure, not a cancellation", async () => {
+  const error = await runAnidbCurlWithRetry(["curl"], undefined, spawnExiting(6)).catch(
+    (thrown: Error) => thrown,
+  );
+
+  expect((error as Error).message).toBe("curl exit 6");
+  expect(classifyProviderFailure({ message: (error as Error).message }).failureClass).not.toBe(
+    "user-cancelled",
+  );
+});

--- a/packages/providers/test/anidb-stale-relay.test.ts
+++ b/packages/providers/test/anidb-stale-relay.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, expect, test } from "bun:test";
+
+import { RELAY_HOP_HEADER, type ProviderRuntimeContext } from "@kunai/types";
+
+import { clearAnidbCachesForTest, fetchAnidbEpisodeCatalog } from "../src/anidb/direct";
+
+/**
+ * A relay deployed before `anidb` existed answers its RPC route with a 404
+ * `unknown-provider` of its own. Read as anidb.app's verdict that took the
+ * whole anime lane down: the catalogue was marked permanently missing, the miss
+ * was cached, and every later resolve returned "no episodes" — while the same
+ * id resolved fine over curl. The relay's status is not the upstream's answer.
+ */
+afterEach(() => {
+  clearAnidbCachesForTest();
+});
+
+function relayContext(status: number, body: string): ProviderRuntimeContext {
+  return {
+    fetch: {
+      async fetch() {
+        return new Response(body, { status, headers: { [RELAY_HOP_HEADER]: "1" } });
+      },
+    },
+  } as unknown as ProviderRuntimeContext;
+}
+
+test("a 404 from a stale relay is not treated as a missing catalogue", async () => {
+  // No curl fallback is reachable in the unit environment, so the call fails
+  // rather than resolving — the point is that it does NOT report `missing`,
+  // which is what poisoned the cache and blanked the lane.
+  const context = relayContext(
+    404,
+    JSON.stringify({ error: { code: "unknown-provider", providerId: "anidb" } }),
+  );
+
+  const catalog = await fetchAnidbEpisodeCatalog("onigiri-3942", undefined, context).catch(
+    () => "threw" as const,
+  );
+
+  expect(catalog).not.toEqual({ episodes: [], missing: true });
+});
+
+test("a 404 straight from anidb.app is still a missing catalogue", async () => {
+  // Unmarked: no relay hop, so the status is the upstream's own verdict and the
+  // reindexed-slug repair path must still see `missing`.
+  const context = {
+    fetch: {
+      async fetch() {
+        return new Response("not found", { status: 404 });
+      },
+    },
+  } as unknown as ProviderRuntimeContext;
+
+  const catalog = await fetchAnidbEpisodeCatalog("solo-leveling-19413", undefined, context);
+
+  expect(catalog).toEqual({ episodes: [], missing: true });
+});

--- a/packages/providers/test/anidb-upstream-outage.test.ts
+++ b/packages/providers/test/anidb-upstream-outage.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { ProviderRuntimeContext } from "@kunai/types";
+
+import { AnidbHttpStatusError, fetchAnidbMasterUrl, searchAnidb } from "../src/anidb/client";
+import { clearAnidbCachesForTest } from "../src/anidb/direct";
+import { urlHasHostname } from "./helpers/anidb-urls";
+
+/**
+ * anidb.app answers a site-wide outage with `503 Under Maintenance` on every
+ * route. Scraping that page for result rows finds none, so an outage used to be
+ * indistinguishable from "this anime does not exist" — search reported zero
+ * results for Naruto, One Piece and Frieren alike, threw nothing, and left no
+ * health signal for provider fallback to act on.
+ */
+const MAINTENANCE_HTML = `<!DOCTYPE html>
+<html lang="en"><head><title>Under Maintenance</title></head>
+<body><h1>Under Maintenance</h1><p>We will be back shortly.</p></body></html>`;
+
+const BROWSE_HTML = readFileSync(
+  join(import.meta.dir, "fixtures/anidb/browse-current.html"),
+  "utf8",
+);
+
+afterEach(() => {
+  clearAnidbCachesForTest();
+});
+
+function contextReturning(handler: (url: string) => { status: number; body: string }): {
+  readonly context: ProviderRuntimeContext;
+  readonly calls: string[];
+} {
+  const calls: string[] = [];
+  const context = {
+    fetch: {
+      async fetch(url: string) {
+        if (!urlHasHostname(url, "anidb.app")) throw new Error(`unexpected host: ${url}`);
+        calls.push(url);
+        const { status, body } = handler(url);
+        return new Response(body, { status });
+      },
+    },
+  } as unknown as ProviderRuntimeContext;
+  return { context, calls };
+}
+
+describe("search during an upstream outage", () => {
+  test("a 503 maintenance page is surfaced, not parsed as zero results", async () => {
+    const { context } = contextReturning(() => ({ status: 503, body: MAINTENANCE_HTML }));
+
+    await expect(searchAnidb("Naruto", undefined, context)).rejects.toBeInstanceOf(
+      AnidbHttpStatusError,
+    );
+  });
+
+  test("a 5xx is not retried through curl — an outage is not a fingerprint problem", async () => {
+    const { context, calls } = contextReturning(() => ({ status: 503, body: MAINTENANCE_HTML }));
+
+    await expect(searchAnidb("Naruto", undefined, context)).rejects.toBeInstanceOf(
+      AnidbHttpStatusError,
+    );
+    expect(calls).toHaveLength(1);
+  });
+
+  test("a healthy browse page still parses into results", async () => {
+    const { context } = contextReturning(() => ({ status: 200, body: BROWSE_HTML }));
+
+    const results = await searchAnidb("Naruto", undefined, context);
+
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  test("an empty result set from a healthy page stays an empty result set", async () => {
+    const { context } = contextReturning(() => ({
+      status: 200,
+      body: "<html><body><main>No results found.</main></body></html>",
+    }));
+
+    await expect(searchAnidb("nonexistent title", undefined, context)).resolves.toEqual([]);
+  });
+});
+
+describe("stream embeds during an upstream outage", () => {
+  test("a 503 embed page is surfaced, not read as a missing master playlist", async () => {
+    const { context } = contextReturning(() => ({ status: 503, body: MAINTENANCE_HTML }));
+
+    await expect(
+      fetchAnidbMasterUrl("https://anidb.app/embed/1", undefined, context),
+    ).rejects.toBeInstanceOf(AnidbHttpStatusError);
+  });
+
+  test("a healthy embed page still yields its master url", async () => {
+    const { context } = contextReturning(() => ({
+      status: 200,
+      body: "<script>var player = { file: 'https://cdn.example/master.m3u8' };</script>",
+    }));
+
+    await expect(
+      fetchAnidbMasterUrl("https://anidb.app/embed/1", undefined, context),
+    ).resolves.toBe("https://cdn.example/master.m3u8");
+  });
+});

--- a/packages/providers/test/curl-argv-terminator.test.ts
+++ b/packages/providers/test/curl-argv-terminator.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+
+/**
+ * Both curl call sites put the fetch URL last in argv, and those URLs come from
+ * upstream JSON (AniDB `embed_url`, the Miruro pipe payload). Without a `--`
+ * terminator curl reads a value beginning with `-` as options rather than as
+ * the address, so upstream JSON gets a say in the argv of a local subprocess.
+ *
+ * Guarded at the source because the argv is assembled inside the fetch
+ * helpers, with no seam to observe it from a behavioural test.
+ */
+const CURL_ARGV_SITES = [
+  { file: "src/anidb/client.ts", url: "url" },
+  { file: "src/miruro/direct.ts", url: "url" },
+] as const;
+
+for (const site of CURL_ARGV_SITES) {
+  test(`${site.file} terminates curl options before the URL operand`, async () => {
+    const source = await Bun.file(new URL(`../${site.file}`, import.meta.url)).text();
+
+    // The argv array literal ends with the terminator immediately before the
+    // URL. Comments and whitespace between them are fine; another argument is
+    // not, because it would land after `--` and be read as a second operand.
+    const terminated = new RegExp(String.raw`"--",\s*(?://[^\n]*\n\s*)*${site.url},\s*\]`);
+
+    expect(source).toMatch(terminated);
+  });
+}


### PR DESCRIPTION
> **Stacked on #348** (which is stacked on #347) — review those first. This diff is only the anime-lane commit.

## Why

Three ways the anime lane turned a knowable failure into a shrug.

### 1. AniDB swallowed HTTP status

Status reporting was **opt-in**, so a read that came back `503` from a site-wide outage was handled as "no episodes here" and the provider reported an empty result. The user sees "no sources"; the actual cause is that the site is down.

Every read now raises `AnidbHttpStatusError` for status >= 400. `403` and `429` additionally mark the fingerprint retryable, because those two mean *this impersonation profile* rather than *this site* — everything else is the site's own answer.

### 2. A relay's own 404 was read as the upstream's verdict

A relay deployed before `anidb` existed answers that RPC route with its own `unknown-provider` 404. That was taken as anidb.app saying the catalogue is gone: the miss was cached, and every later resolve returned "no episodes" — while the same id resolved fine over curl.

A response carrying the relay hop header is now the relay's status, not the upstream's. `anidb-stale-relay.test.ts` pins both directions: a hop-marked 404 is not `missing`, an unmarked 404 still is.

### 3. curl's argv was not terminated

AniDB and Miruro both pass an upstream URL straight into a `curl` argv, and those URLs come from a JSON payload we do not control. A value beginning with `-` was read as flags. `--` before the operand closes that, and `curl-argv-terminator.test.ts` fails if either provider loses it.

## Travelling with it

Two consequences of the same principle — say what actually happened:

- Search falls back to sibling anime providers when AniList is down, instead of reporting no results.
- The stream request adapter lifts identity across catalogs, so an anime title resolved in one lane can be requested in the other.

## Miruro, recorded not fixed

The dossier and plan now carry the 2026-09-09 sweep. Short version: every mirror (`.bz`, `.ru`, `.to`, `.tv`) answers `403 Just a moment...`; **twelve** impersonation profiles were tried and all twelve are challenged, so this is a managed JS challenge, not a fingerprint gap, and installing a newer curl-impersonate build cannot help. `miruro.com` is a hub page with no `/api/secure/pipe`, and no `api.`/`backend.`/`pipe.`/`cdn.` subdomain resolves.

The **relay path is verified wired**: pointing `KUNAI_RELAY_BASE_URL` at a local recording stand-in showed four `POST /rpc/miruro` calls carrying the correct upstream URLs for both mirrors. It only wants an egress Miruro's WAF tolerates.

⚠️ Methodology warning recorded for whoever picks this up: `fallbackToDirect` defaults to **true**, so aiming the relay at a dead port produces the *same* Cloudflare error as no relay at all. That silently fakes a negative result — I got one that way before catching it. Use a recording stand-in, never an unreachable port.

The earlier "the pipe is fingerprint-gated and a current impersonate build clears it" bullet is now scoped to when the challenge is absent, so the dossier no longer gives two conflicting recovery instructions.

https://claude.ai/code/session_01JwGMDjtMd6ozHYGXaCr13N
