### PR TITLE
test(install): bound termination, not a runner's speed

### DIFF
--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -164,6 +164,14 @@ async function runInstallShAsync(
   return { status, stdout, stderr };
 }
 
+/**
+ * Long enough that only a non-terminating installer can exceed it.
+ *
+ * Wall-clock budgets in this file bound whether a run *finishes*, never how
+ * fast it is — a CI runner's speed is not a contract.
+ */
+const ACTIVATION_TERMINATION_BUDGET_MS = 5_000;
+
 async function runInstallShWithin(
   args: string[],
   env: NodeJS.ProcessEnv,
@@ -1538,7 +1546,14 @@ describe("install.sh lifecycle contract", () => {
               KUNAI_ACTIVATION_LOCK_POLL_MS: "0",
               PATH: `${shimDir}${delimiter}${sandbox.env.PATH ?? ""}`,
             },
-            500,
+            // Bounds *termination*, not speed. A zero poll that hot-loops never
+            // returns, so any finite completion proves the contract — while the
+            // budget has to cover the whole script (bash startup, the shimmed
+            // `mv`, the fixture download and its checksum), not just the 40ms
+            // lock wait. At 500ms a loaded macOS runner lost the race at 541ms
+            // and reported a hot-loop that was not there. Do not tighten this
+            // to make it "stricter": it would only re-pin one runner's speed.
+            ACTIVATION_TERMINATION_BUDGET_MS,
           );
           expect(result).not.toBeNull();
           expect(result?.status).not.toBe(0);


### PR DESCRIPTION
## The failure

`install.sh lifecycle contract > a failed reclaim with zero poll observes the activation deadline instead of hot-looping` fails on macOS with:

```
error: expect(received).not.toBeNull()
(fail) ... [541.67ms]
```

541ms against a 500ms budget. It is not random — it is marginal, and it failed **twice on the same commit** while the identical installer code passed on four other branches in the same hour.

## Why the budget was measuring the wrong thing

`runInstallShWithin` races the process against `Bun.sleep(timeoutMs)` and returns `null` if the sleep wins. So `expect(result).not.toBeNull()` asserts *the entire `bash install.sh` run finished in 500ms* — bash startup, resolving the shimmed `mv`, the fixture download, its checksum, and only then the activation attempt.

The lock wait the test is named for is `KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "40"` — 40ms of that 500. The other 460ms is the runner's speed, which is not a contract.

## What the test actually proves

With `KUNAI_ACTIVATION_LOCK_POLL_MS: "0"`, a hot-looping implementation never returns. So **any finite completion** is the evidence, and the budget only has to be large enough that nothing but a non-terminating run can exceed it.

5s does that. The constant carries the reason, so the next person does not tighten it back to make it feel stricter — that would only re-pin one runner's speed and reintroduce the flake.

I did not touch the sibling assertion above it (`toBeLessThan(300)`), which is scoped to the activation phase alone rather than the whole script and so is not exposed the same way.

## Verification

- `bun test apps/cli/test/integration/install-scripts.test.ts` — 86 pass, 0 fail
- `bun run typecheck --force` — 14/14, 0 cached
- `bun run lint --force` — 12/12, 0 cached

## Context

Found while landing the provider stack (#347–#351): this red is the only thing blocking #347, and it is not that PR's doing — #348 and #349 *contain* #347's commit and their macOS job passed. Merging this first, then bringing `main` into #347, clears it.

https://claude.ai/code/session_01JwGMDjtMd6ozHYGXaCr13N
