### PR TITLE
test(installer): stop pinning activation contention to a runner's wall clock

### DIFF
--- a/apps/cli/test/integration/install-scripts.test.ts
+++ b/apps/cli/test/integration/install-scripts.test.ts
@@ -1493,13 +1493,18 @@ describe("install.sh lifecycle contract", () => {
             ...sandbox.env,
             KUNAI_DL_BASE: baseUrl,
             KUNAI_ACTIVATION_LOCK_TIMEOUT_MS: "40",
-            KUNAI_ACTIVATION_LOCK_POLL_MS: "500",
+            KUNAI_ACTIVATION_LOCK_POLL_MS: "10000",
           });
           await waitForPaths([join(sandbox.dataDir, "versions", "9.8.7", "version.json")]);
           const activationStartedAt = performance.now();
           const result = await install;
           expect(result.status).not.toBe(0);
-          expect(performance.now() - activationStartedAt).toBeLessThan(300);
+          // The claim is "it does not sleep a whole poll interval", so the poll
+          // and the bound are far apart: a correct run returns at the 40ms
+          // deadline, a regression waits 10s. Measuring a spawned shell's wall
+          // clock against 300ms instead made a loaded macOS runner fail a
+          // working installer — the same ratio the pwsh test already uses.
+          expect(performance.now() - activationStartedAt).toBeLessThan(5_000);
         },
       );
     } finally {
@@ -1538,7 +1543,10 @@ describe("install.sh lifecycle contract", () => {
               KUNAI_ACTIVATION_LOCK_POLL_MS: "0",
               PATH: `${shimDir}${delimiter}${sandbox.env.PATH ?? ""}`,
             },
-            500,
+            // A hot-looping reclaim never exits, so any budget catches it; this
+            // one only has to outlast bash startup, the fixture download and
+            // teardown on a shared runner, which 500ms did not.
+            5_000,
           );
           expect(result).not.toBeNull();
           expect(result?.status).not.toBe(0);


### PR DESCRIPTION
The **macOS CLI parity** job failed on #382 — a providers-only PR that cannot touch the installer:

```
2 tests failed:
(fail) install.sh lifecycle contract > bounds activation contention by real elapsed time when poll exceeds timeout
(fail) install.sh lifecycle contract > a failed reclaim with zero poll observes the activation deadline instead of hot-looping
```

Both pass locally and on the sibling PR off the same base, so this is the flake `CLAUDE.md` calls out directly: *"A test that needs a timeout or a real sleep to pass is wrong."*

## Why they flaked

Both tests assert something true and worth testing — activation contention must honour the 40 ms deadline rather than sleeping a whole poll interval or hot-looping. They measured it as an **absolute wall-clock budget around a spawned `bash`**:

| test | timeout | poll | budget |
| --- | --- | --- | --- |
| poll exceeds timeout | 40 ms | 500 ms | `elapsed < 300 ms` |
| zero-poll reclaim | 40 ms | 0 | killed at 500 ms |

On a shared macOS runner, bash startup plus the fixture download plus teardown can exceed 300 ms with the lock logic behaving perfectly — so a correct installer fails.

## The fix

Express the claim as a **ratio**, which is exactly what the pwsh variant of the first test already does (`poll 10000`, bound `5_000`):

- poll `500 ms` → `10000 ms`, bound `300 ms` → `5_000 ms`. A correct run returns at the 40 ms deadline; a regression waits 10 s. 2.5 s+ of runner slowness no longer matters.
- the zero-poll reclaim budget `500 ms` → `5_000 ms`. A hot loop never exits, so any budget catches it; this one only has to outlast process startup and teardown.

Both still fail on the regressions they were written for. No production code is touched — this is test infrastructure only, and it unblocks the macOS job for every PR.

268 integration tests pass locally; lint, fmt and typecheck green.
