### PR TITLE
fix: protect storage and downloads, scope player TLS, and exclude share telemetry

### DIFF
--- a/.changeset/audit-reliability-privacy.md
+++ b/.changeset/audit-reliability-privacy.md
@@ -1,0 +1,13 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Preserve healthy SQLite databases when startup encounters locks, permissions, or
+I/O failures; only recognized corruption errors trigger quarantine and recovery.
+
+Keep episode identifiers in long download filenames and refuse to overwrite or
+delete another download's artifact. New downloads use short staging filenames and
+exclusive publication; their destination filesystem must support hard links.
+
+Limit the mp4upload TLS compatibility exception to the current file in persistent
+mpv sessions, restoring the user's previous TLS setting when playback moves on.

--- a/.docs/architecture.md
+++ b/.docs/architecture.md
@@ -201,6 +201,13 @@ A session upgrades its own working `TitleInfo` the moment the catalog answers, t
 
 The SQLite storage model is described in [.plans/storage-hardening.md](../.archive/plans/storage-hardening.md), with durable history/progress in the OS app data directory and disposable cache in the OS cache directory.
 
+Database opening quarantines a file only for recognized SQLite corruption codes
+(`SQLITE_CORRUPT`, its known extended forms, or `SQLITE_NOTADB`). Lock contention,
+permissions, I/O failures, and unknown errors surface the original failure without
+moving the database or its siblings. Reopening after the cause is resolved retains
+the original durable data. Confirmed corruption preserves the main file in a
+timestamped backup before creating a replacement; siblings never move first.
+
 Automatic storage maintenance is conservative:
 
 - it may prune expired `stream_cache`, `source_inventory`, `recommendation_cache`, and `schedule_cache` rows

--- a/.docs/download-offline-onboarding.md
+++ b/.docs/download-offline-onboarding.md
@@ -134,6 +134,12 @@ accounts, usage ping, done. Implementation is
   Legacy destinations claimed by another job or offline asset are refused during publication
   and recovery. Artifact deletion requires a completed/repairable job with no conflicting owner;
   deleting a failed job preserves an unknown existing file.
+  On Windows, ownership comparisons conservatively normalize separators and uppercase
+  Unicode across jobs and offline assets without rewriting stored paths. This safety check
+  may refuse distinct paths; it does not model every filesystem's case rules. Once this worker
+  publishes successfully, metadata/completion write failures surface and leave the running
+  lease recoverable. After that lease expires, recovery validates and adopts the artifact
+  without downloading again; persistent database failures remain visible, not successful completion.
 - Queue ownership is a SQLite compare-and-set from `queued` to `running`. Heartbeats form a
   bounded lease across Kunai processes; recovery never touches a freshly heartbeating owner.
 - Blocking download intent is unique in SQLite by canonical title and exact nullable

--- a/.docs/download-offline-onboarding.md
+++ b/.docs/download-offline-onboarding.md
@@ -126,8 +126,14 @@ accounts, usage ping, done. Implementation is
   but do not schedule offline runway work unless `Keep watching offline` was selected and do not
   revoke an existing title enrollment.
 - HLS size is reported honestly as unknown when content length cannot be known.
-- Temporary files use a `.tmp.*` suffix, validate after a clean exit, and are renamed only
-  after that validation. An invalid candidate never replaces an existing playable output.
+- New temporary files use a short `.tmp.<job-id>.mp4` sibling name so a long final filename
+  does not overflow the filesystem component limit. Existing jobs retain their recorded paths.
+  Candidates validate after a clean exit, then publish using an exclusive hard link before the
+  temporary name is removed. An existing destination is never overwritten; filesystems without
+  hard-link support fail safely. Choose another directory or resolve the existing file explicitly.
+  Legacy destinations claimed by another job or offline asset are refused during publication
+  and recovery. Artifact deletion requires a completed/repairable job with no conflicting owner;
+  deleting a failed job preserves an unknown existing file.
 - Queue ownership is a SQLite compare-and-set from `queued` to `running`. Heartbeats form a
   bounded lease across Kunai processes; recovery never touches a freshly heartbeating owner.
 - Blocking download intent is unique in SQLite by canonical title and exact nullable
@@ -197,6 +203,10 @@ confirmation, and filesystem naming all consume it instead of re-deriving "is th
   re-labelled on read. There is no destructive migration.
 - `download-path-naming.ts` consumes `CanonicalMediaPosition` **before** sanitization: it adds
   path-safe encoding only and never reinterprets content kind.
+- Filename budgets reserve the episode suffix and extension before shortening the display
+  title, including every Windows path-budget adjustment. Ordinary names remain unchanged;
+  existing completed files are not renamed. A Windows directory too deep to retain identity
+  is rejected with guidance to choose a shorter path.
 
 ## Download And Library Layout Ownership
 

--- a/.docs/mpv-in-process-reconnect.md
+++ b/.docs/mpv-in-process-reconnect.md
@@ -18,6 +18,12 @@ When playback hits certain failure signals, Kunai **reloads the same stream URL*
 
 After a successful reload, **external subtitles are re-attached** from the current cycle options (same as a fresh file load path).
 
+Provider TLS compatibility options are file-local on startup and replay. The
+mp4upload exception follows the current URL; replacing it with another host restores
+the user's prior mpv TLS setting. Native transition coverage includes exceptional
+startup, same-URL replay, normal replacement, and both enabled/disabled baselines in
+`apps/cli/test/integration/persistent-mpv-local-transition-native.test.ts`.
+
 ## When it runs
 
 1. **`network-read-dead`** (from `playback-watchdog`): demuxer reports network + underrun + `raw-input-rate === 0` while paused-for-cache, sustained for ~8s. Fires at most once per stall incident from the watchdog; **reconnect attempts** are still capped per cycle.

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -480,6 +480,14 @@ rotations — lives in
 
 ## Capability Flags
 
+The mp4upload TLS compatibility exception is scoped to the current file. Persistent
+startup uses mpv's per-file command-line group; subsequent loads and same-stream
+replays use file-local loadfile options. Leaving that file restores mpv's prior
+configuration, including a user-selected TLS policy. Kunai does not force verification
+on for other hosts or change the existing one-shot exception. A native mpv 0.41 Linux
+test observes effective options at `file-loaded` with local transport substituted:
+it proves option lifetime, not a live certificate attack or other platform behavior.
+
 | Field                   | Meaning                                                      |
 | ----------------------- | ------------------------------------------------------------ |
 | `isAnimeProvider: true` | Include provider in anime mode                               |

--- a/.docs/share-links.md
+++ b/.docs/share-links.md
@@ -9,7 +9,7 @@ lastReviewed: "2026-08-24"
 
 Kunai copies browser-safe `https://kunai.kitsunekode.in/w/<code>` links while preserving the portable `kunai://` application handoff. Both decode to the same catalog-anchored playback target.
 
-The web code is a checksummed, base64url-encoded ref. The landing page is a pure decoder: it uses no share database and drops `/w/` page views before analytics sends. Compact `k1…` catalog codes are accepted directly and inside `/w/<code>`; search anchors deliberately have no compact form.
+The web code is a checksummed, base64url-encoded ref. The landing page is a pure decoder: it uses no share database. Both Vercel Web Analytics and Speed Insights suppress `/w/` events through their `beforeSend` hooks. The filter checks the event URL, including relative URLs and delayed samples after navigation; malformed URLs fail closed. Ordinary non-share events retain their existing behavior. Compact `k1…` catalog codes are accepted directly and inside `/w/<code>`; search anchors deliberately have no compact form.
 
 ## URL grammar
 

--- a/apps/cli/src/mpv.ts
+++ b/apps/cli/src/mpv.ts
@@ -564,7 +564,8 @@ export function buildMpvArgs(
   const headerFields = [...(origin ? [`Origin: ${origin}`] : []), ...extraFields];
   if (headerFields.length > 0) args.push(`--http-header-fields=${headerFields.join(",")}`);
   // ani-cli plays mp4upload with --tls-verify=no; without it mpv rejects some hosts.
-  if (shouldDisableMpvTlsVerify(opts.url, opts.headers)) {
+  const disableTlsVerify = shouldDisableMpvTlsVerify(opts.url, opts.headers);
+  if (disableTlsVerify && !config?.persistent) {
     args.push("--tls-verify=no");
   }
 
@@ -683,7 +684,14 @@ export function buildMpvArgs(
     if (scriptOpts) args.push(`--script-opts=${scriptOpts}`);
   }
 
-  args.push("--", opts.url);
+  if (disableTlsVerify && config?.persistent) {
+    // mpv restores the user's baseline after this file, just as loadfile's
+    // per-file options do for replacements and reconnects. The validated
+    // exception URL is HTTPS and cannot be parsed as a command-line option.
+    args.push("--{", "--tls-verify=no", opts.url, "--}");
+  } else {
+    args.push("--", opts.url);
+  }
 
   return args;
 }

--- a/apps/cli/src/services/download/DownloadService.ts
+++ b/apps/cli/src/services/download/DownloadService.ts
@@ -1,4 +1,4 @@
-import { mkdir, rename, rm, stat, statfs } from "node:fs/promises";
+import { link, mkdir, rm, stat, statfs } from "node:fs/promises";
 import { dirname, extname, join } from "node:path";
 
 import { resolveTitleHistoryLookupId } from "@/domain/catalog/title-history-lookup";
@@ -398,7 +398,9 @@ export class DownloadService {
     const now = new Date().toISOString();
     const id = crypto.randomUUID();
     const outputPath = this.resolveOutputPath(input);
-    const tempPath = `${outputPath}.tmp.${id}`;
+    // A full-length output component cannot also fit an appended UUID.
+    // Keep staging in the same directory for atomic, exclusive publication.
+    const tempPath = join(dirname(outputPath), `.tmp.${id}${DOWNLOAD_FILE_EXT}`);
     await mkdir(dirname(outputPath), { recursive: true });
 
     const storage = await this.evaluateStorageForPath(
@@ -1041,7 +1043,10 @@ export class DownloadService {
       await this.abort(jobId);
     }
     await rm(job.tempPath, { force: true }).catch(() => {});
-    if (opts.deleteArtifact) {
+    const ownsArtifact =
+      ["completed", "completed-with-notes", "repairable"].includes(job.status) &&
+      !this.deps.repo.hasConflictingOutputOwner(job.id, job.outputPath);
+    if (opts.deleteArtifact && ownsArtifact) {
       await rm(job.outputPath, { force: true }).catch(() => {});
       if (job.subtitlePath) await rm(job.subtitlePath, { force: true }).catch(() => {});
       if (job.thumbnailPath) await rm(job.thumbnailPath, { force: true }).catch(() => {});
@@ -1234,7 +1239,37 @@ export class DownloadService {
     // publication so an empty/invalid result can never replace a playable
     // last-known-good output at the stable path.
     const validation = await this.validateCompletedArtifact(job.tempPath, job.id);
-    await rename(job.tempPath, job.outputPath);
+    if (this.deps.repo.hasConflictingOutputOwner(job.id, job.outputPath)) {
+      throw new Error(
+        "Download destination is shared with another job; choose a different directory",
+      );
+    }
+    // Hard-link publication is atomic and fails if ANY destination exists.
+    // Never fall back to overwriting rename on filesystems without hard links.
+    try {
+      await link(job.tempPath, job.outputPath);
+    } catch (error) {
+      const code =
+        typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
+      if (code === "EEXIST") {
+        throw new Error(
+          "Download destination already exists; existing file preserved. Choose a different download directory.",
+          { cause: error },
+        );
+      }
+      if (code === "EPERM" || code === "ENOTSUP" || code === "EOPNOTSUPP" || code === "EXDEV") {
+        throw new Error(
+          "Download directory does not support safe publication. Choose a writable directory on a filesystem with hard-link support.",
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+    await rm(job.tempPath).catch(() => {
+      // Publication succeeded. A locked staging name must not turn a valid
+      // artifact into a retry that collides with its own published output.
+      this.deps.logger.warn("Published download retained a temporary name", { jobId: job.id });
+    });
     this.persistValidatedArtifactMetadata(job.id, validation);
     return this.deps.repo.get(job.id) ?? job;
   }
@@ -1744,6 +1779,13 @@ export class DownloadService {
 
       const publishedOutput = await stat(runningJob.outputPath).catch(() => null);
       if (publishedOutput) {
+        if (this.deps.repo.hasConflictingOutputOwner(runningJob.id, runningJob.outputPath)) {
+          const message =
+            "Download destination ownership is ambiguous; existing artifact preserved";
+          this.deps.repo.fail(runningJob.id, message, false, now, "artifact-invalid");
+          this.emit({ type: "failed", jobId: runningJob.id, error: message });
+          continue;
+        }
         let validation: ArtifactValidationResult;
         try {
           validation = await this.validateCompletedArtifact(runningJob.outputPath, runningJob.id);

--- a/apps/cli/src/services/download/DownloadService.ts
+++ b/apps/cli/src/services/download/DownloadService.ts
@@ -267,6 +267,7 @@ export class DownloadService {
     { readonly mode: "abort" | "pause"; readonly reason: string }
   >();
   private readonly activeProcesses = new Map<string, ActiveDownloadProcess>();
+  private readonly publishedJobIds = new Set<string>();
   // Jobs picked by a worker but not yet markRunning in the DB. Lets multiple
   // concurrent workers run without two of them claiming the same queued job in
   // the window between `selectEligibleQueuedJob` and `markRunning` (an await).
@@ -733,6 +734,11 @@ export class DownloadService {
       }
       return completed;
     } catch (error) {
+      // Only successful no-clobber publication proves this worker owns the
+      // output. Keep its running lease recoverable if metadata/completion
+      // persistence fails; queueing a download retry would collide with itself.
+      // Surface the error, including persistent database failures on recovery.
+      if (this.publishedJobIds.has(next.id)) throw error;
       const active = this.activeProcesses.get(next.id);
       const cancellation = this.cancellationRequests.get(next.id);
       const cancelled = active?.cancelRequested === true || cancellation !== undefined;
@@ -790,6 +796,7 @@ export class DownloadService {
       return this.deps.repo.get(next.id) ?? null;
     } finally {
       stopHeartbeat();
+      this.publishedJobIds.delete(next.id);
       this.activeProcesses.delete(next.id);
       this.cancellationRequests.delete(next.id);
       this.claimedJobIds.delete(next.id);
@@ -1248,6 +1255,7 @@ export class DownloadService {
     // Never fall back to overwriting rename on filesystems without hard links.
     try {
       await link(job.tempPath, job.outputPath);
+      this.publishedJobIds.add(job.id);
     } catch (error) {
       const code =
         typeof error === "object" && error !== null && "code" in error ? error.code : undefined;

--- a/apps/cli/src/services/download/download-path-naming.ts
+++ b/apps/cli/src/services/download/download-path-naming.ts
@@ -167,6 +167,7 @@ export function resolveDownloadOutputPath(input: DownloadPathInput): string {
 
   const components: string[] = [titleWithYear];
   let fileStem = titleWithYear;
+  let identitySuffix = "";
 
   if (input.position.kind === "episode") {
     // Clamp defensively. The seam already rejects non-positive values, but a
@@ -177,11 +178,22 @@ export function resolveDownloadOutputPath(input: DownloadPathInput): string {
     if (input.position.seasonIsMeaningful && input.position.season !== undefined) {
       const seasonLabel = String(Math.max(1, Math.trunc(input.position.season))).padStart(2, "0");
       components.push(`Season ${seasonLabel}`);
-      fileStem = `${title} - S${seasonLabel}E${episodeLabel}`;
+      identitySuffix = ` - S${seasonLabel}E${episodeLabel}`;
     } else {
-      fileStem = `${title} - E${episodeLabel}`;
+      identitySuffix = ` - E${episodeLabel}`;
     }
+    fileStem = `${title}${identitySuffix}`;
   }
+
+  const buildFile = (limits: ComponentLimits): string => {
+    if (!identitySuffix) return clampComponent(`${fileStem}${input.extension}`, limits);
+    const tail = `${identitySuffix}${input.extension}`;
+    const display = stripTrailingDotsAndSpaces(
+      truncateToLimits(title, limits.maxBytes - utf8Length(tail), limits.maxUtf16 - tail.length),
+    );
+    if (!display) throw new Error("Download path is too long to preserve episode identity");
+    return `${display}${tail}`;
+  };
 
   const budget = componentBudget({
     platform,
@@ -194,7 +206,7 @@ export function resolveDownloadOutputPath(input: DownloadPathInput): string {
 
   let limits = budget;
   let safeComponents = components.map((part) => clampComponent(part, limits));
-  let safeFile = clampComponent(`${fileStem}${input.extension}`, limits);
+  let safeFile = buildFile(limits);
 
   if (platform === "win32") {
     // `componentBudget` is an estimate: it shares the overrun across every
@@ -209,11 +221,14 @@ export function resolveDownloadOutputPath(input: DownloadPathInput): string {
       const next = Math.max(16, limits.maxUtf16 - Math.max(1, Math.ceil(overrun / variableCount)));
       // Floor reached: the base directory alone is too deep. Truncating the
       // title further destroys it without making the path legal, so stop and
-      // let the write surface the real error rather than silently mangling.
+      // reject below rather than silently dropping episode identity.
       if (next === limits.maxUtf16) break;
       limits = { ...limits, maxUtf16: next };
       safeComponents = components.map((part) => clampComponent(part, limits));
-      safeFile = clampComponent(`${fileStem}${input.extension}`, limits);
+      safeFile = buildFile(limits);
+    }
+    if (join(input.baseDir, ...safeComponents, safeFile).length > cap) {
+      throw new Error("Download path is too long; choose a shorter download directory");
     }
   }
 

--- a/apps/cli/test/integration/persistent-mpv-local-transition-native.test.ts
+++ b/apps/cli/test/integration/persistent-mpv-local-transition-native.test.ts
@@ -11,6 +11,19 @@ import { PersistentMpvSession } from "@/infra/player/PersistentMpvSession";
 const MPV_BIN = Bun.which("mpv");
 const mpvTest = MPV_BIN ? test : test.skip;
 
+function parseTlsObservations(output: string): string[] {
+  // Lua's text-mode file writes use CRLF on Windows and LF on POSIX.
+  return output.trim().split(/\r?\n/);
+}
+
+test.each(["\n", "\r\n"])("TLS observations accept native line ending %j", (lineEnding) => {
+  expect(parseTlsObservations(["no", "no", "yes", ""].join(lineEnding))).toEqual([
+    "no",
+    "no",
+    "yes",
+  ]);
+});
+
 let tempDir: string | null = null;
 
 afterEach(async () => {
@@ -252,7 +265,7 @@ for (const [startsExceptional, baseline] of [
             ).endReason,
           ).toBe("eof");
         expect(children).toHaveLength(1);
-        expect((await Bun.file(observationsPath).text()).trim().split("\n")).toEqual(
+        expect(parseTlsObservations(await Bun.file(observationsPath).text())).toEqual(
           startsExceptional ? ["no", "no", baseline] : [baseline, "no", baseline],
         );
       } finally {

--- a/apps/cli/test/integration/persistent-mpv-local-transition-native.test.ts
+++ b/apps/cli/test/integration/persistent-mpv-local-transition-native.test.ts
@@ -7,6 +7,7 @@ import { bundledKunaiMpvBridgePath } from "@/infra/player/kunai-mpv-bridge";
 import type { MpvIpcSession } from "@/infra/player/mpv-ipc";
 import type { PersistentMpvSessionRuntime } from "@/infra/player/persistent-mpv-runtime";
 import { PersistentMpvSession } from "@/infra/player/PersistentMpvSession";
+import { DEFAULT_CONFIG } from "@/services/persistence/ConfigService";
 
 const MPV_BIN = Bun.which("mpv");
 const mpvTest = MPV_BIN ? test : test.skip;
@@ -132,10 +133,11 @@ mpvTest("real mpv reuses one process across two local loadfile transitions", asy
       },
       mpv: { clean: true },
       kitsuneConfig: {
+        ...DEFAULT_CONFIG,
         mpvKunaiScriptPath: bundledKunaiMpvBridgePath(),
         mpvInProcessStreamReconnect: false,
         mpvInProcessStreamReconnectMaxAttempts: 0,
-      } as never,
+      },
       onControlReady: () => {},
       runtime,
     });
@@ -242,10 +244,11 @@ for (const [startsExceptional, baseline] of [
           options: { displayTitle: "TLS scope", primarySubtitle: null },
           mpv: { clean: true },
           kitsuneConfig: {
+            ...DEFAULT_CONFIG,
             mpvKunaiScriptPath: bundledKunaiMpvBridgePath(),
             mpvInProcessStreamReconnect: false,
             mpvInProcessStreamReconnectMaxAttempts: 0,
-          } as never,
+          },
           onControlReady() {},
           runtime,
         });

--- a/apps/cli/test/integration/persistent-mpv-local-transition-native.test.ts
+++ b/apps/cli/test/integration/persistent-mpv-local-transition-native.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { bundledKunaiMpvBridgePath } from "@/infra/player/kunai-mpv-bridge";
+import type { MpvIpcSession } from "@/infra/player/mpv-ipc";
 import type { PersistentMpvSessionRuntime } from "@/infra/player/persistent-mpv-runtime";
 import { PersistentMpvSession } from "@/infra/player/PersistentMpvSession";
 
@@ -73,11 +74,18 @@ mpvTest("real mpv reuses one process across two local loadfile transitions", asy
   ]);
 
   const children: Array<ReturnType<typeof Bun.spawn>> = [];
+  let ipc: MpvIpcSession | undefined;
   const runtime: PersistentMpvSessionRuntime = {
     which: () => MPV_BIN,
     spawn(command, options) {
       const separator = command.indexOf("--");
-      const headless = ["--force-window=no", "--vo=null", "--ao=null", "--really-quiet"];
+      const headless = [
+        "--pause=yes",
+        "--force-window=no",
+        "--vo=null",
+        "--ao=null",
+        "--really-quiet",
+      ];
       const cmd =
         separator === -1
           ? [...command, ...headless]
@@ -92,7 +100,8 @@ mpvTest("real mpv reuses one process across two local loadfile transitions", asy
     },
     openIpcSession: async (options) => {
       const { openMpvIpcSession } = await import("@/infra/player/mpv-ipc");
-      return await openMpvIpcSession(options);
+      ipc = await openMpvIpcSession(options);
+      return ipc;
     },
   };
 
@@ -118,7 +127,9 @@ mpvTest("real mpv reuses one process across two local loadfile transitions", asy
       runtime,
     });
 
-    const first = await withTimeout(session.waitForCurrentPlayback(), "first local playback");
+    const initialPlayback = session.waitForCurrentPlayback();
+    expect((await ipc!.send(["set_property", "pause", false])).ok).toBe(true);
+    const first = await withTimeout(initialPlayback, "first local playback");
     expect(first.endReason).toBe("eof");
 
     const second = await withTimeout(
@@ -143,3 +154,111 @@ mpvTest("real mpv reuses one process across two local loadfile transitions", asy
     await Promise.all(children.map(async (child) => await child.exited.catch(() => -1)));
   }
 });
+
+for (const [startsExceptional, baseline] of [
+  [true, "yes"],
+  [false, "yes"],
+  [true, "no"],
+] as const) {
+  mpvTest(
+    `TLS exception stays file-local with exceptional startup=${startsExceptional}, baseline=${baseline}`,
+    async () => {
+      tempDir = await mkdtemp(join(tmpdir(), "kunai-mpv-tls-"));
+      const mediaPath = join(tempDir, "fixture.wav");
+      const scriptPath = join(tempDir, "tls-probe.lua");
+      const observationsPath = join(tempDir, "observations.txt");
+      await Bun.write(mediaPath, pcmWav(1_000, 440));
+      // Real Kunai options are constructed for remote hosts. Only transport is
+      // redirected, before opening: no DNS, provider or certificate fixture.
+      // file-loaded observes mpv's effective option while that file is active.
+      const luaString = (value: string) =>
+        `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+      await Bun.write(
+        scriptPath,
+        `
+      mp.add_hook("on_load", 1, function()
+        mp.set_property("stream-open-filename", ${luaString(mediaPath)})
+      end)
+      mp.register_event("file-loaded", function()
+        local file = assert(io.open(${luaString(observationsPath)}, "a"))
+        file:write(mp.get_property("options/tls-verify") .. "\\n")
+        file:close()
+      end)
+    `,
+      );
+      const children: Array<ReturnType<typeof Bun.spawn>> = [];
+      let ipc: MpvIpcSession | undefined;
+      const runtime: PersistentMpvSessionRuntime = {
+        which: () => MPV_BIN,
+        spawn(command, options) {
+          // Model the user's enabled TLS verification independently of mpv's
+          // build default (this mpv defaults to no); Kunai must restore it.
+          const child = Bun.spawn(
+            [
+              command[0]!,
+              "--pause=yes",
+              `--tls-verify=${baseline}`,
+              "--force-window=no",
+              "--vo=null",
+              "--ao=null",
+              "--really-quiet",
+              `--script=${scriptPath}`,
+              ...command.slice(1),
+            ],
+            options,
+          );
+          children.push(child);
+          return child;
+        },
+        waitForIpcEndpoint: async (...args) =>
+          (await import("@/infra/player/mpv-ipc")).waitForMpvIpcEndpoint(...args),
+        openIpcSession: async (options) => {
+          ipc = await (await import("@/infra/player/mpv-ipc")).openMpvIpcSession(options);
+          return ipc;
+        },
+      };
+      const exceptional = "https://www.mp4upload.com/fixture.mp4";
+      const normal = "https://example.com/fixture.mp4";
+      const urls = startsExceptional
+        ? [exceptional, exceptional, normal]
+        : [normal, exceptional, normal];
+      let session: PersistentMpvSession | undefined;
+      try {
+        session = await PersistentMpvSession.create({
+          stream: { url: urls[0]!, headers: {}, timestamp: Date.now() },
+          options: { displayTitle: "TLS scope", primarySubtitle: null },
+          mpv: { clean: true },
+          kitsuneConfig: {
+            mpvKunaiScriptPath: bundledKunaiMpvBridgePath(),
+            mpvInProcessStreamReconnect: false,
+            mpvInProcessStreamReconnectMaxAttempts: 0,
+          } as never,
+          onControlReady() {},
+          runtime,
+        });
+        const initialPlayback = session.waitForCurrentPlayback();
+        expect((await ipc!.send(["set_property", "pause", false])).ok).toBe(true);
+        expect((await withTimeout(initialPlayback, "TLS initial playback")).endReason).toBe("eof");
+        for (const url of urls.slice(1))
+          expect(
+            (
+              await withTimeout(
+                session.play(
+                  { url, headers: {}, timestamp: Date.now() },
+                  { displayTitle: "TLS replacement", primarySubtitle: null },
+                ),
+                "TLS replacement playback",
+              )
+            ).endReason,
+          ).toBe("eof");
+        expect(children).toHaveLength(1);
+        expect((await Bun.file(observationsPath).text()).trim().split("\n")).toEqual(
+          startsExceptional ? ["no", "no", baseline] : [baseline, "no", baseline],
+        );
+      } finally {
+        await session?.close();
+        await Promise.all(children.map((child) => child.exited));
+      }
+    },
+  );
+}

--- a/apps/cli/test/unit/services/download/download-path-naming.test.ts
+++ b/apps/cli/test/unit/services/download/download-path-naming.test.ts
@@ -131,6 +131,53 @@ describe("clampComponent", () => {
 });
 
 describe("resolveDownloadOutputPath", () => {
+  for (const platform of ["linux", "darwin", "win32"] as const) {
+    for (const titleName of ["A".repeat(300), "錬".repeat(300), "🎬".repeat(300)]) {
+      for (const seasonIsMeaningful of [true, false]) {
+        test(`keeps adjacent episode identity for ${platform}, ${titleName[0]}, season=${seasonIsMeaningful}`, () => {
+          const input = {
+            baseDir: platform === "win32" ? "C:\\Downloads" : "/downloads",
+            titleName,
+            extension: ".mp4",
+            platform,
+          };
+          const paths = [1, 2].map((episode) =>
+            resolveDownloadOutputPath({
+              ...input,
+              position: { kind: "episode", season: 1, episode, seasonIsMeaningful },
+            }),
+          );
+          expect(paths[0]).not.toBe(paths[1]);
+          for (const [index, path] of paths.entries()) {
+            expect(path.endsWith(`${seasonIsMeaningful ? "S01" : ""}E0${index + 1}.mp4`)).toBe(
+              true,
+            );
+            for (const part of path.split(/[/\\]/)) expect(bytes(part)).toBeLessThanOrEqual(255);
+            expect(new TextDecoder().decode(utf8.encode(path))).toBe(path);
+            if (platform === "win32") expect(path.length).toBeLessThanOrEqual(248);
+            expect(
+              resolveDownloadOutputPath({
+                ...input,
+                position: { kind: "episode", season: 1, episode: index + 1, seasonIsMeaningful },
+              }),
+            ).toBe(path);
+          }
+        });
+      }
+    }
+  }
+
+  test("rejects a Windows base directory that leaves no room for identity", () => {
+    expect(() =>
+      resolveDownloadOutputPath({
+        baseDir: `C:\\${"a".repeat(235)}`,
+        titleName: "Long title",
+        extension: ".mp4",
+        position: { kind: "episode", season: 1, episode: 2, seasonIsMeaningful: true },
+        platform: "win32",
+      }),
+    ).toThrow("too long");
+  });
   test("builds the documented episode layout on POSIX", () => {
     expect(
       resolveDownloadOutputPath({

--- a/apps/cli/test/unit/services/download/download-service.test.ts
+++ b/apps/cli/test/unit/services/download/download-service.test.ts
@@ -52,6 +52,53 @@ describe("DownloadService", () => {
    * second guess about what "movie" means.
    */
   describe("output naming derives from canonical media position", () => {
+    test.each(["updateFileSize", "complete"] as const)(
+      "recovers publication after %s persistence failure without downloading again",
+      async (method) => {
+        const service = buildService({
+          repo,
+          downloadsEnabled: true,
+          ytDlpAvailable: true,
+          downloadPath: tempDir,
+        });
+        const job = await service.enqueue({
+          title: { id: "tmdb:9999", type: "movie", name: "Persistence" },
+          providerId: "vidking",
+          stream: { url: "https://example.com/fixture.mp4", headers: {}, timestamp: 0 },
+        });
+        spawnSpy.mockImplementation((command: string[]) => {
+          writeFileSync(command[command.indexOf("-o") + 1]!, "published bytes");
+          // SAFETY: the download worker consumes only these subprocess streams,
+          // exit promise, and kill method; no native process is created here.
+          return {
+            stdout: streamOf(""),
+            stderr: streamOf(""),
+            exited: Promise.resolve(0),
+            kill() {},
+          } as never;
+        });
+        const failure = spyOn(repo, method).mockImplementation(() => {
+          throw new Error("database write unavailable");
+        });
+        await expect(service.processQueue()).rejects.toThrow("database write unavailable");
+        expect(repo.get(job.id)?.status).toBe("running");
+        expect(repo.get(job.id)?.retryCount).toBe(0);
+        expect(await Bun.file(job.outputPath).text()).toBe("published bytes");
+        const expireLease = () =>
+          db
+            .query("UPDATE download_jobs SET last_heartbeat_at = ? WHERE id = ?")
+            .run(new Date(Date.now() - 120_000).toISOString(), job.id);
+        expireLease();
+        await expect(service.processQueue()).rejects.toThrow("database write unavailable");
+        expect(repo.get(job.id)?.status).toBe("running");
+        failure.mockRestore();
+        expireLease();
+        await service.processQueue();
+        expect(repo.get(job.id)?.status).toBe("completed");
+        expect(await Bun.file(job.outputPath).text()).toBe("published bytes");
+        expect(spawnSpy).toHaveBeenCalledTimes(1);
+      },
+    );
     test("staging cleanup failure does not undo a published download", async () => {
       const service = buildService({
         repo,
@@ -88,39 +135,46 @@ describe("DownloadService", () => {
       }
     });
 
-    test("an offline asset without a job owner blocks recovery and completed-job deletion", async () => {
-      const service = buildService({
-        repo,
-        downloadsEnabled: true,
-        ytDlpAvailable: true,
-        downloadPath: tempDir,
-      });
-      const job = await service.enqueue({
-        title: { id: "tmdb:1111", type: "movie", name: "Offline owner" },
-        providerId: "vidking",
-      });
-      writeFileSync(job.outputPath, "unowned offline bytes");
-      new OfflineAssetsRepository(db).upsertPlayable({
-        titleId: "tmdb:2222",
-        titleName: "Other",
-        mediaKind: "movie",
-        profileKey: "default",
-        filePath: job.outputPath,
-        state: "ready",
-        updatedAt: new Date().toISOString(),
-      });
-      repo.markRunning(job.id, new Date(Date.now() - 120_000).toISOString());
-      await buildService({
-        repo,
-        downloadsEnabled: false,
-        ytDlpAvailable: false,
-        downloadPath: tempDir,
-      }).processQueue();
-      expect(repo.get(job.id)?.status).toBe("failed");
-      repo.complete(job.id, new Date().toISOString());
-      await service.deleteJob(job.id, { deleteArtifact: true });
-      expect(await Bun.file(job.outputPath).text()).toBe("unowned offline bytes");
-    });
+    test.each(["native", "win32-case-variant"] as const)(
+      "an offline asset blocks recovery and completed-job deletion (%s)",
+      async (pathKind) => {
+        if (pathKind === "win32-case-variant") repo = new DownloadJobsRepository(db, "win32");
+        const service = buildService({
+          repo,
+          downloadsEnabled: true,
+          ytDlpAvailable: true,
+          downloadPath: tempDir,
+        });
+        const job = await service.enqueue({
+          title: { id: "tmdb:1111", type: "movie", name: "Offline owner" },
+          providerId: "vidking",
+        });
+        writeFileSync(job.outputPath, "unowned offline bytes");
+        new OfflineAssetsRepository(db).upsertPlayable({
+          titleId: "tmdb:2222",
+          titleName: "Other",
+          mediaKind: "movie",
+          profileKey: "default",
+          filePath:
+            pathKind === "win32-case-variant"
+              ? job.outputPath.toUpperCase().replaceAll("/", "\\")
+              : job.outputPath,
+          state: "ready",
+          updatedAt: new Date().toISOString(),
+        });
+        repo.markRunning(job.id, new Date(Date.now() - 120_000).toISOString());
+        await buildService({
+          repo,
+          downloadsEnabled: false,
+          ytDlpAvailable: false,
+          downloadPath: tempDir,
+        }).processQueue();
+        expect(repo.get(job.id)?.status).toBe("failed");
+        repo.complete(job.id, new Date().toISOString());
+        await service.deleteJob(job.id, { deleteArtifact: true });
+        expect(await Bun.file(job.outputPath).text()).toBe("unowned offline bytes");
+      },
+    );
     test("publishes distinct long-title episodes through real temporary files", async () => {
       const service = buildService({
         repo,

--- a/apps/cli/test/unit/services/download/download-service.test.ts
+++ b/apps/cli/test/unit/services/download/download-service.test.ts
@@ -1,11 +1,17 @@
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import * as fsPromises from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { DownloadEnqueueRejectedError, DownloadService } from "@/services/download/DownloadService";
 import type { ConfigService } from "@/services/persistence/ConfigService";
-import { DownloadJobsRepository, openKunaiDatabase, runMigrations } from "@kunai/storage";
+import {
+  DownloadJobsRepository,
+  OfflineAssetsRepository,
+  openKunaiDatabase,
+  runMigrations,
+} from "@kunai/storage";
 
 import { waitUntil as sharedWaitUntil } from "../../../support/wait-until";
 
@@ -46,6 +52,169 @@ describe("DownloadService", () => {
    * second guess about what "movie" means.
    */
   describe("output naming derives from canonical media position", () => {
+    test("staging cleanup failure does not undo a published download", async () => {
+      const service = buildService({
+        repo,
+        downloadsEnabled: true,
+        ytDlpAvailable: true,
+        downloadPath: tempDir,
+      });
+      const job = await service.enqueue({
+        title: { id: "tmdb:9999", type: "movie", name: "Cleanup" },
+        providerId: "vidking",
+        stream: { url: "https://example.com/fixture.mp4", headers: {}, timestamp: 0 },
+      });
+      spawnSpy.mockImplementation((command: string[]) => {
+        writeFileSync(command[command.indexOf("-o") + 1]!, "published bytes");
+        return {
+          stdout: streamOf(""),
+          stderr: streamOf(""),
+          exited: Promise.resolve(0),
+          kill() {},
+        } as never;
+      });
+      const originalRm = fsPromises.rm;
+      const remove = spyOn(fsPromises, "rm").mockImplementation(async (path, options) => {
+        if (path === job.tempPath && existsSync(job.outputPath))
+          throw new Error("staging name locked");
+        return originalRm(path, options);
+      });
+      try {
+        await service.processQueue();
+        expect(repo.get(job.id)?.status).toBe("completed");
+        expect(await Bun.file(job.outputPath).text()).toBe("published bytes");
+      } finally {
+        remove.mockRestore();
+      }
+    });
+
+    test("an offline asset without a job owner blocks recovery and completed-job deletion", async () => {
+      const service = buildService({
+        repo,
+        downloadsEnabled: true,
+        ytDlpAvailable: true,
+        downloadPath: tempDir,
+      });
+      const job = await service.enqueue({
+        title: { id: "tmdb:1111", type: "movie", name: "Offline owner" },
+        providerId: "vidking",
+      });
+      writeFileSync(job.outputPath, "unowned offline bytes");
+      new OfflineAssetsRepository(db).upsertPlayable({
+        titleId: "tmdb:2222",
+        titleName: "Other",
+        mediaKind: "movie",
+        profileKey: "default",
+        filePath: job.outputPath,
+        state: "ready",
+        updatedAt: new Date().toISOString(),
+      });
+      repo.markRunning(job.id, new Date(Date.now() - 120_000).toISOString());
+      await buildService({
+        repo,
+        downloadsEnabled: false,
+        ytDlpAvailable: false,
+        downloadPath: tempDir,
+      }).processQueue();
+      expect(repo.get(job.id)?.status).toBe("failed");
+      repo.complete(job.id, new Date().toISOString());
+      await service.deleteJob(job.id, { deleteArtifact: true });
+      expect(await Bun.file(job.outputPath).text()).toBe("unowned offline bytes");
+    });
+    test("publishes distinct long-title episodes through real temporary files", async () => {
+      const service = buildService({
+        repo,
+        downloadsEnabled: true,
+        ytDlpAvailable: true,
+        downloadPath: tempDir,
+      });
+      spawnSpy.mockImplementation((command: string[]) => {
+        const path = command[command.indexOf("-o") + 1]!;
+        writeFileSync(path, command.at(-1)!);
+        return {
+          stdout: streamOf(""),
+          stderr: streamOf(""),
+          exited: Promise.resolve(0),
+          kill() {},
+        } as never;
+      });
+      const jobs = [];
+      for (const episode of [1, 2])
+        jobs.push(
+          await service.enqueue({
+            title: { id: "tmdb:999", type: "series", name: "A".repeat(300) },
+            episode: { season: 1, episode },
+            providerId: "vidking",
+            stream: { url: `https://example.com/${episode}.mp4`, headers: {}, timestamp: 0 },
+          }),
+        );
+      await service.processQueue();
+      for (const [index, job] of jobs.entries()) {
+        expect(repo.get(job.id)?.status).toBe("completed");
+        expect(await Bun.file(job.outputPath).text()).toBe(`https://example.com/${index + 1}.mp4`);
+      }
+    });
+
+    test("refuses publication over an unknown existing destination", async () => {
+      const service = buildService({
+        repo,
+        downloadsEnabled: true,
+        ytDlpAvailable: true,
+        downloadPath: tempDir,
+      });
+      const job = await service.enqueue({
+        title: { id: "tmdb:888", type: "movie", name: "Existing" },
+        providerId: "vidking",
+        stream: { url: "https://example.com/new.mp4", headers: {}, timestamp: 0 },
+      });
+      writeFileSync(job.outputPath, "user-owned bytes");
+      spawnSpy.mockImplementation((command: string[]) => {
+        writeFileSync(command[command.indexOf("-o") + 1]!, "new bytes");
+        return {
+          stdout: streamOf(""),
+          stderr: streamOf(""),
+          exited: Promise.resolve(0),
+          kill() {},
+        } as never;
+      });
+      await service.processQueue();
+      expect(await Bun.file(job.outputPath).text()).toBe("user-owned bytes");
+      expect(repo.get(job.id)?.status).not.toBe("completed");
+      await service.deleteJob(job.id, { deleteArtifact: true });
+      expect(await Bun.file(job.outputPath).text()).toBe("user-owned bytes");
+    });
+
+    test("legacy conflicting jobs cannot adopt or delete one another's output", async () => {
+      const service = buildService({
+        repo,
+        downloadsEnabled: true,
+        ytDlpAvailable: true,
+        downloadPath: tempDir,
+      });
+      const jobs = [];
+      for (const id of [111, 222])
+        jobs.push(
+          await service.enqueue({
+            title: { id: `tmdb:${id}`, type: "movie", name: "Collision" },
+            providerId: "vidking",
+          }),
+        );
+      const [first, second] = jobs;
+      writeFileSync(first!.outputPath, "first owner's bytes");
+      repo.complete(first!.id, new Date().toISOString());
+      repo.markRunning(second!.id, new Date(Date.now() - 120_000).toISOString());
+      const recovery = buildService({
+        repo,
+        downloadsEnabled: false,
+        ytDlpAvailable: false,
+        downloadPath: tempDir,
+      });
+      await recovery.processQueue();
+      expect(repo.get(second!.id)?.status).toBe("failed");
+      await service.deleteJob(second!.id, { deleteArtifact: true });
+      expect(await Bun.file(first!.outputPath).text()).toBe("first owner's bytes");
+      expect(repo.get(first!.id)?.status).toBe("completed");
+    });
     test("an anime job is named episode-only, with no season folder", async () => {
       const service = buildService({
         repo,

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable import/no-unassigned-import */
 import "./global.css";
 import { PrivacyAnalytics } from "@/components/analytics/privacy-analytics";
+import { PrivacySpeedInsights } from "@/components/analytics/privacy-speed-insights";
 import { KunaiFoxRoamer } from "@/components/brand/kunai-fox-roamer";
 import { KunaiSearchDialog } from "@/components/search/kunai-search-dialog";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { fontClassNames } from "@/lib/fonts";
 /* eslint-enable import/no-unassigned-import */
 import { docsSiteUrl } from "@/lib/site";
-import { SpeedInsights } from "@vercel/speed-insights/next";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
@@ -67,7 +67,7 @@ export default function RootLayout({ children }: { readonly children: ReactNode 
             rather than remounting — she keeps walking while you navigate. */}
         <KunaiFoxRoamer />
         <PrivacyAnalytics />
-        <SpeedInsights />
+        <PrivacySpeedInsights />
       </body>
     </html>
   );

--- a/apps/docs/components/analytics/privacy-speed-insights.tsx
+++ b/apps/docs/components/analytics/privacy-speed-insights.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { filterPrivateShareAnalytics } from "@/lib/analytics-privacy";
+import { SpeedInsights } from "@vercel/speed-insights/next";
+
+export function PrivacySpeedInsights() {
+  return <SpeedInsights beforeSend={filterPrivateShareAnalytics} />;
+}

--- a/apps/docs/lib/analytics-privacy.ts
+++ b/apps/docs/lib/analytics-privacy.ts
@@ -1,12 +1,17 @@
-import type { BeforeSendEvent } from "@vercel/analytics/next";
-
-/** Share paths contain the title/ref itself, so they never enter web analytics. */
-export function filterPrivateShareAnalytics(event: BeforeSendEvent): BeforeSendEvent | null {
+/** Both telemetry SDKs carry a URL. Never forward a private or unparseable URL. */
+export function filterPrivateShareAnalytics<T extends { readonly url: string }>(
+  event: T,
+): T | null {
   try {
-    if (new URL(event.url).pathname.startsWith("/w/")) return null;
+    // Root-relative SDK events are supported without relying on the current
+    // browser location: delayed events keep the privacy of their source page.
+    const parsed = event.url.startsWith("/")
+      ? new URL(event.url, "https://telemetry.invalid")
+      : new URL(event.url);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+    if (parsed.pathname === "/w" || parsed.pathname.startsWith("/w/")) return null;
   } catch {
-    // An unexpected analytics URL shape is not a share path; preserve the
-    // existing site behavior instead of silently dropping unrelated metrics.
+    return null;
   }
   return event;
 }

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "9399f4e19c122a598078ee554d5ef0659a4c62985eef9ea2a9a7b0aa8ac691de",
-  "docsContentFingerprint": "6cf519d315982a3c8c0617891325b79a3179587b3761e6097f012d298ee5dfc7",
+  "docsContentFingerprint": "14018ab1b9cd0a12cb7b5b6d22fcd8c8930319d788e3fe19092958cf19033fb9",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/apps/docs/test/share-landing.test.tsx
+++ b/apps/docs/test/share-landing.test.tsx
@@ -4,6 +4,8 @@ import { encodePlaybackTargetWebUrl } from "@kunai/types";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import SharePage, { generateMetadata } from "../app/w/[code]/page";
+import { PrivacyAnalytics } from "../components/analytics/privacy-analytics";
+import { PrivacySpeedInsights } from "../components/analytics/privacy-speed-insights";
 import { filterPrivateShareAnalytics } from "../lib/analytics-privacy";
 
 function webCode(url: string): string {
@@ -60,6 +62,34 @@ test("share codes never enter site analytics", () => {
 
   expect(filterPrivateShareAnalytics(shareEvent)).toBeNull();
   expect(filterPrivateShareAnalytics(docsEvent)).toBe(docsEvent);
+});
+
+test("relative share URLs and malformed telemetry URLs fail closed", () => {
+  for (const url of ["/w/v1.private?query=1", "/w/invalid", "http://[", "unparseable"]) {
+    expect(filterPrivateShareAnalytics({ type: "pageview", url })).toBeNull();
+  }
+});
+
+test("both mounted SDK wrappers suppress share events across navigation and delayed delivery", () => {
+  const analytics = PrivacyAnalytics();
+  const speed = PrivacySpeedInsights();
+  // Inspect the actual SDK props emitted by each client boundary, not a detached helper.
+  expect(analytics.props.beforeSend).toBeFunction();
+  expect(speed.props.beforeSend).toBeFunction();
+  for (const [url, allowed] of [
+    ["https://kunai.kitsunekode.in/docs", true],
+    ["https://kunai.kitsunekode.in/w/v1.private", false],
+    ["/w/invalid?title=private", false],
+    ["https://kunai.kitsunekode.in/docs/users", true],
+    // A share-page performance sample delivered after navigation to docs.
+    ["https://kunai.kitsunekode.in/w/v1.private?query=1", false],
+    ["http://[", false],
+  ] as const) {
+    const pageview = { type: "pageview", url };
+    const vital = { type: "vital", url, route: "/w/[code]" };
+    expect(analytics.props.beforeSend(pageview)).toBe(allowed ? pageview : null);
+    expect(speed.props.beforeSend(vital)).toBe(allowed ? vital : null);
+  }
 });
 
 test("share metadata leaves the image slot to the segment card", async () => {

--- a/docs/users/share-links.mdx
+++ b/docs/users/share-links.mdx
@@ -6,10 +6,11 @@ status: shipped
 
 Kunai shares browser-safe `https://kunai.kitsunekode.in/w/<code>` links. The web page shows what was shared, offers an **Open in Kunai** handoff, and gives native install commands to someone who does not have Kunai yet. Links remain anchored to catalog metadata (TMDB, AniList, MAL, IMDb), so the receiver resolves through their own providers instead of repeating a title search.
 
-The URL contains the playback ref itself. There is no shortener database, and share-page visits are excluded from site analytics. Anyone holding the URL can read the title and episode it contains.
+The URL contains the playback ref itself. There is no shortener database. Share-page events are excluded from both site analytics and performance telemetry, including samples delivered after you navigate away. Anyone holding the URL can read the title and episode it contains.
 
 <ScopeCallout variant="beta" title="Protocol handler is Linux-only">
-  `kunai --open` works on every platform without OS registration. `kunai --install-protocol-handler` registers the `kunai://` OS handler on **Linux only** in 0.3.0.
+  `kunai --open` works on every platform without OS registration. `kunai --install-protocol-handler`
+  registers the `kunai://` OS handler on **Linux only** in 0.3.0.
 </ScopeCallout>
 
 ## Copy a link from the shell
@@ -76,15 +77,15 @@ kunai://download?...   # same query params; queues a download instead of playbac
 kunai://play?q=<query>&kind=...   # search fallback when no catalog id is known
 ```
 
-| Parameter | Meaning |
-| --- | --- |
-| `cat` | Catalog anchor: `tmdb:`, `anilist:`, `mal:`, or `imdb:` namespace + id |
-| `q` | Search query fallback (use instead of `cat` when no stable id) |
-| `kind` | `movie`, `series`, or `anime` |
-| `s` / `e` | Season and episode (1-based) |
-| `t` | Start offset in seconds, `1m23s`, or `1:23` |
-| `src` | Optional provider hint |
-| `sq` | Optional quality hint |
+| Parameter | Meaning                                                                |
+| --------- | ---------------------------------------------------------------------- |
+| `cat`     | Catalog anchor: `tmdb:`, `anilist:`, `mal:`, or `imdb:` namespace + id |
+| `q`       | Search query fallback (use instead of `cat` when no stable id)         |
+| `kind`    | `movie`, `series`, or `anime`                                          |
+| `s` / `e` | Season and episode (1-based)                                           |
+| `t`       | Start offset in seconds, `1m23s`, or `1:23`                            |
+| `src`     | Optional provider hint                                                 |
+| `sq`      | Optional quality hint                                                  |
 
 ## Examples
 

--- a/packages/storage/src/repositories/download-jobs.ts
+++ b/packages/storage/src/repositories/download-jobs.ts
@@ -1,4 +1,5 @@
 import { SQLiteError } from "bun:sqlite";
+import { win32 } from "node:path";
 
 import type {
   MediaKind,
@@ -146,6 +147,19 @@ const DOWNLOAD_INTENT_UNIQUE_INDEX = "idx_download_jobs_blocking_intent";
 export class DownloadJobsRepository {
   /** A legacy shared destination is ambiguous even when the other job failed. */
   hasConflictingOutputOwner(jobId: string, outputPath: string): boolean {
+    if (this.platform === "win32") {
+      // Compare only at the ownership boundary: keep recorded paths intact.
+      // SQLite NOCASE is ASCII-only; filenames can include Unicode letters.
+      const identity = win32.normalize(outputPath).toUpperCase();
+      return this.db
+        .query<{ path: string }, [string, string]>(
+          `SELECT output_path AS path FROM download_jobs WHERE id <> ?
+         UNION ALL
+         SELECT file_path AS path FROM offline_assets WHERE origin_job_id IS NULL OR origin_job_id <> ?`,
+        )
+        .all(jobId, jobId)
+        .some(({ path }) => win32.normalize(path).toUpperCase() === identity);
+    }
     return (
       this.db
         .query<{ conflict: number }, [string, string, string, string]>(
@@ -158,7 +172,10 @@ export class DownloadJobsRepository {
         .get(outputPath, jobId, outputPath, jobId)?.conflict === 1
     );
   }
-  constructor(private readonly db: KunaiDatabase) {}
+  constructor(
+    private readonly db: KunaiDatabase,
+    private readonly platform: NodeJS.Platform = process.platform,
+  ) {}
 
   enqueue(
     input: Omit<

--- a/packages/storage/src/repositories/download-jobs.ts
+++ b/packages/storage/src/repositories/download-jobs.ts
@@ -144,6 +144,20 @@ export class DownloadJobAdmissionConflictError extends Error {
 const DOWNLOAD_INTENT_UNIQUE_INDEX = "idx_download_jobs_blocking_intent";
 
 export class DownloadJobsRepository {
+  /** A legacy shared destination is ambiguous even when the other job failed. */
+  hasConflictingOutputOwner(jobId: string, outputPath: string): boolean {
+    return (
+      this.db
+        .query<{ conflict: number }, [string, string, string, string]>(
+          `SELECT EXISTS (
+        SELECT 1 FROM download_jobs WHERE output_path = ? AND id <> ?
+        UNION ALL
+        SELECT 1 FROM offline_assets WHERE file_path = ? AND (origin_job_id IS NULL OR origin_job_id <> ?)
+      ) AS conflict`,
+        )
+        .get(outputPath, jobId, outputPath, jobId)?.conflict === 1
+    );
+  }
   constructor(private readonly db: KunaiDatabase) {}
 
   enqueue(

--- a/packages/storage/src/sqlite-errors.ts
+++ b/packages/storage/src/sqlite-errors.ts
@@ -1,0 +1,12 @@
+/** Only SQLite's corruption result codes authorize moving a user's database. */
+export function isSqliteCorruptionError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("code" in error)) return false;
+  // Bun exposes SQLite result codes as strings, including extended CORRUPT codes.
+  return (
+    error.code === "SQLITE_CORRUPT" ||
+    error.code === "SQLITE_CORRUPT_VTAB" ||
+    error.code === "SQLITE_CORRUPT_SEQUENCE" ||
+    error.code === "SQLITE_CORRUPT_INDEX" ||
+    error.code === "SQLITE_NOTADB"
+  );
+}

--- a/packages/storage/src/sqlite.ts
+++ b/packages/storage/src/sqlite.ts
@@ -2,6 +2,8 @@ import { Database } from "bun:sqlite";
 import { chmodSync, existsSync, mkdirSync, renameSync } from "node:fs";
 import { dirname } from "node:path";
 
+import { isSqliteCorruptionError } from "./sqlite-errors";
+
 export type KunaiDatabase = Database;
 
 /**
@@ -93,7 +95,7 @@ export type OpenDatabaseWithRecoveryResult = {
 };
 
 /**
- * Open a database, quarantining an unreadable file instead of bricking startup.
+ * Open a database, quarantining a confirmed corrupt file instead of bricking startup.
  *
  * A corrupt `kunai-data.sqlite` (power loss, disk fault) used to throw out of
  * bootstrap on every launch with no way back in. Mirroring the JSON config
@@ -122,6 +124,7 @@ export function openKunaiDatabaseWithCorruptionRecovery(
     } catch {
       // The handle may itself be unusable; quarantine only needs the files.
     }
+    if (!isSqliteCorruptionError(error)) throw error;
     const moved = quarantineCorruptDatabaseFiles(path);
     if (moved.length === 0) {
       // Nothing could be moved aside (locked file, unwritable dir) — surface

--- a/packages/storage/test/download-job-admission.test.ts
+++ b/packages/storage/test/download-job-admission.test.ts
@@ -3,6 +3,7 @@ import { afterEach, expect, test } from "bun:test";
 import {
   dataMigrations,
   DownloadJobsRepository,
+  OfflineAssetsRepository,
   openKunaiDatabase,
   runMigrations,
   type KunaiDatabase,
@@ -10,6 +11,31 @@ import {
 import { createTempStoreRegistry } from "./helpers/temp-store";
 
 const stores = createTempStoreRegistry();
+
+test.each(["win32", "linux"] as const)(
+  "output ownership respects %s path identity in both tables",
+  (platform) => {
+    const db = stores.store(`download-owner-${platform}`, "data");
+    const repo = new DownloadJobsRepository(db, platform);
+    const original = "C:\\Downloads\\Épisode-Σ.mp4";
+    const alternate = "c:/downloads/épisode-ς.mp4";
+    repo.enqueue(enqueueInput("owner", { outputPath: original }));
+    expect(repo.hasConflictingOutputOwner("other", alternate)).toBe(platform === "win32");
+    expect(repo.hasConflictingOutputOwner("owner", alternate)).toBe(false);
+    expect(repo.get("owner")?.outputPath).toBe(original);
+    repo.delete("owner");
+    new OfflineAssetsRepository(db).upsertPlayable({
+      titleId: "tmdb:other",
+      titleName: "Other",
+      mediaKind: "movie",
+      profileKey: "default",
+      filePath: original,
+      state: "ready",
+      updatedAt: new Date().toISOString(),
+    });
+    expect(repo.hasConflictingOutputOwner("other", alternate)).toBe(platform === "win32");
+  },
+);
 
 afterEach(() => {
   stores.cleanup();

--- a/packages/storage/test/sqlite-errors.test.ts
+++ b/packages/storage/test/sqlite-errors.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+
+import { isSqliteCorruptionError } from "../src/sqlite-errors";
+
+test.each([
+  "SQLITE_CORRUPT",
+  "SQLITE_CORRUPT_VTAB",
+  "SQLITE_CORRUPT_SEQUENCE",
+  "SQLITE_CORRUPT_INDEX",
+  "SQLITE_NOTADB",
+])("recognizes %s as corruption", (code) => {
+  expect(isSqliteCorruptionError({ code })).toBe(true);
+});
+
+test.each([
+  "SQLITE_BUSY",
+  "SQLITE_LOCKED",
+  "SQLITE_READONLY",
+  "SQLITE_PERM",
+  "SQLITE_IOERR",
+  "SQLITE_CANTOPEN",
+  "SQLITE_ERROR",
+  "SQLITE_CORRUPT_UNKNOWN",
+  "EACCES",
+])("preserves files on %s", (code) => {
+  expect(isSqliteCorruptionError({ code, message: "database is corrupt" })).toBe(false);
+});
+
+test("unknown failures cannot authorize quarantine", () => {
+  for (const error of [
+    null,
+    undefined,
+    11,
+    "SQLITE_CORRUPT",
+    new Error("database is corrupt"),
+    { errno: 11 },
+  ]) {
+    expect(isSqliteCorruptionError(error)).toBe(false);
+  }
+});

--- a/packages/storage/test/sqlite-recovery.test.ts
+++ b/packages/storage/test/sqlite-recovery.test.ts
@@ -1,3 +1,4 @@
+import { Database } from "bun:sqlite";
 import { expect, test } from "bun:test";
 import {
   chmodSync,
@@ -13,6 +14,40 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { openKunaiDatabaseWithCorruptionRecovery } from "../src/sqlite";
+
+test("a healthy exclusive lock never quarantines durable data", () => {
+  const dir = mkdtempSync(join(tmpdir(), "kunai-sqlite-contention-"));
+  let owner: Database | undefined;
+  let attempted: Database | undefined;
+  let reopened: Database | undefined;
+  try {
+    const path = join(dir, "data.sqlite");
+    owner = new Database(path, { create: true });
+    owner.exec(
+      "PRAGMA journal_mode = DELETE; CREATE TABLE durable (id INTEGER); INSERT INTO durable VALUES (42); BEGIN EXCLUSIVE",
+    );
+    let failure: unknown;
+    try {
+      attempted = openKunaiDatabaseWithCorruptionRecovery(path, { busyTimeoutMs: 0 }).db;
+    } catch (error) {
+      failure = error;
+    }
+    attempted?.close();
+    attempted = undefined;
+    expect(readdirSync(dir).filter((name) => name.includes(".corrupt."))).toEqual([]);
+    expect(failure).toBeDefined();
+    owner.exec("ROLLBACK");
+    owner.close();
+    owner = undefined;
+    reopened = openKunaiDatabaseWithCorruptionRecovery(path).db;
+    expect(reopened.query("SELECT id FROM durable").get()).toEqual({ id: 42 });
+  } finally {
+    attempted?.close();
+    reopened?.close();
+    owner?.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 test("quarantines a corrupt database file and opens a fresh one", () => {
   const dir = mkdtempSync(join(tmpdir(), "kunai-sqlite-recovery-"));


### PR DESCRIPTION
## What changed
Four scoped audit fixes: preserve healthy SQLite databases on non-corruption open failures; retain episode filename identity and refuse artifact collisions; scope mp4upload TLS compatibility to the current file; exclude share URLs from both web telemetry integrations.

## Evidence
Regression tests cover a real locked SQLite database, long Unicode/platform filenames, existing destination preservation, ambiguous ownership during recovery/deletion, and successful publication despite staging cleanup failure. Real Linux mpv tests exercise normal → exception → normal and exception → replay → normal while preserving the user TLS baseline. Both mounted telemetry wrappers reject share/malformed events, including delayed events.

## Checklist
- [x] CLI patch changeset added; guard passes.
- [x] Fresh uncached typecheck, lint, formatting and full tests pass.
- [x] Fresh CLI and docs production builds pass.
- [x] Package-content check and documentation-path checks pass.
- [x] Repository pre-push test hook passes.
- [x] Live provider/Discord smokes intentionally skipped; deterministic fixtures used.

## Limits
Download destinations now require hard-link support; unsupported filesystems fail safely with actionable guidance. Native macOS/Windows and browser telemetry interception were not verified locally. Hosted CI is separate evidence. No merge or release is requested.

Lint cleanup is excluded to avoid duplicating existing #255; #354 supplies its targeted advisory and enforcement-test follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite recovery so only confirmed corruption triggers repair; locked or inaccessible databases remain untouched.
  * Download publication and cleanup now prevent overwriting files owned by other downloads or offline assets.
  * Download filenames preserve episode identifiers while handling long titles and platform path limits safely.
  * mp4upload TLS compatibility is limited to the affected file during persistent mpv playback, restoring your configured setting afterward.

* **Privacy**
  * Share-page events are excluded from analytics and performance telemetry, including delayed events after navigation.

* **Documentation**
  * Updated guidance for download safety, playback compatibility, database recovery, and share-link privacy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->