### PR TITLE
fix(playback): stop reporting a short watch as playback that never started

### DIFF
--- a/apps/cli/src/app/playback/playback-session-controller.ts
+++ b/apps/cli/src/app/playback/playback-session-controller.ts
@@ -1,5 +1,6 @@
 import {
   didPlaybackFailToStart,
+  didPlaybackStart,
   explainAutoplayBlockReason,
   explainAutoplayNoNextEpisodeCatalogHint,
   resolveAutoplayAdvanceEpisode,
@@ -58,6 +59,7 @@ export type { AutoAdvanceArgs, AutoAdvanceBlockReason };
 
 export {
   didPlaybackFailToStart,
+  didPlaybackStart,
   explainAutoplayBlockReason,
   explainAutoplayNoNextEpisodeCatalogHint,
   resolveAutoplayAdvanceEpisode,

--- a/apps/cli/src/app/playback/policies/playback-result-policy.ts
+++ b/apps/cli/src/app/playback/policies/playback-result-policy.ts
@@ -11,6 +11,10 @@ import {
   type PlaybackEndPolicy,
   DEFAULT_PLAYBACK_END_POLICY,
 } from "@/domain/playback/playback-policy";
+import {
+  isDidNotStartProgress,
+  trustedProgressFromPlaybackResult,
+} from "@/domain/playback/progress-engage-policy";
 import type {
   EpisodeInfo,
   PlaybackResult,
@@ -49,6 +53,33 @@ export type AutoAdvanceArgs = {
 };
 
 /** True when mpv never meaningfully started (load failure, dead URL, immediate exit). */
+/**
+ * Did this playback session actually start?
+ *
+ * Answered from evidence, never from how much was watched. "Nothing was
+ * recorded for this title" and "playback didn't start" are different claims,
+ * and only the second one tells the user the app failed — so it has to be
+ * proven, by one of:
+ *
+ * - a failure the player reported (`didPlaybackFailToStart`), or
+ * - a file that loaded with a known duration and never advanced
+ *   (`isDidNotStartProgress`, the same policy the history ledger uses).
+ *
+ * Everything else started. A twelve-second watch is a short session; a session
+ * whose IPC stats never arrived is unmeasured. Neither is a failure to start,
+ * and reporting them as one is what teaches a user to distrust every status
+ * the app shows afterwards.
+ */
+export function didPlaybackStart(result: PlaybackResult): boolean {
+  if (didPlaybackFailToStart(result)) return false;
+  // mpv reaching the end of the file is direct evidence that it played it, and
+  // outranks a missing progress sample: `isDidNotStartProgress` reads a known
+  // duration with no trusted progress as "never advanced", which is exactly the
+  // shape an EOF with no IPC samples takes.
+  if (result.endReason === "eof") return true;
+  return !isDidNotStartProgress(trustedProgressFromPlaybackResult(result));
+}
+
 export function didPlaybackFailToStart(result: PlaybackResult): boolean {
   if (result.endReason === "eof" || result.endReason === "quit") {
     return false;

--- a/apps/cli/src/app/playback/run-post-playback-menu.ts
+++ b/apps/cli/src/app/playback/run-post-playback-menu.ts
@@ -34,6 +34,7 @@ import {
 } from "@/app/playback/playback-recommendation-actions";
 import type { PlaybackRunState } from "@/app/playback/playback-run-state";
 import {
+  didPlaybackStart,
   resolvePostPlaybackSessionAction,
   type PlaybackSessionPhaseEvent,
   type PlaybackSessionState,
@@ -390,8 +391,12 @@ export async function runPostPlaybackMenu(
       };
       deps.updatePlaybackFeedback({ detail: null, note: null });
     }
-    const playbackStarted =
-      result.endReason === "eof" || result.watchedSeconds >= 30 || resumeSeconds > 10;
+    // One policy answers this, shared with the recovery panel and the history
+    // ledger. The threshold that used to live here (`eof || watchedSeconds >= 30
+    // || resumeSeconds > 10`) required proof of success and read its absence as
+    // proof of failure, so a short watch — or one whose stats never arrived —
+    // was reported to the user as "playback didn't start".
+    const playbackStarted = didPlaybackStart(result);
     const postPlayInput = buildPostPlayInputFromPlaybackContext({
       title,
       currentEpisode,

--- a/apps/cli/test/unit/app/playback-session-controller.test.ts
+++ b/apps/cli/test/unit/app/playback-session-controller.test.ts
@@ -7,6 +7,7 @@ import {
   resolveAutoplayAdvanceEpisode,
   transitionPlaybackSessionPhase,
   didPlaybackFailToStart,
+  didPlaybackStart,
   resolvePlaybackResultDecision,
   resolvePostPlaybackSessionAction,
   syncPlaybackSessionState,
@@ -237,6 +238,51 @@ describe("resolvePlaybackResultDecision", () => {
 
     expect(decision.shouldRefreshSource).toBe(true);
     expect(decision.shouldFallbackProvider).toBe(false);
+  });
+
+  test("didPlaybackStart calls a short watch a start, not a failure", () => {
+    // The post-play hero used to answer this with a success threshold —
+    // `eof || watchedSeconds >= 30 || resumeSeconds > 10` — so a real but short
+    // session was reported as "playback didn't start". That is a claim about the
+    // app failing, and it needs evidence rather than the absence of evidence.
+    expect(
+      didPlaybackStart({
+        watchedSeconds: 12,
+        duration: 5000,
+        endReason: "quit",
+        lastTrustedProgressSeconds: 12,
+      }),
+    ).toBe(true);
+
+    // Stats can go missing (no IPC sample) on a session that genuinely played.
+    // Unknown duration is not proof of a failure to start.
+    expect(
+      didPlaybackStart({
+        watchedSeconds: 0,
+        duration: 0,
+        endReason: "quit",
+        playerExitedCleanly: true,
+      }),
+    ).toBe(true);
+
+    expect(didPlaybackStart({ watchedSeconds: 1400, duration: 1400, endReason: "eof" })).toBe(true);
+  });
+
+  test("didPlaybackStart still reports the cases with real evidence of no start", () => {
+    // mpv exited non-zero without ever reporting progress.
+    expect(
+      didPlaybackStart({ watchedSeconds: 0, duration: 0, endReason: "error", playerExitCode: 1 }),
+    ).toBe(false);
+
+    // The file loaded — duration is known — and playback never advanced.
+    expect(
+      didPlaybackStart({
+        watchedSeconds: 0,
+        duration: 1400,
+        endReason: "quit",
+        lastTrustedProgressSeconds: 0,
+      }),
+    ).toBe(false);
   });
 
   test("didPlaybackFailToStart detects load failures without treating user quit as failure", () => {


### PR DESCRIPTION
A user reported that after playback actually worked — YouTube, and a cancelled replay — Kunai still told them it had failed. This is the root cause.

## What was happening

Post-play decided whether playback started with its own expression:

```ts
const playbackStarted =
  result.endReason === "eof" || result.watchedSeconds >= 30 || resumeSeconds > 10;
```

It asks for proof of success and treats the absence of proof as proof of failure. Anything below the threshold rendered as **"▢ playback didn't start"** — an accusation that the app failed, shown to someone who had just watched something.

The same question already had two answers in the tree, both evidence-based:

| Policy | Asks for | Default when silent |
| --- | --- | --- |
| `didPlaybackFailToStart` (`playback-result-policy.ts:52`) | the player reported a failure | not a failure |
| `isDidNotStartProgress` (`progress-engage-policy.ts:21`, used by the history ledger) | a file that loaded with a known duration and never advanced | not a failure |
| the post-play expression | ≥30s watched, or EOF, or a resume past 10s | **failure** |

Three answers to one question, and the hero label used the only one whose default is "assume the worst".

## Evidence

Running representative results through the failure policy and the post-play expression, before the fix:

```
case                                       failToStart  postPlayStarted
watched 12s then quit                      false        false   <-- no evidence of failure, yet "didn't start"
watched 12s, stats lost (source unknown)   false        false   <-- same
full watch, stats never arrived            false        false   <-- same
cancelled replay, mpv opened               false        false   <-- same
mpv died on load                           true         false       (agree: a real failure)
clean eof                                  false        true        (agree)
```

After:

```
case                                 before   after
watched 12s then quit                DIDN'T   started   <-- changed
watched, IPC stats never arrived     DIDN'T   started   <-- changed
cancelled replay, mpv played 3s      DIDN'T   started   <-- changed
eof, progress samples missing        started  started
mpv died on load                     DIDN'T   DIDN'T
loaded, never advanced               DIDN'T   DIDN'T
```

## The fix

`didPlaybackStart` composes the two existing policies, and post-play calls it instead of rolling a third:

- a reported player failure → did not start
- EOF → started (mpv played the file to its end, which outranks a progress sample that never arrived)
- loaded with a known duration and never advanced → did not start
- anything else → started

Both genuine no-start cases still report as such. What changed is the silence in between, which is now a short session rather than an accusation.

The `resumeSeconds > 10` term is deliberately not replaced: it asked whether a *previous* session had progress, which is not evidence about this one, and the loaded-and-never-advanced check answers the resumed case directly.

## Verification

`typecheck`, `lint`, `fmt`, and `bun run test` all run with `--force` so nothing is a turbo cache replay: 23/23 tasks, no failures. The two new tests fail against the old expression.

## Not fixed here

The same report mentions a title resolving to a track chooser that then never auto-played. That enters through `openRecoverySourcePanelOnPostPlay`, which uses `didPlaybackFailToStart` and so is a different path — I could not root-cause it from the code alone and did not want to guess at it inside this change.

Closes #379
