### PR TITLE
test(shell): pin the shell-action routing contract, and correct plan 010's premise

### DIFF
--- a/.plans/010-characterization-tests-for-giants.md
+++ b/.plans/010-characterization-tests-for-giants.md
@@ -19,11 +19,13 @@
 
 ## Why this matters
 
-The four highest-churn files in the repo — `PlaybackPhase.ts` (3,635 lines, 185 commits/3mo), `shell-workflows.ts` (3,080), `ink-shell.tsx` (2,102, 214 commits), `root-overlay-shell.tsx` (1,945) — carry the most change and the least _direct_ behavioral coverage. `PlaybackPhase` is exercised only by a 187-line test of one private method; `shell-workflows` by a 32-line test of one function; `ink-shell` only by an import-boundary lint. Splitting these files (plans 011–013) with no safety net is how regressions ship. This plan pins current end-to-end behavior with characterization tests so the later refactors can prove they preserved it. It changes no runtime code.
+The four highest-churn files in the repo — `PlaybackPhase.ts` (3,635 lines, 185 commits/3mo), `shell-workflows.ts` (3,080), `ink-shell.tsx` (2,102, 214 commits), `root-overlay-shell.tsx` (1,945) — carry the most change and the least _direct_ behavioral coverage. At the time this plan was written `PlaybackPhase` was exercised only by a 187-line test of one private method; `shell-workflows` by a 32-line test of one function; `ink-shell` only by an import-boundary lint.
+
+**That is no longer true for `PlaybackPhase`.** A dedicated `apps/cli/test/unit/app/playback/` directory has since appeared — 13 files, 1,939 lines, 63 tests — including `playback-phase-outer-loop.test.ts` (11), `run-mpv-playback-session.test.ts` (17), `run-post-playback-menu.test.ts` (10), `playback-source-failover.test.ts` (5) and `playback-catalog-autoadvance.test.ts` (2). Those cover the resolve → play → post-play, auto-advance and dead-stream fallback scenarios Step 2 asks for, so Step 2 is treated as satisfied and is not re-done here. The remaining gap is the shell side. Splitting these files (plans 011–013) with no safety net is how regressions ship. This plan pins current end-to-end behavior with characterization tests so the later refactors can prove they preserved it. It changes no runtime code.
 
 ## Current state
 
-- Test harness support already exists: `apps/cli/test/support/` and `apps/cli/test/harness/` (confirm with `ls apps/cli/test/support apps/cli/test/harness`), including container fakes and a render-capture helper (`test/harness/render-capture.ts` per the audit — verify path). Existing good patterns: `apps/cli/test/unit/services/playback/playback-resolve-service.test.ts`, `apps/cli/test/unit/app-shell/input-router.useinput.test.tsx`, `apps/cli/test/unit/app/mpv-session-lifecycle.test.ts`.
+- Test harness support already exists and was re-confirmed: `apps/cli/test/support/container-fixture.ts`, `apps/cli/test/support/session-state-fixture.ts` and `apps/cli/test/harness/render-capture.ts` (a 644-line Ink harness with `render()`, a stdin bridge and `simulateTicks`). Step 1's STOP condition does not fire. Existing good patterns: `apps/cli/test/unit/services/playback/playback-resolve-service.test.ts`, `apps/cli/test/unit/app-shell/input-router.useinput.test.tsx`, `apps/cli/test/unit/app/mpv-session-lifecycle.test.ts`.
 - Runner: `bun run --cwd apps/cli test` (turbo → bun:test). Never `bun test` directly (CLAUDE.md).
 
 ## Commands you will need
@@ -62,7 +64,7 @@ Read `apps/cli/test/support/` and `apps/cli/test/harness/` and one exemplar test
 
 **Verify**: you can run one existing shell test: `cd apps/cli && bun run test:file test/unit/app-shell/input-router.useinput.test.tsx` → pass.
 
-### Step 2: Characterize `PlaybackPhase` transitions
+### Step 2: Characterize `PlaybackPhase` transitions — SATISFIED, do not re-do
 
 Drive the _observable_ behavior, not internals: given a title + episode selection and a fake provider/mpv, assert the sequence of high-level outcomes (resolve → play → post-play), auto-advance decisions (next episode chosen), dead-stream fallback (switches provider), and cancel-before-play (returns to prior surface). Assert on emitted events / returned `PlaybackOutcome` / dispatched state — never on private method names (the existing `playback-phase-events.test.ts` uses reflection casts; do NOT copy that; see plan 012 for extracting that logic). Cover 5–8 whole-flow scenarios.
 

--- a/.plans/roadmap.md
+++ b/.plans/roadmap.md
@@ -97,7 +97,7 @@ the K-reconciliation below and the commit history both cite them by id.
 | ---------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------- |
 | [006](./006-startup-defer-network-and-providers.md)  | Startup provider loading residue                                          | BLOCKED (engine registry is intentionally fixed)  |
 | [008](./008-tui-timer-and-poster-perf.md)            | Download-alert root coupling                                              | BLOCKED (other timer/poster slices landed)        |
-| [010](./010-characterization-tests-for-giants.md)    | Characterization net for private `AppRoot`                                | BLOCKED (needs a full-container harness)          |
+| [010](./010-characterization-tests-for-giants.md)    | Shell-side characterization; Step 2 satisfied by the playback test dir    | PARTIAL (the harness exists; not blocked)         |
 | [011](./011-split-shell-workflows.md)                | Split `shell-workflows.ts`                                                | BLOCKED by 010                                    |
 | [012](./012-decompose-playback-phase.md)             | Extract `PlaybackPhase` transition core                                   | BLOCKED by 010                                    |
 | [013](./013-split-ink-shell-host-surface.md)         | Split Ink host/surface/overlay winner                                     | BLOCKED by 010                                    |

--- a/apps/cli/test/unit/app-shell/workflows-characterization.test.ts
+++ b/apps/cli/test/unit/app-shell/workflows-characterization.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
+import type { ShellAction } from "@/app-shell/types";
 import { buildPickerActionContext, waitForOverlayClose } from "@/app-shell/workflows";
+import {
+  handleShellAction,
+  runShellWorkflowFromOverlay,
+} from "@/app-shell/workflows/shell-workflows";
+import type { Container } from "@/container";
 
 import { createContainerFixture } from "../../support/container-fixture";
 
@@ -51,5 +57,138 @@ describe("workflows characterization", () => {
     closeTopOverlay();
 
     await expect(pending).resolves.toBeUndefined();
+  });
+});
+
+/**
+ * `actionHandlers` is a `Record<string, ActionHandler | undefined>`, so an action
+ * with no entry falls through to `"unhandled"` silently — there is no type error
+ * and no log. That is the intended contract (the input router keeps ownership of
+ * navigation and playback keys), but it means a split of `shell-workflows.ts`
+ * could drop a handler and nothing would fail.
+ *
+ * These tests pin both sides of the split so a refactor has to be deliberate:
+ * the pass-through set answers `"unhandled"` without touching the container, and
+ * a workflow-owned action still reaches a handler.
+ */
+describe("handleShellAction routing contract", () => {
+  /**
+   * Every `ShellAction` with no entry in `actionHandlers`. The
+   * `satisfies readonly ShellAction[]` is load-bearing: if one of these is
+   * removed from the union, typecheck fails here rather than the list quietly
+   * describing an action that no longer exists.
+   */
+  const PASS_THROUGH_ACTIONS = [
+    "anime-calendar",
+    "anime-mode",
+    "audio",
+    "back-to-results",
+    "back-to-search",
+    "calendar",
+    "command-mode",
+    "details",
+    "fallback",
+    "filters",
+    "image-pane",
+    "memory",
+    "narrow-results",
+    "next",
+    "next-season",
+    "notifications",
+    "pick-episode",
+    "play-local",
+    "play-offline-ready",
+    "play-queue-next",
+    "previous",
+    "quality",
+    "random",
+    "recommendation",
+    "recompute",
+    "recover",
+    "replay",
+    "resume",
+    "resume-continue-watching",
+    "search",
+    "series-calendar",
+    "series-mode",
+    "source",
+    "stop-after-current",
+    "subtitle",
+    "surprise",
+    "toggle-autoplay",
+    "toggle-autoskip",
+    "toggle-mode",
+    "toggle-mode-reverse",
+    "tracked-calendar",
+    "trending",
+    "watch-online",
+    "youtube-mode",
+  ] as const satisfies readonly ShellAction[];
+
+  /**
+   * Any property read is a failure. A pass-through action must not reach a
+   * handler at all, so "did not touch the container" is the observable proof —
+   * stronger than asserting the return value alone.
+   */
+  function throwingContainer(): Container {
+    return new Proxy(
+      {},
+      {
+        get(_target, property) {
+          throw new Error(`handleShellAction read container.${String(property)}`);
+        },
+      },
+    ) as unknown as Container;
+  }
+
+  test("every pass-through action answers unhandled without reading the container", async () => {
+    const container = throwingContainer();
+    for (const action of PASS_THROUGH_ACTIONS) {
+      expect(await handleShellAction({ action, container })).toBe("unhandled");
+    }
+  });
+
+  test("the pass-through set is exactly 44 actions", () => {
+    // A handler added for one of these, or a new unhandled action, changes this
+    // number. Updating it should be a conscious edit in the same change set.
+    expect(new Set(PASS_THROUGH_ACTIONS).size).toBe(44);
+  });
+
+  test("a workflow-owned action still reaches its handler", async () => {
+    // `quit` routes to resolveQuitWithDownloadQueue, whose first act is
+    // `container.downloadService.hasActiveJobs()` — so the proxy throw proves
+    // the handler ran rather than the action falling through.
+    await expect(
+      handleShellAction({ action: "quit", container: throwingContainer() }),
+    ).rejects.toThrow(/read container\.downloadService/);
+  });
+});
+
+describe("runShellWorkflowFromOverlay dismissal", () => {
+  test("a picker is cancelled by id instead of closing the overlay beneath it", async () => {
+    const { container, dispatches, stateManager } = createContainerFixture();
+    stateManager.dispatch({ type: "OPEN_OVERLAY", overlay: { type: "library" } });
+    dispatches.length = 0;
+
+    const result = await runShellWorkflowFromOverlay(container, "settings", {
+      cancelPickerId: "episode-picker",
+      execute: async () => "handled",
+    });
+
+    expect(result).toBe("handled");
+    // The fixture records overlay mutations only, so a CANCEL_PICKER leaves it
+    // empty — the point is that the overlay underneath was NOT closed.
+    expect(dispatches).not.toContain("close");
+  });
+
+  test("an empty overlay stack closes nothing before running the workflow", async () => {
+    const { container, dispatches } = createContainerFixture();
+
+    const result = await runShellWorkflowFromOverlay(container, "settings", {
+      execute: async () => "handled",
+    });
+
+    expect(result).toBe("handled");
+    expect(dispatches).toEqual([]);
   });
 });


### PR DESCRIPTION
First increment of plan 010, plus a correction to the plan itself.

## The plan's premise had decayed

Plan 010 says the four giants carry "the least *direct* behavioral coverage",
and specifically that `PlaybackPhase` is *"exercised only by a 187-line test of
one private method."* That was accurate when it was written at `4b351cb0` —
`playback-phase-events.test.ts` is still exactly 187 lines.

It is not accurate now. A dedicated `apps/cli/test/unit/app/playback/`
directory has since appeared:

**13 files, 1,939 lines, 63 tests** — including `playback-phase-outer-loop.test.ts`
(11 tests), `run-mpv-playback-session.test.ts` (17), `run-post-playback-menu.test.ts`
(10), `playback-source-failover.test.ts` (5), `playback-catalog-autoadvance.test.ts` (2)
and `playback-provider-handoff.test.ts` (2).

Those cover exactly the scenarios Step 2 asks for — resolve → play → post-play,
auto-advance, dead-stream provider switch. Writing five to eight more whole-flow
playback tests on top of them would be redundant, so **Step 2 is marked
satisfied and not re-done**. `roadmap.md` says "Code wins. If a plan disagrees
with the repo, the repo is right — fix the plan in the same change set", which
is what this does.

The roadmap row also said 010 was `BLOCKED (needs a full-container harness)`.
The harness exists — `apps/cli/test/support/container-fixture.ts`,
`session-state-fixture.ts`, and a 644-line `apps/cli/test/harness/render-capture.ts`
with `render()`, a stdin bridge and `simulateTicks`. Step 1's STOP condition
does not fire, so the row is now `PARTIAL (the harness exists; not blocked)`.
That matters beyond 010: **011, 012 and 013 are blocked *by* 010, and 015 by
011+012.**

## What this adds

Five tests extending `workflows-characterization.test.ts` (the existing home for
this subject — a new `shell-workflows-characterization.test.ts` would have been a
confusing near-duplicate).

`actionHandlers` is a `Record<string, ActionHandler | undefined>`, so an action
with no entry falls through to `"unhandled"` with no type error and no log. The
split is **50 handled / 44 pass-through, and zero stray keys**. Nothing pinned
that, so a split of `shell-workflows.ts` could drop a handler silently.

- every one of the 44 pass-through actions answers `"unhandled"` **without
  reading the container** — proved with a `Proxy` that throws on any property
  access, which is stronger than asserting the return value alone
- the pass-through set is exactly 44
- `quit` still reaches its handler — the same proxy throws on
  `container.downloadService`, so the mechanism is validated in both
  directions and the pass-through assertions can genuinely fail
- `runShellWorkflowFromOverlay` cancels a picker by id instead of closing the
  overlay beneath it
- an empty overlay stack dispatches nothing before running the workflow

The `satisfies readonly ShellAction[]` on the list is load-bearing: remove one
from the union and typecheck fails here rather than the list quietly describing
an action that no longer exists.

No `mock.module` — the repo deliberately avoids it (`dispatch-palette-command.test.ts`
and `open-active-playback-episode-picker.test.ts` both carry comments about it
being process-global and applying at file-load time). No source file under
`apps/cli/src` changed.

## Verification

- `bun run typecheck --force` — 14/14, 0 cached
- `bun run lint --force` — 12/12, 0 warnings 0 errors
- `bun run test -- --force` — full suite, 0 failures
- `bun run verify:doc-paths` — 51 docs, 2114 source files, all resolve

## Still open in 010

Step 4 — `ink-shell.tsx` (2,260 lines, 5 behavioral tests) and
`root-overlay-shell.tsx` (2,343 lines, ~11). Both are still thin and the
render-capture harness is ready for them.

https://claude.ai/code/session_015oRmB2pFEhVuMHrx4iSmcM
