### PR TITLE
fix(download): honor cancellation during stream resolution

### DIFF
--- a/.changeset/calm-download-cancellation.md
+++ b/.changeset/calm-download-cancellation.md
@@ -1,0 +1,6 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Prevent a downloader from launching after an abort or shutdown request received
+during stream resolution, preserving the job's cancellation or paused state.

--- a/.docs/download-offline-onboarding.md
+++ b/.docs/download-offline-onboarding.md
@@ -145,6 +145,10 @@ accounts, usage ping, done. Implementation is
   bounded retry. This closes the unavoidable filesystem-rename/SQLite-commit crash window.
 - Abort terminates active download processes (`yt-dlp`), deletes temporary files, and persists an aborted job state.
 - App shutdown pauses active downloads, cleans temporary workers, and leaves jobs retryable.
+- Abort or shutdown requested while stream resolution is pending prevents a later
+  downloader launch and fresh-stream metadata writes. When resolution settles,
+  the queue preserves the recorded abort/pause decision without consuming a
+  failure retry; a shutdown-paused job remains eligible for a later session.
 - Failed jobs retry with bounded backoff and then surface as failed when retry limits are exhausted.
 - Storage exhaustion is deferred, not retried. The pre-flight reserve check
   pauses a job whose start would breach the free-space reserve; a volume that

--- a/apps/cli/src/services/download/DownloadService.ts
+++ b/apps/cli/src/services/download/DownloadService.ts
@@ -1065,6 +1065,10 @@ export class DownloadService {
 
   private async executeYtDlpDownload(job: DownloadJobRecord): Promise<DownloadJobRecord> {
     const resolved = await this.resolveStreamForJob(job);
+    // Resolution can outlive abort/shutdown. Let the queue's cancellation
+    // handler retain that decision before persisting metadata or starting a child.
+    if (this.cancellationRequests.has(job.id))
+      throw new Error("download cancelled during resolution");
     const selectedStream = resolved.stream.providerResolveResult?.streams.find(
       (stream) => stream.id === resolved.stream.providerResolveResult?.selectedStreamId,
     );

--- a/apps/cli/test/unit/services/download/youtube-download.test.ts
+++ b/apps/cli/test/unit/services/download/youtube-download.test.ts
@@ -135,6 +135,60 @@ describe("DownloadService youtube argv contract", () => {
     expect(runYtDlpSpy).not.toHaveBeenCalled();
   });
 
+  test.each(["abort", "shutdown"] as const)(
+    "%s during stream resolution does not launch a downloader or persist fresh stream metadata",
+    async (action) => {
+      const resolving = Promise.withResolvers<void>();
+      const releaseResolution = Promise.withResolvers<void>();
+      const resolved = youtubeResolveResult();
+      const freshStreamUrl = "https://www.youtube.com/watch?v=refreshed";
+      const service = buildYoutubeService({
+        repo,
+        downloadPath: tempDir,
+        resolveDownloadStream: async () => {
+          resolving.resolve();
+          await releaseResolution.promise;
+          return {
+            ...resolved,
+            stream: { ...resolved.stream, url: freshStreamUrl },
+          } as unknown as DownloadResolveResult;
+        },
+      });
+      // If the regression starts a child, it exits immediately so the test
+      // reports the forbidden launch rather than hanging behind its lifetime.
+      runYtDlpSpy.mockImplementation(() => ({
+        process: { kill: mock(() => {}), exited: Promise.resolve(1) } as never,
+        completed: Promise.resolve({ exitCode: 1, stderr: "unexpected late launch" }),
+        cancel: mock(() => {}),
+      }));
+      const job = await service.enqueue({
+        title: { id: "youtube:video:abc123", type: "movie", name: "Example video" },
+        stream: { url: "https://www.youtube.com/watch?v=abc123", headers: {}, timestamp: 0 },
+        providerId: "youtube",
+        mode: "youtube",
+      });
+
+      const running = service.processQueue();
+      await resolving.promise;
+      expect(repo.get(job.id)?.status).toBe("running");
+      if (action === "abort") await service.abort(job.id);
+      else service.beginShutdown("download paused during resolution");
+      releaseResolution.resolve();
+      await running;
+
+      expect(runYtDlpSpy).not.toHaveBeenCalled();
+      const reloaded = repo.get(job.id);
+      expect(reloaded?.status).toBe(action === "abort" ? "aborted" : "queued");
+      expect(reloaded?.streamUrl).toBe(job.streamUrl);
+      expect(reloaded?.retryCount).toBe(0);
+      if (action === "abort") expect(reloaded?.nextRetryAt).toBeUndefined();
+      else {
+        expect(reloaded?.errorMessage).toBe("download paused during resolution");
+        expect(reloaded?.nextRetryAt).toBeDefined();
+      }
+    },
+  );
+
   test("abort calls runYtDlpProcess cancel handle", async () => {
     const resolving = Promise.withResolvers<void>();
     const releaseResolution = Promise.withResolvers<void>();


### PR DESCRIPTION
## Summary
- Check recorded cancellation immediately after stream resolution, before persisting fresh metadata or launching yt-dlp.
- Preserve existing abort versus shutdown-pause handling and retry budget.
- Add deterministic abort and shutdown regressions, owning documentation, and a CLI patch changeset.

## Dependency
Stacked on #367 (test synchronization). Merge #367 first, then retarget this PR to main. The runtime delta is four scoped files and does not include the separate reliability/privacy PR #355. A merge-tree check with #355 succeeds; combined runtime gates have not been run.

## Evidence
Both new regressions failed before the guard because cancellation still launched one downloader. They pass with the guard; there is no intervening await between the guard and process registration.

## Verification
- Independent focused rerun: 61 passed, 239 assertions.
- Fresh full suite: 6977 passed, 59 skipped, 0 failed; 23 uncached tasks.
- Fresh typecheck (14), lint (12), formatting checks (26), and CLI build (10) tasks passed, all uncached.
- Release guard, documentation paths, and diff checks passed. Normal commit and pre-push hooks passed.

## Seam review
Existing cancellation state is consumed by the queue handler; no new flags, settings, or schema. Abort and shutdown/pause are both covered; active-process and pre-probe coverage remain. Shared download execution covers provider and anime/TMDB lanes without adapter changes. Tests use controlled promises, no platform-specific timing. Shutdown-paused rows remain eligible for a later session. No live provider or real-profile validation is claimed.