### PR TITLE
fix(relay,player,youtube): send what the host accepts, not what we happen to have

### DIFF
--- a/apps/cli/src/infra/player/mpv-stream-http-headers.ts
+++ b/apps/cli/src/infra/player/mpv-stream-http-headers.ts
@@ -12,7 +12,7 @@ import { shouldApplyStartAtSeek } from "./mpv-start-seek";
  * provider's `defaultYtdlPlaybackFormat()` — importing it here would pull the whole
  * provider barrel into the launcher bundle, so a test asserts the two agree instead.
  */
-export const DEFAULT_MPV_YTDL_FORMAT = "bv*+ba/b";
+export const DEFAULT_MPV_YTDL_FORMAT = "bv*+ba/b/ba";
 
 export const LOCAL_HLS_DEMUXER_LAVF_OPTIONS =
   "protocol_whitelist=[file,tcp,tls,https,http,crypto,data]";

--- a/apps/cli/src/mpv.ts
+++ b/apps/cli/src/mpv.ts
@@ -28,6 +28,7 @@ import {
 import type { MpvRuntimeOptions } from "@/infra/player/mpv-runtime-options";
 import { shouldApplyStartAtSeek } from "@/infra/player/mpv-start-seek";
 import {
+  DEFAULT_MPV_YTDL_FORMAT,
   composeDemuxerLavfOptions,
   LIVE_DEMUXER_LAVF_OPTIONS,
   LIVE_DEMUXER_OPTIONS,
@@ -544,7 +545,8 @@ export function buildMpvArgs(
   const args: string[] = [];
 
   if (isYoutubeWatchUrl(opts.url) || opts.requiresYtdl) {
-    args.push(`--ytdl-format=${opts.ytdlFormat ?? "bv*+ba/b"}`);
+    args.push("--ytdl=yes");
+    args.push(`--ytdl-format=${opts.ytdlFormat ?? DEFAULT_MPV_YTDL_FORMAT}`);
     if (opts.ytdlRawOptions?.trim()) {
       args.push(`--ytdl-raw-options=${opts.ytdlRawOptions.trim()}`);
     }

--- a/apps/cli/test/unit/infra/player/mpv-stream-http-headers.test.ts
+++ b/apps/cli/test/unit/infra/player/mpv-stream-http-headers.test.ts
@@ -160,7 +160,7 @@ describe("buildPersistentLoadfileOptions", () => {
     });
 
     expect(options.ytdl).toBe("yes");
-    expect(options["ytdl-format"]).toBe("bv*+ba/b");
+    expect(options["ytdl-format"]).toBe("bv*+ba/b/ba");
   });
 
   test("still disables ytdl outright for remote HLS manifests", () => {
@@ -336,7 +336,7 @@ describe("buildPersistentLoadfileCommand", () => {
       undefined,
     );
     expect(options.ytdl).toBe("yes");
-    expect(options["ytdl-format"]).toBe("bv*+ba/b");
+    expect(options["ytdl-format"]).toBe("bv*+ba/b/ba");
   });
 
   test("a remote HLS manifest still turns ytdl off and sets no format", () => {

--- a/apps/cli/test/unit/services/download/download-quality-policy.test.ts
+++ b/apps/cli/test/unit/services/download/download-quality-policy.test.ts
@@ -26,7 +26,7 @@ describe("download-quality-policy", () => {
 
   test("ytDlpFormatSelectorForQuality prefers DASH merge for height caps", () => {
     expect(ytDlpFormatSelectorForQuality("1080p")).toBe(
-      "bv*[height<=?1080]+ba/bv*[height<=?1080]/bv*+ba/b",
+      "bv*[height<=?1080]+ba/bv*[height<=?1080]/bv*+ba/b/ba",
     );
     expect(ytDlpFormatSelectorForQuality("best")).toBeUndefined();
   });

--- a/apps/cli/test/unit/services/download/yt-dlp-format-selector.test.ts
+++ b/apps/cli/test/unit/services/download/yt-dlp-format-selector.test.ts
@@ -11,12 +11,12 @@ test("no quality / best / auto → undefined (keep yt-dlp default = highest)", (
 
 test("a configured quality becomes a height ceiling with DASH merge first", () => {
   expect(ytDlpFormatSelectorForQuality("720p")).toBe(
-    "bv*[height<=?720]+ba/bv*[height<=?720]/bv*+ba/b",
+    "bv*[height<=?720]+ba/bv*[height<=?720]/bv*+ba/b/ba",
   );
   expect(ytDlpFormatSelectorForQuality("1080p")).toBe(
-    "bv*[height<=?1080]+ba/bv*[height<=?1080]/bv*+ba/b",
+    "bv*[height<=?1080]+ba/bv*[height<=?1080]/bv*+ba/b/ba",
   );
   expect(ytDlpFormatSelectorForQuality("HD 480 p")).toBe(
-    "bv*[height<=?480]+ba/bv*[height<=?480]/bv*+ba/b",
+    "bv*[height<=?480]+ba/bv*[height<=?480]/bv*+ba/b/ba",
   );
 });

--- a/apps/relay-server/README.md
+++ b/apps/relay-server/README.md
@@ -46,6 +46,15 @@ builder crashes ("Cannot read properties of undefined (reading 'readFile')")
 on the repo-wide TypeScript 7 catalog entry. Keep the pin; `packages/relay`
 code is kept TS 5.9-compatible for the same reason (no `Headers.entries()`).
 
+**A stale relay is worse than no relay.** A deployment that predates a provider
+answers its RPC route `unknown-provider` (HTTP 404). Until 2026-09 the client
+read that 404 as the _upstream's_ verdict, so a relay deployed before `anidb`
+existed made AniDB report "no such anime", cache the miss, and take the whole
+anime lane down — while the same id resolved fine over curl. The client now
+marks every relayed response with `X-Kunai-Relay-Hop` and refuses to treat a
+status that arrived over a hop as the upstream's own answer, but the relay still
+has to be redeployed to actually serve the provider.
+
 **Redeploy after provider manifest host changes.** The RPC registry is built
 from `@kunai/providers` manifests at deploy time. If a provider's
 `relayProfile.upstreamHosts` changes upstream, an already-deployed relay keeps

--- a/apps/relay-server/scripts/verify-relay-deploy.ts
+++ b/apps/relay-server/scripts/verify-relay-deploy.ts
@@ -1,3 +1,6 @@
+import { relayRegistry } from "../src/provider-registry";
+import { buildRelayDriftProbes, classifyRelayDriftResponse } from "../src/registry-drift";
+
 const baseUrl = (process.env.KUNAI_RELAY_BASE_URL ?? process.env.RELAY_URL ?? "").replace(
   /\/$/,
   "",
@@ -67,13 +70,10 @@ if (token) {
   checks.push({
     name: "registry-matches-current-manifests",
     async run() {
-      const probes = [
-        { providerId: "allanime", url: "https://api.mkissa.net/" },
-        { providerId: "miruro", url: "https://www.miruro.bz/" },
-        { providerId: "rivestream", url: "https://www.rivestream.app/api" },
-        { providerId: "videasy", url: "https://api.speedracelight.com/seed" },
-        { providerId: "vidlink", url: "https://enc-dec.app/api" },
-      ] as const;
+      const probes = buildRelayDriftProbes(relayRegistry);
+      if (probes.length === 0) throw new Error("relay registry is empty");
+
+      const stale: string[] = [];
       for (const probe of probes) {
         const response = await fetch(`${baseUrl}/rpc/${probe.providerId}`, {
           method: "POST",
@@ -83,12 +83,13 @@ if (token) {
           },
           body: JSON.stringify({ method: "GET", upstreamUrl: probe.url, headers: {} }),
         });
-        const text = await response.text();
-        if (text.includes("host-not-allowed")) {
-          throw new Error(
-            `${probe.providerId} rejects ${new URL(probe.url).host} — deployed registry is stale; redeploy from current manifests`,
-          );
-        }
+        const drift = classifyRelayDriftResponse(probe, await response.text());
+        if (drift) stale.push(drift);
+      }
+      if (stale.length > 0) {
+        throw new Error(
+          `deployed registry is stale; redeploy from current manifests — ${stale.join(", ")}`,
+        );
       }
     },
   });

--- a/apps/relay-server/src/registry-drift.ts
+++ b/apps/relay-server/src/registry-drift.ts
@@ -1,0 +1,43 @@
+import type { ProviderRelayRegistry } from "@kunai/relay";
+
+export type RelayDriftProbe = {
+  readonly providerId: string;
+  readonly url: string;
+};
+
+/**
+ * One probe per provider the server actually registers, aimed at that
+ * provider's own first allowlisted host.
+ *
+ * Derived from the registry rather than hand-written: the previous hardcoded
+ * list named only the five providers that existed when it was written, so a
+ * relay deployed before `anidb` answered `unknown-provider` for it while this
+ * check still reported a healthy registry.
+ */
+export function buildRelayDriftProbes(registry: ProviderRelayRegistry): readonly RelayDriftProbe[] {
+  return registry.providers.flatMap((entry) => {
+    const host = entry.profile.upstreamHosts[0];
+    return host ? [{ providerId: entry.providerId, url: `https://${host}/` }] : [];
+  });
+}
+
+/**
+ * Classify one probe response. A relay that never reached the upstream is
+ * stale; anything else is the upstream's own answer and not drift.
+ */
+export function classifyRelayDriftResponse(probe: RelayDriftProbe, body: string): string | null {
+  // Only the relay's own error envelope proves drift. An upstream status is
+  // forwarded as-is, and these hosts sit behind Cloudflare: probing anidb.app
+  // or www.miruro.bz from a datacentre IP answers 403 with a "Just a moment..."
+  // challenge, which is the upstream refusing the relay, not the relay missing
+  // the provider. Reading a bare status as drift reported a correctly deployed
+  // relay as stale. An auth wall in front of the relay is still caught, by the
+  // health and unauthorized checks that run before this one.
+  if (body.includes("unknown-provider")) {
+    return `${probe.providerId} (provider missing from deployment)`;
+  }
+  if (body.includes("host-not-allowed")) {
+    return `${probe.providerId} (rejects ${new URL(probe.url).host})`;
+  }
+  return null;
+}

--- a/apps/relay-server/test/unit/registry-drift.test.ts
+++ b/apps/relay-server/test/unit/registry-drift.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+
+import { classifyRelayDriftResponse, type RelayDriftProbe } from "../../src/registry-drift";
+
+const probe: RelayDriftProbe = { providerId: "anidb", url: "https://anidb.app/" };
+
+test("a relay that does not know the provider is drift", () => {
+  expect(
+    classifyRelayDriftResponse(
+      probe,
+      JSON.stringify({ error: { code: "unknown-provider", providerId: "anidb" } }),
+    ),
+  ).toContain("provider missing from deployment");
+});
+
+test("a stale host allowlist is drift", () => {
+  expect(
+    classifyRelayDriftResponse(
+      probe,
+      JSON.stringify({ error: { code: "host-not-allowed", providerId: "anidb" } }),
+    ),
+  ).toContain("rejects anidb.app");
+});
+
+/**
+ * anidb.app and www.miruro.bz sit behind Cloudflare, so probing them from a
+ * datacentre IP answers 403 with a challenge page. That is the upstream
+ * refusing the relay, not the relay missing the provider — reading the bare
+ * status as drift reported a correctly deployed relay as stale.
+ */
+test("an upstream Cloudflare challenge is not drift", () => {
+  const challenge = '<!DOCTYPE html><html lang="en-US"><head><title>Just a moment...</title>';
+
+  expect(classifyRelayDriftResponse(probe, challenge)).toBeNull();
+});
+
+test("a healthy upstream answer is not drift", () => {
+  expect(classifyRelayDriftResponse(probe, JSON.stringify({ status: 200, result: {} }))).toBeNull();
+});

--- a/packages/providers/src/youtube/metadata-failure.ts
+++ b/packages/providers/src/youtube/metadata-failure.ts
@@ -64,6 +64,19 @@ const RULES: readonly Rule[] = [
   {
     code: "blocked",
     terminal: true,
+    message: "This YouTube video requires payment or rental to watch",
+    patterns: [
+      /requires payment/i,
+      /purchase or rental/i,
+      /buy or rent/i,
+      /rent or buy/i,
+      /available to rent/i,
+    ],
+  },
+
+  {
+    code: "blocked",
+    terminal: true,
     message:
       "YouTube is asking Kunai to prove it is not a bot — try again later or configure cookies",
     patterns: [/confirm you'?re not a bot/i, /not a bot/i],

--- a/packages/providers/src/youtube/yt-dlp-metadata.ts
+++ b/packages/providers/src/youtube/yt-dlp-metadata.ts
@@ -71,7 +71,7 @@ export function defaultYtdlPlaybackFormat(): string {
   // yt-dlp's own documented default. `bv*` means "best format that contains
   // video" — `bv`/`bestvideo` is video-*only* (`best*[acodec=none]`), which drops
   // the pre-merged renditions YouTube serves for live HLS and for older uploads.
-  return "bv*+ba/b";
+  return "bv*+ba/b/ba";
 }
 
 export function buildYtdlFormatSelector(qualityLabel?: string): string {

--- a/packages/providers/test/youtube/format-selector.test.ts
+++ b/packages/providers/test/youtube/format-selector.test.ts
@@ -8,16 +8,16 @@ import {
 
 describe("buildYtdlFormatSelector", () => {
   test("best uses DASH merge first", () => {
-    expect(defaultYtdlPlaybackFormat()).toBe("bv*+ba/b");
-    expect(buildYtdlFormatSelector("best")).toBe("bv*+ba/b");
+    expect(defaultYtdlPlaybackFormat()).toBe("bv*+ba/b/ba");
+    expect(buildYtdlFormatSelector("best")).toBe("bv*+ba/b/ba");
   });
 
   test("height caps prefer bestvideo+bestaudio, not muxed best[height]", () => {
     expect(buildYtdlFormatSelector("1080p")).toBe(
-      "bv*[height<=?1080]+ba/bv*[height<=?1080]/bv*+ba/b",
+      "bv*[height<=?1080]+ba/bv*[height<=?1080]/bv*+ba/b/ba",
     );
     expect(buildYtdlFormatSelector("2160p")).toBe(
-      "bv*[height<=?2160]+ba/bv*[height<=?2160]/bv*+ba/b",
+      "bv*[height<=?2160]+ba/bv*[height<=?2160]/bv*+ba/b/ba",
     );
   });
 });

--- a/packages/providers/test/youtube/metadata-failure.test.ts
+++ b/packages/providers/test/youtube/metadata-failure.test.ts
@@ -34,6 +34,11 @@ describe("youtube metadata failure classification", () => {
       "blocked",
       "your country",
     ],
+    [
+      "ERROR: [youtube] abc: This video requires payment to watch. Available for purchase or rental.",
+      "blocked",
+      "payment or rental",
+    ],
   ])("%s is terminal", (stderr, code, fragment) => {
     const classified = classifyYoutubeMetadataFailure(new Error(stderr));
     expect(classified.terminal).toBe(true);

--- a/packages/providers/test/youtube/yt-dlp-metadata.test.ts
+++ b/packages/providers/test/youtube/yt-dlp-metadata.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe("buildYtdlFormatSelector", () => {
   test("returns default format for undefined, best, auto", () => {
-    const def = "bv*+ba/b";
+    const def = "bv*+ba/b/ba";
     expect(buildYtdlFormatSelector(undefined)).toBe(def);
     expect(buildYtdlFormatSelector("best")).toBe(def);
     expect(buildYtdlFormatSelector("auto")).toBe(def);
@@ -16,12 +16,14 @@ describe("buildYtdlFormatSelector", () => {
 
   test("builds height ceiling with DASH merge for numeric qualities", () => {
     expect(buildYtdlFormatSelector("1080p")).toBe(
-      "bv*[height<=?1080]+ba/bv*[height<=?1080]/bv*+ba/b",
+      "bv*[height<=?1080]+ba/bv*[height<=?1080]/bv*+ba/b/ba",
     );
     expect(buildYtdlFormatSelector("1440p")).toBe(
-      "bv*[height<=?1440]+ba/bv*[height<=?1440]/bv*+ba/b",
+      "bv*[height<=?1440]+ba/bv*[height<=?1440]/bv*+ba/b/ba",
     );
-    expect(buildYtdlFormatSelector("4K")).toBe("bv*[height<=?2160]+ba/bv*[height<=?2160]/bv*+ba/b");
+    expect(buildYtdlFormatSelector("4K")).toBe(
+      "bv*[height<=?2160]+ba/bv*[height<=?2160]/bv*+ba/b/ba",
+    );
   });
 });
 

--- a/packages/providers/test/youtube/ytdl-profile.test.ts
+++ b/packages/providers/test/youtube/ytdl-profile.test.ts
@@ -41,7 +41,7 @@ describe("buildYoutubeYtdlProfile", () => {
 
   test("uses live playback format when stream is live", () => {
     const profile = buildYoutubeYtdlProfile({ isLive: true, qualityLabel: "1080p" });
-    expect(profile.formatSelector).toBe("bv*+ba/b");
+    expect(profile.formatSelector).toBe("bv*+ba/b/ba");
     expect(profile.cliArgs).toContain("--no-live-from-start");
   });
 });

--- a/packages/relay/src/create-relay-fetch-port.ts
+++ b/packages/relay/src/create-relay-fetch-port.ts
@@ -1,5 +1,5 @@
 import { resolveEffectiveProviderRelayConfig } from "./resolve-relay-config";
-import { RELAY_ERROR_CODE_HEADER, type RelayRpcRequest } from "./types";
+import { RELAY_ERROR_CODE_HEADER, RELAY_HOP_HEADER, type RelayRpcRequest } from "./types";
 import type { RelayFetchPort, RelayFetchPortOptions } from "./types";
 
 type RelayHeadersInit = ConstructorParameters<typeof Headers>[0];
@@ -52,7 +52,7 @@ export function createRelayFetchPort(options: RelayFetchPortOptions): RelayFetch
         if (fallbackToDirect && isRelayAuthorizationFailure(response)) {
           return fetchImpl(input, init);
         }
-        return response;
+        return markRelayHop(response);
       } catch (error) {
         if (!fallbackToDirect) throw error;
         return fetchImpl(input, init);
@@ -62,6 +62,24 @@ export function createRelayFetchPort(options: RelayFetchPortOptions): RelayFetch
 }
 
 export { normalizeRelayBaseUrl } from "./normalize-relay-base-url";
+
+/**
+ * Stamp a response that travelled over a relay hop.
+ *
+ * Written after the fact and always overwriting, so an upstream cannot forge or
+ * suppress it. A successful body is passed through untouched; only failures
+ * need the marker, and rebuilding every 200 would cost a copy for nothing.
+ */
+function markRelayHop(response: Response): Response {
+  if (response.ok) return response;
+  const headers = new Headers(response.headers);
+  headers.set(RELAY_HOP_HEADER, "1");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
 
 function isRelayAuthorizationFailure(response: Response): boolean {
   const code = response.headers.get(RELAY_ERROR_CODE_HEADER);

--- a/packages/relay/src/forward-headers.ts
+++ b/packages/relay/src/forward-headers.ts
@@ -10,6 +10,11 @@ const METADATA_HEADER_ALLOWLIST = new Set([
   "user-agent",
   "x-build-id",
   "x-aa-boot",
+  // VidLink answers `deliveryType: "file"` without this — bcdn MP4s flagged
+  // `requiresProxy` that 429 every non-browser client, so a relayed lane
+  // resolved and then could not play. Dropping it made the relay the only
+  // difference between a playable DASH manifest and a dead one.
+  "x-playback-environment",
   "x-obfuscated",
   "x-session-token",
 ]);

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -109,4 +109,6 @@ export const DEFAULT_MAX_REQUEST_BODY_BYTES = 64 * 1024;
 export const DEFAULT_MAX_RESPONSE_BODY_BYTES = 2 * 1024 * 1024;
 export const DEFAULT_MAX_REDIRECTS = 5;
 export const DEFAULT_RELAY_TIMEOUT_MS = 20_000;
+export { RELAY_HOP_HEADER } from "@kunai/types";
+
 export const RELAY_ERROR_CODE_HEADER = "X-Kunai-Relay-Error-Code";

--- a/packages/relay/test/forward-headers.test.ts
+++ b/packages/relay/test/forward-headers.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+
+import { filterForwardHeaders } from "../src/forward-headers";
+
+/**
+ * VidLink answers `deliveryType: "file"` without `x-playback-environment:
+ * webkit` — bcdn MP4s flagged `requiresProxy` that 429 every non-browser
+ * client. The relay dropped the header, so a relayed VidLink lane resolved and
+ * then would not play, while the same request direct played fine. The relay
+ * being the only difference is what made it hard to see.
+ */
+test("forwards the VidLink playback environment header", () => {
+  const forwarded = filterForwardHeaders({
+    "x-playback-environment": "webkit",
+    "user-agent": "kunai",
+  });
+
+  expect(forwarded["x-playback-environment"]).toBe("webkit");
+});
+
+test("still drops credentials and unlisted headers", () => {
+  const forwarded = filterForwardHeaders({
+    authorization: "Bearer secret",
+    cookie: "session=secret",
+    "x-not-allowed": "nope",
+    connection: "keep-alive",
+    referer: "https://example.test/",
+  });
+
+  expect(forwarded.authorization).toBeUndefined();
+  expect(forwarded.cookie).toBeUndefined();
+  expect(forwarded["x-not-allowed"]).toBeUndefined();
+  expect(forwarded.connection).toBeUndefined();
+  expect(forwarded.Referer).toBe("https://example.test/");
+});


### PR DESCRIPTION
> **Stacked on #349** (→ #348 → #347) — review those first. This diff is only the transport commit.

## Why

Three places where the request or the argv we hand to something **outside the process** was not the one that works.

### VidLink's CDN 429s everything without `x-playback-environment`

BunnyCDN rate-limits relayed requests to zero unless that header travels with them. VidLink then answers `deliveryType: "file"` — bcdn MP4s flagged `requiresProxy` that 429 every non-browser client — so a relayed lane resolved and then could not play. Dropping the header was the only difference between a playable DASH manifest and a dead one.

It goes on the forward allowlist, not a special case, and `forward-headers.test.ts` pins it. A header dropped somewhere in the hop chain is invisible until playback fails.

### `ytdl=no` in a user's `mpv.conf` silently broke every YouTube play

YouTube hands mpv a **watch URL** and lets ytdl resolve the media at play time. With `ytdl=no` in a config file there is nothing to play, and the error names neither the config nor the provider. mpv is now launched with `--ytdl=yes` so a config file cannot switch off the resolver the provider depends on.

### The format selector could not express "there is no video track"

`bv*+ba/b` fails outright on audio-only uploads — music, podcasts, radio streams — so it widens to `bv*+ba/b/ba`. The launcher keeps its own copy of that string to avoid pulling the provider barrel into the launcher bundle; a test asserts the two agree, so they cannot drift.

Purchase- and rental-gated videos are now classified as such instead of surfacing as a metadata parse failure.

## Also

`registry-drift.ts` in the relay server catches this class of bug before deploy: a provider the CLI knows about that the deployed relay does not. That mismatch is what produced the stale-relay 404 handled in the previous PR.

Relay stays **metadata-only** — no media route, no video fallback, stream URLs stay direct. Nothing here changes that.

https://claude.ai/code/session_01JwGMDjtMd6ozHYGXaCr13N
