### PR TITLE
docs(readme): disclose AI assistance alongside the review gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,9 @@ suite, changesets, and the release gate are all in
 [CONTRIBUTING.md](CONTRIBUTING.md). Design docs live in
 [.docs/architecture.md](.docs/architecture.md).
 
+AI tooling assists with code and review here; every change still lands through human
+review and the same typecheck, lint, and deterministic test gate as everything else.
+
 ---
 
 ## Appreciation


### PR DESCRIPTION
Adds a one-line AI disclosure to the README.

It sits at the end of **Contributing and development** rather than as its own
section, so the table of contents is unchanged:

> AI tooling assists with code and review here; every change still lands through
> human review and the same typecheck, lint, and deterministic test gate as
> everything else.

The framing is deliberate — it states the assistance and the gate in the same
breath, so the disclosure reads as a description of how the project works rather
than as a caveat about it.

Prettier-clean. No other files touched.

https://claude.ai/code/session_015oRmB2pFEhVuMHrx4iSmcM
