### PR TITLE
fix(miruro): stop reading a dead upstream server as a Cloudflare block

### DIFF
--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -518,7 +518,7 @@ modes.
 | `rivestream` | movie, series | direct-http | `packages/providers/src/rivestream/direct.ts` |
 | `videasy`    | movie, series | direct-http | `packages/providers/src/videasy/direct.ts`    |
 | `anidb`      | anime         | direct-http | `packages/providers/src/anidb/direct.ts`      |
-| `allanime`   | anime, series | direct-http | `packages/providers/src/allmanga/direct.ts`   |
+| `allanime`   | anime         | direct-http | `packages/providers/src/allmanga/direct.ts`   |
 | `miruro`     | anime         | direct-http | `packages/providers/src/miruro/direct.ts`     |
 | `youtube`    | video         | direct-http | `packages/providers/src/youtube/direct.ts`    |
 

--- a/apps/cli/src/domain/types.ts
+++ b/apps/cli/src/domain/types.ts
@@ -258,7 +258,8 @@ export interface ProviderMetadata {
   readonly isYoutubeProvider: boolean;
   readonly providerLane: ProviderLane;
   readonly catalogIdentity?: "provider-native" | "anilist" | "tmdb";
-  readonly status?: "production" | "candidate" | "experimental" | "research";
+  /** Display-only; mirrors `ProviderManifestStatus` in `@kunai/core`. */
+  readonly status?: "production" | "candidate";
   readonly domain?: string;
 }
 

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,7 +1,7 @@
 {
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceFingerprint": "9399f4e19c122a598078ee554d5ef0659a4c62985eef9ea2a9a7b0aa8ac691de",
+  "cliSourceFingerprint": "970f2b0ea4a34e8034a0210a63fca94ffc6e1924b36f64a03abe50b0cd33ce29",
   "docsContentFingerprint": "6cf519d315982a3c8c0617891325b79a3179587b3761e6097f012d298ee5dfc7",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
@@ -103,7 +103,8 @@
         "Uses Miruro pipe API with XOR/gzip decryption key 71951034f8fbcf53d89db52ceb3dc22c.",
         "The default anime priority names AniDB first; that list is ordering, not an allowlist, so Miruro remains a registered fallback and manually selectable when the curl/http2 path works.",
         "May hit Cloudflare rate limits if called too frequently.",
-        "2026-08-17: curl --http2 with browser headers also receives CF 403 HTML from some networks; the WAF block message now carries a relay hint."
+        "2026-09-11: the pipe is reachable — Bun fetch is always CF-403'd (its TLS fingerprint), and curl clears the edge on both mirrors. The superseded 2026-08-17 note claiming curl also received CF 403 was measured through a predicate that read any HTML body as a Cloudflare block, including the mirror's own `502 upstream unreachable` page.",
+        "A 444/502 from the pipe is one of Miruro's backing servers being down (pewe follows AniDB, ally follows AllManga), not a WAF block, and must not stop the cycle — the remaining servers are usually healthy."
       ]
     },
     {

--- a/packages/core/src/provider-manifest.ts
+++ b/packages/core/src/provider-manifest.ts
@@ -34,7 +34,21 @@ export interface CoreProviderManifest {
   readonly notes?: readonly string[];
 }
 
-export type ProviderManifestStatus = "production" | "candidate" | "experimental" | "research";
+/**
+ * How a registered provider presents itself in the UI — and *only* that.
+ *
+ * `candidate` appends a `· candidate` suffix to the provider's display name in
+ * the Tracks panel and the provider picker. It does not gate registration,
+ * ordering, fallback eligibility, or health: registration is
+ * `loadProductionProviderModules()` and ordering is `providerPriority`.
+ *
+ * `experimental` and `research` used to sit in this union. No manifest ever set
+ * either and no code ever branched on them, so both rendered identically to
+ * `production` while reading like they meant something. Research-only modules
+ * are tracked in `packages/providers/src/research.ts` and are kept out of the
+ * runtime by not being in the bootstrap list — which is the real mechanism.
+ */
+export type ProviderManifestStatus = "production" | "candidate";
 
 export function resolveProviderCatalogIdentity(
   manifest: Pick<CoreProviderManifest, "catalogIdentity" | "mediaKinds">,

--- a/packages/providers/src/_template.ts
+++ b/packages/providers/src/_template.ts
@@ -55,7 +55,10 @@ export const templateManifest = defineProviderManifest({
   },
   browserSafe: true,
   relaySafe: true,
-  status: "experimental",
+  // Display-only. What actually keeps a new module out of the runtime is not
+  // being in `loadProductionProviderModules()`; research standing is tracked in
+  // `packages/providers/src/research.ts`.
+  status: "candidate",
   notes: ["This is a community template. Copy and paste this file to start building."],
 });
 

--- a/packages/providers/src/cineby/index.ts
+++ b/packages/providers/src/cineby/index.ts
@@ -66,7 +66,9 @@ export const cinebyManifest = defineProviderManifest({
   },
   browserSafe: false,
   relaySafe: false,
-  status: "research",
+  // Research standing lives in `research.ts` (`cineby` is `research-only`
+  // there); this field is display-only and the module is not registered.
+  status: "candidate",
   notes: [
     "Research wrapper only; production fallback order still prefers the proven vidking module.",
     "Keeps flavor labels and audio-language hints while reusing the VidKing direct engine.",

--- a/packages/providers/src/miruro/direct.ts
+++ b/packages/providers/src/miruro/direct.ts
@@ -46,6 +46,7 @@ import {
 import {
   curlCipherArgs,
   type CurlCandidate,
+  isCloudflareBlockBody,
   resolveCurlCandidate,
 } from "../shared/curl-impersonate";
 import { expandHlsMasterPlaylist, looksLikeHlsMasterUrl } from "../shared/hls-ladder";
@@ -1437,47 +1438,6 @@ function isMiruroObfuscatedPipeBody(body: string, xObfuscated: string | null): b
 function isHtmlBody(body: string): boolean {
   const head = body.slice(0, 200).toLowerCase();
   return head.includes("<!doctype html") || head.includes("<html");
-}
-
-/**
- * Markers that appear on Cloudflare's own block and challenge interstitials and
- * on nothing the origin serves.
- *
- * The word "cloudflare" and the `/cdn-cgi/` path are deliberately absent. The
- * mirror sits behind Cloudflare, so its *own* error pages carry the
- * `cloudflareinsights.com` beacon and `/cdn-cgi/` asset links — matching on
- * either reads an origin failure as a WAF block. Verified 2026-09-11 against a
- * live WAF 403 and a live `502 upstream unreachable` page from the same host:
- * these six hit the former and none of them hit the latter.
- */
-const CLOUDFLARE_BLOCK_MARKERS = [
-  "attention required",
-  "cf-error-details",
-  "cf-wrapper",
-  "just a moment",
-  "checking your browser",
-  "__cf_chl",
-] as const;
-
-/**
- * A Cloudflare block, as opposed to "a body that happens to be HTML".
- *
- * The predicate this replaced matched any body opening with `<!doctype html` or
- * `<html>`, which is true of Cloudflare's block page and equally true of the
- * mirror's `502 upstream unreachable` page. One dead upstream server therefore
- * read as a region-wide WAF block: it tripped the fail-fast threshold, which
- * suppressed the curl fallback on the remaining mirror and stopped the whole
- * provider cycle — so healthy servers ordered behind the dead one were never
- * tried, and the user was told to configure a relay for something no relay can
- * fix.
- */
-export function isCloudflareBlockBody(body: string): boolean {
-  if (!isHtmlBody(body)) return false;
-  // Cloudflare puts these in <head> and in the error wrapper. The origin's whole
-  // error page is ~4.5 KB, so this window covers both without scanning a
-  // multi-megabyte success body on every call.
-  const head = body.slice(0, 4_000).toLowerCase();
-  return CLOUDFLARE_BLOCK_MARKERS.some((marker) => head.includes(marker));
 }
 
 /**

--- a/packages/providers/src/miruro/direct.ts
+++ b/packages/providers/src/miruro/direct.ts
@@ -43,7 +43,11 @@ import {
   formatAnimeSourceDetail,
   miruroSubtitleDeliveryToMode,
 } from "../shared/anime-source-presentation";
-import { curlCipherArgs, resolveCurlCandidate } from "../shared/curl-impersonate";
+import {
+  curlCipherArgs,
+  type CurlCandidate,
+  resolveCurlCandidate,
+} from "../shared/curl-impersonate";
 import { expandHlsMasterPlaylist, looksLikeHlsMasterUrl } from "../shared/hls-ladder";
 import { TTLCache } from "../shared/provider-cache";
 import {
@@ -1430,11 +1434,65 @@ function isMiruroObfuscatedPipeBody(body: string, xObfuscated: string | null): b
   return body.startsWith("bh4YNPj7") || xObfuscated === "2";
 }
 
-function isCloudflareHtmlBody(body: string): boolean {
+function isHtmlBody(body: string): boolean {
   const head = body.slice(0, 200).toLowerCase();
-  return (
-    head.includes("<!doctype html") || head.includes("<html") || head.includes("just a moment")
-  );
+  return head.includes("<!doctype html") || head.includes("<html");
+}
+
+/**
+ * Markers that appear on Cloudflare's own block and challenge interstitials and
+ * on nothing the origin serves.
+ *
+ * The word "cloudflare" and the `/cdn-cgi/` path are deliberately absent. The
+ * mirror sits behind Cloudflare, so its *own* error pages carry the
+ * `cloudflareinsights.com` beacon and `/cdn-cgi/` asset links — matching on
+ * either reads an origin failure as a WAF block. Verified 2026-09-11 against a
+ * live WAF 403 and a live `502 upstream unreachable` page from the same host:
+ * these six hit the former and none of them hit the latter.
+ */
+const CLOUDFLARE_BLOCK_MARKERS = [
+  "attention required",
+  "cf-error-details",
+  "cf-wrapper",
+  "just a moment",
+  "checking your browser",
+  "__cf_chl",
+] as const;
+
+/**
+ * A Cloudflare block, as opposed to "a body that happens to be HTML".
+ *
+ * The predicate this replaced matched any body opening with `<!doctype html` or
+ * `<html>`, which is true of Cloudflare's block page and equally true of the
+ * mirror's `502 upstream unreachable` page. One dead upstream server therefore
+ * read as a region-wide WAF block: it tripped the fail-fast threshold, which
+ * suppressed the curl fallback on the remaining mirror and stopped the whole
+ * provider cycle — so healthy servers ordered behind the dead one were never
+ * tried, and the user was told to configure a relay for something no relay can
+ * fix.
+ */
+export function isCloudflareBlockBody(body: string): boolean {
+  if (!isHtmlBody(body)) return false;
+  // Cloudflare puts these in <head> and in the error wrapper. The origin's whole
+  // error page is ~4.5 KB, so this window covers both without scanning a
+  // multi-megabyte success body on every call.
+  const head = body.slice(0, 4_000).toLowerCase();
+  return CLOUDFLARE_BLOCK_MARKERS.some((marker) => head.includes(marker));
+}
+
+/**
+ * Upstream-unavailable statuses the mirror returns when one of its own backing
+ * servers is down. These are per-server facts, never evidence about the mirror's
+ * reachability, so they must not count toward the WAF fail-fast.
+ */
+const MIRURO_UPSTREAM_UNAVAILABLE_STATUSES = new Set([444, 502, 503, 504]);
+
+export function describeMiruroPipeFailure(status: number, body: string): string {
+  if (isCloudflareBlockBody(body)) return `HTTP ${status} (cloudflare html)`;
+  if (MIRURO_UPSTREAM_UNAVAILABLE_STATUSES.has(status)) {
+    return `HTTP ${status} (upstream server unavailable)`;
+  }
+  return `HTTP ${status}`;
 }
 
 function buildMiruroPipeHeaders(baseUrl: string, referer?: string): Record<string, string> {
@@ -1540,7 +1598,7 @@ async function fetchMiruroPipeBody(
   // failures. Request exceptions propagate to pipeCall's next-mirror loop.
   if (
     response.ok &&
-    !isCloudflareHtmlBody(responseText) &&
+    !isHtmlBody(responseText) &&
     !isMiruroObfuscatedPipeBody(responseText, response.headers.get("x-obfuscated"))
   ) {
     return {
@@ -1551,9 +1609,7 @@ async function fetchMiruroPipeBody(
     };
   }
 
-  const fetchWasCloudflare =
-    isCloudflareHtmlBody(responseText) ||
-    (response.status === 403 && isCloudflareHtmlBody(responseText));
+  const fetchWasCloudflare = isCloudflareBlockBody(responseText);
 
   // Region-wide WAF: do not spend 20s of curl on every remaining mirror.
   if (options.wafLikely && fetchWasCloudflare) {
@@ -1571,7 +1627,7 @@ async function fetchMiruroPipeBody(
       status: response.status || 403,
       text: responseText,
       xObfuscated: null,
-      cloudflareHtml: fetchWasCloudflare || isCloudflareHtmlBody(responseText),
+      cloudflareHtml: fetchWasCloudflare,
     };
   }
 
@@ -1645,7 +1701,7 @@ async function fetchMiruroPipeBody(
       status,
       text,
       xObfuscated: isMiruroObfuscatedPipeBody(text, null) ? "2" : null,
-      cloudflareHtml: isCloudflareHtmlBody(text),
+      cloudflareHtml: isCloudflareBlockBody(text),
     };
   } finally {
     signal?.removeEventListener("abort", onAbort);
@@ -1711,20 +1767,15 @@ async function pipeCall(
           keyHex: PIPE_KEY,
         });
       }
-      if (
-        candidate.cloudflareHtml ||
-        (candidate.status === 403 && isCloudflareHtmlBody(candidate.text))
-      ) {
+      if (candidate.cloudflareHtml) {
         wafHits += 1;
-        lastError = new Error("HTTP 403 (cloudflare html)");
+        lastError = new Error(`HTTP ${candidate.status || 403} (cloudflare html)`);
         if (wafHits >= MIRURO_WAF_FAIL_FAST_THRESHOLD) {
-          throw new Error(MIRURO_WAF_BLOCK_MESSAGE, { cause: lastError });
+          throw new Error(miruroWafBlockMessage(), { cause: lastError });
         }
         continue;
       }
-      lastError = new Error(
-        `HTTP ${candidate.status}${isCloudflareHtmlBody(candidate.text) ? " (cloudflare html)" : ""}`,
-      );
+      lastError = new Error(describeMiruroPipeFailure(candidate.status, candidate.text));
       // Try next mirror; curl fallback already attempted inside fetchMiruroPipeBody.
     } catch (error) {
       if (error instanceof MiruroPipeDecodeError) throw error;
@@ -1741,10 +1792,27 @@ async function pipeCall(
 
 /**
  * One owner for the WAF-block signal. `runProviderCycle` stops the whole cycle on
- * it, so the message shape and this predicate must not drift apart.
+ * it, so this prefix and `isMiruroWafBlockError` must not drift apart.
  */
-const MIRURO_WAF_BLOCK_MESSAGE =
-  "Miruro pipe blocked by Cloudflare WAF on multiple mirrors (HTTP 403 HTML). A user-owned relay (providerRelay.baseUrl) in an ungated region can bypass this.";
+const MIRURO_WAF_BLOCK_PREFIX =
+  "Miruro pipe blocked by Cloudflare WAF on multiple mirrors (HTTP 403 HTML).";
+
+/**
+ * The remedy depends on what curl we actually used, so ask before advising.
+ *
+ * A plain-curl TLS handshake is fingerprinted by Cloudflare long before any
+ * header is read, and an impersonate build clears it locally — so telling a user
+ * on plain curl to stand up a relay sends them to the most expensive fix first.
+ * ani-cli reaches the same conclusion from the other direction: it dies with
+ * "Blocked by cloudflare. Try installing curl-impersonate" only when
+ * `$curl_exe` is still plain `curl` (ani-cli:171, v5.0.4).
+ */
+export function miruroWafBlockMessage(curl: CurlCandidate | null = resolveCurlCandidate()): string {
+  if (!curl?.impersonates) {
+    return `${MIRURO_WAF_BLOCK_PREFIX} Install curl-impersonate (a curl_chrome*/curl_firefox* build on PATH) so the TLS handshake is not fingerprinted; a user-owned relay (providerRelay.baseUrl) in an ungated region also bypasses this.`;
+  }
+  return `${MIRURO_WAF_BLOCK_PREFIX} curl-impersonate (${curl.profile}) was already used and still blocked, so the block is region-wide: a user-owned relay (providerRelay.baseUrl) in an ungated region can bypass it.`;
+}
 
 function isMiruroWafBlockError(error: Error): boolean {
   return error.message.includes("Cloudflare WAF on multiple mirrors");

--- a/packages/providers/src/miruro/manifest.ts
+++ b/packages/providers/src/miruro/manifest.ts
@@ -80,6 +80,7 @@ export const miruroManifest = defineProviderManifest({
     "Uses Miruro pipe API with XOR/gzip decryption key 71951034f8fbcf53d89db52ceb3dc22c.",
     "The default anime priority names AniDB first; that list is ordering, not an allowlist, so Miruro remains a registered fallback and manually selectable when the curl/http2 path works.",
     "May hit Cloudflare rate limits if called too frequently.",
-    "2026-08-17: curl --http2 with browser headers also receives CF 403 HTML from some networks; the WAF block message now carries a relay hint.",
+    "2026-09-11: the pipe is reachable — Bun fetch is always CF-403'd (its TLS fingerprint), and curl clears the edge on both mirrors. The superseded 2026-08-17 note claiming curl also received CF 403 was measured through a predicate that read any HTML body as a Cloudflare block, including the mirror's own `502 upstream unreachable` page.",
+    "A 444/502 from the pipe is one of Miruro's backing servers being down (pewe follows AniDB, ally follows AllManga), not a WAF block, and must not stop the cycle — the remaining servers are usually healthy.",
   ],
 });

--- a/packages/providers/src/shared/curl-impersonate.ts
+++ b/packages/providers/src/shared/curl-impersonate.ts
@@ -179,8 +179,58 @@ export function resolveCurlCandidate(
   return plain ? { path: plain, impersonates: false, profile: null } : null;
 }
 
+/**
+ * Markers that appear on Cloudflare's own interstitials and on nothing an
+ * origin serves.
+ *
+ * The word "cloudflare" and the `/cdn-cgi/` path are deliberately absent. A site
+ * behind Cloudflare serves its *own* error pages through it, so those pages
+ * carry the `cloudflareinsights.com` beacon and `/cdn-cgi/challenge-platform/`
+ * scripts. Matching on either turns "one of this host's upstreams is down" into
+ * "Cloudflare blocked us" — which is exactly the bug this table replaced in the
+ * Miruro pipe. Verified 2026-09-11 against a live WAF 403 and a live
+ * `502 upstream unreachable` page from the same host.
+ */
+const CLOUDFLARE_CHALLENGE_MARKERS = [
+  "just a moment",
+  "checking your browser",
+  "__cf_chl",
+] as const;
+
+const CLOUDFLARE_BLOCK_MARKERS = [
+  ...CLOUDFLARE_CHALLENGE_MARKERS,
+  "attention required",
+  "cf-error-details",
+  "cf-wrapper",
+] as const;
+
+/**
+ * Cloudflare's *interactive challenge* only — the "Just a moment…" interstitial
+ * a browser can pass and a CLI cannot.
+ *
+ * Narrower than {@link isCloudflareBlockBody} on purpose: callers that retry or
+ * re-search on a challenge should not also do so for a hard 1020-style block,
+ * which no retry clears.
+ */
 export function isCloudflareChallengeText(text: string): boolean {
-  return /just a moment/i.test(text);
+  const head = text.slice(0, 4_000).toLowerCase();
+  return CLOUDFLARE_CHALLENGE_MARKERS.some((marker) => head.includes(marker));
+}
+
+/**
+ * Any Cloudflare interstitial — a hard block or a challenge — as opposed to "a
+ * body that happens to be HTML".
+ *
+ * Reach for this when the question is "did Cloudflare stop us", and for
+ * {@link isCloudflareChallengeText} when it is specifically "can a better TLS
+ * fingerprint get through". A non-Cloudflare HTML body here is a normal origin
+ * failure and must be classified by its HTTP status instead.
+ */
+export function isCloudflareBlockBody(body: string): boolean {
+  const head = body.slice(0, 200).toLowerCase();
+  if (!head.includes("<!doctype html") && !head.includes("<html")) return false;
+  const window = body.slice(0, 4_000).toLowerCase();
+  return CLOUDFLARE_BLOCK_MARKERS.some((marker) => window.includes(marker));
 }
 
 /** Test-only: drop the memoized PATH scan. */

--- a/packages/providers/test/miruro-direct.test.ts
+++ b/packages/providers/test/miruro-direct.test.ts
@@ -10,7 +10,6 @@ import {
   decodeMiruroPipePayload,
   describeMiruroPipeFailure,
   interpretMiruroCurlResult,
-  isCloudflareBlockBody,
   miruroWafBlockMessage,
   isMiruroAudioFallback,
   MiruroPipeDecodeError,
@@ -19,6 +18,7 @@ import {
   resolveMiruroAnilistId,
   type MiruroServerProfile,
 } from "../src/miruro/direct";
+import { isCloudflareBlockBody, isCloudflareChallengeText } from "../src/shared/curl-impersonate";
 import { inferSubtitleFormat } from "../src/shared/subtitle-helpers";
 
 const TEST_CONTEXT: ProviderRuntimeContext = {
@@ -599,6 +599,23 @@ describe("Cloudflare block detection separates a WAF block from a dead upstream"
     expect(isCloudflareBlockBody("<html><head><title>Just a moment...</title></head></html>")).toBe(
       true,
     );
+  });
+
+  test("the challenge predicate is the narrower of the two, and stays that way", () => {
+    const challenge = "<html><head><title>Just a moment...</title></head></html>";
+    // A challenge is both a challenge and a block.
+    expect(isCloudflareChallengeText(challenge)).toBe(true);
+    expect(isCloudflareBlockBody(challenge)).toBe(true);
+
+    // A hard 1020-style block is a block but NOT a challenge: no better TLS
+    // fingerprint clears it, so callers that retry on a challenge must not
+    // retry on this. AniDB depends on that distinction.
+    expect(isCloudflareChallengeText(CLOUDFLARE_BLOCK_PAGE)).toBe(false);
+    expect(isCloudflareBlockBody(CLOUDFLARE_BLOCK_PAGE)).toBe(true);
+
+    // And neither fires on the origin's own error page.
+    expect(isCloudflareChallengeText(UPSTREAM_502_PAGE)).toBe(false);
+    expect(isCloudflareBlockBody(UPSTREAM_502_PAGE)).toBe(false);
   });
 });
 

--- a/packages/providers/test/miruro-direct.test.ts
+++ b/packages/providers/test/miruro-direct.test.ts
@@ -8,7 +8,10 @@ import {
   computeMiruroEpisodesPersistTtlMs,
   createMiruroResultFromPayload,
   decodeMiruroPipePayload,
+  describeMiruroPipeFailure,
   interpretMiruroCurlResult,
+  isCloudflareBlockBody,
+  miruroWafBlockMessage,
   isMiruroAudioFallback,
   MiruroPipeDecodeError,
   type MiruroPipeDecodeFailureCode,
@@ -534,5 +537,122 @@ describe("computeMiruroEpisodesPersistTtlMs", () => {
   test("uses the newest air date across mixed entries", () => {
     const entries = [ep("2020-01-01T00:00:00.000Z"), ep(new Date(NOW - 6 * DAY).toISOString())];
     expect(computeMiruroEpisodesPersistTtlMs(entries, NOW)).toBe(DAY);
+  });
+});
+
+/**
+ * Both fixtures are trimmed from live 2026-09-11 captures of
+ * `www.miruro.bz/api/secure/pipe`. The origin sits behind Cloudflare, so its own
+ * error page carries the `cloudflareinsights.com` beacon and a
+ * `/cdn-cgi/challenge-platform/` script — that is exactly what made the previous
+ * "body starts with <html>" predicate read one dead upstream server as a
+ * region-wide WAF block.
+ */
+const CLOUDFLARE_BLOCK_PAGE = `<!DOCTYPE html>
+<!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en-US"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="en-US"> <!--<![endif]-->
+<head>
+<title>Attention Required! | Cloudflare</title>
+</head>
+<body>
+  <div id="cf-wrapper">
+    <div id="cf-error-details" class="cf-error-details-wrap">blocked</div>
+  </div>
+</body>
+</html>`;
+
+const UPSTREAM_502_PAGE = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="robots" content="noindex" />
+<title>502 upstream unreachable</title>
+</head>
+<body>
+  <h1>502</h1>
+  <script src="/cdn-cgi/challenge-platform/scripts/jsd/main.js"></script>
+  <script type="module" src="https://static.cloudflareinsights.com/beacon.min.js/v31edd6df"></script>
+</body>
+</html>`;
+
+describe("Cloudflare block detection separates a WAF block from a dead upstream", () => {
+  test("classifies Cloudflare's own block interstitial as a block", () => {
+    expect(isCloudflareBlockBody(CLOUDFLARE_BLOCK_PAGE)).toBe(true);
+  });
+
+  test("does not classify the origin's 502 page as a Cloudflare block", () => {
+    // The regression: this page is HTML, is served through Cloudflare, and
+    // mentions both `cdn-cgi` and `cloudflareinsights.com` — and is still just
+    // one of the mirror's backing servers being down.
+    expect(isCloudflareBlockBody(UPSTREAM_502_PAGE)).toBe(false);
+  });
+
+  test("does not classify an obfuscated success body as a Cloudflare block", () => {
+    expect(isCloudflareBlockBody("bh4YNPj7abcdef")).toBe(false);
+  });
+
+  test("does not classify a JSON error body as a Cloudflare block", () => {
+    expect(isCloudflareBlockBody('{"error":"Invalid envelope format"}')).toBe(false);
+  });
+
+  test("still catches a managed challenge, which is a block by another name", () => {
+    expect(isCloudflareBlockBody("<html><head><title>Just a moment...</title></head></html>")).toBe(
+      true,
+    );
+  });
+});
+
+describe("describeMiruroPipeFailure names the failure the mirror actually had", () => {
+  test("reports an upstream-unavailable status as an upstream failure", () => {
+    // 444 is what the mirror returns when a backing server (pewe/ally/hop) is
+    // down. Calling it Cloudflare sent users to configure a relay that cannot
+    // help.
+    expect(describeMiruroPipeFailure(444, UPSTREAM_502_PAGE)).toBe(
+      "HTTP 444 (upstream server unavailable)",
+    );
+    expect(describeMiruroPipeFailure(502, UPSTREAM_502_PAGE)).toBe(
+      "HTTP 502 (upstream server unavailable)",
+    );
+  });
+
+  test("still reports a real Cloudflare block as cloudflare html", () => {
+    expect(describeMiruroPipeFailure(403, CLOUDFLARE_BLOCK_PAGE)).toBe(
+      "HTTP 403 (cloudflare html)",
+    );
+  });
+
+  test("leaves an unremarkable status unqualified", () => {
+    expect(describeMiruroPipeFailure(418, "{}")).toBe("HTTP 418");
+  });
+});
+
+describe("the WAF block message advises the cheapest fix that can still work", () => {
+  test("tells a plain-curl user to install curl-impersonate before suggesting a relay", () => {
+    const message = miruroWafBlockMessage({
+      path: "/usr/bin/curl",
+      impersonates: false,
+      profile: null,
+    });
+    expect(message).toContain("curl-impersonate");
+    expect(message.indexOf("curl-impersonate")).toBeLessThan(message.indexOf("providerRelay"));
+  });
+
+  test("tells a user who already impersonated that the block is region-wide", () => {
+    const message = miruroWafBlockMessage({
+      path: "/usr/bin/curl_chrome150",
+      impersonates: true,
+      profile: "chrome150",
+    });
+    expect(message).toContain("chrome150");
+    expect(message).toContain("providerRelay");
+  });
+
+  test("keeps the prefix runProviderCycle keys on", () => {
+    for (const curl of [
+      null,
+      { path: "/usr/bin/curl_chrome150", impersonates: true, profile: "chrome150" },
+    ]) {
+      expect(miruroWafBlockMessage(curl)).toContain("Cloudflare WAF on multiple mirrors");
+    }
   });
 });

--- a/packages/relay/test/handler.test.ts
+++ b/packages/relay/test/handler.test.ts
@@ -70,7 +70,7 @@ const redirectProbeManifest = {
       "Content-Type": "application/json",
     },
   },
-  status: "experimental",
+  status: "candidate",
 } satisfies CoreProviderManifest;
 
 const redirectRegistry = buildProviderRelayRegistry([


### PR DESCRIPTION
## What was wrong

Miruro looked dead. It wasn't — it was the only working anime provider, and a predicate was hiding it.

```ts
function isCloudflareHtmlBody(body: string): boolean {
  const head = body.slice(0, 200).toLowerCase();
  return head.includes("<!doctype html") || head.includes("<html") || head.includes("just a moment");
}
```

That is true of Cloudflare's block page. It is equally true of the mirror's own error page:

```
HTTP 444 — <title>502 upstream unreachable</title>
```

So one dead backing server read as a region-wide WAF block, and the misclassification cascaded:

1. the false WAF hit set `wafLikely` for the second mirror, which **suppressed the curl fallback** there
2. two hits crossed `MIRURO_WAF_FAIL_FAST_THRESHOLD` and threw the WAF error
3. `shouldStopAfterFailure` matched `"cloudflare"` in that message and **stopped the whole cycle**

Every server ordered behind the dead one was skipped, and the error told the user to configure a relay — advice that cannot help, because nothing was blocking them.

## Live measurements (2026-09-11)

Per-server `sources` probe, One Piece ep 1159:

| Server | Backing | Result |
| --- | --- | --- |
| `pewe` | AniDB | 444 — anidb.app is serving "Under Maintenance" |
| `moo` | AnimeGG | **200, 4 streams** |
| `bee` | Anikoto | **200, 2 streams** |
| `ally` | AllManga | 444 — api.mkissa.net is 403 |
| `bonk` | — | **200, 7 streams** |
| `kiwi` | owocdn | **200, 4 streams** |
| `hop` | — | 444 |

Transport, same window: Bun `fetch` is **always** CF-403'd (its TLS fingerprint); curl clears the edge on both mirrors given the `sec-fetch-*` triplet the code already sends. The 2026-08-17 manifest note claiming curl also received CF 403 was measured through the broken predicate and is corrected here.

**Live smoke: `ok: false` → `ok: true`**, resolving through `moo` from `www.animegg.org` in 4.6s. The trace now shows `pewe` failing and the cycle *continuing* rather than aborting.

## How detection changed

The new marker set contains only strings that appear on Cloudflare's own interstitials: `attention required`, `cf-error-details`, `cf-wrapper`, `just a moment`, `checking your browser`, `__cf_chl`.

Deliberately **absent**: the word `cloudflare`, and `/cdn-cgi/`. The origin sits behind Cloudflare, so its own error page carries the `cloudflareinsights.com` beacon *and* a `/cdn-cgi/challenge-platform/scripts/jsd` script — matching on either reproduces the exact bug being fixed. Both fixtures in the new tests are trimmed from the live captures, so the regression is pinned to real bodies rather than a guess at their shape.

ani-cli arrives at the same design from the other direction: it tests only for `"Just a moment"` (`ani-cli:171`, v5.0.4), never for HTML-ness.

A 444/502/503/504 that is *not* a Cloudflare page is now reported as `HTTP 444 (upstream server unavailable)` — a per-server fact that does not touch the WAF counter and does not stop the cycle.

## Block message

When a real block does happen, the message now names the cheapest fix that can work. A user on plain curl is told to install curl-impersonate first; a user who *already* impersonated and is still blocked is told the block is region-wide and pointed at the relay. This mirrors ani-cli, which raises `"Blocked by cloudflare. Try installing curl-impersonate"` only while `$curl_exe` is still plain `curl`.

`resolveCurlCandidate()` already returned `{impersonates, profile}` for exactly this purpose; nothing was reading it.

## Also in here

- **`ProviderManifestStatus` drops `"experimental"` and `"research"`.** No code ever branched on them, so both rendered identically to `production` while reading like they gated something. The only three sites setting them are a template, a research-only module and a relay test fixture — none registered. Real research standing already lives in `packages/providers/src/research.ts`, and the real gate is `loadProductionProviderModules()`. `candidate` is now documented as what it actually is: a display suffix in the Tracks panel and provider picker, with no effect on registration, ordering, fallback or health.
- **`.docs/providers.md` listed `allanime` as `anime, series`.** Its manifest is `mediaKinds: ["anime"]` and its resolver has no series path.

## Verification

`typecheck` 14/14 · `test` 23/23, 0 fail · `lint` 0 errors · `fmt` · `verify:doc-paths` all resolve — each run with `--force` to defeat turbo cache replay. Live: `test:live:miruro` green.

## Not in scope

`MIRURO_SERVER_TRY_ORDER` still leads with `pewe` and demotes `kiwi` to 10th as "stalling/444-returning", which today's data contradicts. Left alone on purpose: that ranking is one machine at one moment, and `pewe`/`ally` are only down because AniDB and AllManga are down — both may return. Worth revisiting with data over time rather than a single sample.

https://claude.ai/code/session_01WwutAzrfta2SHPLTjMzoRN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - AllAnime is now documented as covering anime content only.
  - Provider status options have been simplified to “production” and “candidate.”
  - The template and Cineby providers now display as candidates.

- **Bug Fixes**
  - Improved Miruro error reporting distinguishes Cloudflare blocks from unavailable upstream servers.
  - Miruro can continue checking remaining servers after temporary 444, 502, 503, or 504 responses.
  - Cloudflare detection is more accurate across supported connection methods.

- **Documentation**
  - Updated Miruro guidance with current connection behavior and clearer troubleshooting details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->