### PR TITLE
fix(analytics): make a failed snapshot cron say what failed

### DIFF
--- a/.docs/analytics-privacy-contract.md
+++ b/.docs/analytics-privacy-contract.md
@@ -103,6 +103,18 @@ small-cell suppression, not a claim of joint k-anonymity across the separately
 published version, OS, and architecture tables. `daily_rollup.computed_at` is
 the public `updatedAt`, so a stale value signals cron failure.
 
+That signal is only readable if a failed run means the rollup failed. The rollup
+and the two retention sweeps run as separate statements in separate
+transactions, so a prune that throws leaves an already-committed rollup behind
+it. The cron therefore reports them apart: a rollup failure answers `503` with
+the same opaque `upstream_unavailable` every endpoint returns, while a retention
+failure keeps the `200` the committed rollup earned and names the skipped sweep
+in the operator-only `deferred` array. Both write the failing stage to the
+function log, with any connection string reduced to its scheme. So
+`computed_at` stays the rollup signal and `deferred` is the retention one;
+neither masks the other, and retention that could not run today is retried on
+the next run rather than being lost.
+
 ### The day-by-day series
 
 `/metrics/series.json` publishes the same aggregates over a window (90 days by

--- a/apps/analytics-ingest/api/cron/snapshot.ts
+++ b/apps/analytics-ingest/api/cron/snapshot.ts
@@ -52,11 +52,14 @@ function redactConnectionStrings(message: string): string {
  * anywhere that said *why* it failed, so the signal was undiagnosable.
  */
 function logFailure(stage: string, error: unknown): void {
+  // Redact the whole description, not just the message: `name` is a writable
+  // string too, and the contract promises *any* connection string is reduced
+  // to its scheme.
   const described =
-    error instanceof Error
-      ? `${error.name}: ${redactConnectionStrings(error.message)}`
-      : `non-error: ${typeof error}`;
-  console.error(`[analytics:cron:snapshot] ${stage} failed — ${described}`);
+    error instanceof Error ? `${error.name}: ${error.message}` : `non-error: ${typeof error}`;
+  console.error(
+    `[analytics:cron:snapshot] ${stage} failed — ${redactConnectionStrings(described)}`,
+  );
 }
 
 /**

--- a/apps/analytics-ingest/api/cron/snapshot.ts
+++ b/apps/analytics-ingest/api/cron/snapshot.ts
@@ -3,7 +3,10 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { authorizeBearer } from "../../src/bearer-auth.js";
 import { RAW_RETENTION_DAYS } from "../../src/ingest.js";
 import { buildPublicMetrics, snapshotDayKey } from "../../src/public-metrics.js";
-import { loadAnalyticsRuntimeConfig } from "../../src/runtime-config.js";
+import {
+  loadAnalyticsRuntimeConfig,
+  type AnalyticsRuntimeConfig,
+} from "../../src/runtime-config.js";
 import type { AnalyticsStore } from "../../src/store.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -28,6 +31,35 @@ function sendJson(res: ServerResponse, status: number, payload: Record<string, u
 }
 
 /**
+ * A connection string carries credentials and Postgres puts the host into plenty
+ * of its error messages. Function logs are operator-only, but a password does
+ * not belong in one regardless, so URLs are reduced to their scheme.
+ */
+function redactConnectionStrings(message: string): string {
+  return message.replace(
+    /\b[a-z][a-z0-9+.-]*:\/\/\S*/gi,
+    (match) => `${match.split("://")[0]}://…`,
+  );
+}
+
+/**
+ * The reply body stays the uniform opaque `upstream_unavailable` every other
+ * endpoint returns — the caller learns nothing new. The reason goes to stderr,
+ * which Vercel keeps as function logs, tagged with the step that failed.
+ *
+ * Before this, one `catch {}` swallowed the error entirely. The contract says a
+ * stale `daily_rollup.computed_at` signals cron failure, but there was nothing
+ * anywhere that said *why* it failed, so the signal was undiagnosable.
+ */
+function logFailure(stage: string, error: unknown): void {
+  const described =
+    error instanceof Error
+      ? `${error.name}: ${redactConnectionStrings(error.message)}`
+      : `non-error: ${typeof error}`;
+  console.error(`[analytics:cron:snapshot] ${stage} failed — ${described}`);
+}
+
+/**
  * Days that still hold raw rows but never got a rollup, oldest first.
  *
  * The previous revision rolled up exactly yesterday. A cron run that failed, or
@@ -48,54 +80,91 @@ async function daysToRollUp(
   return ordered.slice(-MAX_BACKFILL_DAYS);
 }
 
-export default async function handler(req: IncomingMessage, res: ServerResponse): Promise<void> {
-  const runtime = loadAnalyticsRuntimeConfig();
-  if (!runtime || !runtime.cronSecret) {
-    sendJson(res, 503, { ok: false, error: "misconfigured" });
-    return;
-  }
+export type SnapshotHandlerDependencies = {
+  readonly loadConfig?: () => AnalyticsRuntimeConfig | null;
+};
 
-  const method = req.method ?? "GET";
-  if (method !== "GET" && method !== "POST") {
-    sendJson(res, 405, { ok: false, error: "method_not_allowed" });
-    return;
-  }
+/**
+ * Mirrors `createRelayRpcHandler` in `apps/relay-server`: the default export is
+ * the real handler, and the factory exists so a test can supply a store without
+ * `mock.module`, which is process-global in Bun and applies at file-load time.
+ */
+export function createSnapshotHandler(dependencies: SnapshotHandlerDependencies = {}) {
+  const loadConfig = dependencies.loadConfig ?? loadAnalyticsRuntimeConfig;
 
-  if (!authorizeBearer(req, runtime.cronSecret)) {
-    sendJson(res, 401, { ok: false, error: "unauthorized" });
-    return;
-  }
+  return async function handler(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const runtime = loadConfig();
+    if (!runtime || !runtime.cronSecret) {
+      sendJson(res, 503, { ok: false, error: "misconfigured" });
+      return;
+    }
 
-  try {
+    const method = req.method ?? "GET";
+    if (method !== "GET" && method !== "POST") {
+      sendJson(res, 405, { ok: false, error: "method_not_allowed" });
+      return;
+    }
+
+    if (!authorizeBearer(req, runtime.cronSecret)) {
+      sendJson(res, 401, { ok: false, error: "unauthorized" });
+      return;
+    }
+
     const now = Date.now();
     const today = new Date(now).toISOString().slice(0, 10);
     const day = snapshotDayKey(now);
 
+    // The rollup is the permanent record and the only part the public JSON
+    // reads. It gets its own failure path: nothing after this point is allowed
+    // to turn a committed rollup into a reported failure.
+    let metrics: ReturnType<typeof buildPublicMetrics>;
     const rolledUp: string[] = [];
-    for (const pending of await daysToRollUp(runtime.store, today, day)) {
-      rolledUp.push((await runtime.store.rollUpDay(pending)).day);
+    try {
+      for (const pending of await daysToRollUp(runtime.store, today, day)) {
+        rolledUp.push((await runtime.store.rollUpDay(pending)).day);
+      }
+      const rollup = await runtime.store.readRollup(day);
+      if (!rollup) throw new Error(`snapshot day ${day} has no rollup`);
+      metrics = buildPublicMetrics(rollup);
+    } catch (error) {
+      logFailure("rollup", error);
+      sendJson(res, 503, { ok: false, error: "upstream_unavailable" });
+      return;
     }
-    const rollup = await runtime.store.readRollup(day);
-    if (!rollup) throw new Error(`snapshot day ${day} has no rollup`);
-    const metrics = buildPublicMetrics(rollup);
 
-    // Raw dimension rows past retention go now; the rollups above already
-    // captured everything the public JSON and the admin view need.
-    const pruned = await runtime.store.pruneRawBefore(dayKeyBefore(today, RAW_RETENTION_DAYS));
+    // Retention runs on its own statements, in its own transactions — a prune
+    // failure cannot roll the rollup back. Reporting 503 here would mark the
+    // cron run failed for a day whose data actually landed, which is the
+    // opposite of what an operator needs to know. Deferred work is named in the
+    // reply and logged instead.
+    const deferred: string[] = [];
+
+    let pruned = 0;
+    try {
+      pruned = await runtime.store.pruneRawBefore(dayKeyBefore(today, RAW_RETENTION_DAYS));
+    } catch (error) {
+      logFailure("pruneRaw", error);
+      deferred.push("pruneRaw");
+    }
 
     // install_lifetime is the only table with no natural ceiling: every install
     // id ever seen leaves a permanent row, and ids are minted by the client.
     // Retiring long-silent installs into a counter bounds both the storage and
     // the durable pseudonymous set without losing the exact lifetime total.
+    let retired = 0;
     const retention = runtime.limits.lifetimeRetentionDays;
-    const retired =
-      retention > 0
-        ? (await runtime.store.pruneLifetimeBefore(dayKeyBefore(today, retention))).retired
-        : 0;
+    if (retention > 0) {
+      try {
+        retired = (await runtime.store.pruneLifetimeBefore(dayKeyBefore(today, retention))).retired;
+      } catch (error) {
+        logFailure("pruneLifetime", error);
+        deferred.push("pruneLifetime");
+      }
+    }
 
     // Operators only — not public; cron secret required.
-    sendJson(res, 200, { ok: true, metrics, rolledUp, pruned, retired });
-  } catch {
-    sendJson(res, 503, { ok: false, error: "upstream_unavailable" });
-  }
+    sendJson(res, 200, { ok: true, metrics, rolledUp, pruned, retired, deferred });
+  };
 }
+
+export default createSnapshotHandler();

--- a/apps/analytics-ingest/test/cron-snapshot.test.ts
+++ b/apps/analytics-ingest/test/cron-snapshot.test.ts
@@ -1,0 +1,184 @@
+/**
+ * The cron's failure reporting is the only thing standing between a stale
+ * `daily_rollup.computed_at` and an operator who can act on it.
+ *
+ * Two behaviours matter and neither was covered: a retention failure must not
+ * be reported as a failed snapshot (the rollup it follows is already
+ * committed, on its own statement, in its own transaction), and whatever does
+ * fail has to say so somewhere, because the reply body is deliberately opaque.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import { createSnapshotHandler } from "../api/cron/snapshot";
+import { loadAnalyticsLimits } from "../src/limits";
+import { snapshotDayKey } from "../src/public-metrics";
+import type { AnalyticsRuntimeConfig } from "../src/runtime-config";
+import type { AnalyticsStore, DailyRollup } from "../src/store";
+
+const CRON_SECRET = "cron-secret-value";
+
+function rollup(day: string): DailyRollup {
+  return {
+    day,
+    computedAt: `${day}T00:05:00.000Z`,
+    activeInstalls: 11,
+    byVersion: { "0.3.0": 11 },
+    byOs: { linux: 11 },
+    byArch: { x64: 11 },
+    lifetimeInstalls: 57,
+  };
+}
+
+function createStore(overrides: Partial<AnalyticsStore> = {}): AnalyticsStore {
+  return {
+    recordPing: async () => ({ admitted: true }),
+    rollUpDay: async (day) => rollup(day),
+    readRollup: async (day) => rollup(day),
+    readLatestRollupAtOrBefore: async (day) => rollup(day),
+    readRollups: async () => [],
+    findDaysNeedingRollup: async () => [],
+    pruneRawBefore: async () => 3,
+    pruneLifetimeBefore: async () => ({ retired: 2 }),
+    ...overrides,
+  };
+}
+
+function createConfig(store: AnalyticsStore): AnalyticsRuntimeConfig {
+  return {
+    hashSecret: "hash-secret",
+    cronSecret: CRON_SECRET,
+    adminToken: "admin-token",
+    limits: loadAnalyticsLimits({}),
+    store,
+  };
+}
+
+type Captured = { status: number; body: Record<string, unknown> };
+
+async function run(
+  store: AnalyticsStore,
+  { authorization = `Bearer ${CRON_SECRET}` }: { authorization?: string | null } = {},
+): Promise<{ captured: Captured; logs: string[] }> {
+  const handler = createSnapshotHandler({ loadConfig: () => createConfig(store) });
+
+  const req = {
+    method: "GET",
+    headers: authorization ? { authorization } : {},
+  } as unknown as IncomingMessage;
+
+  const captured: Captured = { status: 0, body: {} };
+  const res = {
+    setHeader: () => {},
+    set statusCode(value: number) {
+      captured.status = value;
+    },
+    end: (payload: string) => {
+      captured.body = JSON.parse(payload) as Record<string, unknown>;
+    },
+  } as unknown as ServerResponse;
+
+  const logs: string[] = [];
+  const realError = console.error;
+  console.error = (...args: unknown[]) => {
+    logs.push(args.map(String).join(" "));
+  };
+  try {
+    await handler(req, res);
+  } finally {
+    console.error = realError;
+  }
+  return { captured, logs };
+}
+
+describe("cron snapshot failure reporting", () => {
+  test("a retention failure does not report a committed rollup as failed", async () => {
+    const { captured, logs } = await run(
+      createStore({
+        pruneRawBefore: async () => {
+          throw new Error("statement timeout");
+        },
+      }),
+    );
+
+    // The rollup landed, so the run did its job — 503 here would tell an
+    // operator the day is missing when it is not.
+    expect(captured.status).toBe(200);
+    expect(captured.body.ok).toBe(true);
+    expect(captured.body.deferred).toEqual(["pruneRaw"]);
+    expect(logs.join("\n")).toContain("pruneRaw failed");
+  });
+
+  test("a lifetime-retention failure is reported the same way", async () => {
+    const { captured } = await run(
+      createStore({
+        pruneLifetimeBefore: async () => {
+          throw new Error("deadlock detected");
+        },
+      }),
+    );
+
+    expect(captured.status).toBe(200);
+    expect(captured.body.deferred).toEqual(["pruneLifetime"]);
+    expect(captured.body.pruned).toBe(3);
+  });
+
+  test("a rollup failure still fails the run, opaquely, but is logged", async () => {
+    const { captured, logs } = await run(
+      createStore({
+        rollUpDay: async () => {
+          throw new Error("connection refused");
+        },
+      }),
+    );
+
+    expect(captured.status).toBe(503);
+    // The body stays the uniform shape every other endpoint returns.
+    expect(captured.body).toEqual({ ok: false, error: "upstream_unavailable" });
+    expect(logs.join("\n")).toContain("rollup failed");
+    expect(logs.join("\n")).toContain("connection refused");
+  });
+
+  test("a healthy run defers nothing", async () => {
+    const { captured, logs } = await run(createStore());
+
+    expect(captured.status).toBe(200);
+    expect(captured.body.deferred).toEqual([]);
+    expect(captured.body.rolledUp).toEqual([snapshotDayKey()]);
+    expect(logs).toEqual([]);
+  });
+
+  test("credentials in an error message never reach the log", async () => {
+    const { logs } = await run(
+      createStore({
+        rollUpDay: async () => {
+          throw new Error(
+            "connect ECONNREFUSED postgres://admin:hunter2@db.example.com:5432/analytics",
+          );
+        },
+      }),
+    );
+
+    const line = logs.join("\n");
+    expect(line).toContain("postgres://…");
+    expect(line).not.toContain("hunter2");
+    expect(line).not.toContain("db.example.com");
+  });
+
+  test("an unauthenticated caller is refused before any store work", async () => {
+    let touched = false;
+    const { captured } = await run(
+      createStore({
+        findDaysNeedingRollup: async () => {
+          touched = true;
+          return [];
+        },
+      }),
+      { authorization: null },
+    );
+
+    expect(captured.status).toBe(401);
+    expect(touched).toBe(false);
+  });
+});

--- a/apps/analytics-ingest/test/cron-snapshot.test.ts
+++ b/apps/analytics-ingest/test/cron-snapshot.test.ts
@@ -166,6 +166,26 @@ describe("cron snapshot failure reporting", () => {
     expect(line).not.toContain("db.example.com");
   });
 
+  test("credentials in an error's name never reach the log either", async () => {
+    // `name` is a writable string, not only a class name. The contract says any
+    // connection string is reduced to its scheme, so the whole description is
+    // redacted — not just the message half of it.
+    const { logs } = await run(
+      createStore({
+        rollUpDay: async () => {
+          const error = new Error("connection refused");
+          error.name = "postgres://admin:hunter2@db.example.com:5432/analytics";
+          throw error;
+        },
+      }),
+    );
+
+    const line = logs.join("\n");
+    expect(line).toContain("postgres://…");
+    expect(line).not.toContain("hunter2");
+    expect(line).not.toContain("db.example.com");
+  });
+
   test("an unauthenticated caller is refused before any store work", async () => {
     let touched = false;
     const { captured } = await run(


### PR DESCRIPTION
Started from "the snapshot data isn't updating." It **is** updating — the cron is
healthy. What follows is what I found while proving that, and the two real
defects behind it.

## The cron is not broken

```
GET /metrics/daily.json  ->  day: 2026-09-09,  updatedAt: 2026-09-10 00:27:00 UTC
```

The `"5 0 * * *"` job ran at 00:27 UTC and did its work. It looks two days stale
only from IST: at 00:59 IST on Sept 11 the newest **complete UTC day** is
Sept 09, because UTC Sept 10 does not close until 05:30 IST.

## Why the schedule is deliberately unchanged

`snapshotDayKey()` is `now - 24h`. At 19:30 UTC (1 AM IST) that lands on `D-1`
while day `D` still has 4.5 hours to run, so each UTC day would be rolled up
~19.5 hours after closing instead of ~0.5. Moving the cron to 1 AM IST makes the
public payload **~19 hours staler**, and nothing would error — `snapshotDayKey`
stays correct at every clock time, so the numbers would just quietly be older.

Complete UTC-day data cannot exist before 05:30 IST. Getting it by 1 AM would
require redefining the analytics day as IST, which changes what `day` means,
puts a permanent UTC→IST discontinuity in the series, and shifts the small-cell
suppression buckets. Not done here.

Separately: the 00:05 → 00:27 drift is consistent with Vercel **Hobby**, where
crons fire "within the hour" and only one per day is allowed. I could not verify
the plan from the repo — worth confirming in the dashboard, because on Hobby an
exact cron minute is not honoured anyway.

## Defect 1 — a retention failure was reported as a failed snapshot

`rollUpDay`, `pruneRawBefore` and `pruneLifetimeBefore` are separate statements
in separate transactions (`postgres-store.ts`); nothing wraps them together. So
a prune that throws leaves the rollup **already committed** — and the old
handler answered 503, marking the run failed for a day whose data had landed.
A `pruneRaw` failure also skipped `pruneLifetime` entirely, since one `try`
covered both.

Retention now keeps the 200 the committed rollup earned, names the skipped sweep
in the operator-only `deferred` array, and each sweep runs independently.

## Defect 2 — nothing recorded what failed

One `catch {}` discarded the error, and there is no `console.*` or logger
anywhere in `apps/analytics-ingest`. Each stage now logs to stderr with any
connection string reduced to its scheme, so a password never reaches a log.

**The reply body is unchanged.** A rollup failure still answers the same opaque
`upstream_unavailable` every other endpoint returns — an unauthenticated caller
learns nothing new.

## The handler was untested

Only `api/ping.ts` had a handler test. This follows `createRelayRpcHandler` in
`apps/relay-server`: a factory taking an injectable config, default export
unchanged, so a test supplies a store without `mock.module` (process-global in
Bun, applied at file-load time — the repo avoids it deliberately).

Six tests: both failure paths, the credential redaction, and that an
unauthenticated caller is refused before any store work.

## Verification

- `bun run typecheck --force` — 14/14, 0 cached
- `bun run lint --force` — 12/12, 0 warnings
- `bun run test -- --force` — 23/23, 0 failures
- `bun run verify:doc-paths` — clean
- `apps/analytics-ingest/vercel.json` — **not modified**

`.docs/analytics-privacy-contract.md` updated in the same change set, as its own
last line requires. `docs/users/reliability-and-privacy.mdx` is untouched on
purpose: the public payload, retention thresholds and suppression are all
byte-identical, so nothing a user can observe changed.

https://claude.ai/code/session_015oRmB2pFEhVuMHrx4iSmcM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Analytics snapshots now preserve successful rollup results even when retention cleanup cannot complete.
  - Rollup failures return a clear service-unavailable response, while retention issues keep the successful response and identify deferred cleanup.
  - Retention cleanup is skipped when configured retention is nonpositive and retried during the next scheduled run.

- **Documentation**
  - Documented snapshot processing, response behavior, deferred cleanup reporting, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->