### PR TITLE
fix(miruro): stop paying for backends that cannot answer

### DIFF
--- a/.changeset/miruro-faster-start.md
+++ b/.changeset/miruro-faster-start.md
@@ -1,0 +1,16 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Start anime from Miruro in about a second instead of about four.
+
+Two things were costing every episode. Kunai checked each Miruro backend before
+playing it, and for the one that plays most reliably right now that check could
+never get an answer — so it waited out its full timeout every time, for nothing.
+And a backend that was down got checked again on every single episode.
+
+The check now skips the backend it cannot judge, and a backend that keeps
+failing is set aside for an hour instead of being asked again, the same way
+Kunai already does for its movie and series sources. While it is set aside the
+source list shows it as temporarily unavailable, and it is tried again once the
+hour is up.

--- a/.docs/providers.md
+++ b/.docs/providers.md
@@ -533,6 +533,20 @@ demands — the stream does not play for anyone — so Miruro now matches the
 resolve gate's policy that every 4xx is definitive, and 401/403 remain the
 narrow exception because only Bun's fetch sees them.
 
+A rejected backend is recorded against its server id (`pewe`, `moo` — sub and
+dub share one) as a `server-error` through `context.endpointHealth`, and the
+cycle is handed the same port, so a backend quarantined by the usual rules
+(three consecutive failures on one title, or two titles) is skipped without a
+request. The engine records nothing for `candidate-empty`, which is correct — an
+episode a server lacks is not evidence against the server — so the definitive
+status is recorded by Miruro itself, and never for a timeout or an aborted probe.
+
+The probe does not ask `animegg.org` at all. Its `/play` endpoint, where every
+`moo` stream starts, never answers Bun's fetch while curl and mpv get a 302 at
+once, so each probe spent the full timeout to learn nothing. Measured on
+2026-09-12 against the live pipe, a Miruro resolve went from ~4.3 s to ~2.3 s
+from that alone, and ~1.1 s once `pewe` was quarantined.
+
 Miruro's own single point of failure is `miruro.bz`/`.ru` — every one of its
 backends is reached through it, so the two providers behind it are the ones that
 share none of that. `kickassanime` is second and `animegg` third: both have their

--- a/.docs/release-reliability-gate.md
+++ b/.docs/release-reliability-gate.md
@@ -261,6 +261,16 @@ Expected result for each provider:
 - `failureCodes` is empty or contains only non-blocking fallback evidence when a fallback stream was selected
 - output includes `isolatedProfile: true`
 
+The route signoff needs `streamReachable: true` — proof, not neutrality. Its
+first judge is a Bun probe; when that times out, the route is settled by mpv
+decoding one frame (`mpvDecodesStream` in `apps/cli/test/live/provider-smoke.ts`)
+and a `[signoff] … mpv decode says …` line is written to stderr. Some hosts never
+answer Bun's fetch while mpv plays them — AnimeGG's `/play`, where Miruro's `moo`
+streams start — and reading that silence as `provider-drift` failed the signoff
+on a stream that played. mpv giving up without a frame is still a failure; mpv
+missing or still working at 45 s leaves the route inconclusive, which still
+fails approval.
+
 Do not run live provider smokes in default CI. They are opt-in checks for provider drift and release confidence.
 
 Provider smokes should be run once per touched provider family, not in a loop while developing. Repeated iteration belongs in fixture-backed provider tests and mocked fetch/runtime ports.

--- a/apps/cli/test/live/provider-smoke.ts
+++ b/apps/cli/test/live/provider-smoke.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { StreamInfo, TitleInfo } from "@/domain/types";
+import { normalizeStreamHttpHeaders } from "@/infra/player/mpv-stream-http-headers";
 import type { StreamRequest } from "@/services/providers/Provider";
 import { providerResolveResultToStreamInfo } from "@/services/providers/provider-result-adapter";
 import { streamRequestToResolveInput } from "@/services/providers/stream-request-adapter";
@@ -258,4 +259,57 @@ export function smokeStreamReachable(
   if (probe.status === "reachable") return true;
   if (probe.status === "unreachable") return false;
   return null;
+}
+
+/**
+ * Whether mpv decodes a frame from the stream — the only thing this repo
+ * accepts as proof of playback. For a release gate that demands proof
+ * (`streamReachable === true`), a Bun probe that times out is not an answer:
+ * some hosts never reply to Bun's fetch while mpv plays them (AnimeGG's
+ * `/play`, which Miruro's `moo` streams start at), and reading that silence as
+ * provider drift failed the signoff on a stream that plays.
+ *
+ * - `true`  -- a frame was written
+ * - `false` -- mpv gave up without one; evidence the stream will not play
+ * - `null`  -- no mpv on PATH, or it was still working when time ran out
+ */
+export async function mpvDecodesStream(input: {
+  readonly url: string;
+  readonly headers?: Record<string, string>;
+  readonly timeoutMs?: number;
+}): Promise<boolean | null> {
+  const mpv = Bun.which("mpv");
+  if (!mpv) return null;
+  const outDir = mkdtempSync(join(tmpdir(), "kunai-smoke-frame-"));
+  try {
+    const { referer, userAgent, origin, extraFields } = normalizeStreamHttpHeaders(input.headers);
+    const headerFields = [...(origin ? [`Origin: ${origin}`] : []), ...extraFields];
+    const args = [
+      "--no-config",
+      "--ytdl=no",
+      "--ao=null",
+      "--vo=image",
+      `--vo-image-outdir=${outDir}`,
+      "--frames=1",
+      "--really-quiet",
+      ...(referer ? [`--referrer=${referer}`] : []),
+      ...(userAgent ? [`--user-agent=${userAgent}`] : []),
+      ...(headerFields.length > 0 ? [`--http-header-fields=${headerFields.join(",")}`] : []),
+      "--",
+      input.url,
+    ];
+    const child = Bun.spawn([mpv, ...args], { stdout: "ignore", stderr: "ignore" });
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+    }, input.timeoutMs ?? 45_000);
+    await child.exited;
+    clearTimeout(timer);
+    const wroteFrame = [...new Bun.Glob("*").scanSync(outDir)].length > 0;
+    if (wroteFrame) return true;
+    return timedOut ? null : false;
+  } finally {
+    rmSync(outDir, { recursive: true, force: true });
+  }
 }

--- a/apps/cli/test/live/release-provider-signoff.smoke.ts
+++ b/apps/cli/test/live/release-provider-signoff.smoke.ts
@@ -21,6 +21,7 @@ import { probeStreamReachability } from "@kunai/providers";
 
 import {
   createProviderSmokeProfile,
+  mpvDecodesStream,
   providerSmokeError,
   resolveProviderSmokeStream,
   smokeStreamReachable,
@@ -149,11 +150,17 @@ async function resolveRoute(
         timeoutMs: 5_000,
       })
     : null;
-  const streamReachable = streamProbe
-    ? smokeStreamReachable(streamProbe)
-    : streamUrl
-      ? false
-      : null;
+  const probed = streamProbe ? smokeStreamReachable(streamProbe) : streamUrl ? false : null;
+  // A probe that timed out has not answered; settle it the way playback would.
+  const streamReachable =
+    probed === null && streamUrl
+      ? await mpvDecodesStream({ url: streamUrl, headers: streamHeaders })
+      : probed;
+  if (probed === null && streamUrl) {
+    console.error(
+      `[signoff] ${routeCase.lane}: probe inconclusive; mpv decode says ${String(streamReachable)}`,
+    );
+  }
   const resolved = Boolean(streamUrl);
   const errorText =
     resolveError instanceof Error

--- a/apps/docs/lib/generated-metadata.json
+++ b/apps/docs/lib/generated-metadata.json
@@ -1,7 +1,7 @@
 {
   "version": "0.3.0",
   "cliVersion": "0.3.0",
-  "cliSourceFingerprint": "ffdfa5be23df476ac5a3c93dc1b40fd724ec9e034b097cee5cac5c2a1deb5b0c",
+  "cliSourceFingerprint": "0dc85f2095dcee356ec428b0ed542170b9fc0479318c415c81c7b3f90ec6b45c",
   "docsContentFingerprint": "5c9acc4b183e57aa6e0a73a7736224f03568c0c68f8b30bdbf48280d932a3f31",
   "featureStatusRevision": "5a88d5e2542655bbbfab1e4d050f51632669ac5d46e2b22ef14596f3684a8257",
   "commandCount": 82,
@@ -126,6 +126,7 @@
         "May hit Cloudflare rate limits if called too frequently.",
         "2026-09-11: the pipe is reachable — Bun fetch is always CF-403'd (its TLS fingerprint), and curl clears the edge on both mirrors. The superseded 2026-08-17 note claiming curl also received CF 403 was measured through a predicate that read any HTML body as a Cloudflare block, including the mirror's own `502 upstream unreachable` page.",
         "2026-09-12: 429 joined that list. The release signoff's anime lane resolved a pewe stream that answered 429 to mpv, to curl with the stream's headers and to curl with none — a rate-limited master is refused to everyone, unlike the 403 that only Bun's fetch sees. Skipping it costs one server attempt; accepting it cost a failed play on the default anime provider. With pewe skipped the cycle lands on moo and plays (verified: 1080p frame).",
+        "2026-09-12: rejected backends are recorded through context.endpointHealth as server-error against the server id, and the cycle skips a quarantined one without asking it. The probe also no longer asks animegg.org, whose /play never answers Bun's fetch (curl and mpv get a 302 at once): it spent the full timeout on every Moo resolve. Together they took a Miruro resolve from ~4.3s to ~1.1s once pewe was quarantined.",
         "A 444/502 from the pipe is one of Miruro's backing servers being down (pewe follows AniDB, ally follows AllManga), not a WAF block, and must not stop the cycle — the remaining servers are usually healthy."
       ]
     },

--- a/packages/providers/src/miruro/direct.ts
+++ b/packages/providers/src/miruro/direct.ts
@@ -1937,6 +1937,21 @@ function isSameHost(requestedUrl: string, responseUrl: string | undefined): bool
  * from URLs mpv could not open (issue #361) — so a pass here is not evidence of
  * playability, only the absence of evidence of death.
  */
+/**
+ * Stream hosts this probe cannot judge from Bun, so it does not ask them.
+ *
+ * AnimeGG's `/play` (every `moo` stream) never answers Bun's fetch — it hung
+ * past a 6s timeout on 2026-09-12, redirect followed or not, while curl and mpv
+ * got a 302 at once. The probe returns null on a timeout, so asking only ever
+ * spent the full `MIRURO_BACKEND_PROBE_TIMEOUT_MS` to learn nothing, on every
+ * resolve that landed on Moo — the backend that plays now that `pewe` is down.
+ * AnimeGG's own dossier already says a probe cannot judge these streams.
+ */
+const MIRURO_UNPROBEABLE_STREAM_HOSTS: ReadonlySet<string> = new Set([
+  "www.animegg.org",
+  "animegg.org",
+]);
+
 export async function probeMiruroBackendDown(
   url: string,
   headers: Readonly<Record<string, string>> | undefined,
@@ -1944,6 +1959,7 @@ export async function probeMiruroBackendDown(
   signal?: AbortSignal,
 ): Promise<number | null> {
   if (!/^https?:\/\//i.test(url)) return null;
+  if (MIRURO_UNPROBEABLE_STREAM_HOSTS.has(new URL(url).hostname)) return null;
   const requester = context.fetch?.fetch.bind(context.fetch) ?? fetch;
   const timeout = AbortSignal.timeout(MIRURO_BACKEND_PROBE_TIMEOUT_MS);
   try {
@@ -2229,6 +2245,11 @@ export const miruroProviderModule: CoreProviderModule = {
         signal: context.signal,
         now: context.now,
         emit: context.emit,
+        // Skips a server whose backend is quarantined, so a dead one costs a
+        // probe for its first few plays instead of on every episode. The keys
+        // are server ids (`pewe`, `moo`): sub and dub share a backend.
+        endpointHealth: context.endpointHealth,
+        titleId: input.title.id,
         maxAttemptsPerCandidate: 1,
         candidateTimeoutMs: providerCycleCandidateTimeoutMs(
           input.startupPriority ?? "balanced",
@@ -2313,6 +2334,15 @@ export const miruroProviderModule: CoreProviderModule = {
               )
             : null;
           if (downStatus !== null) {
+            // The engine records nothing for `candidate-empty` — rightly, since
+            // an episode with no dub must not quarantine a server — so this
+            // definitive backend status is recorded here instead. A timeout or
+            // an aborted probe returns null above and never reaches this line.
+            context.endpointHealth?.recordFailure(MIRURO_PROVIDER_ID, metadata.serverId, {
+              class: "server-error",
+              titleId: input.title.id,
+              at: context.now(),
+            });
             throw createProviderCycleFailureError(candidate, {
               // Not `candidate-network`: retryable schedules a retry of a host
               // that is still down, and non-retryable stops the whole cycle as

--- a/packages/providers/src/miruro/manifest.ts
+++ b/packages/providers/src/miruro/manifest.ts
@@ -94,6 +94,7 @@ export const miruroManifest = defineProviderManifest({
     "May hit Cloudflare rate limits if called too frequently.",
     "2026-09-11: the pipe is reachable — Bun fetch is always CF-403'd (its TLS fingerprint), and curl clears the edge on both mirrors. The superseded 2026-08-17 note claiming curl also received CF 403 was measured through a predicate that read any HTML body as a Cloudflare block, including the mirror's own `502 upstream unreachable` page.",
     "2026-09-12: 429 joined that list. The release signoff's anime lane resolved a pewe stream that answered 429 to mpv, to curl with the stream's headers and to curl with none — a rate-limited master is refused to everyone, unlike the 403 that only Bun's fetch sees. Skipping it costs one server attempt; accepting it cost a failed play on the default anime provider. With pewe skipped the cycle lands on moo and plays (verified: 1080p frame).",
+    "2026-09-12: rejected backends are recorded through context.endpointHealth as server-error against the server id, and the cycle skips a quarantined one without asking it. The probe also no longer asks animegg.org, whose /play never answers Bun's fetch (curl and mpv get a 302 at once): it spent the full timeout on every Moo resolve. Together they took a Miruro resolve from ~4.3s to ~1.1s once pewe was quarantined.",
     "A 444/502 from the pipe is one of Miruro's backing servers being down (pewe follows AniDB, ally follows AllManga), not a WAF block, and must not stop the cycle — the remaining servers are usually healthy.",
   ],
 });

--- a/packages/providers/test/miruro-direct.test.ts
+++ b/packages/providers/test/miruro-direct.test.ts
@@ -840,9 +840,11 @@ describe("probeMiruroBackendDown", () => {
     // {"error":"Invalid request (bad hand off)"} with 500 to a bare ranged GET
     // while mpv plays the same URL. Rejecting on it skipped the most reliable
     // backend Miruro has.
+    // Uses another host: AnimeGG itself is no longer asked (see below), and
+    // this test is about the 500 rule, which any backend's CDN can trip.
     const { context } = withStatus(500);
     expect(
-      await probeMiruroBackendDown("https://www.animegg.org/play/1/video.mp4", {}, context),
+      await probeMiruroBackendDown("https://cdn.backend.test/v/video.mp4", {}, context),
     ).toBeNull();
   });
 
@@ -858,8 +860,28 @@ describe("probeMiruroBackendDown", () => {
       },
     } as never;
     expect(
+      await probeMiruroBackendDown("https://handoff.backend.test/play/1/video.mp4", {}, context),
+    ).toBeNull();
+  });
+
+  test("does not ask AnimeGG at all — Bun gets no answer from it, only a timeout", async () => {
+    // Every moo stream is an animegg.org/play URL, and that endpoint never
+    // answers Bun's fetch; the probe spent its whole timeout on every Moo
+    // resolve to return "no evidence".
+    let asked = 0;
+    const context = {
+      fetch: {
+        fetch: async () => {
+          asked += 1;
+          return new Response("", { status: 503 });
+        },
+      },
+    } as never;
+
+    expect(
       await probeMiruroBackendDown("https://www.animegg.org/play/1/video.mp4", {}, context),
     ).toBeNull();
+    expect(asked).toBe(0);
   });
 
   test("a same-host redirect still counts", async () => {
@@ -900,7 +922,7 @@ describe("probeMiruroBackendDown", () => {
     for (const status of [200, 206]) {
       const { context } = withStatus(status);
       expect(
-        await probeMiruroBackendDown("https://www.animegg.org/play/1/video.mp4", {}, context),
+        await probeMiruroBackendDown("https://cdn.backend.test/v/video.mp4", {}, context),
       ).toBe(null);
     }
   });

--- a/packages/providers/test/miruro-endpoint-health.test.ts
+++ b/packages/providers/test/miruro-endpoint-health.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { EndpointHealthFailureInfo, ProviderRuntimeContext } from "@kunai/types";
+
+import { clearMiruroCachesForTest, miruroProviderModule } from "../src/miruro/direct";
+import { __testing as mirrorsTesting } from "../src/miruro/mirrors";
+
+/**
+ * Drives the real Miruro cycle against a stubbed pipe, so what is pinned is the
+ * behaviour a user sees — whether a known-dead backend is asked again — rather
+ * than which function got called.
+ */
+
+const PIPE_KEY = "71951034f8fbcf53d89db52ceb3dc22c";
+const PEWE_MASTER = "https://hls.anidb.app/stream/dead/master.m3u8";
+const MOO_FILE = "https://www.animegg.org/play/1/video.mp4";
+
+/** `base64url(xor(json, PIPE_KEY))` — the pipe's obfuscation, without gzip. */
+function encodePipe(value: unknown): string {
+  const key = Uint8Array.from((PIPE_KEY.match(/.{2}/g) ?? []).map((byte) => parseInt(byte, 16)));
+  const bytes = new TextEncoder().encode(JSON.stringify(value));
+  return Buffer.from(bytes.map((byte, index) => byte ^ (key[index % key.length] ?? 0))).toString(
+    "base64url",
+  );
+}
+
+function pipeRequest(url: URL): { path?: string; query?: Record<string, unknown> } {
+  return JSON.parse(Buffer.from(url.searchParams.get("e") ?? "", "base64url").toString("utf8"));
+}
+
+const pipe = (value: unknown) =>
+  new Response(encodePipe(value), { status: 200, headers: { "x-obfuscated": "2" } });
+
+type Recorded = { endpoint: string; info: EndpointHealthFailureInfo };
+
+function harness(options: {
+  readonly quarantined?: readonly string[];
+  readonly peweStatus?: number | "network-error";
+  readonly peweStreams?: boolean;
+}) {
+  const requests: string[] = [];
+  const failures: Recorded[] = [];
+  const successes: string[] = [];
+  const context = {
+    providerId: "miruro",
+    now: () => "2026-09-12T00:00:00.000Z",
+    endpointHealth: {
+      shouldTry: (_providerId: string, endpoint: string) =>
+        !(options.quarantined ?? []).includes(endpoint),
+      recordFailure: (_providerId: string, endpoint: string, info: EndpointHealthFailureInfo) =>
+        void failures.push({ endpoint, info }),
+      recordSuccess: (_providerId: string, endpoint: string) => void successes.push(endpoint),
+    },
+    fetch: {
+      runtime: "direct-http" as const,
+      async fetch(input: string | URL | Request) {
+        const url = new URL(String(input));
+        requests.push(`${url.host}${url.pathname}`);
+        if (url.pathname === "/api/secure/pipe") {
+          const request = pipeRequest(url);
+          if (request.path === "episodes") {
+            return pipe({
+              providers: {
+                pewe: { episodes: { sub: [{ id: "pewe-1", number: 1 }] } },
+                moo: { episodes: { sub: [{ id: "moo-1", number: 1 }] } },
+              },
+            });
+          }
+          if (request.path === "sources") {
+            const provider = request.query?.provider;
+            if (provider === "pewe") {
+              return pipe({
+                streams: options.peweStreams === false ? [] : [{ url: PEWE_MASTER, type: "hls" }],
+              });
+            }
+            return pipe({ streams: [{ url: MOO_FILE, type: "mp4", quality: "720p" }] });
+          }
+        }
+        if (url.host === "hls.anidb.app") {
+          if (options.peweStatus === "network-error") throw new TypeError("fetch failed");
+          return new Response("", { status: options.peweStatus ?? 429 });
+        }
+        if (url.host === "www.animegg.org") return new Response("", { status: 206 });
+        // Mirror discovery and anything else: absent, never a crash.
+        return new Response("not found", { status: 404 });
+      },
+    },
+  } as unknown as ProviderRuntimeContext;
+  return { context, requests, failures, successes };
+}
+
+const INPUT = {
+  title: { id: "anilist:154587", anilistId: "154587", kind: "anime", title: "Frieren" },
+  episode: { season: 1, episode: 1 },
+  mediaKind: "anime",
+  intent: "play",
+  startupPriority: "balanced",
+  preferredAudioLanguage: "original",
+  allowedRuntimes: ["direct-http"],
+} as const;
+
+describe("miruro endpoint health", () => {
+  afterEach(() => {
+    clearMiruroCachesForTest();
+    mirrorsTesting.reset();
+  });
+
+  test("a rate-limited backend is recorded against its server, and the next one plays", async () => {
+    const { context, failures } = harness({ peweStatus: 429 });
+
+    const result = await miruroProviderModule.resolve(INPUT as never, context);
+
+    expect(result.status).toBe("resolved");
+    expect(result.streams[0]?.url).toBe(MOO_FILE);
+    expect(failures).toEqual([
+      {
+        endpoint: "pewe",
+        info: { class: "server-error", titleId: "anilist:154587", at: "2026-09-12T00:00:00.000Z" },
+      },
+    ]);
+  });
+
+  test("a quarantined backend is not asked at all — the point of recording it", async () => {
+    // Before this, every episode paid the dead server's probe again: the
+    // release signoff's anime lane took 13s against 2s for the others.
+    const { context, requests } = harness({ quarantined: ["pewe"] });
+
+    const result = await miruroProviderModule.resolve(INPUT as never, context);
+
+    expect(result.status).toBe("resolved");
+    expect(result.streams[0]?.url).toBe(MOO_FILE);
+    expect(requests.some((request) => request.startsWith("hls.anidb.app"))).toBe(false);
+  });
+
+  test("a probe that could not reach the backend is no evidence against it", async () => {
+    // Offline must not read as a dead server: that is how a healthy pool
+    // got quarantined for an hour before.
+    const { context, failures } = harness({ peweStatus: "network-error" });
+
+    await miruroProviderModule.resolve(INPUT as never, context);
+
+    expect(failures.filter((failure) => failure.endpoint === "pewe")).toEqual([]);
+  });
+
+  test("an episode a server simply lacks is no evidence against the server", async () => {
+    const { context, failures } = harness({ peweStreams: false });
+
+    const result = await miruroProviderModule.resolve(INPUT as never, context);
+
+    expect(result.status).toBe("resolved");
+    expect(failures.filter((failure) => failure.endpoint === "pewe")).toEqual([]);
+  });
+
+  test("a server that plays clears its record", async () => {
+    const { context, successes } = harness({ quarantined: ["pewe"] });
+
+    await miruroProviderModule.resolve(INPUT as never, context);
+
+    expect(successes).toContain("moo");
+  });
+});


### PR DESCRIPTION
Stacked on #383. Closes #384 — and corrects it.

## #384 guessed wrong

The issue blamed a 2 s probe timeout on the dead `pewe` backend. A 429 answers in ~300 ms. Timing every request in one resolve against the live pipe:

| cost | cause |
| --- | --- |
| **~2000 ms** | the **`moo`** probe timing out — on every resolve |
| ~1300 ms | three Bun fetches Cloudflare refuses before curl answers |
| ~650 ms | `pewe`'s ladder GET + probe |

## Moo: a probe that could never answer

Every `moo` stream starts at `animegg.org/play/…`, and that endpoint **never answers Bun's fetch** — 6 s and still nothing, with or without following redirects — while curl and mpv get a 302 immediately. The probe returns `null` on a timeout, so it spent its full 2 s to learn nothing, on the backend that actually plays now. It no longer asks `animegg.org`; AnimeGG's own dossier already says a probe cannot judge its streams.

## Pewe: asked again every episode

Miruro was the only production provider not using `EndpointHealthPort`. The shared cycle engine already skips quarantined candidates — Miruro just never passed the port. Now it does, and a definitive backend status is recorded as `server-error` against the server id (`pewe`, `moo`; sub and dub share a backend).

The engine deliberately records nothing for `candidate-empty`, because an episode a server lacks is not evidence against it — so Miruro records the definitive status itself, and **never** for a timeout or an aborted probe. That keeps clear of the earlier incident where an over-eager record quarantined healthy servers for an hour.

## Measured

Real `ProviderEndpointHealthService`, in-memory store, live pipe, consecutive episodes:

| | resolve |
| --- | --- |
| before | ~4.3 s |
| with the Moo fix | ~2.3 s |
| once `pewe` is quarantined | **~1.1 s** |

The first play still varies (9–30 s seen) depending on which backends the catalog offers in that fetch — upstream, not this change.

## Tests

`miruro-endpoint-health.test.ts` drives the **real cycle against a stubbed pipe** (XOR-encoded responses), so it pins behaviour a user sees:

- a rate-limited backend is recorded and the next one plays
- a quarantined backend is **not asked at all**
- a probe that couldn't reach the backend records nothing
- an episode a server lacks records nothing
- a server that plays clears its record

Three of those fail against the unfixed code; the two "no false evidence" guards pass both ways, as they should. Probe tests that used an AnimeGG URL were repointed so the 500 and cross-host rules they name are still actually exercised.

## Not done, on purpose

The ~1.3 s of Cloudflare round trips before curl. Skipping straight to curl would need a process-level memo in the pipe transport that #358 hardened; ~0.5 s isn't worth that risk here.

## How to see it and how it ends

A set-aside backend shows in the source list as "temporarily unavailable" and is retried when its hour is up — the existing behaviour for Videasy. There is no manual reset for endpoint health in the CLI today; that's pre-existing and unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Miruro playback startup by skipping backends that cannot be evaluated promptly.
  * Temporarily sets repeatedly failing backends aside for one hour, preventing repeated delays between episodes.
  * Clearly marks temporarily unavailable backends in the source list and retries them after the waiting period.
  * Avoids probing a consistently unresponsive endpoint, reducing stream resolution delays.
  * Added a playback fallback check to better confirm stream availability when standard reachability checks are inconclusive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->