### PR TITLE
fix(live): honour the grace-window epoch, and never report a cancelled AniDB resolve as success

### DIFF
--- a/apps/cli/test/live/allmanga-crypto-freshness.smoke.ts
+++ b/apps/cli/test/live/allmanga-crypto-freshness.smoke.ts
@@ -30,46 +30,58 @@ import {
   currentAllMangaEpochCandidates,
 } from "@kunai/providers/allmanga/crypto";
 
-import { allMangaCryptoRemedy, diagnoseAllMangaBootstrap } from "./allmanga-crypto-freshness";
+import {
+  allMangaCryptoRemedy,
+  selectAllMangaBootstrapVerdict,
+  type AllMangaBootstrapAttempt,
+} from "./allmanga-crypto-freshness";
 
 const UA =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
 
-// Near an epoch boundary this returns `[previous, current]`, so the last entry
-// is the live one. Taking `[0]` there compares the pinned material against the
-// epoch that just ended and inverts the verdict.
+// Walk the same candidate list production uses. Asking only the calendar
+// epoch during the grace window returns `invalid_boot_token` while the
+// previous epoch — which fetchAllMangaCryptoMaterial tries first — still
+// bootstraps. That false-red is how this smoke inverted "healthy" on 2026-09-10.
 const epochCandidates = currentAllMangaEpochCandidates(Date.now());
-const epoch = epochCandidates.at(-1) ?? ALLMANGA_EPOCH;
-const boot = buildAllMangaBootToken({
-  epoch,
-  keyGroup: ALLMANGA_KEY_GROUP,
-  refererHost: "mkissa.to",
-  contentLane: ALLMANGA_CONTENT_LANE_EPISODE,
-});
-
-let status = 0;
-let body = "";
-try {
-  const response = await fetch(
-    `${ALLMANGA_BOOTSTRAP_URL}?buildId=${encodeURIComponent(ALLMANGA_BUILD_ID)}&k=${encodeURIComponent(ALLMANGA_CONTENT_LANE_EPISODE)}`,
-    {
-      headers: {
-        "User-Agent": UA,
-        Referer: `${ALLMANGA_SITE_ORIGIN}/`,
-        Origin: ALLMANGA_SITE_ORIGIN,
-        "x-build-id": ALLMANGA_BUILD_ID,
-        "x-aa-boot": boot,
+const liveEpoch = epochCandidates.at(-1) ?? ALLMANGA_EPOCH;
+const attempts: AllMangaBootstrapAttempt[] = [];
+for (const epoch of epochCandidates) {
+  const boot = buildAllMangaBootToken({
+    epoch,
+    keyGroup: ALLMANGA_KEY_GROUP,
+    refererHost: "mkissa.to",
+    contentLane: ALLMANGA_CONTENT_LANE_EPISODE,
+  });
+  let status = 0;
+  let body = "";
+  try {
+    const response = await fetch(
+      `${ALLMANGA_BOOTSTRAP_URL}?buildId=${encodeURIComponent(ALLMANGA_BUILD_ID)}&k=${encodeURIComponent(ALLMANGA_CONTENT_LANE_EPISODE)}`,
+      {
+        headers: {
+          "User-Agent": UA,
+          Referer: `${ALLMANGA_SITE_ORIGIN}/`,
+          Origin: ALLMANGA_SITE_ORIGIN,
+          "x-build-id": ALLMANGA_BUILD_ID,
+          "x-aa-boot": boot,
+        },
+        signal: AbortSignal.timeout(20_000),
       },
-      signal: AbortSignal.timeout(20_000),
-    },
-  );
-  status = response.status;
-  body = (await response.text()).slice(0, 400);
-} catch (error) {
-  body = error instanceof Error ? error.message : String(error);
+    );
+    status = response.status;
+    body = (await response.text()).slice(0, 400);
+  } catch (error) {
+    body = error instanceof Error ? error.message : String(error);
+  }
+  attempts.push({ epoch, status, body });
 }
 
-const diagnosis = diagnoseAllMangaBootstrap(status, body);
+const verdict = selectAllMangaBootstrapVerdict(attempts);
+const diagnosis = verdict.diagnosis;
+const status = verdict.status;
+const body = verdict.body;
+const epoch = verdict.epoch;
 
 /**
  * The bundled fallback carries its own expiry: the epoch is a 7-day bucket, so
@@ -77,7 +89,7 @@ const diagnosis = diagnoseAllMangaBootstrap(status, body);
  * A resolve quietly running on a fallback two epochs old looks exactly like a
  * dead provider.
  */
-const epochsBehind = epoch - ALLMANGA_EPOCH;
+const epochsBehind = liveEpoch - ALLMANGA_EPOCH;
 
 const payload = {
   ok: diagnosis === "current" && epochsBehind <= 1,
@@ -87,7 +99,7 @@ const payload = {
   status,
   pinnedBuildId: ALLMANGA_BUILD_ID,
   pinnedEpoch: ALLMANGA_EPOCH,
-  liveEpoch: epoch,
+  liveEpoch,
   epochsBehind,
   // No partB, boot token, or key material in the report.
   detail:

--- a/apps/cli/test/live/allmanga-crypto-freshness.ts
+++ b/apps/cli/test/live/allmanga-crypto-freshness.ts
@@ -29,6 +29,41 @@ export function diagnoseAllMangaBootstrap(status: number, body: string): AllMang
   return "unreachable";
 }
 
+export type AllMangaBootstrapAttempt = {
+  readonly epoch: number;
+  readonly status: number;
+  readonly body: string;
+};
+
+/**
+ * Pick the bootstrap attempt that actually worked.
+ *
+ * Near an epoch boundary the client signs both the epoch that just ended and
+ * the one that just began (`currentAllMangaEpochCandidates`). The server keeps
+ * honouring the previous epoch for the grace window, so asking *only* the
+ * calendar epoch returns `invalid_boot_token` while production — which walks
+ * the same candidate list — is still healthy. The first `current` diagnosis
+ * wins; if none of them worked, the live (last) epoch's diagnosis stands.
+ */
+export function selectAllMangaBootstrapVerdict(
+  attempts: readonly AllMangaBootstrapAttempt[],
+): AllMangaBootstrapAttempt & { readonly diagnosis: AllMangaCryptoDiagnosis } {
+  const diagnosed = attempts.map((attempt) => ({
+    ...attempt,
+    diagnosis: diagnoseAllMangaBootstrap(attempt.status, attempt.body),
+  }));
+  const current = diagnosed.find((attempt) => attempt.diagnosis === "current");
+  if (current) return current;
+  return (
+    diagnosed.at(-1) ?? {
+      epoch: 0,
+      status: 0,
+      body: "",
+      diagnosis: "unreachable" as const,
+    }
+  );
+}
+
 /** A real bootstrap answer carries the epoch and the key half it exists to hand back. */
 function isBootstrapPayload(body: string): boolean {
   try {

--- a/apps/cli/test/live/provider-matrix-report.ts
+++ b/apps/cli/test/live/provider-matrix-report.ts
@@ -70,10 +70,13 @@ function extractJsonObjects(text: string): SmokePayload[] {
       if (value && typeof value === "object" && !Array.isArray(value)) {
         objects.push(value as SmokePayload);
       }
+      index = end + 1;
     } catch {
-      // A fragment that only looked like an object — keep scanning.
+      // findBalancedObjectEnd can close on a later object's `}` when the
+      // opener belongs to a truncated log line. Skipping to that `end`
+      // would jump over the real payload. Advance one brace and scan again.
+      index = start + 1;
     }
-    index = end + 1;
   }
 
   return objects;

--- a/apps/cli/test/unit/live/allmanga-crypto-freshness.test.ts
+++ b/apps/cli/test/unit/live/allmanga-crypto-freshness.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   allMangaCryptoRemedy,
   diagnoseAllMangaBootstrap,
+  selectAllMangaBootstrapVerdict,
 } from "../../live/allmanga-crypto-freshness";
 
 /**
@@ -55,5 +56,38 @@ describe("allMangaCryptoRemedy", () => {
     // provider.
     expect(allMangaCryptoRemedy("current", 2)).toContain("stale");
     expect(allMangaCryptoRemedy("current", 0)).toBeUndefined();
+  });
+});
+
+describe("selectAllMangaBootstrapVerdict", () => {
+  test("a previous-epoch 200 during grace is current, not a rotation", () => {
+    // 2026-09-10: the calendar epoch was 2958 and answered invalid_boot_token;
+    // epoch 2957 still bootstrapped. Asking only the live epoch inverted the
+    // smoke while production walked both candidates and kept working.
+    const verdict = selectAllMangaBootstrapVerdict([
+      { epoch: 2957, status: 200, body: '{"epoch":2957,"partB":"..."}' },
+      { epoch: 2958, status: 403, body: '{"error":"invalid_boot_token"}' },
+    ]);
+
+    expect(verdict).toMatchObject({ epoch: 2957, diagnosis: "current" });
+  });
+
+  test("a live-epoch 200 wins even if the previous epoch already expired", () => {
+    const verdict = selectAllMangaBootstrapVerdict([
+      { epoch: 2957, status: 403, body: '{"error":"invalid_boot_token"}' },
+      { epoch: 2958, status: 200, body: '{"epoch":2958,"partB":"..."}' },
+    ]);
+
+    expect(verdict).toMatchObject({ epoch: 2958, diagnosis: "current" });
+  });
+
+  test("both epochs invalid_boot_token is a real constants rotation", () => {
+    const verdict = selectAllMangaBootstrapVerdict([
+      { epoch: 2957, status: 403, body: '{"error":"invalid_boot_token"}' },
+      { epoch: 2958, status: 403, body: '{"error":"invalid_boot_token"}' },
+    ]);
+
+    expect(verdict.diagnosis).toBe("derivation-constants-rotated");
+    expect(verdict.epoch).toBe(2958);
   });
 });

--- a/apps/cli/test/unit/live/provider-matrix-report.test.ts
+++ b/apps/cli/test/unit/live/provider-matrix-report.test.ts
@@ -69,6 +69,19 @@ describe("parseSmokePayload", () => {
     expect(parseSmokePayload("boom", "stack trace")).toBeNull();
   });
 
+  test("an unclosed brace does not hide the payload that follows", () => {
+    // A truncated log line that prints `{` plus a later `}` from a real
+    // payload makes findBalancedObjectEnd close on the payload's brace.
+    // JSON.parse fails on the mixed slice; resuming at end+1 used to skip
+    // the payload completely.
+    const stdout = 'log { truncated\n{"ok":true,"provider":"youtube"}';
+
+    expect(parseSmokePayload(stdout, "")).toMatchObject({
+      ok: true,
+      provider: "youtube",
+    });
+  });
+
   test("an auxiliary check line is not mistaken for the provider verdict", () => {
     // A smoke can exit early after printing supplementary check lines, leaving
     // its real failure on stderr. Both carry `ok`, so keying on that alone

--- a/packages/providers/src/anidb/direct.ts
+++ b/packages/providers/src/anidb/direct.ts
@@ -528,7 +528,29 @@ export const anidbProviderModule: CoreProviderModule = {
         context,
         signal: context.signal,
       });
-      if (!gate.accepted && !context.signal?.aborted) {
+      // Abort is not a stream verdict. The gate treats a cut-short probe as
+      // inconclusive and *accepts* it (timeout is not proof the CDN is dead),
+      // so checking only `!gate.accepted` lets a cancelled resolve report
+      // success with an unproven stream. Cancelled takes precedence.
+      if (context.signal?.aborted) {
+        return createExhaustedResult(
+          input,
+          context,
+          ANIDB_PROVIDER_ID,
+          {
+            code: "cancelled",
+            message: "AniDB resolution was cancelled",
+            retryable: false,
+          },
+          {
+            cachePolicy,
+            events,
+            failures,
+            startedAt,
+          },
+        );
+      }
+      if (!gate.accepted) {
         const failure: ProviderFailure = {
           providerId: ANIDB_PROVIDER_ID,
           code: "not-found",


### PR DESCRIPTION
> **Stacked on #351** (→ #350 → #349 → #348 → #347). Review those first. This diff is only the live follow-up.

Live verification on 2026-09-10 found three remaining honesty bugs after the stack already made the four movie/series providers play in mpv.

## What was still wrong

1. **AllManga crypto-freshness smoke inverted "healthy" during the 24h epoch grace window.** Production already walks `[previous, current]`. The smoke asked only the calendar epoch. Today that was 2958, which answers `invalid_boot_token` while 2957 still bootstraps — so the smoke reported a constants rotation while `fetchAllMangaCryptoMaterial` kept working.
2. **AniDB reported success for a cancelled resolve.** The resolve gate treats a cut-short probe as inconclusive and *accepts* it. Combined with `!gate.accepted && !aborted`, abort fell through to a fabricated `resolved` result with an unproven stream.
3. **`parseSmokePayload` could skip a real payload** when `findBalancedObjectEnd` closed on a later `}` from a truncated `{` log line. Resume at `start + 1` on `JSON.parse` failure.

## Proof

- Unit tests for the grace-window sweep, the unclosed-brace parse case, and the existing AniDB outage/curl-cancellation suites.
- Live: AllManga bootstrap is `current` on epoch 2957 during grace. Videasy, Rivestream, VidLink, YouTube decode in headless mpv. AllAnime resolves, is reachable, and decodes in mpv **when the user-owned relay env is set**. AniDB is still an upstream 503 / CF challenge. Miruro's WAF still blocks this network *and* the Vercel relay IP.

## Out of scope here

Miruro from this network is a Cloudflare managed challenge on `.bz`/`.ru`; `www.miruro.com` is a hub page with no pipe API. A Vercel relay is also challenged. That needs a relay in an ungated region, not more client crypto.
