### PR TITLE
test: make download cancellation and polling synchronization deterministic

### DIFF
--- a/.docs/testing-strategy.md
+++ b/.docs/testing-strategy.md
@@ -164,6 +164,19 @@ dropped. Step-level `timeout-minutes` in CI stays the real hang detector.
 
 ### Determinism: prefer `simulateTicks` over `countCommits`
 
+For asynchronous process tests, await a fixture-owned process-start promise
+before asserting active-process cancellation. A persisted download `running`
+lease precedes stream resolution and process registration; it is not a process
+readiness signal. A synchronous spawn acknowledgment resumes its awaiting test
+only after the production call finishes registering the returned handle. Keep
+pre-registration cancellation tests separate from active-process tests.
+
+The polling helper in `apps/cli/test/support/wait-until.ts` accepts both `now`
+and `tick`. Inject both when testing its deadlines, advance the clock from the
+tick, and assert predicate/tick behavior rather than elapsed wall time. Exercise
+readiness exactly at the deadline to cover the final predicate check. Ordinary
+callers retain the real clock, bounded polling, and descriptive timeout errors.
+
 `countCommits` uses real `setTimeout`, which is sensitive to CI load. The same
 property — "this surface commits at most N frames in a window" — is usually
 provable with `simulateTicks` instead, with no time dependence. Keep

--- a/apps/cli/test/support/wait-until.ts
+++ b/apps/cli/test/support/wait-until.ts
@@ -27,6 +27,8 @@ export async function waitUntil(
   options: {
     readonly timeoutMs?: number;
     readonly label?: string;
+    /** Advance this clock with tick when testing deadline behavior deterministically. */
+    readonly now?: () => number;
     /**
      * How to yield between polls. Ink/React suites pass an `act()`-wrapped
      * sleep, because state updates flushed outside an act boundary make React
@@ -37,9 +39,10 @@ export async function waitUntil(
 ): Promise<void> {
   const timeoutMs = options.timeoutMs ?? 5_000;
   const tick = options.tick ?? ((ms: number) => Bun.sleep(ms));
-  const deadline = Date.now() + timeoutMs;
+  const now = options.now ?? Date.now;
+  const deadline = now() + timeoutMs;
 
-  while (Date.now() < deadline) {
+  while (now() < deadline) {
     if (predicate()) return;
     await tick(5);
   }

--- a/apps/cli/test/unit/services/download/download-service.test.ts
+++ b/apps/cli/test/unit/services/download/download-service.test.ts
@@ -1369,6 +1369,7 @@ describe("DownloadService", () => {
   });
 
   test("aborts active process and marks job aborted", async () => {
+    const processStarted = Promise.withResolvers<void>();
     const service = buildService({
       repo,
       downloadsEnabled: true,
@@ -1381,18 +1382,18 @@ describe("DownloadService", () => {
       resolveExit = resolve;
     });
     const killSignals: unknown[] = [];
-    spawnSpy.mockImplementation(
-      () =>
-        ({
-          stdout: streamOf(""),
-          stderr: streamOf(""),
-          exited,
-          kill: (signal?: unknown) => {
-            killSignals.push(signal);
-            if (signal === "SIGKILL") resolveExit?.(1);
-          },
-        }) as never,
-    );
+    spawnSpy.mockImplementation(() => {
+      processStarted.resolve();
+      return {
+        stdout: streamOf(""),
+        stderr: streamOf(""),
+        exited,
+        kill: (signal?: unknown) => {
+          killSignals.push(signal);
+          if (signal === "SIGKILL") resolveExit?.(1);
+        },
+      } as never;
+    });
 
     const job = await service.enqueue({
       title: { id: "tmdb:1", type: "series", name: "Example" },
@@ -1402,7 +1403,9 @@ describe("DownloadService", () => {
     });
 
     const running = service.processQueue();
-    await waitUntil(() => repo.get(job.id)?.status === "running");
+    // Await the spawn acknowledgment, not the earlier durable running lease.
+    // Registration finishes synchronously before this continuation resumes.
+    await processStarted.promise;
     await service.abort(job.id);
     await running;
 
@@ -1411,6 +1414,7 @@ describe("DownloadService", () => {
   });
 
   test("pauses active downloads for shutdown and leaves them retryable", async () => {
+    const processStarted = Promise.withResolvers<void>();
     const service = buildService({
       repo,
       downloadsEnabled: true,
@@ -1423,17 +1427,17 @@ describe("DownloadService", () => {
     const exited = new Promise<number>((resolve) => {
       resolveExit = resolve;
     });
-    spawnSpy.mockImplementation(
-      () =>
-        ({
-          stdout: streamOf(""),
-          stderr: streamOf(""),
-          exited,
-          kill: (signal?: unknown) => {
-            if (signal === "SIGKILL") resolveExit?.(1);
-          },
-        }) as never,
-    );
+    spawnSpy.mockImplementation(() => {
+      processStarted.resolve();
+      return {
+        stdout: streamOf(""),
+        stderr: streamOf(""),
+        exited,
+        kill: (signal?: unknown) => {
+          if (signal === "SIGKILL") resolveExit?.(1);
+        },
+      } as never;
+    });
 
     const job = await service.enqueue({
       title: { id: "tmdb:1", type: "series", name: "Example" },
@@ -1443,7 +1447,7 @@ describe("DownloadService", () => {
     });
 
     const running = service.processQueue();
-    await waitUntil(() => repo.get(job.id)?.status === "running");
+    await processStarted.promise;
     await service.pauseActiveJobsForShutdown("download paused by test shutdown");
     await running;
 
@@ -2183,6 +2187,7 @@ describe("DownloadService", () => {
   });
 
   test("pauseActiveJobsForShutdown honors explicit shutdown wait budgets", async () => {
+    const processStarted = Promise.withResolvers<void>();
     const service = buildService({
       repo,
       downloadsEnabled: true,
@@ -2194,15 +2199,15 @@ describe("DownloadService", () => {
     const exited = new Promise<number>((resolve) => {
       exitProcess = resolve;
     });
-    spawnSpy.mockImplementation(
-      () =>
-        ({
-          stdout: streamOf(""),
-          stderr: streamOf(""),
-          exited,
-          kill: () => exitProcess(0),
-        }) as never,
-    );
+    spawnSpy.mockImplementation(() => {
+      processStarted.resolve();
+      return {
+        stdout: streamOf(""),
+        stderr: streamOf(""),
+        exited,
+        kill: () => exitProcess(0),
+      } as never;
+    });
 
     const job = await service.enqueue({
       title: { id: "tmdb:1", type: "series", name: "Example" },
@@ -2211,7 +2216,7 @@ describe("DownloadService", () => {
       providerId: "vidking",
     });
     const running = service.processQueue();
-    await waitUntil(() => repo.get(job.id)?.status === "running");
+    await processStarted.promise;
 
     const startedAt = Date.now();
     await service.pauseActiveJobsForShutdown("download paused by shutdown", {

--- a/apps/cli/test/unit/services/download/youtube-download.test.ts
+++ b/apps/cli/test/unit/services/download/youtube-download.test.ts
@@ -136,21 +136,34 @@ describe("DownloadService youtube argv contract", () => {
   });
 
   test("abort calls runYtDlpProcess cancel handle", async () => {
+    const resolving = Promise.withResolvers<void>();
+    const releaseResolution = Promise.withResolvers<void>();
+    const processStarted = Promise.withResolvers<void>();
     const cancel = mock(() => {});
     let resolveCompleted!: (value: { exitCode: number; stderr: string }) => void;
     const completed = new Promise<{ exitCode: number; stderr: string }>((resolve) => {
       resolveCompleted = resolve;
     });
-    runYtDlpSpy.mockImplementation(() => ({
-      process: { kill: mock(() => {}) } as never,
-      completed,
-      cancel,
-    }));
+    runYtDlpSpy.mockImplementation(() => {
+      processStarted.resolve();
+      return {
+        process: {
+          kill: mock(() => {}),
+          exited: completed.then(({ exitCode }) => exitCode),
+        } as never,
+        completed,
+        cancel,
+      };
+    });
 
     const service = buildYoutubeService({
       repo,
       downloadPath: tempDir,
-      resolveDownloadStream: async () => youtubeResolveResult() as unknown as DownloadResolveResult,
+      resolveDownloadStream: async () => {
+        resolving.resolve();
+        await releaseResolution.promise;
+        return youtubeResolveResult() as unknown as DownloadResolveResult;
+      },
       abortGraceMs: 0,
     });
 
@@ -165,12 +178,20 @@ describe("DownloadService youtube argv contract", () => {
       mode: "youtube",
     });
     const processPromise = service.processQueue();
-    await Bun.sleep(20);
-    await service.abort(job.id);
+    await resolving.promise;
+    expect(repo.get(job.id)?.status).toBe("running");
+    expect(runYtDlpSpy).not.toHaveBeenCalled();
+    releaseResolution.resolve();
+    // The mock resolves this synchronously; the continuation resumes after
+    // executeYtDlpDownload has registered the returned process handle.
+    await processStarted.promise;
+    const aborting = service.abort(job.id);
     resolveCompleted({ exitCode: 1, stderr: "terminated" });
+    await aborting;
     await processPromise;
 
     expect(cancel).toHaveBeenCalled();
+    expect(repo.get(job.id)?.status).toBe("aborted");
   });
 });
 

--- a/apps/cli/test/unit/support/wait-until.test.ts
+++ b/apps/cli/test/unit/support/wait-until.test.ts
@@ -2,47 +2,72 @@ import { expect, test } from "bun:test";
 
 import { waitUntil } from "../../support/wait-until";
 
-test("returns as soon as the predicate holds, without burning the budget", async () => {
-  let calls = 0;
-  const started = Date.now();
-  await waitUntil(() => {
-    calls += 1;
-    return calls >= 2;
+test("returns after one tick when the predicate becomes ready", async () => {
+  let ticks = 0;
+  let elapsed = 0;
+  await waitUntil(() => ticks === 1, {
+    now: () => elapsed,
+    tick: async (ms) => {
+      expect(ms).toBe(5);
+      elapsed += ms;
+      ticks += 1;
+    },
   });
-  // A generous ceiling must cost nothing when the condition arrives early.
-  expect(Date.now() - started).toBeLessThan(1_000);
+  expect(ticks).toBe(1);
 });
 
-test("returns immediately when the predicate already holds", async () => {
-  const started = Date.now();
-  await waitUntil(() => true);
-  expect(Date.now() - started).toBeLessThan(100);
+test("does not tick when the predicate already holds", async () => {
+  let ticks = 0;
+  await waitUntil(() => true, {
+    now: () => 0,
+    tick: async () => {
+      ticks += 1;
+    },
+  });
+  expect(ticks).toBe(0);
 });
 
-/**
- * The property the unbounded `while (!cond) await Bun.sleep(1)` loops lacked:
- * they could not fail, only hang until the runner's global timeout, which
- * reports as a timeout rather than as the condition that never held.
- */
-test("a condition that never holds fails, and names what was waited for", async () => {
-  await expect(waitUntil(() => false, { timeoutMs: 50, label: "outbox drained" })).rejects.toThrow(
-    /waitUntil\(outbox drained\) timed out after 50ms/,
-  );
+test.each([
+  { label: "outbox drained", message: "waitUntil(outbox drained) timed out after 50ms" },
+  { label: undefined, message: "waitUntil timed out after 50ms" },
+])("a condition that never holds rejects: $message", async ({ label, message }) => {
+  let elapsed = 0;
+  let ticks = 0;
+  const waiting = waitUntil(() => false, {
+    now: () => elapsed,
+    timeoutMs: 50,
+    label,
+    tick: async (ms) => {
+      elapsed += ms;
+      ticks += 1;
+      // A missing clock seam must fail immediately, not spin until real time passes.
+      if (ticks > 10) throw new Error("polled past the injected deadline");
+    },
+  });
+  await expect(waiting).rejects.toThrow(message);
+  expect(ticks).toBe(10);
 });
 
-test("without a label it still reports a timeout rather than hanging", async () => {
-  await expect(waitUntil(() => false, { timeoutMs: 50 })).rejects.toThrow(
-    /waitUntil timed out after 50ms/,
-  );
-});
-
-test("a condition that becomes true on the deadline tick is not a failure", async () => {
-  // The loop can exit on the deadline in the same tick the condition flips;
-  // failing then would be its own flake.
+test("accepts readiness at the deadline without another tick", async () => {
+  let elapsed = 0;
   let ready = false;
-  setTimeout(() => {
-    ready = true;
-  }, 40);
-  await waitUntil(() => ready, { timeoutMs: 200, label: "late flip" });
-  expect(ready).toBe(true);
+  let ticks = 0;
+  let predicateCalls = 0;
+  await waitUntil(
+    () => {
+      predicateCalls += 1;
+      return ready;
+    },
+    {
+      now: () => elapsed,
+      timeoutMs: 50,
+      tick: async () => {
+        ticks += 1;
+        elapsed = 50;
+        ready = true;
+      },
+    },
+  );
+  expect(ticks).toBe(1);
+  expect(predicateCalls).toBe(2);
 });


### PR DESCRIPTION
## Summary
- Synchronize cancellation tests on the downloader registration seam instead of a fixed sleep or a persisted running state.
- Inject the clock and tick into waitUntil tests so deadline behavior is deterministic and meaningful coverage is preserved.
- Document process-readiness and clock guidance. Test/support/docs only; no production behavior change or release changeset.

## Verification
- Focused tests: 64 passed, 235 assertions.
- Fresh serial full suite: 6975 passed, 59 skipped, 0 failed; 23 uncached tasks.
- Fresh typecheck, lint, formatting and documentation-path checks passed.
- The first full run under competing full-suite/push-hook load hit an existing installer concurrency timeout. The isolated rerun passed (201 ms) and serial full rerun passed (306 ms for that test); this PR does not claim that installer flake is fixed.

## Follow-up
The test work exposed a separate production bug: cancellation during stream resolution can still launch a downloader. That fix is being prepared as a separately reviewable stacked PR.