### PR TITLE
fix(mpv): stop losing a stream header whose name is spelled unusually

### DIFF
--- a/apps/cli/src/infra/player/mpv-stream-http-headers.ts
+++ b/apps/cli/src/infra/player/mpv-stream-http-headers.ts
@@ -42,9 +42,26 @@ export function normalizeStreamHttpHeaders(
   headers: Record<string, string> | undefined,
 ): NormalizedStreamHttpHeaders {
   const source = headers ?? {};
-  const referer = source.referer ?? source.Referer;
-  const userAgent = source["user-agent"] ?? source["User-Agent"];
-  const origin = source.origin ?? source.Origin;
+  // HTTP header names are case-insensitive, and the dedicated-option lookups
+  // below used to read two spellings each while the extraFields loop excluded
+  // every spelling via `toLowerCase()`. A provider emitting `REFERER` therefore
+  // lost it twice over: not matched as the referer, and not forwarded as a
+  // header either. No provider in the tree spells it that way today, so this is
+  // a trap for the next one rather than a live bug — but it fails silently,
+  // which is the expensive kind.
+  // The exact lowercase spelling still wins when both are present, which is what
+  // `source.referer ?? source.Referer` did; anything else is decided by key
+  // order, and object key order is not a contract a provider should depend on.
+  const dedicated = (canonical: string): string | undefined => {
+    if (typeof source[canonical] === "string") return source[canonical];
+    for (const [name, value] of Object.entries(source)) {
+      if (name.toLowerCase() === canonical) return value;
+    }
+    return undefined;
+  };
+  const referer = dedicated("referer");
+  const userAgent = dedicated("user-agent");
+  const origin = dedicated("origin");
   const sanitize = (value: unknown, pattern: RegExp): string | undefined => {
     if (typeof value !== "string") return undefined;
     const sanitized = value.trim().replace(pattern, "");

--- a/apps/cli/test/unit/infra/player/mpv-stream-http-headers.test.ts
+++ b/apps/cli/test/unit/infra/player/mpv-stream-http-headers.test.ts
@@ -24,6 +24,35 @@ describe("normalizeStreamHttpHeaders", () => {
     });
   });
 
+  test("recognizes any casing of the headers mpv has a dedicated option for", () => {
+    // HTTP header names are case-insensitive. These spellings used to be lost
+    // twice over — missed by the dedicated lookup, then excluded from
+    // extraFields by the lowercase check — so the header reached neither mpv
+    // option nor the header list.
+    expect(
+      normalizeStreamHttpHeaders({
+        REFERER: "https://example.test/watch",
+        "USER-AGENT": "kunai-test",
+        ORIGIN: "https://example.test",
+      }),
+    ).toEqual({
+      referer: "https://example.test/watch",
+      userAgent: "kunai-test",
+      origin: "https://example.test",
+      extraFields: [],
+    });
+  });
+
+  test("prefers the exact lowercase spelling when a provider sends both", () => {
+    // Object key order must not decide which value wins.
+    const normalized = normalizeStreamHttpHeaders({
+      Referer: "https://uppercase.test/",
+      referer: "https://lowercase.test/",
+    });
+    expect(normalized.referer).toBe("https://lowercase.test/");
+    expect(normalized.extraFields).toEqual([]);
+  });
+
   test("forwards provider headers mpv has no dedicated option for", () => {
     // VidLink's DASH manifests are CloudFront signed and 403 without their
     // Cookie, so a resolve that carried it still failed at the player.


### PR DESCRIPTION
fix(mpv): stop losing a stream header whose name is spelled unusually

`normalizeStreamHttpHeaders` read the dedicated options as
`source.referer ?? source.Referer` — two spellings — while the extraFields
loop skipped every spelling through `name.toLowerCase()`. A provider sending
`REFERER` therefore lost it twice: not matched as the referer, and not
forwarded as a header either. The value simply disappeared between a green
resolve and mpv.

HTTP header names are case-insensitive, so the lookup now is too. The exact
lowercase spelling still wins when a provider sends both, because the
alternative is letting object key order decide.

No provider in the tree spells these unusually today — every emitted casing
is `Referer`/`referer`, `User-Agent`/`user-agent`, `Origin`/`origin` — so
this is a trap for the next adapter rather than a live outage. It is worth
closing anyway because it fails silently.

Deliberately unchanged: values containing a comma are still dropped. mpv
splits `http-header-fields` on commas with no escape, so such a value cannot
be represented, and dropping it is honest where stripping the comma would
corrupt a cookie or signature. That behaviour carries its rationale in a
comment and a test. It was reported as the cause of VidLink 403s in mpv;
a live resolve shows VidLink's CloudFront cookie is 642 characters,
semicolon-delimited, and contains no comma — it passes through intact.

Claude-Session: https://claude.ai/code/session_01WwutAzrfta2SHPLTjMzoRN
