### PR TITLE
test(lint): verify the production ratchet and preserve advisory coverage

### DIFF
--- a/.docs/lint-policy.md
+++ b/.docs/lint-policy.md
@@ -27,10 +27,18 @@ Four rules are clean in `src/` and are therefore **blocking** in
 - `anti-slop/no-reflect-apply`
 - `anti-slop/no-reflect-get`
 
-They are turned **off** for test paths (`**/*.test.*`, `**/test/**`,
+They are turned **off** for test paths (`**/*.test.ts`, `**/*.test.tsx`,
+`**/*.spec.ts`, `**/*.spec.tsx`, `**/test/**`,
 `**/__mocks__/**`), which still carry a legacy baseline — roughly 300 chained
 assertions in tests alone. Production code holds the line; tests are not held to
 it yet.
+
+The default config registers the vendored plugin directly. The separate advisory
+explicitly re-enables these four rules for the exempt test paths, retaining all
+fifteen advisory checks. `apps/cli/test/unit/scripts/anti-slop-config.test.ts` runs
+the installed linter against production violations, clean examples, and test/spec/mock
+fixtures from both root and workspace working directories, so a missing plugin or
+an overbroad exemption fails the test gate.
 
 **Ratcheting a fifth rule means driving its `src/` count to zero first**, then
 moving it into `.oxlintrc.json` alongside these. Do not add a rule to the

--- a/.oxlintrc.anti-slop.json
+++ b/.oxlintrc.anti-slop.json
@@ -5,6 +5,17 @@
   "jsPlugins": [{ "name": "anti-slop", "specifier": "./tools/oxlint/anti-slop/index.ts" }],
 
   "categories": {},
+  "overrides": [
+    {
+      "files": ["**/*.test.*", "**/*.spec.*", "**/test/**", "**/__mocks__/**"],
+      "rules": {
+        "anti-slop/no-chained-type-assertions": "error",
+        "anti-slop/no-object-parameters": "error",
+        "anti-slop/no-reflect-apply": "error",
+        "anti-slop/no-reflect-get": "error"
+      }
+    }
+  ],
 
   "rules": {
     "anti-slop/no-chained-type-assertions": "error",

--- a/apps/cli/test/unit/scripts/anti-slop-config.test.ts
+++ b/apps/cli/test/unit/scripts/anti-slop-config.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+const root = resolve(import.meta.dir, "../../../../..");
+const executable = join(root, "node_modules", "oxlint", "bin", "oxlint");
+const violations = [
+  ["no-chained-type-assertions", "export const value = 1 as unknown as string;"],
+  ["no-object-parameters", "export function identity(value: object) { return value; }"],
+  ["no-reflect-apply", "export const value = Reflect.apply(Math.abs, null, [-1]);"],
+  ["no-reflect-get", 'export const value = Reflect.get({ name: "value" }, "name");'],
+] as const;
+
+async function lint(cwd: string, file: string, advisory = false) {
+  const child = Bun.spawn(
+    [
+      process.execPath,
+      executable,
+      "-c",
+      join(root, advisory ? ".oxlintrc.anti-slop.json" : ".oxlintrc.json"),
+      file,
+    ],
+    { cwd, stdout: "pipe", stderr: "pipe" },
+  );
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  return { exitCode, output: stdout + stderr };
+}
+
+test("real workspace lint blocks each ratcheted production rule and preserves test exemptions", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "kunai-lint-config-"));
+  try {
+    for (const [rule, source] of violations) {
+      const production = join(directory, "src", `${rule}.ts`);
+      await mkdir(dirname(production), { recursive: true });
+      await Bun.write(production, source);
+      for (const cwd of [root, join(root, "apps/cli")]) {
+        const result = await lint(cwd, production);
+        expect(result.exitCode).not.toBe(0);
+        expect(result.output).toContain(`anti-slop(${rule})`);
+      }
+      for (const relative of [
+        `test/${rule}.ts`,
+        `src/${rule}.test.ts`,
+        `src/${rule}.spec.ts`,
+        `__mocks__/${rule}.ts`,
+      ]) {
+        const exempt = join(directory, relative);
+        await mkdir(dirname(exempt), { recursive: true });
+        await Bun.write(exempt, source);
+        const result = await lint(join(root, "apps/cli"), exempt);
+        expect(result.exitCode).toBe(0);
+        const advisory = await lint(root, exempt, true);
+        expect(advisory.exitCode).not.toBe(0);
+        expect(advisory.output).toContain(`anti-slop(${rule})`);
+      }
+    }
+    const clean = join(directory, "src", "clean.ts");
+    await Bun.write(
+      clean,
+      'export const value: number = 1; export function identity(value: {name: string}) { return value.name; } export const result = Math.abs(-1); export const name = {name: "value"}.name;',
+    );
+    expect((await lint(root, clean)).exitCode).toBe(0);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What changed
Adds real-linter regression tests for the four production rules from #255 and restores advisory reporting on exempt test paths. Exactly three files: advisory configuration, regression tests, and lint policy documentation.

## Dependency
Stacked on #255 (stack/4-anti-slop). Merge #255 first, then retarget this PR to main. This does not duplicate its production cleanup.

## Verification
Fresh local full suite: 6,941 passed, 59 skipped, zero failures. Typecheck, lint, formatting, documentation paths, and diff checks passed. Independently rerun focused tests: 3 passed, 67 assertions. Fixtures exercise actual linter subprocesses from root and CLI working directories.

## Checklist
- [x] Changeset N/A: test/config/docs-only infrastructure.
- [x] Formatting, lint, tests, and typecheck passed locally.
- [x] Runtime build N/A for this three-file delta.
- [x] Live provider/Discord checks intentionally skipped.

Hosted CI is separate evidence; no merge or release is requested by this PR.