### PR TITLE
fix(providers): read a JSON body at the boundary, not through a cast

### DIFF
--- a/.changeset/provider-null-json-body.md
+++ b/.changeset/provider-null-json-body.md
@@ -1,0 +1,14 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Stop a provider that answers "nothing" from failing as an internal error.
+
+Some provider APIs reply `200 OK` with a body of `null` when they have no
+source for a title — VidLink does it for every title right now. Kunai read a
+field off that reply and threw, so instead of moving on to the next provider it
+reported an error from inside itself.
+
+Four providers read a response this way — VidLink, Videasy, AllManga's title
+lookup and its key bootstrap — and all four now treat an empty reply as "no
+source here" and hand over to the next one.

--- a/packages/providers/src/allmanga/crypto.ts
+++ b/packages/providers/src/allmanga/crypto.ts
@@ -3,6 +3,7 @@ import { createCipheriv, createHash, createHmac } from "node:crypto";
 import type { ProviderRuntimeContext } from "@kunai/types";
 
 import { providerFetch } from "../runtime/fetch";
+import { readJsonObjectBody } from "../shared/json-body";
 
 /**
  * AllManga / mkissa client-crypto (post-2026-08 buildId scheme).
@@ -246,9 +247,9 @@ export async function fetchAllMangaCryptoMaterial(
           },
         });
         if (!response.ok) continue;
-        const body = (await response.json()) as BootstrapResponse;
+        const body = await readJsonObjectBody<BootstrapResponse>(response);
         if (
-          !body.partB ||
+          !body?.partB ||
           typeof body.epoch !== "number" ||
           !Number.isFinite(body.epoch) ||
           body.epoch <= 0

--- a/packages/providers/src/allmanga/resolve-show-id.ts
+++ b/packages/providers/src/allmanga/resolve-show-id.ts
@@ -1,6 +1,7 @@
 import type { ProviderResolveInput, ProviderRuntimeContext } from "@kunai/types";
 
 import { resolveAnimeAudioIntent } from "../shared/anime-audio-intent";
+import { readJsonObjectBody } from "../shared/json-body";
 import { TTLCache } from "../shared/provider-cache";
 import { createTimeoutSignal } from "../shared/timeout-signal";
 import { searchAllManga } from "./api-client";
@@ -150,7 +151,7 @@ async function buildAllMangaBridgeQueries(
       }),
     });
     if (!response.ok) return queries.slice(0, 5);
-    const payload = (await response.json()) as {
+    const payload = await readJsonObjectBody<{
       readonly data?: {
         readonly Media?: {
           readonly title?: {
@@ -160,8 +161,8 @@ async function buildAllMangaBridgeQueries(
           } | null;
         } | null;
       };
-    };
-    const title = payload.data?.Media?.title;
+    }>(response);
+    const title = payload?.data?.Media?.title;
     if (title?.romaji) queries.push(title.romaji);
     if (title?.english) queries.push(title.english);
     if (title?.native) queries.push(title.native);

--- a/packages/providers/src/shared/index.ts
+++ b/packages/providers/src/shared/index.ts
@@ -5,6 +5,7 @@ export * from "./anime-source-presentation";
 export * from "./known-catalog";
 export * from "./hls-manifest";
 export * from "./hls-ladder";
+export * from "./json-body";
 export * from "./direct-stream-source";
 export * from "./series-coordinates";
 export * from "./provider-cycle";

--- a/packages/providers/src/shared/json-body.ts
+++ b/packages/providers/src/shared/json-body.ts
@@ -1,0 +1,24 @@
+/**
+ * Reading a provider's JSON response at the boundary, so no adapter has to
+ * guess what came back.
+ *
+ * A provider API answering `HTTP 200` with the body `null` is normal, not
+ * exotic: VidLink does it for every title while its backend has nothing to
+ * offer (observed 2026-09-12). `(await response.json()) as { stream?: … }`
+ * types that away, and the next property read throws `null is not an object` —
+ * which surfaces as a crash inside resolve rather than "this provider has no
+ * source", so the lane blames itself instead of falling through.
+ */
+
+/**
+ * The response body when it is a JSON object (or array), else null.
+ *
+ * Returning null for `null`, a bare string, or a number keeps the decision at
+ * the one place that has the raw body; callers branch on the domain value
+ * (`if (!data?.stream)`) instead of trusting a cast.
+ */
+export async function readJsonObjectBody<T>(response: Response): Promise<T | null> {
+  const body: unknown = await response.json();
+  if (body === null || typeof body !== "object") return null;
+  return body as T;
+}

--- a/packages/providers/src/videasy/direct.ts
+++ b/packages/providers/src/videasy/direct.ts
@@ -30,6 +30,7 @@ import type {
 } from "@kunai/types";
 
 import { resolveTmdbCatalogId } from "../shared/catalog-id";
+import { readJsonObjectBody } from "../shared/json-body";
 import { HealthTracker, TTLCache } from "../shared/provider-cache";
 import {
   appendCycleEventsToResult,
@@ -1496,8 +1497,8 @@ async function fetchWingsdatabaseSeed(
             headers: seedHeaders,
           });
           if (!response.ok) throw new Error(`seed HTTP ${response.status}`);
-          const body = (await response.json()) as { seed?: string; ttlMs?: number };
-          if (!body.seed) throw new Error("seed payload missing seed");
+          const body = await readJsonObjectBody<{ seed?: string; ttlMs?: number }>(response);
+          if (!body?.seed) throw new Error("seed payload missing seed");
           return { apiBase, seed: body.seed, ttlMs: body.ttlMs ?? 30_000 };
         } catch (error) {
           // Three different causes reach this catch and only one is host
@@ -2340,13 +2341,14 @@ async function fetchVideasyDbTitleMetadata(
     });
     if (!response.ok) return null;
 
-    const data = (await response.json()) as {
+    const data = await readJsonObjectBody<{
       readonly name?: string;
       readonly title?: string;
       readonly first_air_date?: string;
       readonly release_date?: string;
       readonly external_ids?: { readonly imdb_id?: string | null };
-    };
+    }>(response);
+    if (!data) return null;
 
     const releaseDate = data.first_air_date ?? data.release_date;
     const year =

--- a/packages/providers/src/vidlink/direct.ts
+++ b/packages/providers/src/vidlink/direct.ts
@@ -13,6 +13,7 @@ import {
   type DirectStreamPayload,
 } from "../shared/direct-stream-source";
 import { expandHlsMasterPlaylist, looksLikeHlsMasterUrl } from "../shared/hls-ladder";
+import { readJsonObjectBody } from "../shared/json-body";
 import { vidlinkManifest, VIDLINK_PROVIDER_ID } from "./manifest";
 
 export { VIDLINK_PROVIDER_ID };
@@ -94,8 +95,8 @@ export function resolveVidlinkDirect(
 
       const response = await fetchVidlinkApi(ctx, `${VIDLINK_API_BASE}/${path}`, ctx.signal);
 
-      const data = (await response.json()) as { stream?: VidlinkStream };
-      const stream = data.stream;
+      const data = await readJsonObjectBody<{ stream?: VidlinkStream }>(response);
+      const stream = data?.stream;
       if (!stream) return null;
 
       const streams: DirectStreamInput[] = [];

--- a/packages/providers/test/json-body.test.ts
+++ b/packages/providers/test/json-body.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import { readJsonObjectBody } from "../src/shared/json-body";
+
+const json = (body: string) =>
+  new Response(body, { headers: { "content-type": "application/json" } });
+
+describe("readJsonObjectBody", () => {
+  test("a JSON null body is no payload, not an object to read fields off", async () => {
+    // VidLink answers 200 with exactly this while it has no source; the cast it
+    // replaced turned the next property read into `null is not an object`.
+    expect(await readJsonObjectBody(json("null"))).toBeNull();
+  });
+
+  test("returns the object when there is one", async () => {
+    expect(
+      await readJsonObjectBody<{ stream?: { url: string } }>(json('{"stream":{"url":"u"}}')),
+    ).toEqual({
+      stream: { url: "u" },
+    });
+  });
+
+  test("an array body is a payload — some endpoints answer with one", async () => {
+    expect(await readJsonObjectBody<readonly number[]>(json("[1,2]"))).toEqual([1, 2]);
+  });
+
+  test("a bare scalar is no payload either", async () => {
+    expect(await readJsonObjectBody(json('"done"'))).toBeNull();
+    expect(await readJsonObjectBody(json("7"))).toBeNull();
+    expect(await readJsonObjectBody(json("false"))).toBeNull();
+  });
+
+  test("a body that is not JSON at all still throws — that is a broken response", async () => {
+    await expect(readJsonObjectBody(json("<html>nope</html>"))).rejects.toThrow();
+  });
+});

--- a/packages/providers/test/vidlink-dash.test.ts
+++ b/packages/providers/test/vidlink-dash.test.ts
@@ -88,4 +88,32 @@ describe("vidlink DASH delivery", () => {
     expect(result.subtitles.length).toBe(1);
     expect(result.subtitles[0]?.language).toBe("en");
   });
+
+  test("a 200 with a null body is no source, not a crash", async () => {
+    // What VidLink actually answers for every title while its backend has
+    // nothing (2026-09-12). Reading `.stream` off it threw `null is not an
+    // object`, so the lane reported an internal error instead of stepping aside.
+    const context = {
+      providerId: "vidlink",
+      now: () => new Date().toISOString(),
+      fetch: {
+        runtime: "direct-http",
+        fetch: async (url: string) =>
+          url.includes("enc-dec.app")
+            ? new Response(JSON.stringify({ result: "ENCRYPTED" }), { status: 200 })
+            : new Response("null", {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              }),
+      },
+    } as unknown as ProviderRuntimeContext;
+
+    const result = await resolveVidlinkDirect(INPUT, context);
+
+    expect(result.status).toBe("exhausted");
+    expect(result.streams).toEqual([]);
+    expect(result.failures.map((failure) => failure.message).join(" ")).not.toContain(
+      "is not an object",
+    );
+  });
 });


### PR DESCRIPTION
Found while verifying every production provider end to end.

## What happens

VidLink answers **`200 OK` with the body `null`** for every title right now. Kunai did:

```ts
const data = (await response.json()) as { stream?: VidlinkStream };
const stream = data.stream;   // TypeError: null is not an object
```

So a provider saying "I have nothing" surfaced as an error from inside resolve:

```
vidlink exhausted 1885ms  null is not an object (evaluating '(await (await fetchVidlinkApi(ctx, `${VIDLINK_API_BASE}…
```

The lane blamed itself instead of stepping aside, and the real message ("no sources") never appeared.

## Scope — four providers, same shape

Five call sites dereferenced a body that can be JSON `null`:

| Provider | Call |
| --- | --- |
| VidLink | sources (`data.stream`) — **failing live today** |
| Videasy | the Wings seed (`body.seed`) and the TMDB proxy (`data.first_air_date`) |
| AllManga | the AniList title lookup (`payload.data`) and the key bootstrap (`body.partB`) |

All now go through `readJsonObjectBody`, which returns the object (or an array) and `null` for `null`/scalars, at the one place that holds the raw body — so callers branch on the domain value instead of trusting a cast. A body that isn't JSON at all still throws, because that *is* a broken response.

## Verification

- Live: vidlink now ends with `VidLink returned no playable streams` instead of a TypeError.
- Regression test in `vidlink-dash.test.ts` replays the exact live reply (`200` + `null`) and asserts the result is `exhausted`, with no `is not an object` in any failure message.
- Full `--force` gates plus `build` green.

## What this does not do

VidLink still has no sources — that is upstream (checked with and without the `x-playback-environment` header; the encryptor at enc-dec.app is fine). This only makes the failure honest and the fallback immediate.
