### PR TITLE
fix(rivestream): hand mpv one variant instead of the master

### DIFF
--- a/.changeset/rivestream-single-variant.md
+++ b/.changeset/rivestream-single-variant.md
@@ -1,0 +1,15 @@
+---
+"@kitsunekode/kunai": patch
+---
+
+Start Rivestream playback faster, and show its real quality options.
+
+Rivestream hands out a playlist that lists several qualities. Given that, the
+player opens and inspects every quality before it plays any of them — through a
+slow proxy, roughly seven extra requests before the first frame. Kunai now picks
+one quality itself and gives the player just that, so it starts on the first
+request it needs. The quality picker in `/tracks` also lists the actual
+resolutions instead of a single "HLS" entry.
+
+Streams whose audio lives in a separate track are left as they were, since
+splitting those would play without sound.

--- a/.docs/provider-dossiers/rivestream.md
+++ b/.docs/provider-dossiers/rivestream.md
@@ -66,6 +66,17 @@ sequenceDiagram
 - **Region/block:** Upstream API blocks.
 - **Expired stream:** Tokenized stream URLs.
 - **Slow response:** Upstream aggregator fetching can take 5+ seconds to resolve all sources.
+- **Slow first frame from a master:** sources arrive as an HLS master behind
+  `proxy.valhallastream.dpdns.org` (~1.3 s a request). mpv opening a master makes
+  ffmpeg's HLS demuxer load and probe **every** variant: counted on 2026-09-12,
+  12 requests to a first frame for a 3-variant master against 5 for one of its
+  variants, and a clean A/B round of 18.4 s vs 11.2 s. The adapter therefore
+  splits each master into its rungs (`expandRivestreamHlsMasters`) and mpv gets
+  exactly one; the Tracks panel gains a real ladder instead of a bare "HLS". A
+  master whose variants name an `AUDIO` rendition stays whole — their playlists
+  are video-only — and so does one the proxy fails to return, on a 4 s deadline.
+  The provider's own `quality` string ("HindiCast (1080)") is kept for audio
+  language inference; the rung travels separately.
 - **Missing subtitle:** Normal fallback.
 - **Hardsub-only:** Unpredictable based on upstream source.
 - **Multi-server duplicate:** High probability. Aggregators often scrape the same underlying file hosts. Deduplication required.

--- a/.docs/provider-dossiers/tmdb-embed-aggregator-research.md
+++ b/.docs/provider-dossiers/tmdb-embed-aggregator-research.md
@@ -18,6 +18,27 @@ lastReviewed: "2026-06-12"
 - **Research scripts:** `.reference/experiments/scratchpads/vidapi-research/` (the
   probes that produced the data in this dossier).
 
+## Validation Note — 2026-09-12
+
+Rechecked because VidLink stopped returning sources (it answers `200` with
+`null` for every title), which left the movie/series lane with only Videasy and
+Rivestream — exactly the rescue slot the note below held VidAPI back for.
+
+**The recipe no longer answers.** `GET streamdata.vaplayer.ru/api.php?tmdb=…`
+returns `404` with an empty body for every case in the old matrix (Dune,
+Oppenheimer, Interstellar, Breaking Bad S1E1, Severance S1E1, Attack on Titan
+S1E1) and for Bad Guys S1E4 — with plain curl, with `curl_chrome120` and
+`curl_chrome150`, and with both `https://brightpathsignals.com/` and the exact
+`/embed/movie/{id}` Referer. DNS resolves to ordinary Cloudflare addresses, so
+it is not this network's sinkhole. Whatever the endpoint now requires would have
+to be recovered from a player this dossier already describes as hostile to
+scraping; that is a research task, not a provider change.
+
+Also rechecked, and still not candidates: Braflix (service down, per its own
+dossier), Bitcine (a wrapper over Videasy, so not independent of it), and the
+two adapters already in the tree but unregistered — `vidrock` (its API answers
+HTTP 400) and `rgshows` (`api.rgshows.ru` no longer resolves).
+
 ## Validation Note — 2026-06-05
 
 Follow-up validation from the Kunai provider-quality matrix kept this dossier in

--- a/packages/providers/src/rivestream/direct.ts
+++ b/packages/providers/src/rivestream/direct.ts
@@ -23,6 +23,7 @@ import type {
 
 import { ProviderHttpError, providerJson } from "../runtime/fetch";
 import { resolveTmdbCatalogId } from "../shared/catalog-id";
+import { expandHlsMasterPlaylist } from "../shared/hls-ladder";
 import { TTLCache } from "../shared/provider-cache";
 import {
   findLastCycleFailure,
@@ -101,6 +102,15 @@ let providerServicesCache:
       readonly expiresAtMs: number;
     }
   | undefined;
+
+/**
+ * Test-only: the services cache is process-wide and keyed to the injected clock,
+ * so a test file with a later clock leaves entries another file's earlier clock
+ * still reads as fresh.
+ */
+export function clearRivestreamCachesForTest(): void {
+  providerServicesCache = undefined;
+}
 
 type RivestreamProviderServicesResponse = {
   readonly data?: unknown;
@@ -825,6 +835,60 @@ function isRivestreamAbortOrTimeoutError(error: unknown): boolean {
   return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }
 
+/**
+ * The upstream hands out an HLS master, and mpv opening a master makes ffmpeg's
+ * HLS demuxer load and probe every variant before it plays one. Through
+ * Rivestream's proxy (~1.3s a request) that alone cost ~8s: measured on
+ * 2026-09-12, a 3-variant master took 19.1s to a first frame and one of its
+ * variants 11.2s. So each master is split into its variants here and mpv is
+ * handed exactly one — which also gives the Tracks panel a real quality ladder
+ * instead of a bare "HLS".
+ *
+ * The expander keeps a master whole when its variants take audio from a
+ * separate rendition (their playlists are then video-only), and on any fetch
+ * failure — so the worst case is today's behaviour. The deadline is short
+ * because this sits on the resolve path: a hung proxy must cost seconds, not
+ * the expander's default twelve.
+ */
+const RIVESTREAM_LADDER_TIMEOUT_MS = 4_000;
+
+/**
+ * A source as the provider described it, plus the resolution rung it was split
+ * to. `quality` stays the provider's own string ("HindiCast (1080)"): the audio
+ * language is read from it, and a rung label would erase that.
+ */
+type RivestreamPlayableSource = RivestreamRawSource & {
+  readonly rung?: { readonly label: string; readonly rank: number };
+};
+
+async function expandRivestreamHlsMasters(
+  rawSources: readonly RivestreamRawSource[],
+  context: ProviderRuntimeContext,
+): Promise<RivestreamPlayableSource[]> {
+  const requester = context.fetch?.fetch.bind(context.fetch) ?? fetch;
+  const headers = { referer: RIVESTREAM_REFERER, "user-agent": USER_AGENT };
+  const expanded = await Promise.all(
+    rawSources.map(async (source): Promise<RivestreamPlayableSource[]> => {
+      if (!source.url || !source.url.includes(".m3u8")) return [source];
+      const ladder = await expandHlsMasterPlaylist({
+        fetch: requester,
+        masterUrl: source.url,
+        headers,
+        signal: createTimeoutSignal(context.signal, RIVESTREAM_LADDER_TIMEOUT_MS),
+      });
+      // One row pointing back at the master is the expander declining to
+      // split; keep the source exactly as the provider described it.
+      if (ladder.length <= 1 && ladder[0]?.url === source.url) return [source];
+      return ladder.map((variant) => ({
+        ...source,
+        url: variant.url,
+        rung: { label: variant.qualityLabel, rank: variant.qualityRank },
+      }));
+    }),
+  );
+  return expanded.flat();
+}
+
 async function resolveRivestreamProviderCandidate({
   candidate,
   provider,
@@ -859,11 +923,13 @@ async function resolveRivestreamProviderCandidate({
   const variants: ProviderVariantCandidate[] = [];
   const subtitles: SubtitleCandidate[] = [];
 
-  rawSources.forEach((source) => {
+  const playable = await expandRivestreamHlsMasters(rawSources, context);
+
+  playable.forEach((source) => {
     if (!source.url) return;
     const qualityStr = String(source.quality || source.format || "auto");
-    const qualityLabel = normalizeQualityLabel(qualityStr);
-    const qualityRank = qualityRankFromLabel(qualityStr) ?? 0;
+    const qualityLabel = source.rung?.label ?? normalizeQualityLabel(qualityStr);
+    const qualityRank = source.rung?.rank ?? qualityRankFromLabel(qualityStr) ?? 0;
     const streamId = createStreamId(RIVESTREAM_PROVIDER_ID, [source.url]);
     const variantId = createVariantId(RIVESTREAM_PROVIDER_ID, [sourceId, qualityLabel, source.url]);
     const protocol = source.url.includes(".m3u8") ? "hls" : "mp4";

--- a/packages/providers/src/shared/hls-ladder.ts
+++ b/packages/providers/src/shared/hls-ladder.ts
@@ -48,6 +48,13 @@ export async function expandHlsMasterPlaylist(
     if (!isHlsMasterPlaylist(text)) {
       return [fallback];
     }
+    // A variant that names an AUDIO group gets its sound from that rendition,
+    // and its own playlist is often video-only. Handing mpv one variant would
+    // then play silent video, so such a master stays whole and mpv picks.
+    // Losing the quality picker is the worst this can cost.
+    if (masterVariantsUseAudioRenditions(text)) {
+      return [fallback];
+    }
 
     const variants = parseHlsMasterVariants(text, masterUrl);
     if (variants.length === 0) return [fallback];
@@ -58,6 +65,16 @@ export async function expandHlsMasterPlaylist(
   } catch {
     return [fallback];
   }
+}
+
+/** True when any `#EXT-X-STREAM-INF` takes its audio from a named rendition group. */
+export function masterVariantsUseAudioRenditions(manifestText: string): boolean {
+  return manifestText
+    .split(/\r?\n/)
+    .some(
+      (line) =>
+        line.trim().startsWith("#EXT-X-STREAM-INF:") && /(?:^|[:,])AUDIO="/i.test(line.trim()),
+    );
 }
 
 /** True when a stream URL looks like an HLS master (leaf or path hint). */

--- a/packages/providers/test/hls-ladder.test.ts
+++ b/packages/providers/test/hls-ladder.test.ts
@@ -52,6 +52,42 @@ describe("hls ladder", () => {
     ]);
   });
 
+  test("keeps a master whole when its variants take audio from a rendition group", async () => {
+    // Those variant playlists are video-only; handing mpv one would play
+    // silent video. The quality picker is what gets lost, not the sound.
+    const withAudioGroup = `#EXTM3U
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="stereo",NAME="English",LANGUAGE="eng",URI="a-eng/playlist.m3u8"
+#EXT-X-STREAM-INF:BANDWIDTH=13298235,RESOLUTION=1920x1080,AUDIO="stereo"
+v-1080/playlist.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=1764061,RESOLUTION=640x360,AUDIO="stereo"
+v-360/playlist.m3u8
+`;
+    const variants = await expandHlsMasterPlaylist({
+      masterUrl: "https://cdn.example/master.m3u8",
+      fetch: (async () => new Response(withAudioGroup)) as ExpandHlsMasterPlaylistOptions["fetch"],
+    });
+    expect(variants).toEqual([
+      { url: "https://cdn.example/master.m3u8", qualityLabel: "auto", qualityRank: 0 },
+    ]);
+  });
+
+  test("still splits a master whose variants carry their own audio", async () => {
+    const muxed = `#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=661118,CODECS="mp4a.40.2,avc1.42c015",RESOLUTION=640x256
+v0.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=3652287,CODECS="mp4a.40.2,avc1.640028",RESOLUTION=1920x768
+v2.m3u8
+`;
+    const variants = await expandHlsMasterPlaylist({
+      masterUrl: "https://cdn.example/master.m3u8",
+      fetch: (async () => new Response(muxed)) as ExpandHlsMasterPlaylistOptions["fetch"],
+    });
+    expect(variants.map((variant) => variant.url)).toEqual([
+      "https://cdn.example/v2.m3u8",
+      "https://cdn.example/v0.m3u8",
+    ]);
+  });
+
   test("looksLikeHlsMasterUrl detects master leaf names", () => {
     expect(looksLikeHlsMasterUrl("https://cdn.example/master.m3u8")).toBe(true);
     expect(looksLikeHlsMasterUrl("https://cdn.example/vod/index-v1-a1.m3u8")).toBe(false);

--- a/packages/providers/test/rivestream-hls-ladder.test.ts
+++ b/packages/providers/test/rivestream-hls-ladder.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { ProviderResolveInput, ProviderRuntimeContext } from "@kunai/types";
+
+import { clearRivestreamCachesForTest, rivestreamProviderModule } from "../src/rivestream/direct";
+
+const MASTER_URL = "https://proxy.example/m3u8-proxy?url=https%3A%2F%2Fcdn.example%2Fmaster.m3u8";
+
+/** Trimmed from the live master (2026-09-12): three muxed-audio variants. */
+const MUXED_MASTER = `#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=661118,CODECS="mp4a.40.2,avc1.42c015",RESOLUTION=640x256
+https://proxy.example/v0.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=2191399,CODECS="mp4a.40.2,avc1.64001f",RESOLUTION=1280x512
+https://proxy.example/v1.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=3652287,CODECS="mp4a.40.2,avc1.640028",RESOLUTION=1920x768
+https://proxy.example/v2.m3u8
+`;
+
+const INPUT = {
+  title: { id: "438631", tmdbId: "438631", kind: "movie", title: "Dune" },
+  mediaKind: "movie",
+  intent: "play",
+  startupPriority: "balanced",
+  allowedRuntimes: ["direct-http"],
+} as unknown as ProviderResolveInput;
+
+function context(options: {
+  readonly master?: string | "fail";
+  readonly quality?: string;
+  readonly onMaster?: (signal: AbortSignal | undefined) => void;
+}): ProviderRuntimeContext {
+  return {
+    providerId: "rivestream",
+    now: () => "2026-09-12T00:00:00.000Z",
+    fetch: {
+      runtime: "direct-http",
+      fetch: async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("VideoProviderServices")) {
+          return Response.json({ data: ["flowcast"] });
+        }
+        if (url === MASTER_URL) {
+          options.onMaster?.(init?.signal ?? undefined);
+          if (options.master === "fail") throw new TypeError("fetch failed");
+          return new Response(options.master ?? MUXED_MASTER);
+        }
+        return Response.json({
+          data: {
+            sources: [{ url: MASTER_URL, quality: options.quality ?? "FlowCast", format: "hls" }],
+          },
+        });
+      },
+    },
+  } as unknown as ProviderRuntimeContext;
+}
+
+describe("rivestream hands mpv one variant, not the master", () => {
+  // Leave the process-wide services cache as this file found it.
+  beforeEach(() => clearRivestreamCachesForTest());
+  afterEach(() => clearRivestreamCachesForTest());
+
+  test("splits a muxed master into its rungs, best first", async () => {
+    // A master makes ffmpeg load and probe every variant before playing one:
+    // 19.1s to a first frame against 11.2s for a single variant, live.
+    const result = await rivestreamProviderModule.resolve(INPUT, context({}));
+
+    expect(result.status).toBe("resolved");
+    expect(result.streams.map((stream) => stream.qualityLabel)).toEqual(["768p", "512p", "256p"]);
+    expect(result.streams.every((stream) => stream.url !== MASTER_URL)).toBe(true);
+  });
+
+  test("keeps the audio language the provider's quality string names", async () => {
+    // The language is read from "German (1080)"; a rung label would erase it.
+    const result = await rivestreamProviderModule.resolve(
+      INPUT,
+      context({ quality: "German (1080)" }),
+    );
+
+    expect(result.streams.length).toBe(3);
+    expect(result.streams.every((stream) => stream.audioLanguages?.[0] === "de")).toBe(true);
+  });
+
+  test("a master whose variants need a separate audio track stays whole", async () => {
+    const withAudioGroup = `#EXTM3U
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="a",NAME="English",URI="https://proxy.example/a.m3u8"
+#EXT-X-STREAM-INF:BANDWIDTH=3652287,RESOLUTION=1920x768,AUDIO="a"
+https://proxy.example/v2.m3u8
+`;
+    const result = await rivestreamProviderModule.resolve(
+      INPUT,
+      context({ master: withAudioGroup }),
+    );
+
+    expect(result.streams.map((stream) => stream.url)).toEqual([MASTER_URL]);
+  });
+
+  test("a proxy that fails the master request plays the master as before", async () => {
+    const result = await rivestreamProviderModule.resolve(INPUT, context({ master: "fail" }));
+
+    expect(result.status).toBe("resolved");
+    expect(result.streams.map((stream) => stream.url)).toEqual([MASTER_URL]);
+  });
+
+  test("the master request carries a deadline, so a stalled proxy cannot hold resolve open", async () => {
+    // Asserted on the request rather than by waiting it out: a test that needs
+    // real elapsed time to pass is the flake this repo keeps removing.
+    const signals: (AbortSignal | undefined)[] = [];
+    await rivestreamProviderModule.resolve(
+      INPUT,
+      context({ onMaster: (signal) => signals.push(signal) }),
+    );
+
+    expect(signals.length).toBe(1);
+    expect(signals[0]).toBeInstanceOf(AbortSignal);
+    expect(signals[0]?.aborted).toBe(false);
+  });
+});


### PR DESCRIPTION
Rivestream is the movie lane's only working fallback (VidLink has no sources upstream), and it took **~16 s to a first frame**.

## Where the time went

Bun fetches the master, a variant and a first segment in ~3 s, so most of it was on mpv's side. Given an HLS master, ffmpeg's HLS demuxer **loads and probes every variant** before it plays one. Counted from mpv's own log against the live stream:

| mpv is handed | requests to first frame |
| --- | --- |
| the 3-variant master | **12** (3 playlists + 9 segments) |
| one of its variants | **5** |

Through a proxy at ~1.3 s a request, that's the gap. A clean A/B round measured **18.4 s vs 11.2 s**. Wall-clock through this proxy is noisy — one rung run stalled to 40 s — which is why the claim rests on the request count, not a single timing.

## The fix

Each master is split into its rungs and mpv gets exactly one. Side benefit: `/tracks` shows the real resolutions instead of a bare "HLS".

Two details that would have been bugs:

- **Audio language survives the split.** Rivestream's `quality` string (`"HindiCast (1080)"`, `"German (1080)"`) is also where the audio language is read. The rung travels in a separate field so that string is untouched — overwriting it with `"1080p"` would have silently dropped `de`.
- **Masters with separate audio stay whole.** `expandHlsMasterPlaylist` now declines to split a master whose variants name an `AUDIO` rendition, because those variant playlists are video-only and mpv would play silence. This guard is shared, so AniDB, AllManga, VidLink and Miruro get it too — the worst it can cost them is the quality picker, never sound. (KickAssAnime's masters are exactly this shape.)

The expansion runs on a **4 s deadline** because it sits on the resolve path; any failure keeps the master, so the worst case is today's behaviour.

## Tests

`rivestream-hls-ladder.test.ts` drives the real resolve: a muxed master splits best-first, the quality string's language survives, an audio-group master stays whole, a failing proxy keeps the master, and the master request carries a deadline — asserted on the request, not by waiting it out. Three fail against the unfixed code; the two "unchanged behaviour" guards pass both ways.

Also adds `clearRivestreamCachesForTest`. The services cache is keyed to the injected clock, and the new file's later clock leaked entries that `providers.test.ts`'s earlier clock read as fresh — three existing cases failed only when run after it. The new file now leaves the cache as it found it.

Full `--force` gates green (567 provider tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rivestream streams now offer a quality ladder with selectable resolutions in the Tracks panel.
  * Compatible HLS streams are presented as individual quality options, ordered from highest to lowest resolution.
* **Bug Fixes**
  * Reduced delays before playback begins by avoiding unnecessary inspection of every available quality.
  * Preserved audio for streams using separate audio tracks.
  * Added fallback handling when stream details cannot be retrieved or safely separated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->