### PR TITLE
fix: close six audit findings that fail silently

### DIFF
--- a/.docs/mpv-in-process-reconnect.md
+++ b/.docs/mpv-in-process-reconnect.md
@@ -1,6 +1,6 @@
 ---
 status: current
-lastReviewed: "2026-08-13"
+lastReviewed: "2026-09-12"
 ---
 
 # mpv in-process stream reconnect (persistent session)
@@ -32,16 +32,24 @@ If reconnect **fails** or limits are hit, the cycle ends and the usual `Playback
 
 ## Limits and backoff
 
-- **`mpvInProcessStreamReconnectMaxAttempts`** (default `3`, max `12`): counts **started** reloads per playback cycle (new episode resets the counter).
+- **`mpvInProcessStreamReconnectMaxAttempts`** (default `1`, and `1` is also the
+  cap): counts **started** reloads per playback cycle (new episode resets the
+  counter). `ConfigServiceImpl` clamps whatever is persisted down to
+  `MPV_IN_PROCESS_RECONNECT_MAX_ATTEMPTS` in `packages/config/src/defaults.ts`,
+  so a hand-edited `config.json` asking for more gets one attempt. A dead stream
+  answers a reload as fast as a live one, so a larger budget buys a retry loop
+  against a URL that is not coming back. (`PersistentMpvSession.create` bounds a
+  raw injected config at a higher structural ceiling — that path is for the test
+  harness and the compiled smoke, not for user configuration.)
 - **Backoff** after a failed `loadfile`: exponential from a base delay, capped (see `PersistentMpvSession` constants). Prevents hammering a dead CDN.
 - **`reconnectInFlight`**: serializes overlapping reconnect work.
 
 ## Configuration (`~/.config/kunai/config.json`)
 
-| Field                                    | Default | Meaning                                                                                                    |
-| ---------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------- |
-| `mpvInProcessStreamReconnect`            | `true`  | Master switch. `false` disables automatic same-URL reloads (manual **Ctrl+r** / shell refresh still work). |
-| `mpvInProcessStreamReconnectMaxAttempts` | `3`     | Max reload attempts **per episode play**. Set `0` to disable (same as turning off retries).                |
+| Field                                    | Default | Meaning                                                                                                       |
+| ---------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------- |
+| `mpvInProcessStreamReconnect`            | `true`  | Master switch. `false` disables automatic same-URL reloads (manual **Ctrl+r** / shell refresh still work).    |
+| `mpvInProcessStreamReconnectMaxAttempts` | `1`     | Max reload attempts **per episode play**, and also the cap. Set `0` to disable (same as turning off retries). |
 
 ## Relationship to other recovery
 

--- a/.docs/share-links.md
+++ b/.docs/share-links.md
@@ -1,6 +1,6 @@
 ---
 status: current
-lastReviewed: "2026-08-24"
+lastReviewed: "2026-09-12"
 ---
 
 # Share Links & PlaybackTargetRef
@@ -14,7 +14,7 @@ The web code is a checksummed, base64url-encoded ref. The landing page is a pure
 ## URL grammar
 
 ```
-kunai://play?cat=<ns>:<id>&kind=<movie|series|anime>&s=<season>&e=<episode>&abs=<absolute>&t=<seconds>&src=<providerId>&sq=<quality>&n=<label>
+kunai://play?cat=<ns>:<id>&kind=<movie|series|anime|video>&s=<season>&e=<episode>&abs=<absolute>&t=<seconds>&src=<providerId>&sq=<quality>&n=<label>
 kunai://download?...   # same query params, queues a download instead of playback
 ```
 
@@ -26,17 +26,17 @@ kunai://play?q=<query>&kind=...
 
 ### Parameters
 
-| Param     | Meaning                                                                          |
-| --------- | -------------------------------------------------------------------------------- |
-| `cat`     | Catalog anchor: `tmdb`, `anilist`, `mal`, or `imdb` namespace + id (`tmdb:1396`) |
-| `q`       | Search query fallback (mutually exclusive with `cat`)                            |
-| `kind`    | `movie`, `series`, or `anime`                                                    |
-| `s` / `e` | Season and episode (1-based)                                                     |
-| `abs`     | Absolute episode number (anime)                                                  |
-| `t`       | Start timestamp in seconds, `1m23s`, or `1:23`                                   |
-| `src`     | Provider hint (`allanime`, etc.)                                                 |
-| `sq`      | Quality hint                                                                     |
-| `n`       | Human label (not required for resolution)                                        |
+| Param     | Meaning                                                                                                              |
+| --------- | -------------------------------------------------------------------------------------------------------------------- |
+| `cat`     | Catalog anchor: `tmdb`, `anilist`, `mal`, `imdb`, or `youtube` namespace + id (`tmdb:1396`)                          |
+| `q`       | Search query fallback (mutually exclusive with `cat`)                                                                |
+| `kind`    | `movie`, `series`, `anime`, or `video`. Optional: a link without it is read as `series`, whatever the namespace says |
+| `s` / `e` | Season and episode (1-based)                                                                                         |
+| `abs`     | Absolute episode number (anime)                                                                                      |
+| `t`       | Start timestamp in seconds, `1m23s`, or `1:23`                                                                       |
+| `src`     | Provider hint (`allanime`, etc.)                                                                                     |
+| `sq`      | Quality hint                                                                                                         |
+| `n`       | Human label (not required for resolution)                                                                            |
 
 Parser returns `null` when neither `cat` nor `q` is present, or when the catalog namespace is invalid.
 

--- a/apps/cli/src/domain/media/episode-cursor.ts
+++ b/apps/cli/src/domain/media/episode-cursor.ts
@@ -27,20 +27,42 @@ export function isNormalEpisodeCursor(cursor: EpisodeCursor): boolean {
   return typeof cursor.absoluteEpisode === "number" || typeof cursor.episode === "number";
 }
 
+/**
+ * Orders two cursors of the *same* shape.
+ *
+ * Absolute against absolute wins outright; otherwise it is season, then
+ * episode, with a missing season read as 0 so an unseasoned cursor sorts below
+ * season 1.
+ *
+ * Mixed shapes — one side absolute-only, the other season/episode — are not
+ * comparable and return 0, because the two numbering schemes have no shared
+ * scale: absolute 25 is not "greater than" S2E3 by any arithmetic available
+ * here. Ordering them would fabricate an answer, and a caller picking a highest
+ * cursor would act on it. The producers do not mix shapes today —
+ * `toReleaseReconciliationHistoryRows` normalises every row to season+episode
+ * before a cursor exists — so this is the contract, not a live hazard.
+ */
 export function compareEpisodeCursors(left: EpisodeCursor, right: EpisodeCursor): number {
-  if (typeof left.absoluteEpisode === "number" && typeof right.absoluteEpisode === "number") {
-    return left.absoluteEpisode - right.absoluteEpisode;
+  const leftAbsolute = left.absoluteEpisode;
+  const rightAbsolute = right.absoluteEpisode;
+  if (typeof leftAbsolute === "number" && typeof rightAbsolute === "number") {
+    return leftAbsolute - rightAbsolute;
   }
+
+  const leftEpisode = left.episode;
+  const rightEpisode = right.episode;
+  const leftIsNumbered = typeof leftEpisode === "number";
+  const rightIsNumbered = typeof rightEpisode === "number";
+  // One side numbers by season/episode and the other only absolutely.
+  // `isNormalEpisodeCursor` guarantees each carries at least one of the two, so
+  // this is the mixed case rather than an empty cursor.
+  if (leftIsNumbered !== rightIsNumbered) return 0;
 
   const seasonDelta = (left.season ?? 0) - (right.season ?? 0);
   if (seasonDelta !== 0) return seasonDelta;
 
-  if (typeof left.episode === "number" && typeof right.episode === "number") {
-    return left.episode - right.episode;
-  }
-
-  if (typeof left.absoluteEpisode === "number" && typeof right.absoluteEpisode === "number") {
-    return left.absoluteEpisode - right.absoluteEpisode;
+  if (typeof leftEpisode === "number" && typeof rightEpisode === "number") {
+    return leftEpisode - rightEpisode;
   }
 
   return 0;

--- a/apps/cli/src/infra/player/PersistentMpvSession.ts
+++ b/apps/cli/src/infra/player/PersistentMpvSession.ts
@@ -20,6 +20,7 @@ import { buildMpvArgs, shouldApplyStartAtSeek } from "@/mpv";
 import type { KitsuneConfig } from "@/services/persistence/ConfigService";
 import { resolveTuning } from "@/services/persistence/tuning";
 import { checkStreamPreflight } from "@/services/playback/stream-health-check";
+import { MPV_IN_PROCESS_RECONNECT_MAX_ATTEMPTS } from "@kunai/config";
 
 import {
   buildKunaiBridgeScriptOptsArg,
@@ -84,6 +85,14 @@ export {
 
 const IN_PROCESS_RECONNECT_BASE_BACKOFF_MS = 1_800;
 const IN_PROCESS_RECONNECT_MAX_BACKOFF_MS = 16_000;
+
+/**
+ * Upper bound on a reconnect budget handed to `create` in a raw config object.
+ * Well above the persisted cap (`MPV_IN_PROCESS_RECONNECT_MAX_ATTEMPTS`) so the
+ * session harness can drive multi-attempt paths; nothing a user can configure
+ * reaches it.
+ */
+const RECONNECT_ATTEMPT_CEILING = 12;
 
 type InProcessReconnectTrigger = "network-read-dead" | "premature-eof" | "error";
 
@@ -363,10 +372,19 @@ export class PersistentMpvSession {
     const cfg = opts.kitsuneConfig;
     session.mpvInProcessStreamReconnectEnabled = cfg.mpvInProcessStreamReconnect !== false;
     const maxAttempts = cfg.mpvInProcessStreamReconnectMaxAttempts;
+    // The fallback is the shipped default, not a number of its own. It read 3
+    // while the default has been 1 and `ConfigServiceImpl` has capped persisted
+    // values at 1 — so a config that reached here without the key got a budget
+    // the CLI does not offer anywhere in its UI.
+    //
+    // `RECONNECT_ATTEMPT_CEILING` stays above that cap on purpose: it bounds a
+    // raw config object handed straight to this factory (compiled smoke, the
+    // session harness), which never passes through the persisted clamp. It is a
+    // structural guard against a nonsense value, not the user-facing policy.
     session.mpvInProcessStreamReconnectMaxAttempts =
       typeof maxAttempts === "number" && Number.isFinite(maxAttempts)
-        ? Math.max(0, Math.min(12, Math.trunc(maxAttempts)))
-        : 3;
+        ? Math.max(0, Math.min(RECONNECT_ATTEMPT_CEILING, Math.trunc(maxAttempts)))
+        : MPV_IN_PROCESS_RECONNECT_MAX_ATTEMPTS;
     const tuning = resolveTuning(cfg.tuningOverrides);
     session.reconnectBaseBackoffMs = tuning.mpvReconnectBaseBackoffMs;
     session.reconnectMaxBackoffMs = tuning.mpvReconnectMaxBackoffMs;

--- a/apps/cli/src/infra/player/kunai-mpv-bridge.ts
+++ b/apps/cli/src/infra/player/kunai-mpv-bridge.ts
@@ -81,6 +81,12 @@ export function buildKunaiBridgeScriptOptsArg(
   for (const [k, v] of Object.entries(opts)) {
     const key = k.trim();
     if (!key || v === "") continue;
+    // mpv splits `--script-opts` on commas and a key on its first `=`, with no
+    // escape for either. An entry carrying one cannot be represented, and
+    // emitting it anyway does not fail loudly — it silently redefines the
+    // neighbouring option or truncates this one. Dropping it is the honest
+    // outcome, as with a comma in a stream header value.
+    if (key.includes(",") || key.includes("=") || v.includes(",")) continue;
     parts.push(`${SCRIPT_OPTS_ID}-${key}=${v}`);
   }
   if (parts.length === 0) return undefined;

--- a/apps/cli/src/infra/player/mpv-stream-http-headers.ts
+++ b/apps/cli/src/infra/player/mpv-stream-http-headers.ts
@@ -37,6 +37,19 @@ export type NormalizedStreamHttpHeaders = {
 /** Headers mpv sets through dedicated options rather than the header list. */
 const DEDICATED_HEADER_NAMES = new Set(["referer", "user-agent", "origin"]);
 
+/**
+ * RFC 7230 token: the characters a header name may contain.
+ *
+ * Values are sanitised below, but the names were not, and they are not ours —
+ * a provider builds its header map partly from what the upstream API answered
+ * (VidLink spreads `stream.headers` into its payload). A name carrying a comma
+ * splits one field into two inside `http-header-fields`, and one carrying a
+ * colon or CR/LF writes a field the host never sent us. Nothing legitimate
+ * needs a character outside this set, so an odd name is dropped rather than
+ * forwarded.
+ */
+const HEADER_NAME_PATTERN = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+
 /** Canonical HTTP header fields used for mpv launch args and persistent loadfile options. */
 export function normalizeStreamHttpHeaders(
   headers: Record<string, string> | undefined,
@@ -51,8 +64,10 @@ export function normalizeStreamHttpHeaders(
     return sanitized.length > 0 ? sanitized : undefined;
   };
   const extraFields: string[] = [];
-  for (const [name, value] of Object.entries(source)) {
+  for (const [rawName, value] of Object.entries(source)) {
+    const name = rawName.trim();
     if (DEDICATED_HEADER_NAMES.has(name.toLowerCase())) continue;
+    if (!HEADER_NAME_PATTERN.test(name)) continue;
     const cleaned = sanitize(value, /[\r\n]/g);
     if (!cleaned) continue;
     // mpv separates this list on commas and offers no escape, so a value

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -203,19 +203,23 @@ function getShutdownCoordinator(): ShutdownCoordinator {
   return shutdownCoordinator;
 }
 
-async function maybeRunOfflineMode(
+/**
+ * `--offline` opens the library and then plays on: offline is a starting
+ * surface, not a mode that owns the process. This deliberately does not end the
+ * run, which is why it reports nothing — it used to return `false`
+ * unconditionally while its caller branched on the result, so the exit path
+ * behind that branch had never run.
+ */
+function openOfflineLibrary(
   args: { offline: boolean },
   container: Awaited<ReturnType<typeof createContainer>>,
-): Promise<boolean> {
-  if (!args.offline) {
-    return false;
-  }
+): void {
+  if (!args.offline) return;
 
   container.stateManager.dispatch({
     type: "OPEN_OVERLAY",
     overlay: { type: "library", view: "library" },
   });
-  return false;
 }
 
 type StartupHistoryTarget = {
@@ -1133,12 +1137,7 @@ export async function runCli(argv = process.argv.slice(2)): Promise<void> {
     container,
     loadSetupWorkflow: () => import("./app-shell/workflows/setup-workflows"),
   });
-  if (await maybeRunOfflineMode(args, container)) {
-    await shutdownShell();
-    await disposeContainer(container);
-    if (process.stdin.isTTY) process.stdin.unref();
-    return;
-  }
+  openOfflineLibrary(args, container);
   if (await maybeRunDownloadMode(args, container, bootstrapTitle)) {
     await shutdownShell();
     await disposeContainer(container);

--- a/apps/cli/src/services/analytics/usage-analytics-service.ts
+++ b/apps/cli/src/services/analytics/usage-analytics-service.ts
@@ -200,22 +200,30 @@ export class UsageAnalyticsService {
     }
     if (!canSend(state)) return { kind: "quiet" };
 
-    this.pingInBackground();
+    this.pingInBackground(options);
     return { kind: "pinged" };
   }
 
   /** Fire-and-forget; never blocks startup/playback. Failures are silent. */
-  pingInBackground(): void {
-    void this.maybePing().catch(() => {
+  pingInBackground(options: { readonly isInteractive: boolean }): void {
+    void this.maybePing(options).catch(() => {
       // Silent by design — analytics must never surface as a user-facing failure.
     });
   }
 
-  async maybePing(): Promise<void> {
+  /**
+   * `isInteractive` is the caller's, never assumed. This gate is deliberately a
+   * second one — `onSessionStart` has already refused a non-TTY session — but a
+   * second gate that hardcodes the permissive answer is not a gate. Non-TTY is a
+   * hard delivery bar even for an opted-in install (`consent-policy.ts`), so
+   * re-deriving it as `true` here would make the next caller of this method a
+   * contract breach rather than a bug.
+   */
+  async maybePing(options: { readonly isInteractive: boolean }): Promise<void> {
     const config = this.deps.config.getRaw();
     const state = resolveConsentState({
       env: this.env,
-      isInteractive: true,
+      isInteractive: options.isInteractive,
       stored: config.analytics,
     });
     if (!canSend(state)) return;

--- a/apps/cli/src/services/diagnostics/retention.ts
+++ b/apps/cli/src/services/diagnostics/retention.ts
@@ -1,4 +1,4 @@
-import { readdir, rm, stat } from "node:fs/promises";
+import { lstat, readdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 
 export async function pruneOldDiagnosticFiles({
@@ -26,8 +26,14 @@ export async function pruneOldDiagnosticFiles({
         .map(async (entry) => {
           const path = join(dir, entry);
           try {
-            const stats = await stat(path);
-            return stats.isFile() ? { entry, path, mtimeMs: stats.mtimeMs } : null;
+            // `lstat`, so a symlink is judged as itself rather than by whatever
+            // it points at. `rm` unlinks the link either way, so following it
+            // only ever meant sorting by a target's mtime — and letting a link
+            // planted in the diagnostics directory decide which real files are
+            // old enough to delete.
+            const stats = await lstat(path);
+            const prunable = stats.isFile() || stats.isSymbolicLink();
+            return prunable ? { entry, path, mtimeMs: stats.mtimeMs } : null;
           } catch {
             return null;
           }

--- a/apps/cli/src/services/persistence/ConfigServiceImpl.ts
+++ b/apps/cli/src/services/persistence/ConfigServiceImpl.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_OFFLINE_RUNWAY_TARGET,
   DEFAULT_UNKNOWN_EPISODE_ESTIMATE_BYTES,
 } from "@/services/download/StorageBudgetPolicy";
+import { MPV_IN_PROCESS_RECONNECT_MAX_ATTEMPTS } from "@kunai/config";
 import { migrateLegacyProviderId } from "@kunai/providers";
 import { normalizeRelayBaseUrl as normalizeRelayBaseUrlValue } from "@kunai/relay";
 import type { ProviderRelayConfig, StartupPriority } from "@kunai/types";
@@ -883,8 +884,10 @@ function normalizeRunwayTarget(value: unknown): number {
 }
 
 function normalizeMpvReconnectAttempts(value: unknown): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) return 1;
-  return Math.max(0, Math.min(1, Math.trunc(value)));
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return MPV_IN_PROCESS_RECONNECT_MAX_ATTEMPTS;
+  }
+  return Math.max(0, Math.min(MPV_IN_PROCESS_RECONNECT_MAX_ATTEMPTS, Math.trunc(value)));
 }
 
 function normalizeMaxConcurrentDownloads(value: unknown): number {

--- a/apps/cli/test/integration/analytics-wire-contract.test.ts
+++ b/apps/cli/test/integration/analytics-wire-contract.test.ts
@@ -88,7 +88,7 @@ describe("CLI → ingest → docs wire contract", () => {
     const config = makeConfig({ analytics: "enabled", installId: "" });
     const { service, results } = wireCliToIngest({ store, config });
 
-    await service.maybePing();
+    await service.maybePing({ isInteractive: true });
 
     expect(results).toHaveLength(1);
     // `stored` reports whether the day's global write budget admitted the ping,
@@ -109,7 +109,7 @@ describe("CLI → ingest → docs wire contract", () => {
     for (const machine of fleet) {
       const config = makeConfig({ analytics: "enabled", installId: "" });
       const { service } = wireCliToIngest({ store, ...machine, config });
-      await service.maybePing();
+      await service.maybePing({ isInteractive: true });
     }
 
     const rollup = await store.rollUpDay(utcDayKey(NOW));
@@ -123,7 +123,7 @@ describe("CLI → ingest → docs wire contract", () => {
     const store = createMemoryAnalyticsStore();
     const config = makeConfig({ analytics: "enabled", installId: "" });
     const { service } = wireCliToIngest({ store, config });
-    await service.maybePing();
+    await service.maybePing({ isInteractive: true });
 
     const rollup = await store.rollUpDay(utcDayKey(NOW));
     const published = buildPublicMetrics({ ...rollup, computedAt: new Date(NOW).toISOString() });
@@ -143,7 +143,7 @@ describe("CLI → ingest → docs wire contract", () => {
     const store = createMemoryAnalyticsStore();
     const config = makeConfig({ analytics: "enabled", installId: "" });
     const { service } = wireCliToIngest({ store, config, os: "win32", arch: "arm64" });
-    await service.maybePing();
+    await service.maybePing({ isInteractive: true });
 
     const published = buildPublicMetrics(await store.rollUpDay(utcDayKey(NOW)));
 
@@ -180,7 +180,7 @@ describe("CLI → ingest → docs wire contract", () => {
     const config = makeConfig({ analytics: "disabled", installId: "" });
     const { service, results } = wireCliToIngest({ store, config });
 
-    await service.maybePing();
+    await service.maybePing({ isInteractive: true });
     await service.onSessionStart({ isInteractive: true });
 
     expect(results).toEqual([]);

--- a/apps/cli/test/unit/domain/media/episode-cursor.test.ts
+++ b/apps/cli/test/unit/domain/media/episode-cursor.test.ts
@@ -26,6 +26,29 @@ describe("episode cursor", () => {
     ).toBeGreaterThan(0);
   });
 
+  test("reports mixed numbering as incomparable instead of inventing an order", () => {
+    // Absolute 25 and S2E3 share no scale. The old branch fell through to a
+    // season comparison with a missing season read as 0, so the absolute cursor
+    // sorted below every seasoned one — an answer, but not a true one.
+    const absolute = { absoluteEpisode: 25 };
+    const seasoned = { season: 2, episode: 3 };
+
+    expect(compareEpisodeCursors(absolute, seasoned)).toBe(0);
+    expect(compareEpisodeCursors(seasoned, absolute)).toBe(0);
+    // Carrying both numberings is not mixed: the absolute pair still decides.
+    expect(
+      compareEpisodeCursors(
+        { absoluteEpisode: 25 },
+        { season: 2, episode: 3, absoluteEpisode: 15 },
+      ),
+    ).toBeGreaterThan(0);
+  });
+
+  test("orders a seasonless cursor below a seasoned one", () => {
+    expect(compareEpisodeCursors({ episode: 5 }, { season: 1, episode: 3 })).toBeLessThan(0);
+    expect(compareEpisodeCursors({ episode: 5 }, { episode: 3 })).toBeGreaterThan(0);
+  });
+
   test("picks the highest watched cursor even when an older episode was updated later", () => {
     const highest = pickHighestEpisodeCursor([
       { season: 1, episode: 6, updatedAt: "2026-05-20T00:00:00.000Z" },

--- a/apps/cli/test/unit/infra/player/mpv-stream-http-headers.test.ts
+++ b/apps/cli/test/unit/infra/player/mpv-stream-http-headers.test.ts
@@ -55,6 +55,29 @@ describe("normalizeStreamHttpHeaders", () => {
   test("drops empty header values", () => {
     expect(normalizeStreamHttpHeaders({ referer: "  ", origin: "" })).toEqual({ extraFields: [] });
   });
+
+  test("drops a header name that is not an RFC 7230 token", () => {
+    // Header names are not ours: VidLink spreads what its API answered into the
+    // payload, so an upstream can name a header. A comma in the name splits one
+    // field into two, and a colon or CR/LF writes a field the host never sent.
+    const normalized = normalizeStreamHttpHeaders({
+      "X-Ok": "kept",
+      "X-Bad,X-Injected": "dropped",
+      "X-Bad: Injected": "dropped",
+      "X-Bad\r\nX-Injected": "dropped",
+      "X Bad": "dropped",
+    });
+
+    expect(normalized.extraFields).toEqual(["X-Ok: kept"]);
+  });
+
+  test("keeps the unusual-but-legal characters a token allows", () => {
+    // The pattern is a whitelist, so it has to admit the odd names that are
+    // genuinely valid — dropping those would be the same silent loss.
+    expect(normalizeStreamHttpHeaders({ "X-Odd_Name.1~*": "kept" }).extraFields).toEqual([
+      "X-Odd_Name.1~*: kept",
+    ]);
+  });
 });
 
 describe("shouldDisableMpvTlsVerify", () => {

--- a/apps/cli/test/unit/kunai-mpv-bridge.test.ts
+++ b/apps/cli/test/unit/kunai-mpv-bridge.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  buildKunaiBridgeScriptOptsArg,
   bundledKunaiMpvBridgePath,
   ensureUserKunaiMpvBridge,
 } from "@/infra/player/kunai-mpv-bridge";
@@ -17,6 +18,29 @@ test("bundledKunaiMpvBridgePath resolves to a readable bridge asset", async () =
   const path = bundledKunaiMpvBridgePath();
   expect(existsSync(path)).toBe(true);
   expect(await Bun.file(path).text()).toContain("kunai");
+});
+
+test("buildKunaiBridgeScriptOptsArg joins entries mpv can actually parse", () => {
+  expect(buildKunaiBridgeScriptOptsArg({ margin_bottom: "40", chip_width: "12" })).toBe(
+    "kunai-bridge-margin_bottom=40,kunai-bridge-chip_width=12",
+  );
+  expect(buildKunaiBridgeScriptOptsArg(undefined)).toBeUndefined();
+  expect(buildKunaiBridgeScriptOptsArg({ margin_bottom: "" })).toBeUndefined();
+});
+
+test("buildKunaiBridgeScriptOptsArg drops an entry carrying mpv's separators", () => {
+  // `--script-opts` splits on commas and a key on its first `=`, with no escape
+  // for either. Emitting such an entry does not fail loudly: it redefines the
+  // neighbouring option or truncates this one.
+  expect(
+    buildKunaiBridgeScriptOptsArg({
+      margin_bottom: "40",
+      "chip,width": "12",
+      "chip=width": "12",
+      label: "a,b",
+    }),
+  ).toBe("kunai-bridge-margin_bottom=40");
+  expect(buildKunaiBridgeScriptOptsArg({ "chip,width": "12" })).toBeUndefined();
 });
 
 test("ensureUserKunaiMpvBridge materializes the bridge at the dest", async () => {

--- a/apps/cli/test/unit/services/analytics/usage-analytics-service.test.ts
+++ b/apps/cli/test/unit/services/analytics/usage-analytics-service.test.ts
@@ -272,10 +272,31 @@ describe("endpoint configuration", () => {
       },
     });
 
-    await service.maybePing();
+    await service.maybePing({ isInteractive: true });
 
     expect(calls).toBe(0);
     expect(config.rawRef.lastAnalyticsPingAt).toBe(0);
+  });
+
+  test("an opted-in install sends nothing from a non-interactive session", async () => {
+    // The send gate is `maybePing`'s own, not an assumption about who called it.
+    // A prior opt-in does not let a scripted or piped run emit a ping, and the
+    // only thing that made that true here was the caller checking first.
+    const config = makeConfig({ analytics: "enabled", installId: UUID });
+    let calls = 0;
+    const service = makeService(config, {
+      fetchImpl: async () => {
+        calls += 1;
+        return new Response(null, { status: 204 });
+      },
+    });
+
+    await service.maybePing({ isInteractive: false });
+
+    expect(calls).toBe(0);
+    expect(config.rawRef.lastAnalyticsPingAt).toBe(0);
+    // Nor may a suppressed ping be what mints the identifier.
+    expect(config.rawRef.installId).toBe(UUID);
   });
 
   test("a default endpoint is not consent: the gates are unchanged by it", () => {

--- a/apps/cli/test/unit/services/diagnostics/retention.test.ts
+++ b/apps/cli/test/unit/services/diagnostics/retention.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -26,4 +26,41 @@ describe("diagnostics retention", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  // Creating a symlink on Windows needs a privilege an unelevated CI job does
+  // not have, and the behaviour under test is the stat call, not the platform.
+  test.skipIf(process.platform === "win32")(
+    "ages a symlink by the link itself, never by what it points at",
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), "kunai-retention-"));
+      const outside = await mkdtemp(join(tmpdir(), "kunai-retention-target-"));
+      try {
+        // The target is old and lives outside the pruned directory. Reading its
+        // mtime through the link is what let a planted link decide which real
+        // diagnostics files counted as newest.
+        const target = join(outside, "precious.jsonl");
+        await writeFile(target, "keep me");
+        await utimes(target, new Date("2020-01-01T00:00:00Z"), new Date("2020-01-01T00:00:00Z"));
+
+        const real = join(dir, "kunai-trace-real.jsonl");
+        await writeFile(real, "");
+        await utimes(real, new Date("2021-01-01T00:00:00Z"), new Date("2021-01-01T00:00:00Z"));
+
+        const link = join(dir, "kunai-trace-link.jsonl");
+        await symlink(target, link);
+
+        await pruneOldDiagnosticFiles({ dir, prefix: "kunai-trace-", maxFiles: 1 });
+
+        // Judged as itself the link is the newest entry, so it is the one kept.
+        // Judged by its target it would read as 2020 — older than the real file
+        // — and the real diagnostics file would have been deleted instead.
+        expect(await readdir(dir)).toEqual(["kunai-trace-link.jsonl"]);
+        // Pruning unlinks the link, never the file it names.
+        expect(await readFile(target, "utf8")).toBe("keep me");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+        await rm(outside, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "cliVersion": "0.3.0",
   "cliSourceFingerprint": "9399f4e19c122a598078ee554d5ef0659a4c62985eef9ea2a9a7b0aa8ac691de",
-  "docsContentFingerprint": "6cf519d315982a3c8c0617891325b79a3179587b3761e6097f012d298ee5dfc7",
+  "docsContentFingerprint": "eec3a1e5be216f9796877a6fc500d55c23e58efaa01a48f791107cd6613cf2ac",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
   "providerIds": ["videasy", "vidlink", "rivestream", "anidb", "allanime", "miruro", "youtube"],

--- a/docs/users/customization.mdx
+++ b/docs/users/customization.mdx
@@ -206,9 +206,9 @@ Config keys tune the Kunai Lua bridge script:
 | Key | Purpose |
 | --- | --- |
 | `mpvKunaiScriptPath` | Custom path to `kunai-bridge.lua` (empty = auto-resolve) |
-| `mpvKunaiScriptOpts` | `--script-opts` entries for the bridge (e.g. `margin_bottom`, `chip_width`) |
+| `mpvKunaiScriptOpts` | `--script-opts` entries for the bridge (e.g. `margin_bottom`, `chip_width`). An entry whose key or value contains `,` or `=` is dropped — mpv's option list cannot represent one |
 | `mpvInProcessStreamReconnect` | Reload same URL after network-read-dead stalls |
-| `mpvInProcessStreamReconnectMaxAttempts` | Max reload attempts per playback cycle |
+| `mpvInProcessStreamReconnectMaxAttempts` | Max reload attempts per playback cycle (clamped 0–1; `0` disables reconnect) |
 
 Example `mpvKunaiScriptOpts`:
 

--- a/docs/users/share-links.mdx
+++ b/docs/users/share-links.mdx
@@ -71,16 +71,16 @@ https://kunai.kitsunekode.in/w/v1.<encoded-ref>
 The application handoff inside that page keeps the existing grammar:
 
 ```text
-kunai://play?cat=<namespace>:<id>&kind=<movie|series|anime>&s=<season>&e=<episode>&t=<seconds>
+kunai://play?cat=<namespace>:<id>&kind=<movie|series|anime|video>&s=<season>&e=<episode>&t=<seconds>
 kunai://download?...   # same query params; queues a download instead of playback
 kunai://play?q=<query>&kind=...   # search fallback when no catalog id is known
 ```
 
 | Parameter | Meaning |
 | --- | --- |
-| `cat` | Catalog anchor: `tmdb:`, `anilist:`, `mal:`, or `imdb:` namespace + id |
+| `cat` | Catalog anchor: `tmdb:`, `anilist:`, `mal:`, `imdb:`, or `youtube:` namespace + id |
 | `q` | Search query fallback (use instead of `cat` when no stable id) |
-| `kind` | `movie`, `series`, or `anime` |
+| `kind` | `movie`, `series`, `anime`, or `video`. Optional, but write it: a link without it is read as `series` even when the namespace says otherwise |
 | `s` / `e` | Season and episode (1-based) |
 | `t` | Start offset in seconds, `1m23s`, or `1:23` |
 | `src` | Optional provider hint |

--- a/packages/config/src/defaults.ts
+++ b/packages/config/src/defaults.ts
@@ -5,6 +5,22 @@ export const DEFAULT_UNKNOWN_EPISODE_ESTIMATE_BYTES = 768 * 1024 * 1024;
 export const DEFAULT_OFFLINE_RUNWAY_TARGET = 2;
 
 /**
+ * Ceiling on same-url mpv reloads per playback cycle — and, at 1, also the
+ * shipped default.
+ *
+ * A dead stream answers a reload exactly as fast as a live one, so a budget
+ * above 1 buys a retry loop against a URL that is not coming back rather than
+ * recovery. One attempt covers the case worth covering: a transient network
+ * read that a single reload resolves.
+ *
+ * This is the only place the number lives. `ConfigServiceImpl` clamps persisted
+ * values to it, `PersistentMpvSession.create` clamps a raw config to it, and
+ * `.docs/mpv-in-process-reconnect.md` documents it — those three disagreed
+ * (1 / 3 / 12) until they were made to read from here.
+ */
+export const MPV_IN_PROCESS_RECONNECT_MAX_ATTEMPTS = 1;
+
+/**
  * yt-dlp player clients Kunai asks for by default.
  *
  * This mirrors yt-dlp's own unauthenticated default (`_DEFAULT_CLIENTS` in
@@ -59,7 +75,7 @@ export const DEFAULT_CONFIG: KitsuneConfig = {
   mpvKunaiScriptPath: "",
   mpvKunaiScriptOpts: {},
   mpvInProcessStreamReconnect: true,
-  mpvInProcessStreamReconnectMaxAttempts: 1,
+  mpvInProcessStreamReconnectMaxAttempts: MPV_IN_PROCESS_RECONNECT_MAX_ATTEMPTS,
   discoverShowOnStartup: false,
   discoverMode: "auto",
   discoverItemLimit: 24,


### PR DESCRIPTION
Six fixes from a line-by-line audit pass, each verified against the tree before it was acted on. One commit per finding.

None of these is a live outage. Five are silent-failure shapes — a gate that assumes the permissive answer, a number that four places describe differently, a comparison that invents an ordering, a branch that cannot run, a stat that judges the wrong file. The house failure mode, in other words.

## What changed

| Commit | Finding | Why it matters |
| --- | --- | --- |
| `fix(analytics)` | `maybePing` resolved consent with `isInteractive: true` written into the call | Non-TTY is a hard delivery bar for an opted-in install. The guarantee lived in the caller; the method that sends assumed it away. Hazard #3 is one new caller away. |
| `fix(mpv)` headers | Header **names** were forwarded unvalidated into `--http-header-fields` | Values were already sanitised; names are not ours. VidLink is live and spreads upstream `stream.headers` into its payload, so the remote end picks the key. A comma in a name splits one field into two. Same fix for `--script-opts` separators. |
| `fix(mpv)` reconnect | `mpvInProcessStreamReconnectMaxAttempts` described four ways, three disagreeing | Ships as 1, capped at 1. The session factory said fall back to 3, ceiling 12; the doc said "default 3, max 12". Now one constant, three readers, and a doc that matches. |
| `fix(history)` | `compareEpisodeCursors` ordered mixed numbering, plus an unreachable branch | Absolute 25 vs S2E3 returned -2, from two scales that share none. Unreachable today — the only producer normalises first — so this states the contract rather than changing behaviour. |
| `refactor(cli)` | `maybeRunOfflineMode` always returned `false` | `main.ts` branched on it into a shutdown path that had never executed. Behaviour was right; the shape lied. |
| `fix(diagnostics)` | Retention prune used `stat`, not `lstat` | A link's target decided where the link sorted, so an outside file's mtime could push a real diagnostics file out of the keep window. |

## Verification

- `typecheck`, `lint`, `fmt:check`, `verify:doc-paths`, `build` — all clean, run with `--force` so no result is a turbo cache replay.
- `bun run test --force`: 23/23 tasks, 6,983 passing, 0 failing. Skips are the usual pwsh-gated and compiled-binary ones.
- Two of the new tests were confirmed to **fail** against the old code before the fix was restored — the analytics non-interactive test (`Expected: 0, Received: 1`) and the retention symlink test. The rest pin contracts rather than defects.

## Review notes

- **Overlaps #360.** `fix/mpv-header-casing-drop` is open against `normalizeStreamHttpHeaders`, a few lines above the header-name hunk. The changes are independent; whichever lands second wants a trivial rebase.
- **The factory ceiling stays above the cap on purpose.** Clamping `PersistentMpvSession.create` to 1 would have deleted the session harness's multi-attempt reconnect coverage, which reaches the factory with a raw config that never meets the persisted clamp. It is now named and commented as a structural guard rather than policy.
- **Retention symlink test is skipped on Windows**, where creating a symlink needs a privilege an unelevated runner lacks.

## Seams walked

Declaration → reader: every constant added here has a named consumer (`MPV_IN_PROCESS_RECONNECT_MAX_ATTEMPTS` — three; `HEADER_NAME_PATTERN` — one). Both lanes: the cursor change is lane-neutral and asserted for anime absolute numbering and TMDB season/episode alike. Every provider: the header rule is provider-shaped and applies to all seven live adapters; VidLink is the one that can actually reach it. Every platform: the one filesystem-dependent test is gated, not pinned. Docs: `.docs/mpv-in-process-reconnect.md` corrected and re-dated in the same change set.

## What was audited and deliberately not changed

Three claims from the same pass were refuted and are not here: `PRAGMA busy_timeout` does not interpolate config (nothing passes `busyTimeoutMs`), `.plans/roadmap.md` exists, and `crypto-js` is used by videasy. Two more describe intended, tested behaviour: the share-link `kind` default and the relay's subdomain host matching.

## Closes

Closes #370 — analytics TTY gate
Closes #371 — mpv header names
Closes #372 — reconnect budget drift
Closes #373 — episode cursor comparison
Closes #374 — dead `--offline` branch
Closes #375 — retention symlink aging


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Share links now support video playback and YouTube catalog targets; links without a specified type open as series.
  - Offline mode now opens the library and continues into the normal session.
- **Bug Fixes**
  - Improved episode ordering for mixed and seasonless numbering.
  - Safer handling of invalid media-player options and HTTP headers.
  - Diagnostic cleanup now correctly handles symbolic links.
  - Reconnect attempts are limited to one by default, with zero disabling retries.
  - Analytics now respects interactive and non-interactive sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->