### PR TITLE
fix(videasy): stop the resolve gate verifying a request mpv never makes

### DIFF
--- a/.changeset/videasy-stream-origin.md
+++ b/.changeset/videasy-stream-origin.md
@@ -1,0 +1,16 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Fix Videasy shipping streams that could not be opened, on the server it picks most often.
+
+Videasy checked each candidate stream before offering it, and reported the check
+had passed — then playback failed immediately. The check and the player were not
+asking the same thing: the check sent one `Origin` header and the stream Kunai
+handed to mpv carried another, and the CDN behind Videasy's Yoru server accepts
+the first and refuses the second. So the provider verified a request that was
+never made, and the failure only appeared once the player had already started.
+
+Both now send the origin of the player these sites actually embed, taken from
+one place so they cannot drift apart again. Where this was failing it now plays;
+the other Videasy servers accept either header and are unaffected.

--- a/packages/providers/src/videasy/direct.ts
+++ b/packages/providers/src/videasy/direct.ts
@@ -138,9 +138,20 @@ export function displayHostForEndpoint(endpoint: string): string {
 
 export type VideasyClientProfile = {
   readonly appId: string;
+  /** Origin sent to the sources API — the site fronting it. */
   readonly origin: string;
   readonly defaultReferer: string;
   readonly streamReferer: string;
+  /**
+   * Origin sent with the stream itself, which is not the API's. Every site in
+   * this family plays media inside the vidking.net player, so that is the origin
+   * a CDN sees from a browser. The peakstorm CDN behind the Yoru server refuses
+   * `Origin: https://www.cineby.at` with a 403 while accepting vidking.net or no
+   * Origin at all (2026-09-12); the other CDNs accept either. The resolve gate
+   * and the shipped stream both read this one field — they diverged once, and
+   * the gate spent months verifying a request mpv never made (issue #361).
+   */
+  readonly streamOrigin: string;
 };
 
 const USER_AGENT =
@@ -1280,6 +1291,7 @@ async function probeSelectedVidkingPayloadStream({
   sourceId,
   server,
   streamReferer,
+  streamOrigin,
   sourceQualityFilter,
   engineOptions,
   events,
@@ -1292,6 +1304,8 @@ async function probeSelectedVidkingPayloadStream({
   readonly sourceId: string;
   readonly server: VidkingServerEndpoint;
   readonly streamReferer?: string;
+  /** Must be the shipped stream's origin: the gate verifies the request mpv will make. */
+  readonly streamOrigin: string;
   readonly sourceQualityFilter?: string;
   readonly engineOptions?: VidKingEngineOptions;
   readonly events: ProviderTraceEvent[];
@@ -1306,6 +1320,7 @@ async function probeSelectedVidkingPayloadStream({
     sourceId,
     server,
     streamReferer,
+    streamOrigin,
     sourceQualityFilter,
     flavorLabel: presentation.themeLabel,
     serverName: presentation.themeLabel,
@@ -1582,6 +1597,7 @@ async function tryVidkingServer(opts: {
   const appId = clientProfile.appId;
   const requestReferer = customReferer ?? clientProfile.defaultReferer;
   const streamReferer = clientProfile.streamReferer;
+  const streamOrigin = clientProfile.streamOrigin;
   const requestServers = resolveVideasyRequestServers(server, clientProfile);
 
   emitTraceEvent(events, context, {
@@ -1738,6 +1754,7 @@ async function tryVidkingServer(opts: {
             sourceId,
             server,
             streamReferer,
+            streamOrigin,
             sourceQualityFilter: engineOptions.filterQuality,
             engineOptions,
             events,
@@ -1767,7 +1784,7 @@ async function tryVidkingServer(opts: {
             startedAt,
             failures,
             streamReferer,
-            streamOrigin: clientProfile.origin,
+            streamOrigin,
             sourceQualityFilter: engineOptions.filterQuality,
             engineOptions,
             streamReachabilityVerified: streamProbe.verified,
@@ -1872,6 +1889,7 @@ export function resolveVideasyClientProfile(
       origin: VIDKING_ORIGIN,
       defaultReferer: referer,
       streamReferer: referer,
+      streamOrigin: VIDKING_ORIGIN,
     };
   }
 
@@ -1889,6 +1907,7 @@ export function resolveVideasyClientProfile(
     origin: CINEBY_ORIGIN,
     defaultReferer: referer,
     streamReferer: referer,
+    streamOrigin: VIDKING_ORIGIN,
   };
 }
 

--- a/packages/providers/src/videasy/direct.ts
+++ b/packages/providers/src/videasy/direct.ts
@@ -1027,8 +1027,10 @@ export function createVidkingResultFromPayload({
     cachePolicy: policy,
     sourceId: resolvedSourceId,
     server: resolvedServer,
-    streamReferer,
-    streamOrigin,
+    // This helper is exported and callable with neither, so the fallbacks live
+    // here; the resolve path always passes the profile's pair.
+    streamReferer: streamReferer ?? VIDKING_REFERER,
+    streamOrigin: streamOrigin ?? VIDKING_ORIGIN,
     sourceQualityFilter,
     flavorLabel: themedLabel,
     serverName: themedLabel,
@@ -1319,7 +1321,7 @@ async function probeSelectedVidkingPayloadStream({
     cachePolicy,
     sourceId,
     server,
-    streamReferer,
+    streamReferer: streamReferer ?? VIDKING_REFERER,
     streamOrigin,
     sourceQualityFilter,
     flavorLabel: presentation.themeLabel,
@@ -2109,8 +2111,8 @@ function normalizeStreamCandidates({
   cachePolicy,
   sourceId,
   server,
-  streamReferer = VIDKING_REFERER,
-  streamOrigin = VIDKING_ORIGIN,
+  streamReferer,
+  streamOrigin,
   sourceQualityFilter,
   flavorLabel,
   serverName,
@@ -2121,8 +2123,15 @@ function normalizeStreamCandidates({
   readonly cachePolicy: CachePolicy;
   readonly sourceId: string;
   readonly server?: string;
-  readonly streamReferer?: string;
-  readonly streamOrigin?: string;
+  /**
+   * Both required, with no default: this is the only place stream headers are
+   * built, and the resolve gate and the shipped result both come through it.
+   * When they were optional the gate took the defaults and the result took the
+   * profile, so the gate verified a request mpv never made (#361). A missing
+   * one is now a type error at the call site rather than a silent divergence.
+   */
+  readonly streamReferer: string;
+  readonly streamOrigin: string;
   readonly sourceQualityFilter?: string;
   readonly flavorLabel?: string;
   readonly serverName?: string;

--- a/packages/providers/test/videasy-client-profile.test.ts
+++ b/packages/providers/test/videasy-client-profile.test.ts
@@ -30,6 +30,23 @@ describe("resolveVideasyClientProfile", () => {
     });
   });
 
+  test("the stream carries the player's origin, not the API's, on every app id", () => {
+    // The Yoru server's CDN (peakstorm) answers 403 to Origin cineby.at and 200
+    // to vidking.net — the player every site in this family embeds. The API
+    // origin stays the site's own. Issue #361: the resolve gate probed with one
+    // origin and shipped the other, so it attested a stream mpv could not open.
+    const enemy = {
+      title: { id: "181886", tmdbId: "181886", kind: "movie" as const, title: "Enemy" },
+      mediaKind: "movie" as const,
+    };
+    const cineby = resolveVideasyClientProfile(enemy, runtimeContext, { appId: "bc-frontend" });
+    const vidking = resolveVideasyClientProfile(enemy, runtimeContext, { appId: "vidking" });
+
+    expect(cineby.origin).toBe("https://www.cineby.at");
+    expect(cineby.streamOrigin).toBe("https://www.vidking.net");
+    expect(vidking.streamOrigin).toBe("https://www.vidking.net");
+  });
+
   test("bc-frontend uses cineby.at movie referer", () => {
     const profile = resolveVideasyClientProfile(
       {


### PR DESCRIPTION
Closes #361.

## What was wrong

Videasy's resolve gate probed the selected stream and shipped `streamReachabilityVerified: true`, then mpv could not open the URL at all. The gate and the player were not asking the same question:

| | `Origin` sent |
| --- | --- |
| resolve gate (`probeSelectedVidkingPayloadStream`) | `https://www.vidking.net` — the default in `normalizeStreamCandidates` |
| the stream that ships | `https://www.cineby.at` — `clientProfile.origin` |

The CDN behind the **Yoru** server accepts the first and answers **403** to the second. So the gate verified a request that was never made, and the false green was then cached (`playbackTrustMs` 5m) and replayed.

The divergence dates to the rename commit that made `bc-frontend` the default profile: the profile's API origin was applied to the stream too, and the gate kept its own default.

## How it was pinned down

Asking **one URL twice in the same second**:

```
200  vidking-origin + cineby-referer  (what the gate sends)
403  cineby-origin  + cineby-referer  (what ships)
200  vidking-origin + vidking-referer
200  no origin      + cineby-referer
```

Same result on two separate titles. The CDN objects to exactly one thing: `Origin: https://www.cineby.at`.

That also **refutes the three hypotheses in the issue**, so they don't get re-investigated:

- **Not a one-shot URL.** With the gate stubbed so it never touched the CDN, mpv going first still got 403.
- **Not a short TTL.** Bun repeating the gate's own headers got 200 for 20+ seconds, and the gate's own second request succeeded at t+2.5s.
- **Not a client fingerprint.** Bun, curl, curl-impersonate and mpv all get 403 with the shipped header and 200 with the gate's.

The issue's "not headers" check was sound but only varied the *shipped* headers — never the gate's.

## The fix

`streamOrigin` becomes one field on `VideasyClientProfile` — the vidking.net player every site in this family embeds, which is what a browser's CDN request actually carries — and both the gate and the shipped result read it. The **API** request keeps the site's own origin (`cineby.at`), which is what it wants.

The gate's `streamOrigin` parameter is **required**, so a future call site cannot silently fall back to the default and drift apart again. That structural point is the real fix; the value is just the value.

## Verification

Live against the provider, not only unit tests:

- Fresh resolve → **mpv writes a frame** under `--vo=image` for **Dune** (movie, 4K) and **Bloodhounds S1E2** — the issue's own fixture, which never opened before.
- The other CDNs in this family (Vyse, `i-arch-*.gufin435siv.com`) accept `vidking.net`, `cineby.at` and no `Origin` alike, so they are unaffected.
- Full `--force` gates green.

## Noted, not fixed here

Two separate things seen while testing, neither caused by this change: a resolved peakstorm URL stops working after tens of minutes (a stale-URL lifetime, the class already noted for cached streams), and mpv is sometimes slow to open on the `sun.peakstorm.top`/`Breach` server. Neither blocks a fresh play.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Videasy playback failures on affected Yoru servers by aligning provider verification with the origin used for embedded streams.
  - Improved stream handling for both supported Videasy app configurations while preserving behavior for other servers.

- **Tests**
  - Added coverage confirming streams use the player’s origin rather than the API origin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->